### PR TITLE
Vestlus: production polish sweep (closes #578)

### DIFF
--- a/app/chat/export.py
+++ b/app/chat/export.py
@@ -1,0 +1,247 @@
+"""Export a chat conversation to Markdown or a .docx file.
+
+Used by the chat routes to give users a downloadable transcript of a
+conversation. System messages are skipped — they're internal
+orchestration scaffolding, not part of the user-visible dialogue.
+
+Both exporters walk the same ``messages`` iterable and apply a simple
+role-to-label mapping:
+
+    user      -> "Kasutaja:"
+    assistant -> "Assistent:"
+    tool      -> "Tööriist <tool_name>:"
+
+Tool messages render their ``tool_output`` (or ``tool_input`` if no
+output is recorded) as pretty-printed JSON inside a fenced code block
+(markdown) or as a monospaced paragraph (docx).
+
+Styling for the .docx mirrors the conventions in
+``app/drafter/docx_builder.py`` and ``app/docs/docx_export.py`` — Heading
+style for the title, normal paragraphs for metadata and body text, bold
+inline runs for role labels.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from docx import Document
+from docx.shared import Pt
+
+from app.chat.models import Conversation, Message
+from app.ui.time import format_tallinn
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_ROLE_LABEL_MD = {
+    "user": "**Kasutaja:**",
+    "assistant": "**Assistent:**",
+}
+
+_ROLE_LABEL_PLAIN = {
+    "user": "Kasutaja:",
+    "assistant": "Assistent:",
+}
+
+
+def _tool_payload(message: Message) -> Any:
+    """Return the most useful payload for a tool message.
+
+    Prefers ``tool_output`` (the result) and falls back to ``tool_input``
+    (the arguments) when no output is recorded. Returning ``None`` means
+    the renderer should emit an empty object placeholder.
+    """
+    if message.tool_output is not None:
+        return message.tool_output
+    if message.tool_input is not None:
+        return message.tool_input
+    return None
+
+
+def _format_tool_json(payload: Any) -> str:
+    """Pretty-print the tool payload as JSON, tolerating non-JSON values."""
+    if payload is None:
+        return "{}"
+    try:
+        return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+    except (TypeError, ValueError):
+        logger.exception("Failed to JSON-encode tool payload")
+        return str(payload)
+
+
+# ---------------------------------------------------------------------------
+# Markdown export
+# ---------------------------------------------------------------------------
+
+
+def conversation_to_markdown(
+    conversation: Conversation,
+    messages: Iterable[Message],
+) -> str:
+    """Render ``conversation`` + ``messages`` as a Markdown string.
+
+    Layout::
+
+        # <title>
+
+        Loodud: DD.MM.YYYY HH:MM
+
+        ---
+
+        **Kasutaja:**
+
+        <content>
+
+        **Assistent:**
+
+        <content>
+
+        **Tööriist <name>:**
+
+        ```json
+        { ... }
+        ```
+
+    System messages are skipped. Assistant content is emitted verbatim
+    (already markdown from the LLM).
+    """
+    title = (conversation.title or "Vestlus").strip() or "Vestlus"
+    parts: list[str] = [
+        f"# {title}",
+        "",
+        f"Loodud: {format_tallinn(conversation.created_at)}",
+        "",
+        "---",
+        "",
+    ]
+
+    for message in messages:
+        role = message.role
+        if role == "system":
+            continue
+
+        if role == "tool":
+            tool_name = message.tool_name or "tööriist"
+            parts.append(f"**Tööriist {tool_name}:**")
+            parts.append("")
+            parts.append("```json")
+            parts.append(_format_tool_json(_tool_payload(message)))
+            parts.append("```")
+            parts.append("")
+            continue
+
+        label = _ROLE_LABEL_MD.get(role)
+        if label is None:
+            # Unknown role — still render so nothing is lost.
+            label = f"**{role}:**"
+
+        parts.append(label)
+        parts.append("")
+        parts.append(message.content or "")
+        parts.append("")
+
+    # Trim trailing blank line, ensure single terminal newline.
+    while parts and parts[-1] == "":
+        parts.pop()
+    return "\n".join(parts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# .docx export
+# ---------------------------------------------------------------------------
+
+
+# Strip a leading ``#`` block (one or more ``#`` followed by space) from a
+# line — converts a markdown heading into flat text without nuking hash
+# characters that appear mid-line (e.g. ``#572`` issue references).
+_LEADING_HASH_RE = re.compile(r"^#{1,6}\s+")
+
+# Match ``**bold**`` spans. Non-greedy so adjacent bold spans don't merge.
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+
+# Match ``*italic*`` or ``_italic_`` spans (single markers).
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+
+
+def _flatten_markdown_line(line: str) -> str:
+    """Strip a handful of markdown markers for cleaner docx rendering.
+
+    This is deliberately simple — python-docx has no native markdown
+    parser and rolling our own is out of scope. We handle the common
+    markers (heading ``#``, bold ``**x**``, italic ``*x*``) and leave
+    everything else alone.
+    """
+    line = _LEADING_HASH_RE.sub("", line)
+    line = _BOLD_RE.sub(r"\1", line)
+    line = _ITALIC_RE.sub(r"\1", line)
+    return line
+
+
+def _add_role_paragraph(doc: Any, label: str, body: str) -> None:
+    """Add a single role-labeled paragraph pair (bold label, then body)."""
+    label_para = doc.add_paragraph()
+    run = label_para.add_run(label)
+    run.bold = True
+
+    if not body:
+        return
+
+    for raw_line in body.splitlines() or [body]:
+        flat = _flatten_markdown_line(raw_line)
+        doc.add_paragraph(flat)
+
+
+def _add_tool_paragraph(doc: Any, tool_name: str, payload: Any) -> None:
+    """Add a tool message as a bold label + monospaced JSON block."""
+    label_para = doc.add_paragraph()
+    run = label_para.add_run(f"Tööriist {tool_name}:")
+    run.bold = True
+
+    json_text = _format_tool_json(payload)
+    body_para = doc.add_paragraph()
+    body_run = body_para.add_run(json_text)
+    body_run.font.name = "Consolas"
+    body_run.font.size = Pt(9)
+
+
+def conversation_to_docx_bytes(
+    conversation: Conversation,
+    messages: Iterable[Message],
+) -> bytes:
+    """Render ``conversation`` + ``messages`` as a .docx, returning bytes.
+
+    The returned bytes are a valid ZIP archive (.docx is a zipped OOXML
+    bundle) so the caller can stream them directly as a file download.
+    """
+    title = (conversation.title or "Vestlus").strip() or "Vestlus"
+
+    doc = Document()
+    doc.add_heading(title, level=0)
+    doc.add_paragraph(f"Loodud: {format_tallinn(conversation.created_at)}")
+    doc.add_paragraph("")  # spacer
+
+    for message in messages:
+        role = message.role
+        if role == "system":
+            continue
+
+        if role == "tool":
+            _add_tool_paragraph(doc, message.tool_name or "tööriist", _tool_payload(message))
+            continue
+
+        label = _ROLE_LABEL_PLAIN.get(role, f"{role}:")
+        _add_role_paragraph(doc, label, message.content or "")
+
+    buffer = io.BytesIO()
+    doc.save(buffer)
+    return buffer.getvalue()

--- a/app/chat/feedback.py
+++ b/app/chat/feedback.py
@@ -1,0 +1,195 @@
+"""Per-message thumbs-up / thumbs-down feedback helpers.
+
+Mirrors the ``message_feedback`` table added in
+``migrations/017_chat_ux_features.sql``:
+
+    CREATE TABLE message_feedback (
+        id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        message_id UUID NOT NULL REFERENCES messages(id)  ON DELETE CASCADE,
+        user_id    UUID NOT NULL REFERENCES users(id)     ON DELETE CASCADE,
+        rating     SMALLINT NOT NULL CHECK (rating IN (-1, 1)),
+        comment    TEXT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE (message_id, user_id)
+    );
+
+Follows the same query-helper conventions as ``app.chat.models``:
+
+    * Explicit ``conn`` parameter from the caller
+    * ``conn.commit()`` on writes is the caller's responsibility
+    * **Reads** (:func:`get_feedback`, :func:`feedback_counts`) swallow DB
+      exceptions, log them, and return a safe default (``None`` / ``(0, 0)``).
+      The feedback widget is a non-critical UI affordance — a transient DB
+      blip must not blank the surrounding page. Callers therefore treat the
+      safe default as a normal result.
+    * **Writes** (:func:`upsert_feedback`, :func:`delete_feedback`) raise
+      on error. Silently swallowing a write would lose a user's vote, so
+      the HTTP handler converts the exception into a 500 for the client
+      to retry explicitly.
+
+Kept in a separate module (``feedback.py`` vs. ``models.py``) so the
+feedback surface can grow — comment moderation, admin analytics, etc. —
+without bloating the chat message model.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from app.db_utils import coerce_uuid
+
+logger = logging.getLogger(__name__)
+
+
+VALID_RATINGS = frozenset({-1, 1})
+
+_FEEDBACK_COLUMNS = "id, message_id, user_id, rating, comment, created_at"
+
+
+@dataclass(frozen=True)
+class MessageFeedback:
+    """Snapshot of a row in the ``message_feedback`` table."""
+
+    id: uuid.UUID
+    message_id: uuid.UUID
+    user_id: uuid.UUID
+    rating: int  # -1 or +1
+    comment: str | None
+    created_at: datetime
+
+
+def _row_to_feedback(row: tuple[Any, ...]) -> MessageFeedback:
+    """Build a ``MessageFeedback`` from a raw cursor row."""
+    fb_id, message_id, user_id, rating, comment, created_at = row
+    return MessageFeedback(
+        id=coerce_uuid(fb_id),
+        message_id=coerce_uuid(message_id),
+        user_id=coerce_uuid(user_id),
+        rating=int(rating),
+        comment=comment,
+        created_at=created_at,
+    )
+
+
+def _validate_rating(rating: int) -> int:
+    """Coerce to ``int`` and validate against the CHECK constraint."""
+    try:
+        value = int(rating)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid rating: {rating!r}") from exc
+    if value not in VALID_RATINGS:
+        raise ValueError(f"Invalid rating {value}: must be -1 (thumbs down) or 1 (thumbs up)")
+    return value
+
+
+def upsert_feedback(
+    conn: Any,
+    *,
+    message_id: uuid.UUID | str,
+    user_id: uuid.UUID | str,
+    rating: int,
+    comment: str | None = None,
+) -> MessageFeedback:
+    """Insert or update the feedback row for ``(message_id, user_id)``.
+
+    Re-voting (e.g. switching thumbs-up to thumbs-down) overwrites the
+    prior rating in place rather than creating a new row; ``created_at``
+    is refreshed to ``now()`` so the feedback timeline reflects the most
+    recent signal.
+
+    Raises ``ValueError`` if ``rating`` is not in ``{-1, 1}`` so the
+    CHECK constraint never fires at the DB level.
+    """
+    validated_rating = _validate_rating(rating)
+
+    row = conn.execute(
+        f"""
+        INSERT INTO message_feedback (message_id, user_id, rating, comment)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (message_id, user_id) DO UPDATE
+            SET rating = EXCLUDED.rating,
+                comment = EXCLUDED.comment,
+                created_at = now()
+        RETURNING {_FEEDBACK_COLUMNS}
+        """,
+        (str(message_id), str(user_id), validated_rating, comment),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("INSERT ... RETURNING message_feedback produced no row")
+    return _row_to_feedback(row)
+
+
+def get_feedback(
+    conn: Any,
+    message_id: uuid.UUID | str,
+    user_id: uuid.UUID | str,
+) -> MessageFeedback | None:
+    """Return the feedback row for ``(message_id, user_id)``, or ``None``."""
+    try:
+        row = conn.execute(
+            f"""
+            SELECT {_FEEDBACK_COLUMNS}
+            FROM message_feedback
+            WHERE message_id = %s AND user_id = %s
+            """,
+            (str(message_id), str(user_id)),
+        ).fetchone()
+    except Exception:
+        logger.exception(
+            "Failed to fetch feedback message_id=%s user_id=%s",
+            message_id,
+            user_id,
+        )
+        return None
+    return _row_to_feedback(row) if row else None
+
+
+def delete_feedback(
+    conn: Any,
+    message_id: uuid.UUID | str,
+    user_id: uuid.UUID | str,
+) -> None:
+    """Remove the current user's feedback for a message (a "retract vote")."""
+    conn.execute(
+        """
+        DELETE FROM message_feedback
+        WHERE message_id = %s AND user_id = %s
+        """,
+        (str(message_id), str(user_id)),
+    )
+
+
+def feedback_counts(
+    conn: Any,
+    message_id: uuid.UUID | str,
+) -> tuple[int, int]:
+    """Return ``(up_count, down_count)`` for a message.
+
+    Returns ``(0, 0)`` on DB error so the caller can render a safe
+    default without special-casing failure modes.
+    """
+    try:
+        row = conn.execute(
+            """
+            SELECT
+                COALESCE(SUM(CASE WHEN rating =  1 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN rating = -1 THEN 1 ELSE 0 END), 0)
+            FROM message_feedback
+            WHERE message_id = %s
+            """,
+            (str(message_id),),
+        ).fetchone()
+    except Exception:
+        logger.exception(
+            "Failed to compute feedback counts for message=%s",
+            message_id,
+        )
+        return (0, 0)
+    if row is None:
+        return (0, 0)
+    up_count, down_count = row
+    return (int(up_count or 0), int(down_count or 0))

--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -1,0 +1,1036 @@
+"""Extra HTTP handlers for the Vestlus polish sweep (issue #17 chat UX).
+
+This module houses the handlers that complement the main conversation
+view defined in :mod:`app.chat.routes`. The split keeps ``routes.py``
+focused on the page-rendering paths and concentrates the chat mutation
++ export surface area here:
+
+    POST   /chat/{conv_id}/pin
+    POST   /chat/{conv_id}/archive
+    POST   /chat/{conv_id}/rename
+    POST   /chat/{conv_id}/fork
+    POST   /chat/{conv_id}/messages/{msg_id}/pin
+    POST   /chat/{conv_id}/messages/{msg_id}/feedback
+    DELETE /chat/{conv_id}/messages/{msg_id}/feedback
+    POST   /chat/{conv_id}/messages/{msg_id}/regenerate
+    POST   /chat/{conv_id}/messages/{msg_id}/edit
+    GET    /chat/{conv_id}/export.md
+    GET    /chat/{conv_id}/export.docx
+    GET    /chat/search
+    GET    /api/me/usage
+
+The handlers follow the same shape as ``app/chat/routes.py``:
+
+    - :func:`require_auth` short-circuit
+    - ``_parse_uuid`` + ``get_conversation`` + ``can_access_conversation``
+      for cross-org rejection (404, never 403)
+    - 204 + ``HX-Trigger`` for successful mutations
+    - 303 / ``HX-Redirect`` for navigations
+    - fire-and-forget audit via ``app.auth.audit.log_action``
+
+CSRF note
+---------
+The app uses JWT-in-cookie auth; ``routes.py`` does **not** install a
+CSRF middleware and neither does this module. If CSRF protection is
+added later it will ship as beforeware across all mutating routes, at
+which point these handlers pick it up automatically.
+
+Models shim
+-----------
+Several helpers expected to live in :mod:`app.chat.models` (``set_conversation_pinned``,
+``set_conversation_archived``, ``update_conversation_title``,
+``set_message_pinned``, ``delete_messages_after``, ``fork_conversation``,
+``list_conversations_for_user(search=...)``) are being authored in a
+parallel wave. To avoid a hard coupling we try the import and fall back
+to inline SQL that matches migration 017. Once the models module lands
+the shims become no-ops via the import path.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from fasthtml.common import A, Div, Li, P, Ul
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse, Response
+
+from app.auth.audit import log_action
+from app.auth.helpers import require_auth as _require_auth
+from app.auth.policy import can_access_conversation
+from app.chat.export import conversation_to_docx_bytes, conversation_to_markdown
+from app.chat.models import (
+    Conversation,
+    Message,
+    delete_messages_after,
+    fork_conversation,
+    get_conversation,
+    list_conversations_for_user,
+    list_messages,
+    set_conversation_archived,
+    set_conversation_pinned,
+    set_message_pinned,
+    update_conversation_title,
+)
+from app.chat.rate_limiter import get_user_quota, seconds_until_hourly_reset
+from app.db import get_connection as _connect
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Small helpers duplicated from routes.py so we don't introduce a cycle
+# ---------------------------------------------------------------------------
+
+
+def _parse_uuid(raw: str) -> uuid.UUID | None:
+    """Return a UUID parsed from *raw*, or ``None`` if invalid."""
+    try:
+        return uuid.UUID(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _is_htmx(req: Request) -> bool:
+    return req.headers.get("HX-Request") == "true"
+
+
+def _not_found_response() -> Response:
+    """Generic 404 body for invalid/cross-org access.
+
+    Handlers in this module answer machine targets (HTMX fragments, JSON,
+    file downloads) rather than a full page so a terse plaintext 404 is
+    the appropriate response. ``routes.py`` uses a themed page because
+    those URLs are direct navigation targets.
+    """
+    return Response("Vestlust ei leitud", status_code=404, media_type="text/plain")
+
+
+def _hx_trigger_response(event: str, status_code: int = 204) -> Response:
+    """204 + ``HX-Trigger: <event>`` response used by most mutations."""
+    return Response(status_code=status_code, headers={"HX-Trigger": event})
+
+
+def _load_conversation_or_404(
+    req: Request, conv_id: str
+) -> tuple[uuid.UUID, Conversation] | Response:
+    """Parse *conv_id*, load the row, and verify ownership.
+
+    Returns ``(parsed_id, conversation)`` on success or a 404 Response
+    otherwise. Any exception from the DB layer collapses into 404 because
+    we deliberately don't leak existence to the caller.
+    """
+    parsed = _parse_uuid(conv_id)
+    if parsed is None:
+        return _not_found_response()
+
+    auth = req.scope.get("auth")
+    try:
+        with _connect() as conn:
+            conversation = get_conversation(conn, parsed)
+    except Exception:
+        logger.exception("Failed to load conversation %s", conv_id)
+        return _not_found_response()
+
+    if conversation is None:
+        return _not_found_response()
+    if not can_access_conversation(auth, conversation):
+        return _not_found_response()
+    return parsed, conversation
+
+
+def _slugify(value: str, fallback: str = "chat") -> str:
+    """Lowercase, ASCII-only slug for use in filenames.
+
+    Drops diacritics via NFKD decomposition, collapses any run of
+    non-alphanumeric characters to ``-``, and trims leading/trailing
+    separators. Returns *fallback* if the result is empty.
+    """
+    if not value:
+        return fallback
+    normalised = unicodedata.normalize("NFKD", value)
+    ascii_only = normalised.encode("ascii", "ignore").decode("ascii")
+    ascii_only = ascii_only.lower()
+    ascii_only = re.sub(r"[^a-z0-9]+", "-", ascii_only)
+    ascii_only = ascii_only.strip("-")
+    return ascii_only or fallback
+
+
+async def _form(req: Request) -> dict[str, str]:
+    """Read the request's form payload into a plain dict of first values.
+
+    ``starlette`` returns a :class:`FormData` multimap; for the single-
+    value fields this module deals with a flat ``dict[str, str]`` is
+    easier to work with. Missing fields are simply absent from the dict.
+    """
+    out: dict[str, str] = {}
+    try:
+        form = await req.form()
+    except Exception:
+        logger.exception("Failed to read form data")
+        return out
+    for key in form.keys():
+        value = form.get(key)
+        if isinstance(value, str):
+            out[key] = value
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Thin wrappers around ``app.chat.models`` helpers
+# ---------------------------------------------------------------------------
+#
+# These wrappers exist purely as patch targets for the tests and to keep
+# the call sites small. They delegate to the real helpers so the
+# migration 017 contracts are the single source of truth.
+
+
+def _set_conversation_pinned(conn: Any, conv_id: uuid.UUID, pinned: bool) -> None:
+    set_conversation_pinned(conn, conv_id, pinned)
+
+
+def _set_conversation_archived(conn: Any, conv_id: uuid.UUID, archived: bool) -> None:
+    set_conversation_archived(conn, conv_id, archived)
+
+
+def _update_conversation_title(conn: Any, conv_id: uuid.UUID, title: str) -> None:
+    # Always pass ``is_custom=True`` here — the contract is "user renamed
+    # the conversation", which the auto-title job must not overwrite.
+    update_conversation_title(conn, conv_id, title, is_custom=True)
+
+
+def _set_message_pinned(conn: Any, msg_id: uuid.UUID, pinned: bool) -> None:
+    set_message_pinned(conn, msg_id, pinned)
+
+
+def _delete_messages_after_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Message) -> int:
+    """Drop every row newer than the pivot in *conv_id*.
+
+    The real :func:`delete_messages_after` takes a ``datetime`` boundary
+    (that's the schema-level truth — there is no "delete after message X"
+    primitive). The pivot ``Message`` is the anchor for both edit (the
+    user message whose reply should be regenerated) and regenerate (the
+    assistant reply's preceding user message); we look up its
+    ``created_at`` and delegate.
+    """
+    return int(delete_messages_after(conn, conv_id, pivot_msg.created_at) or 0)
+
+
+def _update_message_content(conn: Any, msg_id: uuid.UUID, new_content: str) -> None:
+    """Update a user message's content.
+
+    Writes to ``content_encrypted`` when :func:`app.storage.encrypt_text`
+    is available (production) and falls back to the plaintext column
+    otherwise (dev environments without an encryption key). The read
+    path in :func:`_row_to_message` prefers the encrypted column, so the
+    dual-write keeps decryption working after edits.
+
+    Production safety: in ``APP_ENV=production`` (where
+    :func:`app.config.is_stub_allowed` returns ``False``) an encryption
+    failure re-raises instead of silently writing plaintext. Drafts are
+    politically sensitive — a plaintext fallback in prod would leak the
+    very data the encryption-at-rest policy exists to protect. In dev /
+    test the plaintext fallback keeps the app runnable without a key.
+    """
+    from app.config import is_stub_allowed
+
+    try:
+        from app.storage import encrypt_text
+
+        ciphertext = encrypt_text(new_content or "")
+    except Exception:
+        if not is_stub_allowed():
+            logger.exception("encrypt_text failed in production — refusing plaintext fallback")
+            raise
+        logger.exception("encrypt_text failed — writing plaintext content (dev fallback)")
+        conn.execute(
+            "UPDATE messages SET content = %s, content_encrypted = NULL WHERE id = %s",
+            (new_content, str(msg_id)),
+        )
+        return
+
+    conn.execute(
+        "UPDATE messages SET content = NULL, content_encrypted = %s WHERE id = %s",
+        (ciphertext, str(msg_id)),
+    )
+
+
+def _fork_conversation(
+    conn: Any,
+    source_conv: Conversation,
+    pivot_msg_id: uuid.UUID,
+    user_id: uuid.UUID | str,
+    org_id: uuid.UUID | str,
+) -> uuid.UUID:
+    """Wrapper around :func:`app.chat.models.fork_conversation`.
+
+    Returns the new conversation's UUID. The models-level helper returns
+    a :class:`Conversation` but the handler only needs the id for the
+    redirect target.
+    """
+    new_conv = fork_conversation(
+        conn,
+        source_conv.id,
+        pivot_msg_id,
+        user_id=user_id,
+        org_id=org_id,
+    )
+    return new_conv.id
+
+
+# ---------------------------------------------------------------------------
+# Conversation mutations
+# ---------------------------------------------------------------------------
+
+
+def _bool_from_form(raw: str | None, default: bool) -> bool:
+    """Parse a string form field into a bool; ``"1"``/``"true"`` truthy."""
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+async def pin_conversation_handler(req: Request, conv_id: str):
+    """POST /chat/{conv_id}/pin — toggle the conversation's is_pinned flag."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed, conversation = loaded
+
+    # Optional "pinned=1|0" form field; default is toggle.
+    form = await _form(req)
+    raw_pinned = form.get("pinned")
+    if raw_pinned is None:
+        new_pinned = not bool(getattr(conversation, "is_pinned", False))
+    else:
+        new_pinned = _bool_from_form(raw_pinned, True)
+
+    try:
+        with _connect() as conn:
+            _set_conversation_pinned(conn, parsed, new_pinned)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to set pinned=%s on conversation %s", new_pinned, conv_id)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.conversation.pin",
+        {"conversation_id": str(parsed), "pinned": new_pinned},
+    )
+    return _hx_trigger_response("chat:conversation-updated")
+
+
+async def archive_conversation_handler(req: Request, conv_id: str):
+    """POST /chat/{conv_id}/archive — toggle is_archived."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed, conversation = loaded
+
+    form = await _form(req)
+    raw_archived = form.get("archived")
+    if raw_archived is None:
+        new_archived = not bool(getattr(conversation, "is_archived", False))
+    else:
+        new_archived = _bool_from_form(raw_archived, True)
+
+    try:
+        with _connect() as conn:
+            _set_conversation_archived(conn, parsed, new_archived)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to set archived=%s on conversation %s", new_archived, conv_id)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.conversation.archive",
+        {"conversation_id": str(parsed), "archived": new_archived},
+    )
+
+    if _is_htmx(req):
+        return _hx_trigger_response("chat:conversation-updated")
+    return RedirectResponse(url="/chat", status_code=303)
+
+
+async def rename_conversation_handler(req: Request, conv_id: str):
+    """POST /chat/{conv_id}/rename — set a user-chosen title."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed, _ = loaded
+
+    form = await _form(req)
+    title = (form.get("title") or "").strip()
+    if not title:
+        return Response(
+            "Pealkiri ei saa olla tuhi.",
+            status_code=400,
+            media_type="text/plain",
+        )
+    title = title[:200]
+
+    try:
+        with _connect() as conn:
+            _update_conversation_title(conn, parsed, title)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to rename conversation %s", conv_id)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.conversation.rename",
+        {"conversation_id": str(parsed), "title": title},
+    )
+    return _hx_trigger_response("chat:conversation-updated")
+
+
+async def fork_conversation_handler(req: Request, conv_id: str):
+    """POST /chat/{conv_id}/fork — branch a new conversation at a message.
+
+    The caller supplies ``message_id`` in the form body: the new
+    conversation gets every message up to and including that pivot, plus
+    a ``(haru)`` suffix on the title.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, conversation = loaded
+
+    form = await _form(req)
+    pivot_raw = form.get("message_id", "")
+    pivot = _parse_uuid(pivot_raw)
+    if pivot is None:
+        return Response("Puudub message_id.", status_code=400, media_type="text/plain")
+
+    user_id = auth.get("id")
+    if not user_id:
+        return Response(status_code=400)
+
+    try:
+        with _connect() as conn:
+            new_conv_id = _fork_conversation(
+                conn, conversation, pivot, user_id, conversation.org_id
+            )
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to fork conversation %s at %s", conv_id, pivot)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.conversation.fork",
+        {
+            "source_conversation_id": str(parsed_conv),
+            "new_conversation_id": str(new_conv_id),
+            "pivot_message_id": str(pivot),
+        },
+    )
+
+    target = f"/chat/{new_conv_id}"
+    if _is_htmx(req):
+        return Response(status_code=204, headers={"HX-Redirect": target})
+    return RedirectResponse(url=target, status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Message pin / feedback / edit / regenerate
+# ---------------------------------------------------------------------------
+
+
+def _load_message_in_conversation(
+    conn: Any, conv_id: uuid.UUID, msg_id: uuid.UUID
+) -> Message | None:
+    """Fetch a specific message and verify it belongs to *conv_id*.
+
+    Using ``list_messages`` + linear scan keeps the decryption logic
+    centralised; chat transcripts are capped at O(100) messages so this
+    is cheaper than a bespoke SELECT that would need to duplicate the
+    encrypted-column handling.
+    """
+    for msg in list_messages(conn, conv_id):
+        if msg.id == msg_id:
+            return msg
+    return None
+
+
+async def pin_message_handler(req: Request, conv_id: str, msg_id: str):
+    """POST /chat/{conv_id}/messages/{msg_id}/pin — toggle is_pinned."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, _ = loaded
+
+    parsed_msg = _parse_uuid(msg_id)
+    if parsed_msg is None:
+        return _not_found_response()
+
+    form = await _form(req)
+    raw_pinned = form.get("pinned")
+
+    try:
+        with _connect() as conn:
+            msg = _load_message_in_conversation(conn, parsed_conv, parsed_msg)
+            if msg is None:
+                return _not_found_response()
+            if raw_pinned is None:
+                new_pinned = not bool(getattr(msg, "is_pinned", False))
+            else:
+                new_pinned = _bool_from_form(raw_pinned, True)
+            _set_message_pinned(conn, parsed_msg, new_pinned)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to set pinned=%s on message %s", raw_pinned, msg_id)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.message.pin",
+        {
+            "conversation_id": str(parsed_conv),
+            "message_id": str(parsed_msg),
+            "pinned": new_pinned,
+        },
+    )
+    return _hx_trigger_response("chat:message-updated")
+
+
+# ---------------------------------------------------------------------------
+# Feedback (POST upsert / DELETE)
+# ---------------------------------------------------------------------------
+
+
+def _feedback_counts(conn: Any, msg_id: uuid.UUID) -> tuple[int, int]:
+    """Return ``(up, down)`` counts for a message."""
+    from app.chat.feedback import feedback_counts
+
+    try:
+        counts = feedback_counts(conn, msg_id)
+    except Exception:
+        logger.exception("feedback_counts failed for msg_id=%s", msg_id)
+        return 0, 0
+    return int(counts[0]), int(counts[1])
+
+
+def _upsert_feedback(
+    conn: Any, msg_id: uuid.UUID, user_id: str, rating: int, comment: str | None
+) -> None:
+    from app.chat.feedback import upsert_feedback
+
+    upsert_feedback(
+        conn,
+        message_id=msg_id,
+        user_id=user_id,
+        rating=rating,
+        comment=comment,
+    )
+
+
+def _delete_feedback_row(conn: Any, msg_id: uuid.UUID, user_id: str) -> None:
+    from app.chat.feedback import delete_feedback
+
+    delete_feedback(conn, msg_id, user_id)
+
+
+async def _feedback_post(req: Request, parsed_conv: uuid.UUID, parsed_msg: uuid.UUID, auth: Any):
+    form = await _form(req)
+    raw_rating = (form.get("rating") or "").strip()
+    try:
+        rating = int(raw_rating)
+    except ValueError:
+        return JSONResponse({"error": "invalid_rating"}, status_code=400)
+    if rating not in (1, -1):
+        return JSONResponse({"error": "invalid_rating"}, status_code=400)
+
+    comment = (form.get("comment") or "").strip() or None
+    user_id = str(auth.get("id") or "")
+    if not user_id:
+        return Response(status_code=400)
+
+    try:
+        with _connect() as conn:
+            # Make sure the message belongs to the conversation we just
+            # authz-checked — otherwise a caller with a known message id
+            # from another user's chat could leave feedback on it.
+            if _load_message_in_conversation(conn, parsed_conv, parsed_msg) is None:
+                return _not_found_response()
+            _upsert_feedback(conn, parsed_msg, user_id, rating, comment)
+            conn.commit()
+            up, down = _feedback_counts(conn, parsed_msg)
+    except Exception:
+        logger.exception("Failed to upsert feedback for %s", parsed_msg)
+        return Response(status_code=500)
+
+    log_action(
+        user_id,
+        "chat.message.feedback",
+        {
+            "conversation_id": str(parsed_conv),
+            "message_id": str(parsed_msg),
+            "rating": rating,
+            "has_comment": bool(comment),
+        },
+    )
+    return JSONResponse({"up": up, "down": down, "user_rating": rating})
+
+
+def _feedback_delete(parsed_conv: uuid.UUID, parsed_msg: uuid.UUID, auth: Any):
+    user_id = str(auth.get("id") or "")
+    if not user_id:
+        return Response(status_code=400)
+    try:
+        with _connect() as conn:
+            if _load_message_in_conversation(conn, parsed_conv, parsed_msg) is None:
+                return _not_found_response()
+            _delete_feedback_row(conn, parsed_msg, user_id)
+            conn.commit()
+            up, down = _feedback_counts(conn, parsed_msg)
+    except Exception:
+        logger.exception("Failed to delete feedback for %s", parsed_msg)
+        return Response(status_code=500)
+
+    log_action(
+        user_id,
+        "chat.message.feedback.delete",
+        {"conversation_id": str(parsed_conv), "message_id": str(parsed_msg)},
+    )
+    return JSONResponse({"up": up, "down": down, "user_rating": None})
+
+
+async def feedback_handler(req: Request, conv_id: str, msg_id: str):
+    """POST / DELETE /chat/{conv_id}/messages/{msg_id}/feedback.
+
+    Dispatches on ``req.method`` so a single handler registration covers
+    both verbs (some FastHTML/Starlette versions require this pattern).
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, _ = loaded
+
+    parsed_msg = _parse_uuid(msg_id)
+    if parsed_msg is None:
+        return _not_found_response()
+
+    if req.method.upper() == "DELETE":
+        return _feedback_delete(parsed_conv, parsed_msg, auth)
+    return await _feedback_post(req, parsed_conv, parsed_msg, auth)
+
+
+async def regenerate_handler(req: Request, conv_id: str, msg_id: str):
+    """POST /chat/{conv_id}/messages/{msg_id}/regenerate.
+
+    Discards every message *after* the pivot and returns 204. The actual
+    replay is driven by the client: after this call succeeds the page
+    re-sends the preceding user message through the existing chat
+    WebSocket, which re-enters :mod:`app.chat.orchestrator` and streams a
+    fresh assistant turn. Keeping the regenerate trigger out of the WS
+    protocol means the HTTP transaction — delete + audit — cannot race
+    against an in-flight stream.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, _ = loaded
+
+    parsed_msg = _parse_uuid(msg_id)
+    if parsed_msg is None:
+        return _not_found_response()
+
+    try:
+        with _connect() as conn:
+            pivot = _load_message_in_conversation(conn, parsed_conv, parsed_msg)
+            if pivot is None:
+                return _not_found_response()
+            deleted = _delete_messages_after_pivot(conn, parsed_conv, pivot)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to regenerate from message %s", msg_id)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.message.regenerate",
+        {
+            "conversation_id": str(parsed_conv),
+            "pivot_message_id": str(parsed_msg),
+            "deleted_count": deleted,
+        },
+    )
+    return _hx_trigger_response("chat:message-regenerate")
+
+
+async def edit_message_handler(req: Request, conv_id: str, msg_id: str):
+    """POST /chat/{conv_id}/messages/{msg_id}/edit.
+
+    Only ``role='user'`` messages can be edited. Downstream messages
+    (every message strictly after the edited one) are dropped so the
+    assistant can regenerate a response to the new prompt.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, _ = loaded
+
+    parsed_msg = _parse_uuid(msg_id)
+    if parsed_msg is None:
+        return _not_found_response()
+
+    form = await _form(req)
+    new_content = (form.get("content") or "").strip()
+    if not new_content:
+        return Response("Sisu ei saa olla tuhi.", status_code=400, media_type="text/plain")
+
+    try:
+        with _connect() as conn:
+            msg = _load_message_in_conversation(conn, parsed_conv, parsed_msg)
+            if msg is None:
+                return _not_found_response()
+            if msg.role != "user":
+                return Response(
+                    "Vaid kasutaja sonumeid saab muuta.",
+                    status_code=400,
+                    media_type="text/plain",
+                )
+            _update_message_content(conn, parsed_msg, new_content)
+            _delete_messages_after_pivot(conn, parsed_conv, msg)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to edit message %s", msg_id)
+        return Response(status_code=500)
+
+    log_action(
+        auth.get("id"),
+        "chat.message.edit",
+        {
+            "conversation_id": str(parsed_conv),
+            "message_id": str(parsed_msg),
+        },
+    )
+    return _hx_trigger_response("chat:message-edited")
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def _export_filename(conversation: Conversation, extension: str) -> str:
+    date_str = ""
+    created = conversation.created_at
+    if isinstance(created, datetime):
+        date_str = created.strftime("%Y-%m-%d")
+    slug = _slugify(conversation.title)
+    prefix = f"vestlus-{slug}"
+    if date_str:
+        prefix = f"{prefix}-{date_str}"
+    return f"{prefix}.{extension}"
+
+
+def _content_disposition(filename: str) -> str:
+    """Build a Content-Disposition header that handles non-ASCII titles.
+
+    ``filename`` is the *already-slugified* filename (e.g.
+    ``"vestlus-pealkiri-2026-04-14.md"``) — :func:`_export_filename`
+    runs it through :func:`_slugify` on the stem before appending the
+    extension, so re-slugifying here would collapse the dot separator
+    into a hyphen (``"vestlus-pealkiri-2026-04-14-md"``). The ASCII
+    variant therefore uses *filename* as-is; only the RFC 5987 UTF-8
+    variant needs percent-encoding for transport.
+    """
+    # RFC 5987 escaping for the UTF-8 variant.
+    from urllib.parse import quote
+
+    return f"attachment; filename=\"{filename}\"; filename*=UTF-8''{quote(filename)}"
+
+
+def export_md_handler(req: Request, conv_id: str):
+    """GET /chat/{conv_id}/export.md — download the transcript as Markdown."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, conversation = loaded
+
+    try:
+        with _connect() as conn:
+            messages = list_messages(conn, parsed_conv)
+    except Exception:
+        logger.exception("Failed to load messages for export %s", conv_id)
+        return Response(status_code=500)
+
+    markdown = conversation_to_markdown(conversation, messages)
+    filename = _export_filename(conversation, "md")
+    return Response(
+        content=markdown,
+        media_type="text/markdown; charset=utf-8",
+        headers={"Content-Disposition": _content_disposition(filename)},
+    )
+
+
+def export_docx_handler(req: Request, conv_id: str):
+    """GET /chat/{conv_id}/export.docx — download the transcript as .docx."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+
+    loaded = _load_conversation_or_404(req, conv_id)
+    if isinstance(loaded, Response):
+        return loaded
+    parsed_conv, conversation = loaded
+
+    try:
+        with _connect() as conn:
+            messages = list_messages(conn, parsed_conv)
+    except Exception:
+        logger.exception("Failed to load messages for docx export %s", conv_id)
+        return Response(status_code=500)
+
+    try:
+        payload = conversation_to_docx_bytes(conversation, messages)
+    except Exception:
+        logger.exception("Failed to render docx for conversation %s", conv_id)
+        return Response(status_code=500)
+
+    filename = _export_filename(conversation, "docx")
+    return Response(
+        content=payload,
+        media_type=("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        headers={"Content-Disposition": _content_disposition(filename)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+def _search_conversations_impl(
+    conn: Any, user_id: str, term: str, limit: int = 25
+) -> list[Conversation]:
+    """Return conversations whose title matches *term* (case-insensitive).
+
+    Delegates to :func:`list_conversations_for_user` with the ``search``
+    kwarg which performs an ILIKE substring match against ``title``.
+    Full-text search on message bodies is out of scope for this sweep;
+    that would need a tsvector column migration.
+    """
+    try:
+        return list_conversations_for_user(conn, user_id, limit=limit, search=term)
+    except Exception:
+        logger.exception("Search failed for term=%r user=%s", term, user_id)
+        return []
+
+
+def _render_search_results(conversations: list[Conversation], term: str) -> Any:
+    """Render an HTML fragment suitable for ``hx-target`` replacement."""
+    if not conversations:
+        return Div(
+            P(f'Otsingule "{term}" ei vastanud ukski vestlus.', cls="muted-text"),
+            id="chat-search-results",
+            cls="chat-search-results chat-search-empty",
+        )
+    items = []
+    for conv in conversations:
+        items.append(
+            Li(
+                A(
+                    conv.title or "Vestlus",
+                    href=f"/chat/{conv.id}",
+                    cls="chat-search-result-link",
+                ),
+                cls="chat-search-result-item",
+            )
+        )
+    return Div(
+        Ul(*items, cls="chat-search-result-list"),
+        id="chat-search-results",
+        cls="chat-search-results",
+    )
+
+
+def search_conversations_handler(req: Request):
+    """GET /chat/search?q=<term>.
+
+    HTMX callers get an HTML fragment keyed on ``#chat-search-results``;
+    plain browsers are redirected to ``/chat?q=<term>`` so the main list
+    renderer (owned by ``routes.py``) can handle the query parameter.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    term = (req.query_params.get("q") or "").strip()
+    if not _is_htmx(req):
+        target = f"/chat?q={term}" if term else "/chat"
+        return RedirectResponse(url=target, status_code=303)
+
+    if not term:
+        return _render_search_results([], "")
+
+    user_id = auth.get("id")
+    if not user_id:
+        return _render_search_results([], term)
+
+    try:
+        with _connect() as conn:
+            conversations = _search_conversations_impl(conn, str(user_id), term)
+    except Exception:
+        logger.exception("Failed to search conversations for term=%r", term)
+        conversations = []
+
+    return _render_search_results(conversations, term)
+
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+
+def _decimal_to_str(value: Decimal) -> str:
+    """Serialize a :class:`Decimal` for JSON output with 2dp precision.
+
+    Uses ``ROUND_HALF_UP`` rather than Decimal's default ``ROUND_HALF_EVEN``
+    so the rendered values match how humans read financial amounts
+    (``12.345`` → ``12.35``).
+    """
+    from decimal import ROUND_HALF_UP
+
+    return str(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+def _percentage(numerator: float, denominator: float) -> float:
+    if denominator <= 0:
+        return 0.0
+    pct = (numerator / denominator) * 100.0
+    if pct < 0:
+        pct = 0.0
+    return round(pct, 1)
+
+
+def user_usage_handler(req: Request):
+    """GET /api/me/usage — JSON snapshot of per-user quota state."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    user_id = auth.get("id")
+    org_id = auth.get("org_id")
+    if not user_id or not org_id:
+        return JSONResponse({"error": "missing_identity"}, status_code=400)
+
+    quota = get_user_quota(user_id, org_id)
+    seconds_until_reset = seconds_until_hourly_reset(user_id)
+
+    messages_remaining = max(0, quota.message_limit_per_hour - quota.messages_this_hour)
+    cost_remaining = quota.cost_limit_per_month_usd - quota.cost_this_month_usd
+    if cost_remaining < Decimal("0"):
+        cost_remaining = Decimal("0")
+
+    messages_pct = _percentage(
+        float(quota.messages_this_hour), float(quota.message_limit_per_hour)
+    )
+    cost_pct = _percentage(float(quota.cost_this_month_usd), float(quota.cost_limit_per_month_usd))
+
+    payload = {
+        "messages_this_hour": quota.messages_this_hour,
+        "message_limit_per_hour": quota.message_limit_per_hour,
+        "messages_remaining": messages_remaining,
+        "cost_this_month_usd": _decimal_to_str(quota.cost_this_month_usd),
+        "cost_limit_per_month_usd": _decimal_to_str(quota.cost_limit_per_month_usd),
+        "cost_remaining_usd": _decimal_to_str(cost_remaining),
+        "cost_alert_threshold_usd": _decimal_to_str(quota.cost_alert_threshold_usd),
+        "seconds_until_reset": seconds_until_reset,
+        "percentages": {
+            "messages": messages_pct,
+            "cost": cost_pct,
+        },
+    }
+    # Every Decimal has already been stringified via ``_decimal_to_str``;
+    # the payload is now JSON-native so no dump/load round trip is needed.
+    return JSONResponse(payload)
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
+def register_chat_handler_routes(rt) -> None:  # type: ignore[no-untyped-def]
+    """Mount every handler in this module on the FastHTML decorator *rt*.
+
+    ``app.chat.routes.register_chat_routes`` calls this after registering
+    its own page-level routes. Keeping the registrations split means the
+    handlers module has no transitive dependency on the UI primitives
+    imported by ``routes.py``.
+    """
+    rt("/chat/{conv_id}/pin", methods=["POST"])(pin_conversation_handler)
+    rt("/chat/{conv_id}/archive", methods=["POST"])(archive_conversation_handler)
+    rt("/chat/{conv_id}/rename", methods=["POST"])(rename_conversation_handler)
+    rt("/chat/{conv_id}/fork", methods=["POST"])(fork_conversation_handler)
+
+    rt("/chat/{conv_id}/messages/{msg_id}/pin", methods=["POST"])(pin_message_handler)
+    rt(
+        "/chat/{conv_id}/messages/{msg_id}/feedback",
+        methods=["POST", "DELETE"],
+    )(feedback_handler)
+    rt("/chat/{conv_id}/messages/{msg_id}/regenerate", methods=["POST"])(regenerate_handler)
+    rt("/chat/{conv_id}/messages/{msg_id}/edit", methods=["POST"])(edit_message_handler)
+
+    rt("/chat/{conv_id}/export.md", methods=["GET"])(export_md_handler)
+    rt("/chat/{conv_id}/export.docx", methods=["GET"])(export_docx_handler)
+
+    rt("/chat/search", methods=["GET"])(search_conversations_handler)
+    rt("/api/me/usage", methods=["GET"])(user_usage_handler)

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -48,6 +48,13 @@ class Conversation:
     context_draft_id: uuid.UUID | None
     created_at: datetime
     updated_at: datetime
+    # Migration 017 — Vestlus UX polish (pin / archive / custom-title).
+    # Defaulted so older DB rows and unit-test fixtures (which may still
+    # ship pre-017 column layouts) continue to load cleanly.
+    is_pinned: bool = False
+    is_archived: bool = False
+    pinned_at: datetime | None = None
+    title_is_custom: bool = False
 
 
 @dataclass
@@ -66,13 +73,24 @@ class Message:
     tokens_output: int | None
     model: str | None
     created_at: datetime
+    # Migration 017 — per-message pin and partial-generation truncation
+    # flags. Defaulted for backward compatibility with pre-017 fixtures.
+    is_pinned: bool = False
+    is_truncated: bool = False
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-_CONVERSATION_COLUMNS = "id, user_id, org_id, title, context_draft_id, created_at, updated_at"
+# Migration 017 adds ``is_pinned``, ``is_archived``, ``pinned_at`` and
+# ``title_is_custom``. They are appended at the end of the SELECT list so
+# pre-017 test fixtures (which build 7-tuple rows) still map cleanly via
+# :func:`_row_to_conversation`, which indexes defensively.
+_CONVERSATION_COLUMNS = (
+    "id, user_id, org_id, title, context_draft_id, created_at, updated_at, "
+    "is_pinned, is_archived, pinned_at, title_is_custom"
+)
 
 # NOTE (#570): SELECT returns both the plaintext and the ``*_encrypted``
 # columns. ``_row_to_message`` prefers the encrypted column when set and
@@ -83,7 +101,7 @@ _MESSAGE_COLUMNS = (
     "id, conversation_id, role, content, tool_name, tool_input, "
     "tool_output, rag_context, tokens_input, tokens_output, model, created_at, "
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
-    "rag_context_encrypted"
+    "rag_context_encrypted, is_pinned, is_truncated"
 )
 
 
@@ -122,16 +140,25 @@ def _decode_encrypted_json(ciphertext: bytes | memoryview | None) -> Any:
 
 
 def _row_to_conversation(row: tuple[Any, ...]) -> Conversation:
-    """Build a ``Conversation`` from a raw cursor row."""
-    (
-        conv_id,
-        user_id,
-        org_id,
-        title,
-        context_draft_id,
-        created_at,
-        updated_at,
-    ) = row
+    """Build a ``Conversation`` from a raw cursor row.
+
+    Indexing is defensive: the migration-017 pin / archive / title-is-custom
+    columns are read via positional lookup with ``None``/``False`` fallbacks
+    so pre-017 test fixtures (7-tuple rows) and freshly-migrated prod rows
+    (11-tuple rows) both load cleanly.
+    """
+    conv_id = row[0]
+    user_id = row[1]
+    org_id = row[2]
+    title = row[3]
+    context_draft_id = row[4]
+    created_at = row[5]
+    updated_at = row[6]
+
+    is_pinned = bool(row[7]) if len(row) > 7 and row[7] is not None else False
+    is_archived = bool(row[8]) if len(row) > 8 and row[8] is not None else False
+    pinned_at = row[9] if len(row) > 9 else None
+    title_is_custom = bool(row[10]) if len(row) > 10 and row[10] is not None else False
 
     return Conversation(
         id=coerce_uuid(conv_id),
@@ -141,6 +168,10 @@ def _row_to_conversation(row: tuple[Any, ...]) -> Conversation:
         context_draft_id=coerce_uuid(context_draft_id) if context_draft_id else None,
         created_at=created_at,
         updated_at=updated_at,
+        is_pinned=is_pinned,
+        is_archived=is_archived,
+        pinned_at=pinned_at,
+        title_is_custom=title_is_custom,
     )
 
 
@@ -152,24 +183,26 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
     only matters for rows written before the #570 rollout (see migration
     014 and ``scripts/migrate_chat_encryption.py``).
     """
-    (
-        msg_id,
-        conversation_id,
-        role,
-        content_plain,
-        tool_name,
-        tool_input_raw,
-        tool_output_raw,
-        rag_context_raw,
-        tokens_input,
-        tokens_output,
-        model,
-        created_at,
-        content_encrypted,
-        tool_input_encrypted,
-        tool_output_encrypted,
-        rag_context_encrypted,
-    ) = row
+    msg_id = row[0]
+    conversation_id = row[1]
+    role = row[2]
+    content_plain = row[3]
+    tool_name = row[4]
+    tool_input_raw = row[5]
+    tool_output_raw = row[6]
+    rag_context_raw = row[7]
+    tokens_input = row[8]
+    tokens_output = row[9]
+    model = row[10]
+    created_at = row[11]
+    content_encrypted = row[12]
+    tool_input_encrypted = row[13]
+    tool_output_encrypted = row[14]
+    rag_context_encrypted = row[15]
+    # Migration 017 — pin / truncated flags. Defensive indexing so pre-017
+    # test fixtures that build 16-tuple rows continue to work.
+    is_pinned = bool(row[16]) if len(row) > 16 and row[16] is not None else False
+    is_truncated = bool(row[17]) if len(row) > 17 and row[17] is not None else False
 
     # Content: prefer encrypted blob, fall back to plaintext TEXT column.
     decrypted_content = _decode_encrypted_text(content_encrypted)
@@ -207,6 +240,8 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
         tokens_output=int(tokens_output) if tokens_output is not None else None,
         model=model,
         created_at=created_at,
+        is_pinned=is_pinned,
+        is_truncated=is_truncated,
     )
 
 
@@ -266,8 +301,22 @@ def list_conversations_for_user(
     *,
     limit: int = 25,
     offset: int = 0,
+    include_archived: bool = False,
+    pinned_first: bool = True,
+    search: str | None = None,
 ) -> list[Conversation]:
-    """Return conversations owned by *user_id*, newest first.
+    """Return conversations owned by *user_id*.
+
+    Ordering:
+      * ``pinned_first=True`` (default) — pinned conversations float to the
+        top, ordered by ``pinned_at DESC NULLS LAST`` then ``updated_at DESC``.
+      * ``pinned_first=False`` — order purely by ``updated_at DESC``.
+
+    Filters:
+      * ``include_archived=False`` (default) — excludes archived rows; the
+        partial index ``idx_conversations_active`` supports this path.
+      * ``search`` — case-insensitive substring match on ``title`` via
+        ``ILIKE`` (v1; a pgvector-backed semantic search lands later).
 
     Note: unlike drafting sessions, conversations are scoped by user_id
     only (a user can list their own conversations across orgs they belong
@@ -275,16 +324,40 @@ def list_conversations_for_user(
     """
     if limit <= 0:
         return []
+
+    where_clauses = ["user_id = %s"]
+    params: list[Any] = [str(user_id)]
+
+    if not include_archived:
+        where_clauses.append("is_archived = FALSE")
+
+    if search:
+        # ILIKE substring match; escape LIKE metacharacters so user-typed
+        # ``%`` / ``_`` / ``\`` match literally instead of acting as
+        # wildcards. ``ESCAPE '\'`` tells PostgreSQL to treat the
+        # backslash as the escape character for the pattern.
+        escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        where_clauses.append("title ILIKE %s ESCAPE '\\'")
+        params.append(f"%{escaped}%")
+
+    if pinned_first:
+        order_by = "is_pinned DESC, pinned_at DESC NULLS LAST, updated_at DESC"
+    else:
+        order_by = "updated_at DESC"
+
+    where_sql = " AND ".join(where_clauses)
+    params.extend([limit, max(0, offset)])
+
     try:
         rows = conn.execute(
             f"""
             SELECT {_CONVERSATION_COLUMNS}
             FROM conversations
-            WHERE user_id = %s
-            ORDER BY updated_at DESC
+            WHERE {where_sql}
+            ORDER BY {order_by}
             LIMIT %s OFFSET %s
             """,
-            (str(user_id), limit, max(0, offset)),
+            tuple(params),
         ).fetchall()
     except Exception:
         logger.exception(
@@ -299,15 +372,71 @@ def update_conversation_title(
     conn: Any,
     conv_id: uuid.UUID | str,
     title: str,
+    *,
+    is_custom: bool = False,
 ) -> None:
-    """Update the title (and bump ``updated_at``) of a conversation."""
+    """Update the title (and bump ``updated_at``) of a conversation.
+
+    ``is_custom=True`` flips ``title_is_custom`` on so the auto-title
+    background job will not overwrite a name the user explicitly set.
+    ``is_custom=False`` (the default, used by the auto-title job) must
+    *not* clobber a previously-set custom flag — otherwise running the
+    auto-titler after a user rename would re-open the row to auto-title
+    overwrites. The ``CASE`` expression keeps the flag sticky: we only
+    ever transition FALSE → TRUE, never TRUE → FALSE.
+    """
     conn.execute(
         """
         UPDATE conversations
-        SET title = %s, updated_at = now()
+        SET title = %s,
+            title_is_custom = CASE WHEN %s THEN TRUE ELSE title_is_custom END,
+            updated_at = now()
         WHERE id = %s
         """,
-        (title, str(conv_id)),
+        (title, bool(is_custom), str(conv_id)),
+    )
+
+
+def set_conversation_pinned(
+    conn: Any,
+    conv_id: uuid.UUID | str,
+    pinned: bool,
+) -> None:
+    """Pin or unpin a conversation.
+
+    Sets ``pinned_at`` to ``now()`` on pin and ``NULL`` on unpin so the
+    pinned-first ordering reflects the most-recently-pinned conversation
+    at the top of the list. Does not touch ``updated_at`` — pinning is a
+    UI affordance, not an edit.
+    """
+    conn.execute(
+        """
+        UPDATE conversations
+        SET is_pinned = %s,
+            pinned_at = CASE WHEN %s THEN now() ELSE NULL END
+        WHERE id = %s
+        """,
+        (bool(pinned), bool(pinned), str(conv_id)),
+    )
+
+
+def set_conversation_archived(
+    conn: Any,
+    conv_id: uuid.UUID | str,
+    archived: bool,
+) -> None:
+    """Archive or unarchive a conversation.
+
+    Archived conversations are hidden from the default list view but are
+    not deleted; the user can restore them from the archive panel.
+    """
+    conn.execute(
+        """
+        UPDATE conversations
+        SET is_archived = %s
+        WHERE id = %s
+        """,
+        (bool(archived), str(conv_id)),
     )
 
 
@@ -424,3 +553,182 @@ def list_messages(
         )
         return []
     return [_row_to_message(row) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Message pin / truncation / delete helpers (migration 017)
+# ---------------------------------------------------------------------------
+
+
+def set_message_pinned(
+    conn: Any,
+    message_id: uuid.UUID | str,
+    pinned: bool,
+) -> None:
+    """Pin or unpin an individual message inside a conversation."""
+    conn.execute(
+        "UPDATE messages SET is_pinned = %s WHERE id = %s",
+        (bool(pinned), str(message_id)),
+    )
+
+
+def update_message_truncated(
+    conn: Any,
+    message_id: uuid.UUID | str,
+    truncated: bool = True,
+) -> None:
+    """Mark an assistant message as truncated (stop-generation path).
+
+    The orchestrator currently writes this column with raw SQL — this
+    helper exists for parity with the other setters and to give tests a
+    single entry point to assert against.
+    """
+    conn.execute(
+        "UPDATE messages SET is_truncated = %s WHERE id = %s",
+        (bool(truncated), str(message_id)),
+    )
+
+
+def list_pinned_messages(
+    conn: Any,
+    conv_id: uuid.UUID | str,
+) -> list[Message]:
+    """Return all pinned messages in a conversation, oldest first."""
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT {_MESSAGE_COLUMNS}
+            FROM messages
+            WHERE conversation_id = %s AND is_pinned = TRUE
+            ORDER BY created_at ASC
+            """,
+            (str(conv_id),),
+        ).fetchall()
+    except Exception:
+        logger.exception(
+            "Failed to list pinned messages for conversation=%s",
+            conv_id,
+        )
+        return []
+    return [_row_to_message(row) for row in rows]
+
+
+def delete_messages_after(
+    conn: Any,
+    conv_id: uuid.UUID | str,
+    after_created_at: datetime,
+) -> int:
+    """Delete all messages strictly after *after_created_at* in the thread.
+
+    Used by the edit-and-resend flow to drop downstream messages when the
+    user rewrites an earlier turn. The boundary message itself
+    (``created_at == after_created_at``) is kept. Returns the number of
+    rows deleted; returns ``0`` on DB error (logged) so callers can treat
+    the operation as a no-op.
+    """
+    try:
+        cursor = conn.execute(
+            """
+            DELETE FROM messages
+            WHERE conversation_id = %s AND created_at > %s
+            """,
+            (str(conv_id), after_created_at),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to delete messages after %s for conversation=%s",
+            after_created_at,
+            conv_id,
+        )
+        return 0
+    # psycopg exposes rowcount on the cursor; the DELETE returns an empty
+    # result set, so rowcount is the only signal.
+    return int(getattr(cursor, "rowcount", 0) or 0)
+
+
+# ---------------------------------------------------------------------------
+# Fork a conversation (migration 017)
+# ---------------------------------------------------------------------------
+
+
+def fork_conversation(
+    conn: Any,
+    source_conv_id: uuid.UUID | str,
+    up_to_message_id: uuid.UUID | str,
+    *,
+    user_id: uuid.UUID | str,
+    org_id: uuid.UUID | str,
+) -> Conversation:
+    """Branch a conversation at *up_to_message_id* into a new thread.
+
+    Copies the source conversation's messages up to and including the
+    given message into a newly-created conversation owned by *user_id* /
+    *org_id*. Encrypted BYTEA columns (``content_encrypted``,
+    ``tool_input_encrypted``, ``tool_output_encrypted``,
+    ``rag_context_encrypted``) are copied byte-for-byte so the fork
+    inherits the exact ciphertexts — no re-encryption, no plaintext
+    round-trip.
+
+    The new conversation's title is ``"Jätk: <original title>"`` with
+    ``title_is_custom=False`` so the auto-title job can still refine it.
+
+    The caller is responsible for committing the transaction.
+    """
+    # Look up the fork point so we can bound the message copy by
+    # ``created_at``. Looking up the message (rather than filtering by
+    # id alone) lets us copy a contiguous time-ordered slice instead of
+    # relying on the caller to know the insertion order.
+    boundary = conn.execute(
+        """
+        SELECT created_at, conversation_id
+        FROM messages
+        WHERE id = %s
+        """,
+        (str(up_to_message_id),),
+    ).fetchone()
+    if boundary is None:
+        raise ValueError(f"Message {up_to_message_id} not found")
+    boundary_created_at, boundary_conv_id = boundary
+    if coerce_uuid(boundary_conv_id) != coerce_uuid(source_conv_id):
+        raise ValueError(
+            f"Message {up_to_message_id} does not belong to conversation {source_conv_id}"
+        )
+
+    source = get_conversation(conn, source_conv_id)
+    if source is None:
+        raise ValueError(f"Source conversation {source_conv_id} not found")
+
+    new_title = f"Jätk: {source.title}" if source.title else "Jätk"
+    new_conv = create_conversation(
+        conn,
+        user_id,
+        org_id,
+        title=new_title,
+        context_draft_id=source.context_draft_id,
+    )
+    # ``create_conversation`` does not set ``title_is_custom``; migration
+    # 017 defaults it to FALSE so we do not need an extra UPDATE.
+
+    # Copy messages byte-for-byte — include the encrypted BYTEA columns
+    # directly. ``created_at`` is preserved so the fork reads in the same
+    # order as the source up to the boundary.
+    conn.execute(
+        """
+        INSERT INTO messages (
+            conversation_id, role, content, tool_name, tool_input,
+            tool_output, rag_context, tokens_input, tokens_output, model,
+            content_encrypted, tool_input_encrypted, tool_output_encrypted,
+            rag_context_encrypted, is_pinned, is_truncated, created_at
+        )
+        SELECT
+            %s, role, content, tool_name, tool_input,
+            tool_output, rag_context, tokens_input, tokens_output, model,
+            content_encrypted, tool_input_encrypted, tool_output_encrypted,
+            rag_context_encrypted, is_pinned, is_truncated, created_at
+        FROM messages
+        WHERE conversation_id = %s AND created_at <= %s
+        ORDER BY created_at ASC
+        """,
+        (str(new_conv.id), str(source_conv_id), boundary_created_at),
+    )
+    return new_conv

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -20,14 +20,37 @@ Phase 3C additions:
   :func:`check_org_cost_budget` are called at the top of
   :meth:`ChatOrchestrator.handle_message` to enforce per-user and
   per-org usage limits.
+
+Phase UX polish additions (issue #594):
+
+- **Safe send**: every ``send(...)`` call is wrapped in
+  :func:`_safe_send` which enforces a 5s timeout. On timeout a
+  :class:`WebSocketSendTimeout` is raised so streaming aborts cleanly
+  when the client has gone away.
+
+- **Richer events**: emits ``retrieval_done``, ``sources``,
+  ``follow_ups`` and a ``tool_call_id`` that pairs ``tool_use`` with
+  ``tool_result`` so the client can reconcile out-of-order events.
+
+- **Cancellation**: ``asyncio.CancelledError`` in the streaming loop is
+  caught and the partial assistant turn is persisted with
+  ``is_truncated=True`` (schema provided by migration 017). A
+  ``stopped`` event is emitted so the client can re-enable its input.
+
+- **Auto-title**: after the first assistant reply, a fire-and-forget
+  :func:`app.chat.title.generate_title` is scheduled to set a short
+  sidebar label. Skipped when ``conversation.title_is_custom`` is true.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import aclosing
 from typing import Any
 
 from app.auth.policy import can_access_conversation
@@ -35,6 +58,7 @@ from app.chat.models import (
     create_message,
     get_conversation,
     list_messages,
+    update_conversation_title,
 )
 from app.chat.rate_limiter import (
     CostBudgetExceededError,
@@ -60,6 +84,92 @@ logger = logging.getLogger(__name__)
 
 MAX_TOOL_ROUNDS = 5
 _MAX_HISTORY_MESSAGES = 50
+_WS_SEND_TIMEOUT_SECONDS = 5.0
+_FOLLOW_UPS_MAX_TOKENS = 180
+
+# Module-level registry of fire-and-forget background tasks (e.g. the
+# auto-title job). Holding a strong reference prevents asyncio from
+# GC'ing the task mid-flight and logging the noisy "Task was destroyed
+# but it is pending!" warning. We also log any unhandled exception via
+# the done-callback so silent failures don't go unnoticed.
+_background_tasks: set[asyncio.Task[Any]] = set()
+
+
+def _track_background_task(task: asyncio.Task[Any]) -> None:
+    """Register *task* so it is not GC'd and its exceptions are logged."""
+    _background_tasks.add(task)
+
+    def _on_done(done: asyncio.Task[Any]) -> None:
+        _background_tasks.discard(done)
+        if done.cancelled():
+            return
+        exc = done.exception()
+        if exc is not None:
+            logger.debug("Background chat task failed: %r", exc, exc_info=exc)
+
+    task.add_done_callback(_on_done)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class WebSocketSendTimeout(Exception):  # noqa: N818 — name fixed by contract with frontend wave
+    """Raised when a ``send(...)`` call exceeds the configured timeout.
+
+    Used internally by :func:`_safe_send` to signal that the client is
+    no longer draining events and the orchestrator should abort the
+    current streaming task cleanly instead of hanging forever.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Safe send helper
+# ---------------------------------------------------------------------------
+
+
+async def _safe_send(
+    send: Callable[[dict[str, Any]], Awaitable[None]],
+    event: dict[str, Any],
+    timeout: float = _WS_SEND_TIMEOUT_SECONDS,
+) -> None:
+    """Invoke *send(event)* with an ``asyncio.wait_for`` timeout.
+
+    If the send coroutine does not complete within *timeout* seconds we
+    log a warning and raise :class:`WebSocketSendTimeout`. This prevents
+    an abandoned client socket from hanging the orchestrator task
+    indefinitely (issue #594.3).
+    """
+    try:
+        await asyncio.wait_for(send(event), timeout=timeout)
+    except TimeoutError as exc:
+        event_type = event.get("type", "<unknown>")
+        logger.warning(
+            "WebSocket send timed out after %.1fs (event type=%s)",
+            timeout,
+            event_type,
+        )
+        raise WebSocketSendTimeout(event_type) from exc
+
+
+# ---------------------------------------------------------------------------
+# Feature flag helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_follow_ups_enabled() -> bool:
+    """Return True when the follow-up suggestions feature should run.
+
+    Controlled by ``CHAT_FOLLOW_UPS_ENABLED``. Defaults to True when
+    unset. Any truthy value (``"1"``, ``"true"``, ``"yes"``, ``"on"``)
+    enables the feature; anything else disables it.
+    """
+    raw = os.environ.get("CHAT_FOLLOW_UPS_ENABLED")
+    if raw is None:
+        return True
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
 
 # ---------------------------------------------------------------------------
 # Draft context loader
@@ -107,6 +217,222 @@ def _load_impact_summary(draft_id: str, org_id: str) -> str | None:
         if summary:
             return str(summary)[:2000]
     return None
+
+
+# ---------------------------------------------------------------------------
+# Source / follow-up helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_sources_payload(rag_chunks: list[Any]) -> list[dict[str, Any]]:
+    """Convert a list of retrieved RAG chunks into ``sources`` event rows.
+
+    Each entry has ``source_uri``, ``title`` (last URI segment, falling
+    back to the full URI), ``score`` and a 200-character ``snippet``.
+    Invalid / unparseable chunks are skipped silently so a malformed
+    metadata entry never aborts the response.
+    """
+    sources: list[dict[str, Any]] = []
+    for chunk in rag_chunks:
+        try:
+            metadata = getattr(chunk, "metadata", None) or {}
+            source_uri = metadata.get("source_uri")
+            content = getattr(chunk, "content", "") or ""
+            snippet = content[:200]
+
+            title: str
+            if source_uri:
+                # Pull the last path segment; strip fragments/query.
+                tail = str(source_uri).rstrip("/").split("/")[-1]
+                tail = tail.split("#")[0].split("?")[0]
+                title = tail or str(source_uri)
+            else:
+                title = snippet[:64] or "(tundmatu allikas)"
+
+            sources.append(
+                {
+                    "source_uri": source_uri,
+                    "title": title,
+                    "score": getattr(chunk, "score", None),
+                    "snippet": snippet,
+                }
+            )
+        except Exception:
+            logger.debug("Skipped malformed RAG chunk while building sources", exc_info=True)
+    return sources
+
+
+async def _generate_follow_ups(
+    user_message: str,
+    assistant_reply: str,
+    *,
+    user_id: Any,
+    org_id: Any,
+) -> list[str]:
+    """Return up to 3 short Estonian follow-up suggestions.
+
+    Uses the default LLM provider's ``acomplete`` with a tiny budget.
+    On any failure (feature flag off, LLM error, malformed output) we
+    return an empty list — the caller is expected to no-op in that case.
+    """
+    if not _is_follow_ups_enabled():
+        return []
+
+    prompt = (
+        "Eelnev vestlus:\n"
+        f"Kasutaja: {user_message}\n\n"
+        f"Assistent: {assistant_reply}\n\n"
+        "Paku välja 3 lühikest (iga kuni 80 tähemärki) eestikeelset järgmist "
+        "küsimust, mida kasutaja võiks küsida. Vasta AINULT JSON-massiiviga, "
+        'nt: ["Küsimus 1?", "Küsimus 2?", "Küsimus 3?"]. Ära lisa muud teksti.'
+    )
+
+    try:
+        # Imported lazily so tests can patch the provider easily.
+        from app.llm import get_default_provider
+
+        provider = get_default_provider()
+        raw = await provider.acomplete(
+            prompt,
+            max_tokens=_FOLLOW_UPS_MAX_TOKENS,
+            temperature=0.5,
+            feature="chat_follow_ups",
+            user_id=user_id,
+            org_id=org_id,
+        )
+    except Exception:
+        logger.debug("Follow-up generation failed; skipping", exc_info=True)
+        return []
+
+    if not raw:
+        return []
+
+    text = raw.strip()
+    # Be forgiving about markdown code fences.
+    if text.startswith("```"):
+        text = text.strip("`")
+        # Drop a leading language hint like ```json
+        if "\n" in text:
+            text = text.split("\n", 1)[1]
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        logger.debug("Follow-up LLM returned non-JSON: %r", raw[:200])
+        return []
+
+    if not isinstance(parsed, list):
+        return []
+    suggestions: list[str] = []
+    for item in parsed[:3]:
+        if isinstance(item, str) and item.strip():
+            suggestions.append(item.strip()[:120])
+    return suggestions
+
+
+# ---------------------------------------------------------------------------
+# Title / truncation persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def _persist_partial_assistant(
+    conversation_id: uuid.UUID,
+    full_content: str,
+    model: str | None,
+    rag_context_json: list[dict[str, Any]] | None,
+    *,
+    is_truncated: bool,
+    error_suffix: str | None = None,
+) -> uuid.UUID | None:
+    """Persist a partial / truncated assistant message.
+
+    Attempts to set ``is_truncated`` on the new row; when the column is
+    missing (migration 017 not yet applied) we fall back to a plain
+    insert + WARNING. Returns the new message id on success or ``None``
+    if persistence itself fails.
+    """
+    if not full_content and not error_suffix:
+        return None
+
+    text = full_content
+    if error_suffix:
+        text = f"{text}{error_suffix}"
+
+    try:
+        with get_connection() as conn:
+            msg = create_message(
+                conn,
+                conversation_id,
+                "assistant",
+                text,
+                model=model,
+                rag_context=rag_context_json,
+            )
+            if is_truncated:
+                try:
+                    conn.execute(
+                        "UPDATE messages SET is_truncated = TRUE WHERE id = %s",
+                        (str(msg.id),),
+                    )
+                except Exception:
+                    # Column may not exist yet (migration 017 not applied).
+                    logger.debug(
+                        "Could not set is_truncated on message %s — column missing?",
+                        msg.id,
+                        exc_info=True,
+                    )
+            conn.commit()
+            return msg.id
+    except Exception:
+        logger.exception("Failed to persist partial assistant message")
+        return None
+
+
+async def _maybe_generate_title(
+    conversation_id: uuid.UUID,
+    conversation: Any,
+    history_length_before: int,
+    user_message: str,
+    assistant_reply: str,
+    auth: dict[str, Any],
+) -> None:
+    """Fire-and-forget auto title generation after the first exchange.
+
+    Runs only when the conversation had zero prior messages (so this is
+    the first user→assistant exchange) and ``title_is_custom`` is not
+    set. Failure is swallowed — title generation is strictly best-effort.
+    """
+    if history_length_before != 0:
+        return
+    # Guard: respect manual titles when the column exists.
+    title_is_custom = bool(getattr(conversation, "title_is_custom", False))
+    if title_is_custom:
+        return
+
+    try:
+        from app.chat.title import generate_title
+
+        title = await generate_title(
+            user_message,
+            assistant_reply,
+            user_id=auth.get("id"),
+            org_id=auth.get("org_id"),
+        )
+    except Exception:
+        logger.debug("Auto-title generation failed", exc_info=True)
+        return
+
+    if not title:
+        return
+
+    try:
+        with get_connection() as conn:
+            # ``update_conversation_title`` already writes ``title_is_custom``;
+            # passing ``is_custom=False`` here is the full expression of the
+            # auto-title intent, so no follow-up UPDATE is needed.
+            update_conversation_title(conn, conversation_id, title, is_custom=False)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to persist auto-generated title")
 
 
 # ---------------------------------------------------------------------------
@@ -180,7 +506,7 @@ class ChatOrchestrator:
           5. Stream content deltas via *send*
           6. On tool_use: execute, send result, continue streaming
           7. Persist assistant message with token counts
-          8. Send ``done`` event
+          8. Send ``done`` event + ``sources`` + optional ``follow_ups``
 
         Parameters
         ----------
@@ -191,22 +517,24 @@ class ChatOrchestrator:
         auth:
             Auth dict from request scope (must have ``id``, ``org_id``).
         send:
-            Async callback for pushing events to the client.
+            Async callback for pushing events to the client. Wrapped in
+            :func:`_safe_send` with a 5-second timeout.
         """
         user_id = auth.get("id")
         org_id = auth.get("org_id")
 
-        # 0. Rate / budget checks
+        # 0. Per-user message rate limit (cheap pre-check, fail-open on DB
+        # error). The per-org cost budget is checked later in step 3 inside
+        # the same transaction that persists the user message so the
+        # advisory lock covers the read-then-insert window (see below).
         try:
             if user_id:
                 check_message_rate(user_id)
-            if org_id:
-                check_org_cost_budget(org_id)
         except RateLimitExceededError as exc:
-            await send({"type": "error", "message": str(exc)})
-            return
-        except CostBudgetExceededError as exc:
-            await send({"type": "error", "message": str(exc)})
+            try:
+                await _safe_send(send, {"type": "error", "message": str(exc)})
+            except WebSocketSendTimeout:
+                pass
             return
 
         # 1. Load conversation
@@ -215,18 +543,31 @@ class ChatOrchestrator:
                 conversation = get_conversation(conn, conversation_id)
         except Exception:
             logger.exception("Failed to load conversation %s", conversation_id)
-            await send({"type": "error", "message": "Vestluse laadimine ebaonnestus."})
+            try:
+                await _safe_send(
+                    send, {"type": "error", "message": "Vestluse laadimine ebaonnestus."}
+                )
+            except WebSocketSendTimeout:
+                pass
             return
 
         if conversation is None:
-            await send({"type": "error", "message": "Vestlust ei leitud."})
+            try:
+                await _safe_send(send, {"type": "error", "message": "Vestlust ei leitud."})
+            except WebSocketSendTimeout:
+                pass
             return
 
         # Access control: owner-only per NFR §5 matrix (fix #569).
         # The previous org-level check allowed any same-org colleague
         # to send turns into another user's private conversation.
         if not can_access_conversation(auth, conversation):
-            await send({"type": "error", "message": "Puudub oigus sellele vestlusele."})
+            try:
+                await _safe_send(
+                    send, {"type": "error", "message": "Puudub oigus sellele vestlusele."}
+                )
+            except WebSocketSendTimeout:
+                pass
             return
 
         # Load message history
@@ -236,6 +577,8 @@ class ChatOrchestrator:
         except Exception:
             logger.exception("Failed to load messages for conversation %s", conversation_id)
             history = []
+
+        history_length_before = len(history)
 
         # 2. Build system prompt
         impact_summary: str | None = None
@@ -252,25 +595,25 @@ class ChatOrchestrator:
         # 2b. RAG retrieval
         # Tenant scoping landed in #576: retriever now filters by caller's
         # org_id (public NULL-scoped rows + caller's own private rows).
-        # rag_chunks is still public-corpus-only in practice until private
-        # draft ingestion ships, but the filtering machinery is in place.
         rag_chunks: list[Any] = []
         rag_context_json: list[dict[str, Any]] | None = None
+        retrieval_attempted = False
 
         if Retriever is not None:
             retriever = self._get_retriever()
             if retriever is not None:
+                retrieval_attempted = True
                 try:
-                    await send({"type": "retrieval_started"})
+                    await _safe_send(send, {"type": "retrieval_started"})
                     # #576: pass the caller's org_id so private chunks from
-                    # other tenants are never retrieved. Public-corpus rows
-                    # (org_id IS NULL in DB) stay visible regardless.
+                    # other tenants are never retrieved.
                     rag_chunks = await retriever.retrieve(
                         user_message,
                         k=10,
                         org_id=str(org_id) if org_id else None,
                     )
-                    await send({"type": "retrieval_done", "chunk_count": len(rag_chunks)})
+                except WebSocketSendTimeout:
+                    return
                 except Exception:
                     logger.warning(
                         "RAG retrieval failed for conversation %s; proceeding without",
@@ -291,14 +634,39 @@ class ChatOrchestrator:
                     for chunk in rag_chunks
                 ]
 
-        # 3. Persist user message
+        # Always emit retrieval_done when we attempted (or skipped) RAG so
+        # the UI can move out of the "Otsin konteksti…" state predictably.
+        if retrieval_attempted:
+            try:
+                await _safe_send(send, {"type": "retrieval_done", "chunk_count": len(rag_chunks)})
+            except WebSocketSendTimeout:
+                return
+
+        # 3. Budget check + persist user message in a single transaction so
+        # the ``pg_advisory_xact_lock`` taken inside ``check_org_cost_budget``
+        # serialises concurrent reads-then-inserts for the same org, closing
+        # the TOCTOU window that allowed two racing requests to both pass a
+        # near-limit budget check.
         try:
             with get_connection() as conn:
+                if org_id:
+                    check_org_cost_budget(org_id, conn=conn)
                 create_message(conn, conversation_id, "user", user_message)
                 conn.commit()
+        except CostBudgetExceededError as exc:
+            try:
+                await _safe_send(send, {"type": "error", "message": str(exc)})
+            except WebSocketSendTimeout:
+                pass
+            return
         except Exception:
             logger.exception("Failed to persist user message")
-            await send({"type": "error", "message": "Sonum salvestamine ebaonnestus."})
+            try:
+                await _safe_send(
+                    send, {"type": "error", "message": "Sonum salvestamine ebaonnestus."}
+                )
+            except WebSocketSendTimeout:
+                pass
             return
 
         # 4-6. LLM streaming with tool use
@@ -307,6 +675,7 @@ class ChatOrchestrator:
         tokens_out = 0
         tool_rounds = 0
         completed = False
+        cancelled = False
 
         # Build conversation messages for the LLM
         messages = _build_llm_messages(history, user_message)
@@ -315,8 +684,9 @@ class ChatOrchestrator:
             while tool_rounds <= MAX_TOOL_ROUNDS:
                 event: StreamEvent
                 pending_tool: dict[str, Any] | None = None
+                pending_tool_call_id: str | None = None
 
-                async for event in self.llm.astream(
+                stream = self.llm.astream(
                     prompt=_messages_to_prompt(messages),
                     system=system_prompt,
                     max_tokens=4096,
@@ -324,29 +694,41 @@ class ChatOrchestrator:
                     feature="chat",
                     user_id=user_id,
                     org_id=org_id,
-                ):
-                    if event.type == "content":
-                        full_content += event.delta or ""
-                        await send(
-                            {
-                                "type": "content_delta",
-                                "delta": event.delta or "",
-                            }
-                        )
-                    elif event.type == "tool_use":
-                        pending_tool = {
-                            "name": event.tool_name,
-                            "input": event.tool_input or {},
-                        }
-                        await send(
-                            {
-                                "type": "tool_use",
-                                "tool": event.tool_name,
+                )
+                # ``aclosing`` guarantees the upstream HTTP connection is
+                # released on every exit path (timeout, cancel, exception).
+                # ``astream`` is declared to return an ``AsyncIterator`` but
+                # concrete implementations are always async generators, which
+                # expose ``aclose`` — hence the local type-ignore.
+                async with aclosing(stream) as managed_stream:  # type: ignore[type-var]
+                    async for event in managed_stream:
+                        if event.type == "content":
+                            full_content += event.delta or ""
+                            await _safe_send(
+                                send,
+                                {
+                                    "type": "content_delta",
+                                    "delta": event.delta or "",
+                                },
+                            )
+                        elif event.type == "tool_use":
+                            pending_tool_call_id = uuid.uuid4().hex[:12]
+                            pending_tool = {
+                                "name": event.tool_name,
                                 "input": event.tool_input or {},
+                                "id": pending_tool_call_id,
                             }
-                        )
-                    elif event.type == "stop":
-                        pass  # handled after loop
+                            await _safe_send(
+                                send,
+                                {
+                                    "type": "tool_use",
+                                    "tool": event.tool_name,
+                                    "input": event.tool_input or {},
+                                    "tool_call_id": pending_tool_call_id,
+                                },
+                            )
+                        elif event.type == "stop":
+                            pass  # handled after loop
 
                 # If no tool use requested, we're done
                 if pending_tool is None:
@@ -357,15 +739,19 @@ class ChatOrchestrator:
                 tool_rounds += 1
                 tool_name = pending_tool["name"]
                 tool_input = pending_tool["input"]
+                tool_call_id = pending_tool["id"]
 
                 tool_result = await execute_tool(tool_name, tool_input, self.sparql, auth=auth)
 
-                await send(
+                await _safe_send(
+                    send,
                     {
                         "type": "tool_result",
                         "tool": tool_name,
-                        "output": tool_result,
-                    }
+                        "result_count": _tool_result_count(tool_result),
+                        "result": tool_result,
+                        "tool_call_id": tool_call_id,
+                    },
                 )
 
                 # Persist tool message
@@ -392,33 +778,72 @@ class ChatOrchestrator:
 
                 if tool_rounds >= MAX_TOOL_ROUNDS:
                     full_content += "\n\n(Tööriistade kasutamise limiit saavutatud.)"
-                    await send(
+                    await _safe_send(
+                        send,
                         {
                             "type": "content_delta",
                             "delta": "\n\n(Tööriistade kasutamise limiit saavutatud.)",
-                        }
+                        },
                     )
                     completed = True
                     break
 
+        except asyncio.CancelledError:
+            # Client asked us to stop — persist partial content flagged
+            # as truncated, emit a stopped event, then re-raise so the
+            # caller's task.cancel() propagates correctly.
+            cancelled = True
+            assistant_msg_id = _persist_partial_assistant(
+                conversation_id,
+                full_content,
+                getattr(self.llm, "_model", None),
+                rag_context_json,
+                is_truncated=True,
+            )
+            try:
+                await _safe_send(
+                    send,
+                    {
+                        "type": "stopped",
+                        "message_id": str(assistant_msg_id) if assistant_msg_id else None,
+                    },
+                )
+            except WebSocketSendTimeout:
+                pass
+            raise
+        except WebSocketSendTimeout:
+            # Client socket is unresponsive — persist whatever we have and
+            # bail without sending further events.
+            _persist_partial_assistant(
+                conversation_id,
+                full_content,
+                getattr(self.llm, "_model", None),
+                rag_context_json,
+                is_truncated=True,
+            )
+            return
         except Exception:
             logger.exception("LLM streaming failed for conversation %s", conversation_id)
             # M1: persist partial content with error suffix when streaming fails
             if full_content:
-                full_content += " [Viga: vastus katkestati]"
-                try:
-                    with get_connection() as conn:
-                        create_message(
-                            conn,
-                            conversation_id,
-                            "assistant",
-                            full_content,
-                            model=getattr(self.llm, "_model", None),
-                        )
-                        conn.commit()
-                except Exception:
-                    logger.exception("Failed to persist partial assistant message")
-            await send({"type": "error", "message": "Vastuse genereerimine ebaonnestus."})
+                _persist_partial_assistant(
+                    conversation_id,
+                    full_content,
+                    getattr(self.llm, "_model", None),
+                    rag_context_json,
+                    is_truncated=True,
+                    error_suffix=" [Viga: vastus katkestati]",
+                )
+            try:
+                await _safe_send(
+                    send, {"type": "error", "message": "Vastuse genereerimine ebaonnestus."}
+                )
+            except WebSocketSendTimeout:
+                pass
+            return
+
+        if cancelled:
+            # Belt-and-suspenders — CancelledError should have re-raised.
             return
 
         # 7. Persist assistant message (only when streaming completed successfully)
@@ -446,18 +871,97 @@ class ChatOrchestrator:
             except Exception:
                 logger.exception("Failed to persist assistant message")
 
-        # 8. Send done event
-        await send(
-            {
-                "type": "done",
-                "message_id": str(assistant_msg_id) if assistant_msg_id else None,
-            }
-        )
+        # 8. Emit done, then sources, then (optionally) follow_ups.
+        try:
+            await _safe_send(
+                send,
+                {
+                    "type": "done",
+                    "message_id": str(assistant_msg_id) if assistant_msg_id else None,
+                },
+            )
+        except WebSocketSendTimeout:
+            return
+
+        # sources — always emitted when we attempted retrieval OR when we
+        # have chunks, so the client can show "Allikaid ei leitud" state.
+        try:
+            await _safe_send(
+                send,
+                {
+                    "type": "sources",
+                    "message_id": str(assistant_msg_id) if assistant_msg_id else None,
+                    "sources": _build_sources_payload(rag_chunks),
+                },
+            )
+        except WebSocketSendTimeout:
+            return
+
+        # follow_ups — feature-flag-gated Haiku suggestion call.
+        if completed and full_content and _is_follow_ups_enabled():
+            try:
+                suggestions = await _generate_follow_ups(
+                    user_message,
+                    full_content,
+                    user_id=user_id,
+                    org_id=org_id,
+                )
+            except Exception:
+                logger.debug("Follow-up helper raised unexpectedly", exc_info=True)
+                suggestions = []
+            if suggestions:
+                try:
+                    await _safe_send(
+                        send,
+                        {
+                            "type": "follow_ups",
+                            "message_id": str(assistant_msg_id) if assistant_msg_id else None,
+                            "suggestions": suggestions,
+                        },
+                    )
+                except WebSocketSendTimeout:
+                    return
+
+        # Auto-title: fire-and-forget. Only runs on the first exchange.
+        if completed and full_content and assistant_msg_id is not None:
+            try:
+                title_task = asyncio.create_task(
+                    _maybe_generate_title(
+                        conversation_id,
+                        conversation,
+                        history_length_before,
+                        user_message,
+                        full_content,
+                        auth,
+                    )
+                )
+                _track_background_task(title_task)
+            except RuntimeError:
+                # No running event loop (e.g. sync test driver) — skip.
+                logger.debug("Could not schedule auto-title task", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _tool_result_count(result: Any) -> int:
+    """Return the number of rows/items a tool result carries.
+
+    - ``len(result["results"])`` when the tool returned a mapping with a
+      ``results`` list (the convention used by our SPARQL tools).
+    - ``1`` for any other non-error mapping.
+    - ``0`` for explicit error payloads or unrecognised shapes.
+    """
+    if not isinstance(result, dict):
+        return 0
+    if "error" in result and result.get("error"):
+        return 0
+    inner = result.get("results")
+    if isinstance(inner, list):
+        return len(inner)
+    return 1
 
 
 def _build_llm_messages(

--- a/app/chat/rate_limiter.py
+++ b/app/chat/rate_limiter.py
@@ -15,15 +15,25 @@ Configuration is via environment variables with sensible defaults:
 
     CHAT_MAX_MESSAGES_PER_HOUR  (default: 100)
     ORG_MAX_MONTHLY_COST_USD    (default: 50.0)
+
+In addition, :func:`get_user_quota` and :func:`seconds_until_hourly_reset`
+expose the same state to the upcoming ``/api/me/usage`` endpoint so the
+frontend can display quota headroom and retry timers.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from app.db import get_connection
+
+if TYPE_CHECKING:
+    import psycopg
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +42,9 @@ logger = logging.getLogger(__name__)
 # that config changes take effect without a process restart.
 _MAX_MESSAGES_PER_HOUR = int(os.environ.get("CHAT_MAX_MESSAGES_PER_HOUR", "100"))
 _MAX_MONTHLY_COST_USD = float(os.environ.get("ORG_MAX_MONTHLY_COST_USD", "50.0"))
+
+# Alert when cost usage crosses this fraction of the monthly cap.
+_COST_ALERT_FRACTION = 0.8
 
 
 def _get_max_messages_per_hour() -> int:
@@ -50,6 +63,22 @@ class RateLimitExceededError(Exception):
 
 class CostBudgetExceededError(Exception):
     """Raised when an organisation exceeds its monthly LLM cost cap."""
+
+
+@dataclass(frozen=True)
+class UserQuota:
+    """Snapshot of a user's current quota consumption.
+
+    All currency values are :class:`~decimal.Decimal` to avoid float
+    rounding errors when summing many small LLM charges. Message
+    counts are plain integers.
+    """
+
+    messages_this_hour: int
+    message_limit_per_hour: int
+    cost_this_month_usd: Decimal
+    cost_limit_per_month_usd: Decimal
+    cost_alert_threshold_usd: Decimal  # 80% of limit
 
 
 def check_message_rate(user_id: UUID | str) -> None:
@@ -83,39 +112,74 @@ def check_message_rate(user_id: UUID | str) -> None:
         )
 
 
-def check_org_cost_budget(org_id: UUID | str) -> None:
+def check_org_cost_budget(
+    org_id: UUID | str,
+    conn: psycopg.Connection | None = None,  # type: ignore[type-arg]
+) -> None:
     """Raise :class:`CostBudgetExceeded` if the org's monthly LLM cost exceeds the cap.
 
     Sums ``cost_usd`` from the ``llm_usage`` table for the current
     calendar month. If the total meets or exceeds
     ``ORG_MAX_MONTHLY_COST_USD``, raises immediately.
 
-    .. note:: **Known TOCTOU race condition** — Two concurrent requests
-       can both read the current total, both find it under the cap,
-       and both proceed to call the LLM. This means the budget is a
-       *soft* cap (fail-open), not a hard wall. The overshoot is
-       bounded by the cost of a single LLM call, which is acceptable
-       for our use case. A proper fix (``SELECT ... FOR UPDATE`` on a
-       running total row) is Phase 4 work.
+    **TOCTOU race window and mitigation** — A naive implementation reads
+    the running monthly total with a plain ``SELECT`` and returns. Two
+    concurrent requests can both observe a total below the cap, both
+    pass the check, and both proceed to spend against the budget,
+    causing an unbounded overshoot as concurrency scales.
+
+    To close that window, when this function is invoked with an active
+    ``conn`` the check runs inside the caller's transaction and takes a
+    transaction-scoped PostgreSQL advisory lock keyed to the org id:
+
+        ``pg_advisory_xact_lock(hashtextextended('cost_budget:<org>', 0))``
+
+    This serialises concurrent budget checks for a given org without
+    requiring a dedicated lock row or new table. The lock is released
+    automatically when the caller's transaction commits or rolls back.
+    The caller is expected to insert the message (or otherwise record
+    the work that will drive the next LLM charge) inside the same
+    transaction, so the "read-then-act" sequence is atomic.
+
+    When called without ``conn`` (the legacy shape), the function opens
+    its own short-lived connection and performs the plain SELECT with
+    no locking. This mode is intentionally kept for non-critical paths
+    (status/usage display) where a momentary race is acceptable.
     """
     max_cost = _get_max_monthly_cost_usd()
+    total_cost = 0.0
+
     try:
-        with get_connection() as conn:
+        if conn is not None:
+            # Serialise concurrent budget checks for this org inside the
+            # caller's transaction. The lock is released on commit/rollback.
+            conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended('cost_budget:' || %s::text, 0))",
+                (str(org_id),),
+            )
             row = conn.execute(
                 "SELECT COALESCE(SUM(cost_usd), 0) FROM llm_usage "
                 "WHERE org_id = %s "
                 "AND created_at >= date_trunc('month', now())",
                 (str(org_id),),
             ).fetchone()
+            total_cost = float(row[0]) if row else 0.0
+        else:
+            with get_connection() as own_conn:
+                row = own_conn.execute(
+                    "SELECT COALESCE(SUM(cost_usd), 0) FROM llm_usage "
+                    "WHERE org_id = %s "
+                    "AND created_at >= date_trunc('month', now())",
+                    (str(org_id),),
+                ).fetchone()
+                total_cost = float(row[0]) if row else 0.0
     except Exception:
         logger.exception("Failed to check org cost budget for org_id=%s", org_id)
         # Fail open
         return
 
-    total_cost = float(row[0]) if row else 0.0
-
     # Notify org admins when cost hits 80% of the budget.
-    if total_cost >= max_cost * 0.8 and total_cost < max_cost:
+    if total_cost >= max_cost * _COST_ALERT_FRACTION and total_cost < max_cost:
         try:
             from app.notifications.wire import notify_cost_alert
 
@@ -128,3 +192,94 @@ def check_org_cost_budget(org_id: UUID | str) -> None:
             f"Organisatsiooni igakuine LLM-i kulueelarve ({max_cost:.2f} USD) "
             f"on taidetud (praegune kulu: {total_cost:.2f} USD)."
         )
+
+
+def get_user_quota(user_id: UUID | str, org_id: UUID | str) -> UserQuota:
+    """Return a snapshot of the user's current rate-limit and cost-budget state.
+
+    Reads the same tables as :func:`check_message_rate` and
+    :func:`check_org_cost_budget` but without raising: the caller (the
+    ``/api/me/usage`` endpoint) needs the raw numbers to render a
+    dashboard. Fails open by returning zero usage when the DB is
+    unreachable so the UI can still load.
+    """
+    message_limit = _get_max_messages_per_hour()
+    cost_limit_float = _get_max_monthly_cost_usd()
+    cost_limit = Decimal(str(cost_limit_float))
+    # 80% alert threshold — keep identical to the admin-notification trigger.
+    alert_threshold = (cost_limit * Decimal(str(_COST_ALERT_FRACTION))).quantize(Decimal("0.01"))
+
+    messages_this_hour = 0
+    cost_this_month = Decimal("0")
+
+    try:
+        with get_connection() as conn:
+            message_row = conn.execute(
+                "SELECT COUNT(*) FROM messages "
+                "WHERE conversation_id IN "
+                "  (SELECT id FROM conversations WHERE user_id = %s) "
+                "AND role = 'user' "
+                "AND created_at > now() - interval '1 hour'",
+                (str(user_id),),
+            ).fetchone()
+            if message_row is not None:
+                messages_this_hour = int(message_row[0] or 0)
+
+            cost_row = conn.execute(
+                "SELECT COALESCE(SUM(cost_usd), 0) FROM llm_usage "
+                "WHERE org_id = %s "
+                "AND created_at >= date_trunc('month', now())",
+                (str(org_id),),
+            ).fetchone()
+            if cost_row is not None:
+                cost_value = cost_row[0] or 0
+                cost_this_month = Decimal(str(cost_value))
+    except Exception:
+        logger.exception("Failed to read quota for user_id=%s org_id=%s", user_id, org_id)
+        # Fall through with zeroed usage.
+
+    return UserQuota(
+        messages_this_hour=messages_this_hour,
+        message_limit_per_hour=message_limit,
+        cost_this_month_usd=cost_this_month,
+        cost_limit_per_month_usd=cost_limit,
+        cost_alert_threshold_usd=alert_threshold,
+    )
+
+
+def seconds_until_hourly_reset(user_id: UUID | str) -> int:
+    """Seconds until the oldest message in the current rate-limit window ages out.
+
+    The sliding window is one hour wide. The earliest ``role='user'``
+    message in the last hour determines when the window will have room
+    for a new message: ``3600 - (now - oldest_created_at)`` seconds.
+
+    The result is clamped to ``[0, 3600]``. When there is no message in
+    the window (or on DB error) we return ``0`` — the user can retry
+    immediately.
+    """
+    try:
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT EXTRACT(EPOCH FROM (now() - MIN(created_at))) "
+                "FROM messages "
+                "WHERE conversation_id IN "
+                "  (SELECT id FROM conversations WHERE user_id = %s) "
+                "AND role = 'user' "
+                "AND created_at > now() - interval '1 hour'",
+                (str(user_id),),
+            ).fetchone()
+    except Exception:
+        logger.exception("Failed to compute hourly reset for user_id=%s", user_id)
+        return 0
+
+    if row is None or row[0] is None:
+        return 0
+
+    age_seconds = float(row[0])
+    remaining = 3600 - age_seconds
+    if remaining < 0:
+        return 0
+    if remaining > 3600:
+        return 3600
+    return int(remaining)

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -13,6 +13,7 @@ Cross-org access returns 404 to avoid leaking conversation existence.
 
 from __future__ import annotations
 
+import html as _html
 import logging
 import uuid
 from datetime import datetime
@@ -36,6 +37,7 @@ from app.chat.models import (
     list_conversations_for_user,
     list_messages,
 )
+from app.chat.sanitize import render_markdown_safe, render_plaintext_safe
 from app.db import get_connection as _connect
 from app.ui.data.data_table import Column, DataTable
 from app.ui.data.pagination import Pagination
@@ -137,6 +139,8 @@ def _conversation_rows(conversations: list[Conversation]) -> list[dict[str, Any]
                 "last_message_at": _format_timestamp(last_msg),
                 "context_draft_id": str(c.context_draft_id) if c.context_draft_id else None,
                 "created_at": _format_timestamp(c.created_at),
+                "is_pinned": bool(getattr(c, "is_pinned", False)),
+                "is_archived": bool(getattr(c, "is_archived", False)),
             }
         )
     return rows
@@ -146,10 +150,19 @@ def _conversation_list_columns() -> list[Column]:
     """Return the column definitions for the conversations DataTable."""
 
     def _title_cell(row: dict[str, Any]):
-        return A(  # noqa: F405
-            row["title"],
-            href=f"/chat/{row['id']}",
-            cls="data-table-link",
+        # Star glyph (filled) when pinned.
+        star = (
+            Span("\u2605 ", cls="chat-pin-indicator", aria_label="Kinnitatud")  # noqa: F405
+            if row["is_pinned"]
+            else ""
+        )
+        return Span(  # noqa: F405
+            star,
+            A(  # noqa: F405
+                row["title"],
+                href=f"/chat/{row['id']}",
+                cls="data-table-link",
+            ),
         )
 
     def _context_cell(row: dict[str, Any]):
@@ -158,10 +171,65 @@ def _conversation_list_columns() -> list[Column]:
         return Span("\u2014", cls="muted-text")  # noqa: F405
 
     def _actions_cell(row: dict[str, Any]):
-        return A(  # noqa: F405
+        conv_id = row["id"]
+        pin_label = "Eemalda kinnitus" if row["is_pinned"] else "Kinnita"
+        archive_label = "Taasta" if row["is_archived"] else "Arhiveeri"
+        pin_form = Form(  # noqa: F405
+            Button(pin_label, variant="secondary", size="sm", type="submit"),
+            method="post",
+            action=f"/chat/{conv_id}/pin",
+            hx_post=f"/chat/{conv_id}/pin",
+            hx_target="body",
+            hx_swap="outerHTML",
+            cls="chat-list-action-form",
+        )
+        archive_form = Form(  # noqa: F405
+            Button(archive_label, variant="secondary", size="sm", type="submit"),
+            method="post",
+            action=f"/chat/{conv_id}/archive",
+            hx_post=f"/chat/{conv_id}/archive",
+            hx_target="body",
+            hx_swap="outerHTML",
+            cls="chat-list-action-form",
+        )
+        rename_form = Form(  # noqa: F405
+            Input(  # noqa: F405
+                type="text",
+                name="title",
+                placeholder="Uus pealkiri",
+                cls="chat-list-rename-input",
+                required=True,
+            ),
+            Button("Nimeta", variant="secondary", size="sm", type="submit"),
+            method="post",
+            action=f"/chat/{conv_id}/rename",
+            hx_post=f"/chat/{conv_id}/rename",
+            hx_target="body",
+            hx_swap="outerHTML",
+            cls="chat-list-action-form chat-list-rename-form",
+        )
+        delete_form = Form(  # noqa: F405
+            Button("Kustuta", variant="danger", size="sm", type="submit"),
+            method="post",
+            action=f"/chat/{conv_id}/delete",
+            hx_post=f"/chat/{conv_id}/delete",
+            hx_confirm="Kas olete kindel, et soovite vestluse kustutada?",
+            hx_target="body",
+            hx_swap="outerHTML",
+            cls="chat-list-action-form",
+        )
+        open_link = A(  # noqa: F405
             "Ava",
-            href=f"/chat/{row['id']}",
+            href=f"/chat/{conv_id}",
             cls="btn btn-secondary btn-sm",
+        )
+        return Div(  # noqa: F405
+            open_link,
+            pin_form,
+            archive_form,
+            rename_form,
+            delete_form,
+            cls="chat-list-actions",
         )
 
     return [
@@ -174,13 +242,29 @@ def _conversation_list_columns() -> list[Column]:
     ]
 
 
-def _count_conversations_for_user(user_id: str) -> int:
-    """Count total conversations for a user."""
+def _count_conversations_for_user(
+    user_id: str,
+    *,
+    search: str | None = None,
+    include_archived: bool = False,
+) -> int:
+    """Count total conversations for a user.
+
+    Mirrors the filters used by :func:`list_conversations_for_user` so the
+    pagination total reflects the same result set that is rendered.
+    """
+    where = ["user_id = %s"]
+    params: list[Any] = [user_id]
+    if not include_archived:
+        where.append("is_archived = FALSE")
+    if search:
+        where.append("title ILIKE %s")
+        params.append(f"%{search}%")
     try:
         with _connect() as conn:
             row = conn.execute(
-                "SELECT COUNT(*) FROM conversations WHERE user_id = %s",
-                (user_id,),
+                f"SELECT COUNT(*) FROM conversations WHERE {' AND '.join(where)}",  # type: ignore[arg-type]
+                tuple(params),
             ).fetchone()
         return row[0] if row else 0
     except Exception:
@@ -204,6 +288,10 @@ def chat_list_page(req: Request):
         page = 1
     offset = (page - 1) * _PAGE_SIZE
 
+    # New: search + include-archived filters (migration 017 UX polish).
+    search_q = (req.query_params.get("q") or "").strip()
+    include_archived = req.query_params.get("archived") in ("1", "true", "on")
+
     if not user_id:
         body: Any = Alert(
             "Kasutaja andmed puuduvad.",
@@ -218,15 +306,22 @@ def chat_list_page(req: Request):
                     user_id,
                     limit=_PAGE_SIZE,
                     offset=offset,
+                    include_archived=include_archived,
+                    pinned_first=True,
+                    search=search_q or None,
                 )
         except Exception:
             logger.exception("Failed to list conversations")
             conversations = []
 
-        total = _count_conversations_for_user(user_id)
+        total = _count_conversations_for_user(
+            user_id,
+            search=search_q or None,
+            include_archived=include_archived,
+        )
         total_pages = max(1, (total + _PAGE_SIZE - 1) // _PAGE_SIZE)
 
-        if total == 0:
+        if total == 0 and not search_q:
             body = Div(  # noqa: F405
                 P(  # noqa: F405
                     "Vestlusi pole. Alustage uut vestlust!",
@@ -241,18 +336,57 @@ def chat_list_page(req: Request):
             )
             pagination = None
         else:
-            body = DataTable(
-                columns=_conversation_list_columns(),
-                rows=_conversation_rows(conversations),
-                empty_message="Vestlusi ei leitud.",
+            body = Div(  # noqa: F405
+                DataTable(
+                    columns=_conversation_list_columns(),
+                    rows=_conversation_rows(conversations),
+                    empty_message="Vestlusi ei leitud.",
+                ),
+                id="chat-list-body",
             )
-            pagination = Pagination(
-                current_page=page,
-                total_pages=total_pages,
-                base_url="/chat",
-                page_size=_PAGE_SIZE,
-                total=total,
+            pagination = (
+                Pagination(
+                    current_page=page,
+                    total_pages=total_pages,
+                    base_url="/chat",
+                    page_size=_PAGE_SIZE,
+                    total=total,
+                )
+                if total > 0
+                else None
             )
+
+    # Search + archived toolbar
+    toolbar = Form(  # noqa: F405
+        Input(  # noqa: F405
+            type="search",
+            name="q",
+            placeholder="Otsi vestlusi...",
+            value=search_q,
+            cls="chat-search-input",
+            aria_label="Otsi vestlusi",
+        ),
+        Label(  # noqa: F405
+            Input(  # noqa: F405
+                type="checkbox",
+                name="archived",
+                value="1",
+                checked=include_archived,
+            ),
+            " N\u00e4ita arhiveeritud",
+            cls="chat-archived-toggle",
+        ),
+        Button("Otsi", variant="secondary", size="sm", type="submit"),
+        method="get",
+        action="/chat",
+        hx_get="/chat/search",
+        hx_target="#chat-list-body",
+        hx_trigger=(
+            "input changed delay:300ms from:input[name='q'], "
+            "change from:input[name='archived'], submit"
+        ),
+        cls="chat-list-toolbar",
+    )
 
     header_children: list = [H1("Vestlused", cls="page-title")]  # noqa: F405
     header_children.append(
@@ -276,7 +410,7 @@ def chat_list_page(req: Request):
         )
     )
 
-    card_body_children: list = [body]
+    card_body_children: list = [toolbar, body]
     if pagination is not None:
         card_body_children.append(pagination)
 
@@ -387,28 +521,163 @@ def _get_draft_title(draft_id: str, org_id: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _message_action_row(
+    *,
+    conv_id: str,
+    msg_id: str,
+    is_user: bool,
+):
+    """Render the per-message action toolbar (regenerate/copy/feedback).
+
+    User messages get Edit + Copy; assistant messages get the full set.
+    All buttons carry ``data-message-id`` + ``data-conv-id`` so chat.js
+    can dispatch the right fetch without needing inline handlers.
+    """
+    common_attrs: dict[str, Any] = {
+        "data_message_id": msg_id,
+        "data_conv_id": conv_id,
+    }
+
+    def _btn(label: str, action: str, title: str):
+        return Button(  # noqa: F405
+            label,
+            type="button",
+            variant="secondary",
+            size="sm",
+            cls="chat-message-action-btn",
+            title=title,
+            data_action=action,
+            **common_attrs,
+        )
+
+    if is_user:
+        return Div(  # noqa: F405
+            _btn("Muuda", "edit", "Muuda ja saada uuesti"),
+            _btn("Kopeeri", "copy", "Kopeeri"),
+            cls="chat-message-actions",
+        )
+
+    return Div(  # noqa: F405
+        _btn("Genereeri uuesti", "regenerate", "Genereeri uuesti"),
+        _btn("Kopeeri", "copy", "Kopeeri"),
+        _btn("\u2191", "feedback-up", "Kasulik"),
+        _btn("\u2193", "feedback-down", "Ei olnud kasulik"),
+        cls="chat-message-actions",
+    )
+
+
+def _rag_sources_block(rag_context: list[dict] | None):
+    """Render a ``<details>`` disclosure of RAG source chunks."""
+    if not rag_context:
+        return ""
+
+    items = []
+    for chunk in rag_context:
+        if not isinstance(chunk, dict):
+            continue
+        source_uri = str(chunk.get("source_uri") or "").strip()
+        content = str(chunk.get("content") or "")
+        # Derive a title from the last URI segment; fall back to the URI.
+        title = source_uri.rstrip("/").rsplit("/", 1)[-1] if source_uri else "(allikas)"
+        snippet = content[:200].strip()
+        if len(content) > 200:
+            snippet = snippet + "\u2026"
+        if source_uri:
+            link: Any = A(  # noqa: F405
+                title,
+                href=f"/explorer?q={source_uri}",
+                target="_blank",
+                rel="noopener noreferrer",
+            )
+        else:
+            link = Span(title)  # noqa: F405
+        items.append(
+            Li(  # noqa: F405
+                link,
+                P(snippet, cls="chat-source-snippet") if snippet else "",  # noqa: F405
+            )
+        )
+
+    if not items:
+        return ""
+
+    return Details(  # noqa: F405
+        Summary(f"Allikad ({len(items)})"),  # noqa: F405
+        Ul(*items, cls="chat-sources-list"),  # noqa: F405
+        cls="chat-sources",
+    )
+
+
 def _render_message(msg: Any):
     """Render a single message as a chat bubble."""
     role = msg.role
     content = msg.content or ""
+    msg_id = str(msg.id) if getattr(msg, "id", None) else ""
+    is_pinned = bool(getattr(msg, "is_pinned", False))
+    is_truncated = bool(getattr(msg, "is_truncated", False))
 
     if role == "user":
+        wrapper_cls = "chat-message chat-message-user"
+        if is_pinned:
+            wrapper_cls += " chat-message--pinned"
+        pin_indicator = (
+            Span("\u2605", cls="chat-pin-indicator", title="Kinnitatud")  # noqa: F405
+            if is_pinned
+            else ""
+        )
+        # Escape user-authored text but preserve newlines as <br>.
         return Div(  # noqa: F405
             Div(  # noqa: F405
-                P(content, cls="chat-message-text"),  # noqa: F405
+                pin_indicator,
+                P(Safe(render_plaintext_safe(content)), cls="chat-message-text"),  # noqa: F405
                 cls="chat-bubble chat-bubble-user",
             ),
-            cls="chat-message chat-message-user",
+            _message_action_row(
+                conv_id=str(getattr(msg, "conversation_id", "") or ""),
+                msg_id=msg_id,
+                is_user=True,
+            ),
+            cls=wrapper_cls,
+            data_message_id=msg_id,
         )
     elif role == "assistant":
-        msg_id = str(msg.id) if hasattr(msg, "id") and msg.id else ""
+        rendered = render_markdown_safe(content)
+        if is_truncated:
+            # Append an italic note that the stream was interrupted.
+            rendered = (
+                rendered + ' \u2014 <em class="chat-message-truncated">vastus katkestati</em>'
+            )
+
+        wrapper_cls = "chat-message chat-message-assistant"
+        if is_pinned:
+            wrapper_cls += " chat-message--pinned"
+        pin_indicator = (
+            Span("\u2605", cls="chat-pin-indicator", title="Kinnitatud")  # noqa: F405
+            if is_pinned
+            else ""
+        )
+
+        extras: list = []
+        sources = _rag_sources_block(getattr(msg, "rag_context", None))
+        if sources:
+            extras.append(sources)
+
+        conv_id_str = str(getattr(msg, "conversation_id", "") or "")
         return Div(  # noqa: F405
             Div(  # noqa: F405
-                Div(Safe(_format_assistant_content(content)), cls="chat-message-text"),  # noqa: F405
+                pin_indicator,
+                Div(Safe(rendered), cls="chat-message-text"),  # noqa: F405
                 cls="chat-bubble chat-bubble-assistant",
             ),
+            *extras,
+            _message_action_row(
+                conv_id=conv_id_str,
+                msg_id=msg_id,
+                is_user=False,
+            ),
             AnnotationButton("conversation", msg_id) if msg_id else "",
-            cls="chat-message chat-message-assistant",
+            cls=wrapper_cls,
+            data_message_id=msg_id,
         )
     elif role == "tool":
         tool_name = msg.tool_name or "tool"
@@ -418,138 +687,88 @@ def _render_message(msg: Any):
                 cls="chat-bubble chat-bubble-tool",
             ),
             cls="chat-message chat-message-tool",
+            data_message_id=msg_id,
         )
     # system messages are hidden
     return ""
 
 
-def _format_assistant_content(content: str) -> str:
-    """Apply minimal formatting to assistant content.
+# ---------------------------------------------------------------------------
+# Empty-state example prompts
+# ---------------------------------------------------------------------------
 
-    Handles bold markers for citations and preserves code blocks.
-    This is deliberately simple -- full markdown rendering is deferred.
-    """
-    import html
+# Default prompts — shown when the conversation has no messages yet.
+_DEFAULT_EXAMPLE_PROMPTS: tuple[tuple[str, str], ...] = (
+    (
+        "Isikuandmete t\u00f6\u00f6tlemine",
+        "Millised seadused m\u00f5jutavad isikuandmete t\u00f6\u00f6tlemist?",
+    ),
+    (
+        "Vastuolud EL \u00f5igusega",
+        "Leia vastuolud EL \u00f5igusega minu eeln\u00f5us",
+    ),
+    (
+        "Kohtupraktika",
+        "N\u00e4ita hiljutisi Riigikohtu lahendeid teemal X",
+    ),
+    (
+        "Lihtsas keeles",
+        "Selgita s\u00e4tet lihtsas keeles: ...",
+    ),
+    (
+        "M\u00f5jude kaardistus",
+        "Millised s\u00e4tted seotud karistusseadustikuga peavad muutuma?",
+    ),
+)
 
-    content = html.escape(content)
-    # Bold: **text** -> <strong>text</strong>
-    import re
+# Draft-specific prompts — used when the conversation is anchored to a draft.
+_DRAFT_EXAMPLE_PROMPTS: tuple[tuple[str, str], ...] = (
+    (
+        "V\u00f5rdle kehtiva \u00f5igusega",
+        "V\u00f5rdle eeln\u00f5u kehtiva regulatsiooniga",
+    ),
+    (
+        "Leia vastuolud",
+        "Leia vastuolud EL \u00f5igusega selles eeln\u00f5us",
+    ),
+    (
+        "Sarnased eeln\u00f5ud",
+        "Leia varasemad sarnased eeln\u00f5ud",
+    ),
+    (
+        "Kohtulahendid",
+        "Millised kohtulahendid m\u00f5jutavad seda eeln\u00f5u?",
+    ),
+)
 
-    content = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", content)
-    # Code blocks: ```text``` -> <pre><code>text</code></pre>
-    content = re.sub(
-        r"```(\w*)\n?(.*?)```",
-        r"<pre><code>\2</code></pre>",
-        content,
-        flags=re.DOTALL,
+
+def _empty_state(prompts: tuple[tuple[str, str], ...]):
+    """Render the initial empty-state block with example prompt cards."""
+    cards = []
+    for label, prompt_text in prompts:
+        cards.append(
+            Button(  # noqa: F405
+                Span(label, cls="chat-example-prompt-label"),  # noqa: F405
+                Span(prompt_text, cls="chat-example-prompt-hint"),  # noqa: F405
+                type="button",
+                variant="secondary",
+                cls="chat-example-prompt",
+                data_prompt=prompt_text,
+            )
+        )
+    return Div(  # noqa: F405
+        Div(  # noqa: F405
+            "Tere tulemast AI \u00f5igusn\u00f5ustaja juurde",
+            cls="chat-empty-state-title",
+        ),
+        Div(  # noqa: F405
+            "K\u00fcsi ja ma otsin vastused Eesti \u00f5iguse ontoloogiast ning kohtupraktikast.",
+            cls="chat-empty-state-body",
+        ),
+        Div(*cards, cls="chat-example-prompts"),  # noqa: F405
+        id="chat-empty-state",
+        cls="chat-empty-state",
     )
-    # Inline code: `text` -> <code>text</code>
-    content = re.sub(r"`([^`]+)`", r"<code>\1</code>", content)
-    # Newlines -> <br>
-    content = content.replace("\n", "<br>")
-    return content
-
-
-_CHAT_JS = """
-(function() {
-    var ws = null;
-    var convId = document.getElementById('chat-container').dataset.conversationId;
-    var messagesDiv = document.getElementById('chat-messages');
-    var input = document.getElementById('chat-input');
-    var sendBtn = document.getElementById('chat-send-btn');
-    var statusDiv = document.getElementById('chat-status');
-    var currentAssistantBubble = null;
-
-    function connect() {
-        var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-        ws = new WebSocket(proto + '//' + location.host + '/ws/chat');
-        ws.onopen = function() {
-            if (statusDiv) statusDiv.textContent = 'Uhendatud';
-        };
-        ws.onclose = function() {
-            if (statusDiv) statusDiv.textContent = 'Uhendus katkes';
-            setTimeout(connect, 3000);
-        };
-        ws.onmessage = function(e) {
-            try {
-                var event = JSON.parse(e.data);
-                handleEvent(event);
-            } catch(err) { /* ignore parse errors */ }
-        };
-    }
-
-    function handleEvent(event) {
-        if (event.type === 'content_delta') {
-            if (!currentAssistantBubble) {
-                currentAssistantBubble = document.createElement('div');
-                currentAssistantBubble.className = 'chat-message chat-message-assistant';
-                currentAssistantBubble.innerHTML =
-                    '<div class="chat-bubble chat-bubble-assistant">' +
-                    '<div class="chat-message-text"></div></div>';
-                messagesDiv.appendChild(currentAssistantBubble);
-            }
-            var textDiv = currentAssistantBubble.querySelector('.chat-message-text');
-            textDiv.textContent += event.delta;
-            messagesDiv.scrollTop = messagesDiv.scrollHeight;
-        } else if (event.type === 'tool_use') {
-            var toolDiv = document.createElement('div');
-            toolDiv.className = 'chat-message chat-message-tool';
-            toolDiv.innerHTML = '<div class="chat-bubble chat-bubble-tool">' +
-                '<p class="chat-tool-label">[' + (event.tool || 'tool') + ']</p></div>';
-            messagesDiv.appendChild(toolDiv);
-        } else if (event.type === 'done') {
-            currentAssistantBubble = null;
-            if (sendBtn) sendBtn.disabled = false;
-            if (input) input.disabled = false;
-        } else if (event.type === 'error') {
-            var errDiv = document.createElement('div');
-            errDiv.className = 'chat-message chat-message-error';
-            errDiv.innerHTML = '<div class="chat-bubble chat-bubble-error">' +
-                '<p>' + (event.message || 'Viga') + '</p></div>';
-            messagesDiv.appendChild(errDiv);
-            currentAssistantBubble = null;
-            if (sendBtn) sendBtn.disabled = false;
-            if (input) input.disabled = false;
-        }
-    }
-
-    function sendMessage() {
-        if (!ws || ws.readyState !== WebSocket.OPEN) return;
-        var text = input.value.trim();
-        if (!text) return;
-        // Add user message to UI
-        var userDiv = document.createElement('div');
-        userDiv.className = 'chat-message chat-message-user';
-        userDiv.innerHTML = '<div class="chat-bubble chat-bubble-user">' +
-            '<p class="chat-message-text">' + text.replace(/</g, '&lt;') + '</p></div>';
-        messagesDiv.appendChild(userDiv);
-        messagesDiv.scrollTop = messagesDiv.scrollHeight;
-        // Send via WS
-        ws.send(JSON.stringify({
-            type: 'send_message',
-            conversation_id: convId,
-            content: text
-        }));
-        input.value = '';
-        if (sendBtn) sendBtn.disabled = true;
-        if (input) input.disabled = true;
-    }
-
-    if (sendBtn) {
-        sendBtn.addEventListener('click', sendMessage);
-    }
-    if (input) {
-        input.addEventListener('keydown', function(e) {
-            if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                sendMessage();
-            }
-        });
-    }
-
-    connect();
-})();
-"""
 
 
 def conversation_view_page(req: Request, conv_id: str):
@@ -587,8 +806,13 @@ def conversation_view_page(req: Request, conv_id: str):
         logger.exception("Failed to load messages for conversation %s", conv_id)
         messages = []
 
-    # Render message history
-    message_bubbles = [_render_message(m) for m in messages if m.role != "system"]
+    # Render message history (excluding system turns which are UI-invisible)
+    visible_messages = [m for m in messages if m.role != "system"]
+    message_bubbles = [_render_message(m) for m in visible_messages]
+
+    # Empty-state — only shown on the initial render with no user/assistant turns.
+    prompts = _DRAFT_EXAMPLE_PROMPTS if conversation.context_draft_id else _DEFAULT_EXAMPLE_PROMPTS
+    empty_state = _empty_state(prompts) if not visible_messages else ""
 
     # Draft context header
     draft_header = None
@@ -602,39 +826,101 @@ def conversation_view_page(req: Request, conv_id: str):
                 href=f"/drafts/{conversation.context_draft_id}",
                 cls="draft-context-link",
             ),
+            A(  # noqa: F405
+                "Vaata m\u00f5ju",
+                href=f"/drafts/{conversation.context_draft_id}",
+                target="_blank",
+                rel="noopener noreferrer",
+                cls="draft-context-impact-link",
+            ),
             cls="chat-draft-context",
         )
 
+    # Connection/quota header row. JS populates quota live via /api/me/usage.
+    header_meta = Div(  # noqa: F405
+        Span(  # noqa: F405
+            "\u00dchendatud",
+            id="chat-status",
+            cls="chat-status chat-status--connected",
+            role="status",
+            aria_live="polite",
+        ),
+        Div(  # noqa: F405
+            Span(cls="chat-quota-label"),  # noqa: F405
+            Span(  # noqa: F405
+                Span(cls="chat-quota-bar"),  # noqa: F405
+                cls="chat-quota-bar-wrap",
+            ),
+            id="chat-quota",
+            cls="chat-quota",
+            role="progressbar",
+            aria_valuemin="0",
+            aria_valuemax="100",
+            aria_valuenow="0",
+            # Marked busy until the first /api/me/usage response paints real
+            # values; screen readers otherwise announce a misleading "0".
+            # chat.js clears both attributes after the first refresh.
+            aria_busy="true",
+            data_initial="true",
+        ),
+        cls="chat-header-meta",
+    )
+
     # Build chat page
     chat_container = Div(  # noqa: F405
-        # Message history
+        header_meta,
+        # Message history + empty-state wrapper. aria-live=polite lets
+        # screen readers pick up streamed assistant turns.
         Div(  # noqa: F405
+            empty_state,
             *message_bubbles,
             id="chat-messages",
             cls="chat-messages",
+            aria_live="polite",
         ),
         # Input area help text
         Small(  # noqa: F405
             "K\u00fcsige k\u00fcsimusi Eesti seaduste, kohtuotsuste v\u00f5i "
             "EL-i \u00f5igusaktide kohta. AI kasutab ontoloogiat ja RAG-i "
-            "vastuste p\u00f5hjendamiseks.",
+            "vastuste p\u00f5hjendamiseks. "
+            "Vajuta / nupuks, et n\u00e4ha k\u00e4sklusi.",
             cls="form-field-help",
         ),
+        # Slash-command palette (populated by chat.js)
+        Div(id="chat-slash-palette", cls="chat-slash-palette", hidden=True),  # noqa: F405
         # Input area
         Div(  # noqa: F405
             Textarea(  # noqa: F405
                 id="chat-input",
                 name="content",
-                placeholder="Kirjutage oma kuuimus...",
+                placeholder=(
+                    "K\u00fcsi Eesti \u00f5iguse kohta... "
+                    "(Enter = uus rida, Cmd/Ctrl+Enter = saada, / = k\u00e4sud)"
+                ),
                 cls="chat-input",
                 rows="2",
             ),
             Button("Saada", id="chat-send-btn", variant="primary", type="button"),
+            Button(
+                "Peata",
+                id="chat-stop-btn",
+                variant="secondary",
+                type="button",
+                hidden=True,
+            ),
             cls="chat-input-area",
         ),
         id="chat-container",
         data_conversation_id=str(parsed),
         cls="chat-container",
+    )
+
+    # Document-root toast container (JS appends toasts here).
+    toast_container = Div(  # noqa: F405
+        id="chat-toast-container",
+        cls="chat-toast-container",
+        aria_live="polite",
+        aria_atomic="true",
     )
 
     # Delete button
@@ -659,12 +945,39 @@ def conversation_view_page(req: Request, conv_id: str):
         content_parts.append(draft_header)
     content_parts.append(chat_container)
 
+    # Vendor libs for markdown rendering on the client side. The URLs pin
+    # exact patch versions (marked@12.0.2, dompurify@3.1.6) so SRI hashes
+    # provide a meaningful defence against a compromised CDN serving altered
+    # bytes. Bumping either version requires recomputing the sha384 digest:
+    #
+    #     curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A
+    #
+    # The server-side ``render_markdown_safe`` path remains the primary XSS
+    # boundary; DOMPurify on the client is belt-and-suspenders for messages
+    # rendered entirely from streaming deltas.
+    vendor_scripts = (
+        Script(  # noqa: F405
+            src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js",
+            integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi",
+            crossorigin="anonymous",
+            defer=True,
+        ),
+        Script(  # noqa: F405
+            src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js",
+            integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a",
+            crossorigin="anonymous",
+            defer=True,
+        ),
+        Script(src="/static/js/chat.js", defer=True),  # noqa: F405
+    )
+
     return PageShell(
         *header_children,
         Card(
             CardBody(*content_parts),
         ),
-        Script(Safe(_CHAT_JS)),  # noqa: F405
+        toast_container,
+        *vendor_scripts,
         title=conversation.title,
         user=auth,
         theme=theme,
@@ -733,8 +1046,30 @@ def register_chat_routes(rt) -> None:  # type: ignore[no-untyped-def]
 
     The chat pages are behind the global auth Beforeware, so
     **do not** add ``/chat`` to ``SKIP_PATHS``.
+
+    Registration order matters: Starlette matches routes by the order
+    they are added. Static/parameter-less chat handler paths
+    (``/chat/search``, ``/chat/{conv_id}/pin``, ``/api/me/usage`` etc.)
+    MUST be registered **before** the ``/chat/{conv_id}`` catch-all so
+    the dispatcher resolves them correctly. Delegating to
+    ``register_chat_handler_routes`` first achieves that without needing
+    the post-hoc reordering hack that lives in ``app.chat.handlers``
+    (which remains in place as an idempotent safety net).
     """
+    from app.chat.handlers import register_chat_handler_routes
+
+    # Register mutation / export / search / usage handlers FIRST so their
+    # static paths win over the dynamic /chat/{conv_id} route below.
+    register_chat_handler_routes(rt)
+
     rt("/chat", methods=["GET"])(chat_list_page)
     rt("/chat/new", methods=["GET"])(new_conversation)
     rt("/chat/{conv_id}", methods=["GET"])(conversation_view_page)
     rt("/chat/{conv_id}/delete", methods=["POST"])(delete_conversation_handler)
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat: _html module kept imported so tests that monkeypatch
+# ``app.chat.routes._html`` (the HTML escape helper) continue to work.
+# ---------------------------------------------------------------------------
+_ = _html  # noqa: F841  (silence unused-import warnings on strict linters)

--- a/app/chat/sanitize.py
+++ b/app/chat/sanitize.py
@@ -1,0 +1,264 @@
+"""Safe markdown rendering for chat content.
+
+Renders assistant markdown (and plaintext user messages) to sanitised HTML
+with auto-linked URLs and auto-linked Estonian/EU-style legal citations
+(for example ``KarS § 113``, ``TsUS § 5 lg 2``, ``Art. 5 loige 2``).
+
+Pipeline for :func:`render_markdown_safe`:
+
+1. Render markdown to HTML via :mod:`mistune` (zero-config, fast).
+2. Sanitise with :mod:`bleach` using a strict tag/attribute allowlist and
+   force safe link attributes (``target="_blank"``,
+   ``rel="noopener noreferrer"``).
+3. Linkify bare ``http(s)://`` URLs.
+4. Post-process with BeautifulSoup to wrap legal citations in
+   ``<a class="citation-link" href="/explorer?q=...">`` -- but only
+   inside plain text nodes, never inside existing ``<a>`` or ``<code>``
+   elements.
+
+This module replaces the ad-hoc regex-only approach used previously in
+``app.chat.routes._format_assistant_content``.
+"""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from urllib.parse import quote_plus
+
+import bleach
+import mistune
+from bs4 import BeautifulSoup
+from bs4.element import NavigableString, Tag
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist configuration
+# ---------------------------------------------------------------------------
+
+ALLOWED_TAGS: list[str] = [
+    # Block
+    "p",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "blockquote",
+    "ul",
+    "ol",
+    "li",
+    "pre",
+    "code",
+    "hr",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "br",
+    # Inline
+    "strong",
+    "em",
+    "del",
+    "a",
+    "span",
+]
+
+ALLOWED_ATTRIBUTES: dict[str, list[str]] = {
+    "a": ["href", "title", "target", "rel"],
+    "span": ["class"],
+    "code": ["class"],
+    "pre": ["class"],
+    "th": ["align"],
+    "td": ["align"],
+}
+
+ALLOWED_PROTOCOLS: list[str] = ["http", "https", "mailto"]
+
+
+# ---------------------------------------------------------------------------
+# Citation patterns (Estonian + EU style)
+# ---------------------------------------------------------------------------
+
+# Matches Estonian law abbreviations / names followed by section marker:
+#   "KarS § 113", "TsUS § 5 lg 2", "PS § 13", "Pohiseadus § 13 lg 1 p 2"
+_CITATION_PARAGRAPH_RE = re.compile(
+    r"\b[A-ZÕÄÖÜ][A-Za-zÕÄÖÜõäöü]{1,10}\s*§\s*\d+"
+    r"(?:\s*lg\s*\d+)?"
+    r"(?:\s*p\s*\d+)?\b"
+)
+
+# Matches EU / international Article style: "Art. 5", "Art. 5 loige 2"
+_CITATION_ARTICLE_RE = re.compile(r"\bArt\.\s*\d+(?:\s*l[õo]ige\s*\d+)?\b")
+
+_CITATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    _CITATION_PARAGRAPH_RE,
+    _CITATION_ARTICLE_RE,
+)
+
+# Tags whose descendant text must NOT be rewritten (already a link, or
+# inside code / pre blocks).
+_SKIP_CITATION_PARENTS: frozenset[str] = frozenset({"a", "code", "pre"})
+
+
+# ---------------------------------------------------------------------------
+# Markdown renderer
+# ---------------------------------------------------------------------------
+
+# Single module-level markdown instance. ``mistune.create_markdown`` is
+# thread-safe for rendering; escape=False is fine because we run every
+# output through bleach afterwards.
+_markdown = mistune.create_markdown(
+    escape=False,
+    plugins=["strikethrough", "table", "url"],
+)
+
+
+def _force_safe_link_attrs(attrs: dict, new: bool = False) -> dict:
+    """bleach linkify/cleaner callback -- force safe external-link attrs."""
+    # Keys in bleach callbacks are (namespace, name) tuples.
+    attrs[(None, "target")] = "_blank"
+    attrs[(None, "rel")] = "noopener noreferrer"
+    return attrs
+
+
+def _sanitize_html(raw_html: str) -> str:
+    """Run bleach clean + linkify on rendered markdown HTML."""
+    cleaned = bleach.clean(
+        raw_html,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        protocols=ALLOWED_PROTOCOLS,
+        strip=True,
+    )
+    # Auto-link bare URLs and normalise link attributes on all anchors.
+    # bleach's stubs type callbacks narrowly; the runtime signature we use
+    # matches the documented API, so we cast via ``type: ignore``.
+    linkified = bleach.linkify(
+        cleaned,
+        callbacks=[_force_safe_link_attrs],  # type: ignore[list-item]
+        skip_tags=["pre", "code"],
+        parse_email=False,
+    )
+    return linkified
+
+
+def _wrap_citations_in_text(soup: BeautifulSoup) -> None:
+    """Wrap legal citations in text nodes with ``<a class="citation-link">``.
+
+    Skips any text inside ``<a>``, ``<code>``, or ``<pre>`` elements so
+    that existing links are preserved and code samples remain untouched.
+    """
+    # Collect nodes first; mutating during iteration confuses the tree walker.
+    candidates: list[NavigableString] = []
+    for text_node in soup.find_all(string=True):
+        # Walk up ancestors; skip if any is in the skip set.
+        skip = False
+        parent = text_node.parent
+        while parent is not None and parent.name is not None:
+            if parent.name in _SKIP_CITATION_PARENTS:
+                skip = True
+                break
+            parent = parent.parent
+        if skip:
+            continue
+        candidates.append(text_node)
+
+    for text_node in candidates:
+        original = str(text_node)
+        # Find all matches across all citation patterns, then splice.
+        matches: list[tuple[int, int, str]] = []
+        for pattern in _CITATION_PATTERNS:
+            for m in pattern.finditer(original):
+                matches.append((m.start(), m.end(), m.group(0)))
+        if not matches:
+            continue
+
+        # Sort by start position; drop overlaps (keep earliest/longest).
+        matches.sort(key=lambda t: (t[0], -(t[1] - t[0])))
+        non_overlapping: list[tuple[int, int, str]] = []
+        last_end = -1
+        for start, end, text in matches:
+            if start < last_end:
+                continue
+            non_overlapping.append((start, end, text))
+            last_end = end
+
+        # Build replacement fragments.
+        new_nodes: list[NavigableString | Tag] = []
+        cursor = 0
+        for start, end, citation_text in non_overlapping:
+            if start > cursor:
+                new_nodes.append(NavigableString(original[cursor:start]))
+            anchor = soup.new_tag(
+                "a",
+                href=f"/explorer?q={quote_plus(citation_text)}",
+            )
+            # Multi-valued class attribute: bs4 accepts a list at runtime but
+            # its stubs only type ``str``. The list form is preferred because
+            # it preserves whitespace handling across serialisation.
+            anchor["class"] = ["citation-link"]  # type: ignore[assignment]
+            anchor.string = citation_text
+            new_nodes.append(anchor)
+            cursor = end
+        if cursor < len(original):
+            new_nodes.append(NavigableString(original[cursor:]))
+
+        # Replace the original text node with the expanded sequence.
+        first, *rest = new_nodes
+        text_node.replace_with(first)
+        anchor_point: NavigableString | Tag = first
+        for node in rest:
+            anchor_point.insert_after(node)
+            anchor_point = node
+
+
+def _apply_citation_links(html_fragment: str) -> str:
+    """Post-process HTML to wrap Estonian/EU legal citations in anchors."""
+    if not html_fragment:
+        return html_fragment
+    soup = BeautifulSoup(html_fragment, "html.parser")
+    _wrap_citations_in_text(soup)
+    return str(soup)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def render_markdown_safe(content: str) -> str:
+    """Render user/LLM markdown to sanitised HTML.
+
+    Auto-links bare URLs and Estonian/EU-style legal citations. Strips
+    any tag or attribute not in the allowlist, defeating XSS attempts
+    such as ``<script>``, ``<img onerror=...>``, and ``javascript:`` URLs.
+    """
+    if not content:
+        return ""
+    try:
+        rendered = _markdown(content)
+        if not isinstance(rendered, str):  # defensive: mistune can return state
+            rendered = str(rendered)
+        cleaned = _sanitize_html(rendered)
+        return _apply_citation_links(cleaned)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to render markdown; falling back to escape")
+        return render_plaintext_safe(content)
+
+
+def render_plaintext_safe(content: str) -> str:
+    """Escape plain text and convert newlines to ``<br>`` tags.
+
+    Used for user messages where markdown should NOT be interpreted --
+    the user's literal text is displayed verbatim, with HTML special
+    characters escaped so the output cannot inject markup.
+    """
+    if not content:
+        return ""
+    escaped = html.escape(content, quote=False)
+    return escaped.replace("\r\n", "\n").replace("\n", "<br>")

--- a/app/chat/slash.py
+++ b/app/chat/slash.py
@@ -1,0 +1,115 @@
+"""Slash-command expansion for the advisory chat.
+
+Users can type shortcuts such as ``/draft <teema>`` or ``/sources`` in the
+chat input. This module turns such shortcuts into canonical Estonian prompts
+that the LLM can reason about, and exposes autocomplete helpers for the UI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SlashCommand:
+    """A single slash command shortcut.
+
+    Attributes:
+        name: Command token used after the leading slash (lower-case).
+        label: Short Estonian label shown in the UI autocomplete list.
+        description: One-line Estonian help text.
+        template: Canonical prompt with an ``{arg}`` placeholder. Commands
+            that take no argument should not include ``{arg}``.
+    """
+
+    name: str
+    label: str
+    description: str
+    template: str
+
+
+COMMANDS: list[SlashCommand] = [
+    SlashCommand(
+        name="draft",
+        label="Loo eelnõu",
+        description="Alusta uue eelnõu koostamist antud teemal.",
+        template="Aita mul luua eelnõu järgmisel teemal: {arg}",
+    ),
+    SlashCommand(
+        name="compare",
+        label="Võrdle sättega",
+        description="Võrdle teksti kehtiva õigusega.",
+        template="Võrdle järgnevat kehtiva õigusega: {arg}",
+    ),
+    SlashCommand(
+        name="find-conflicts",
+        label="Leia vastuolud",
+        description="Leia vastuolud Euroopa Liidu õigusega.",
+        template="Leia vastuolud EL õigusega järgnevas: {arg}",
+    ),
+    SlashCommand(
+        name="explain",
+        label="Selgita",
+        description="Selgita sätet või mõistet lihtsas keeles.",
+        template="Selgita lihtsas keeles: {arg}",
+    ),
+    SlashCommand(
+        name="sources",
+        label="Näita allikaid",
+        description="Loetle allikad, millele eelmine vastus tugines.",
+        template=("Millistele allikatele tugined eelmise vastuse puhul? Loetle need täpselt."),
+    ),
+]
+
+
+_COMMANDS_BY_NAME: dict[str, SlashCommand] = {cmd.name: cmd for cmd in COMMANDS}
+
+
+def expand(message: str) -> str:
+    """Expand a leading slash command into its canonical Estonian prompt.
+
+    If ``message`` starts with a known command (after stripping leading
+    whitespace), the command token is replaced with its template. The rest
+    of the message (everything after the first whitespace following the
+    command) is substituted into ``{arg}``. Unknown commands and plain
+    messages are returned unchanged.
+
+    Matching on the command name is case-insensitive, but the user-supplied
+    argument keeps its original casing.
+    """
+
+    if not message:
+        return message
+
+    stripped = message.lstrip()
+    if not stripped.startswith("/"):
+        return message
+
+    # Split "/name" and the remainder on the first whitespace run.
+    head, sep, tail = stripped[1:].partition(" ")
+    # ``partition`` only splits on a single space; normalise by stripping
+    # leading whitespace from the argument so that e.g. "/draft   foo"
+    # yields arg "foo" rather than "  foo".
+    name = head.lower()
+    if name not in _COMMANDS_BY_NAME:
+        return message
+
+    cmd = _COMMANDS_BY_NAME[name]
+    arg = tail.lstrip() if sep else ""
+
+    if "{arg}" not in cmd.template:
+        return cmd.template
+    return cmd.template.format(arg=arg)
+
+
+def match_prefix(prefix: str) -> list[SlashCommand]:
+    """Return commands whose name starts with ``prefix`` (case-insensitive).
+
+    An empty prefix returns all commands in declaration order. Used by the
+    client-side autocomplete dropdown.
+    """
+
+    needle = prefix.lower()
+    if not needle:
+        return list(COMMANDS)
+    return [cmd for cmd in COMMANDS if cmd.name.startswith(needle)]

--- a/app/chat/title.py
+++ b/app/chat/title.py
@@ -1,0 +1,104 @@
+"""Generate short conversation titles from the opening chat exchange.
+
+Called once per conversation, right after the first assistant reply
+has been persisted, to produce a compact Estonian label used in the
+sidebar/history list. The call is best-effort: on any error (feature
+flag off, LLM failure, timeout) we return ``None`` and let the caller
+fall back to a generic placeholder. Pricing-wise we lean on Claude's
+cheapest Haiku tier via a small ``max_tokens`` budget.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from app.config import is_chat_auto_title_enabled
+from app.llm import get_default_provider
+
+logger = logging.getLogger(__name__)
+
+_MAX_TITLE_CHARS = 48
+_MAX_PROMPT_CHARS = 2000
+_MAX_OUTPUT_TOKENS = 60
+
+_SYSTEM_PROMPT = (
+    "Genereeri lühike (kuni 48 märki) pealkiri järgnevale vestlusele. "
+    "Vasta AINULT pealkirjaga, ilma jutumärkideta, ilma punktita lõpus."
+)
+
+
+def _clean_title(raw: str) -> str:
+    """Strip whitespace, wrapping quotes, and trailing punctuation."""
+    text = raw.strip()
+    # Strip matching wrapping quotes (straight or typographic) repeatedly
+    # in case the model layered them.
+    quote_pairs = {
+        '"': '"',
+        "'": "'",
+        "\u201c": "\u201d",  # “ ”
+        "\u2018": "\u2019",  # ‘ ’
+        "\u00ab": "\u00bb",  # « »
+        "\u201e": "\u201c",  # „ “ (Estonian)
+    }
+    changed = True
+    while changed and len(text) >= 2:
+        changed = False
+        for opener, closer in quote_pairs.items():
+            if text.startswith(opener) and text.endswith(closer):
+                text = text[len(opener) : -len(closer)].strip()
+                changed = True
+                break
+    # Drop trailing punctuation the prompt told the model to avoid.
+    text = text.rstrip(" .\t\n\r")
+    if len(text) > _MAX_TITLE_CHARS:
+        text = text[:_MAX_TITLE_CHARS].rstrip()
+    return text
+
+
+async def generate_title(
+    user_message: str,
+    assistant_reply: str,
+    *,
+    user_id: UUID | str | None = None,
+    org_id: UUID | str | None = None,
+) -> str | None:
+    """Return a <=48 char Estonian title, or ``None`` on failure.
+
+    Args:
+        user_message: First user message in the conversation.
+        assistant_reply: First assistant reply in the conversation.
+        user_id: Optional user id for cost tracking attribution.
+        org_id: Optional org id for cost tracking attribution.
+
+    Returns:
+        A cleaned title string no longer than 48 characters, or
+        ``None`` if the feature is disabled or the LLM call fails.
+    """
+    if not is_chat_auto_title_enabled():
+        return None
+
+    prompt = f"Kasutaja: {user_message}\n\nAssistent: {assistant_reply}"
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        prompt = prompt[:_MAX_PROMPT_CHARS]
+
+    try:
+        provider = get_default_provider()
+        raw = await provider.acomplete(
+            prompt,
+            max_tokens=_MAX_OUTPUT_TOKENS,
+            temperature=0.0,
+            system=_SYSTEM_PROMPT,
+            feature="chat_auto_title",
+            user_id=user_id,
+            org_id=org_id,
+        )
+    except Exception:
+        logger.exception("generate_title: LLM call failed")
+        return None
+
+    if not raw:
+        return None
+
+    title = _clean_title(raw)
+    return title or None

--- a/app/chat/websocket.py
+++ b/app/chat/websocket.py
@@ -4,10 +4,24 @@ Uses the same FastHTML ``@app.ws()`` pattern established by
 :mod:`app.explorer.websocket`. The handler parses incoming JSON
 messages, delegates to :class:`~app.chat.orchestrator.ChatOrchestrator`,
 and streams events back to the client as HTML fragments.
+
+Phase UX polish additions (issue #594):
+
+- **Max message length**: user-supplied ``content`` longer than
+  ``_MAX_MESSAGE_LENGTH`` characters is rejected with an error event
+  and never reaches the orchestrator.
+- **JWT fail-closed**: when the JWT provider cannot be constructed we
+  close the WebSocket with code ``1011`` instead of proceeding with an
+  empty auth scope.
+- **Stop generation**: a ``{"type": "stop_generation", ...}`` message
+  cancels the currently-running orchestrator task for the connection.
+  The orchestrator catches ``CancelledError`` and persists the partial
+  assistant turn with ``is_truncated=True``.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -19,6 +33,8 @@ from app.chat.orchestrator import ChatOrchestrator
 from app.llm.claude import get_default_provider
 
 logger = logging.getLogger(__name__)
+
+_MAX_MESSAGE_LENGTH = 10_000
 
 
 async def on_connect(send: Any) -> None:
@@ -32,12 +48,19 @@ async def on_disconnect(send: Any) -> None:
     logger.info("Chat WS client disconnected")
 
 
-async def ws_chat(msg: str, send: Any, scope: dict[str, Any] | None = None) -> None:
+async def ws_chat(
+    msg: str,
+    send: Any,
+    scope: dict[str, Any] | None = None,
+    *,
+    active_tasks: dict[str, asyncio.Task[Any]] | None = None,
+) -> None:
     """Handle incoming chat WebSocket messages.
 
-    Expected message format::
+    Expected message formats::
 
         {"type": "send_message", "conversation_id": "<uuid>", "content": "..."}
+        {"type": "stop_generation", "conversation_id": "<uuid>"}
 
     All other message types are silently ignored.
 
@@ -50,6 +73,10 @@ async def ws_chat(msg: str, send: Any, scope: dict[str, Any] | None = None) -> N
     scope:
         Optional ASGI scope dict for auth extraction (injected by
         test harness or passed from the WS handler wrapper).
+    active_tasks:
+        Optional per-connection mapping of ``conversation_id -> Task``
+        so that ``stop_generation`` can cancel an in-flight stream.
+        When omitted the stop handler is a no-op.
     """
     # Parse JSON
     try:
@@ -63,6 +90,12 @@ async def ws_chat(msg: str, send: Any, scope: dict[str, Any] | None = None) -> N
         return
 
     msg_type = data.get("type")
+
+    # --- stop_generation -------------------------------------------------
+    if msg_type == "stop_generation":
+        await _handle_stop_generation(data, send, active_tasks)
+        return
+
     if msg_type != "send_message":
         # Silently ignore unknown message types
         return
@@ -79,7 +112,25 @@ async def ws_chat(msg: str, send: Any, scope: dict[str, Any] | None = None) -> N
         await send(json.dumps({"type": "error", "message": "Vigane conversation_id."}))
         return
 
-    content = data.get("content", "").strip()
+    raw_content = data.get("content", "")
+    if not isinstance(raw_content, str):
+        await send(json.dumps({"type": "error", "message": "Vigane sõnumi sisu."}))
+        return
+
+    # Length-check BEFORE strip so a 10k+ payload of whitespace is still
+    # rejected — prevents obvious DoS via the orchestrator.
+    if len(raw_content) > _MAX_MESSAGE_LENGTH:
+        await send(
+            json.dumps(
+                {
+                    "type": "error",
+                    "message": "Sõnum on liiga pikk (max 10 000 märki).",
+                }
+            )
+        )
+        return
+
+    content = raw_content.strip()
     if not content:
         await send(json.dumps({"type": "error", "message": "Tühi sõnum."}))
         return
@@ -100,7 +151,77 @@ async def ws_chat(msg: str, send: Any, scope: dict[str, Any] | None = None) -> N
         """Serialize event as JSON and push to WS client."""
         await send(json.dumps(event, default=str))
 
-    await orchestrator.handle_message(conversation_id, content, auth, send_event)
+    conv_key = str(conversation_id)
+
+    async def _run() -> None:
+        try:
+            await orchestrator.handle_message(conversation_id, content, auth, send_event)
+        finally:
+            if active_tasks is not None:
+                active_tasks.pop(conv_key, None)
+
+    if active_tasks is not None:
+        task = asyncio.create_task(_run())
+        active_tasks[conv_key] = task
+        try:
+            await task
+        except asyncio.CancelledError:
+            # Swallow the cancel so the connection stays alive for
+            # the next user message. The orchestrator has already
+            # emitted a "stopped" event and persisted the partial.
+            logger.info("Chat stream cancelled for conversation %s", conv_key)
+    else:
+        # No task registry (test path) — run inline.
+        await orchestrator.handle_message(conversation_id, content, auth, send_event)
+
+
+async def _handle_stop_generation(
+    data: dict[str, Any],
+    send: Any,
+    active_tasks: dict[str, asyncio.Task[Any]] | None,
+) -> None:
+    """Cancel the orchestrator task for ``data['conversation_id']``.
+
+    The actual ``stopped`` event is emitted by the orchestrator's
+    ``CancelledError`` branch so the server owns the message_id.
+    """
+    raw_conv_id = data.get("conversation_id")
+    if not raw_conv_id:
+        await send(json.dumps({"type": "error", "message": "Puudub conversation_id."}))
+        return
+
+    try:
+        conversation_id = uuid.UUID(str(raw_conv_id))
+    except (ValueError, TypeError):
+        await send(json.dumps({"type": "error", "message": "Vigane conversation_id."}))
+        return
+
+    if active_tasks is None:
+        # No registry — nothing to cancel. Surface a minimal ack so the
+        # client isn't left hanging.
+        await send(
+            json.dumps(
+                {"type": "stopped", "message_id": None, "conversation_id": str(conversation_id)}
+            )
+        )
+        return
+
+    task = active_tasks.get(str(conversation_id))
+    if task is None or task.done():
+        await send(
+            json.dumps(
+                {"type": "stopped", "message_id": None, "conversation_id": str(conversation_id)}
+            )
+        )
+        return
+
+    task.cancel()
+    try:
+        await asyncio.shield(task)
+    except (asyncio.CancelledError, Exception):
+        # CancelledError is expected; any other exception has already
+        # been logged inside the orchestrator.
+        pass
 
 
 def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) -> str | None:
@@ -119,6 +240,22 @@ def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) 
     return None
 
 
+async def _ws_close(send: Any, code: int, reason: str) -> None:
+    """Attempt to close the WebSocket with *code*/*reason*.
+
+    FastHTML's ``send`` callback for WS is a plain ASGI send. We try the
+    ASGI ``websocket.close`` envelope first; if the runtime prefers a
+    JSON error event (e.g. in tests) we fall back to that.
+    """
+    try:
+        await send({"type": "websocket.close", "code": code, "reason": reason})
+    except Exception:
+        try:
+            await send(json.dumps({"type": "error", "message": reason, "code": code}))
+        except Exception:
+            logger.debug("Failed to close WS after provider init error", exc_info=True)
+
+
 def register_chat_ws_routes(app: Any) -> None:
     """Register the chat WebSocket route on the FastHTML *app*.
 
@@ -135,10 +272,28 @@ def register_chat_ws_routes(app: Any) -> None:
     # the first time a WS message arrives (avoids import-time DB hits).
     _jwt_provider: list[JWTAuthProvider | None] = [None]
 
-    def _get_jwt_provider() -> JWTAuthProvider:
+    def _get_jwt_provider() -> JWTAuthProvider | None:
+        """Return the shared JWT provider, constructing it lazily.
+
+        Returns ``None`` when construction fails (missing secret, DB
+        unreachable, etc.). Callers MUST treat ``None`` as a
+        fail-closed signal and reject the WS with close code ``1011``
+        instead of silently proceeding with empty auth (#594.4).
+        """
         if _jwt_provider[0] is None:
-            _jwt_provider[0] = JWTAuthProvider()
+            try:
+                _jwt_provider[0] = JWTAuthProvider()
+            except Exception:
+                logger.error("Failed to construct JWTAuthProvider", exc_info=True)
+                return None
         return _jwt_provider[0]
+
+    # One registry per connection is ideal, but the FastHTML WS hook
+    # doesn't give us a per-connection init spot other than ``conn``.
+    # The registry is keyed by (id(send), conversation_id) so that
+    # cancel targets the right socket's stream.  ``id(send)`` is stable
+    # for the lifetime of a single WS connection.
+    _per_send_tasks: dict[int, dict[str, asyncio.Task[Any]]] = {}
 
     async def _ws_handler(msg: str, send: Any, scope: dict[str, Any] | None = None) -> None:
         """Extract JWT from WS handshake cookies and pass auth scope to ws_chat."""
@@ -151,10 +306,61 @@ def register_chat_ws_routes(app: Any) -> None:
 
             if access_token:
                 provider = _get_jwt_provider()
+                if provider is None:
+                    # Fail-closed: we cannot verify tokens, so reject
+                    # the socket rather than letting the request
+                    # through as unauthenticated.
+                    await _ws_close(send, 1011, "auth provider unavailable")
+                    return
+
                 user = provider.get_current_user(access_token)
                 if user is not None:
                     auth_scope["auth"] = dict(user)
 
-        await ws_chat(msg, send, auth_scope if auth_scope else None)
+        key = id(send)
+        tasks = _per_send_tasks.setdefault(key, {})
+        try:
+            await ws_chat(
+                msg,
+                send,
+                auth_scope if auth_scope else None,
+                active_tasks=tasks,
+            )
+        except Exception:
+            # The socket is going away (disconnect, cancellation, handler
+            # error). Cancel every in-flight orchestrator task for this
+            # connection so they don't keep streaming into a dead send
+            # callable and so the registry never leaks an entry.
+            _cancel_all_and_drop(key)
+            raise
+        finally:
+            # Drop the registry slot once no tasks are running. If a task
+            # is still in-flight (normal mid-stream case) we leave it —
+            # its own ``_run`` finally-block pops the conversation key
+            # and the next handler call will GC the outer slot.
+            if not tasks:
+                _per_send_tasks.pop(key, None)
 
-    app.ws("/ws/chat", conn=on_connect, disconn=on_disconnect)(_ws_handler)
+    def _cancel_all_and_drop(key: int) -> None:
+        """Cancel every task registered under *key* and drop the slot."""
+        tasks = _per_send_tasks.pop(key, None)
+        if not tasks:
+            return
+        for task in list(tasks.values()):
+            if not task.done():
+                task.cancel()
+
+    async def _on_disconnect(send: Any) -> None:
+        """Clear the per-send task registry when the socket closes."""
+        try:
+            _cancel_all_and_drop(id(send))
+        finally:
+            await on_disconnect(send)
+
+    # Expose registry + disconnect hook on the handler so tests (and
+    # instrumentation) can inspect per-connection task state without
+    # poking at closure internals.
+    _ws_handler._per_send_tasks = _per_send_tasks  # type: ignore[attr-defined]
+    _ws_handler._on_disconnect = _on_disconnect  # type: ignore[attr-defined]
+
+    app.ws("/ws/chat", conn=on_connect, disconn=_on_disconnect)(_ws_handler)

--- a/app/config.py
+++ b/app/config.py
@@ -42,3 +42,16 @@ def is_stub_allowed() -> bool:
     lock-step with each other.
     """
     return os.environ.get("APP_ENV", "development") != "production"
+
+
+def is_chat_auto_title_enabled() -> bool:
+    """Return True when the chat auto-title feature should run.
+
+    Controlled by ``CHAT_AUTO_TITLE_ENABLED``. Any truthy value
+    (``"1"``, ``"true"``, ``"yes"``, ``"on"``, case-insensitive)
+    enables the feature. Defaults to True when unset.
+    """
+    raw = os.environ.get("CHAT_AUTO_TITLE_ENABLED")
+    if raw is None:
+        return True
+    return raw.strip().lower() in {"1", "true", "yes", "on"}

--- a/app/main.py
+++ b/app/main.py
@@ -131,6 +131,10 @@ _HDRS = (
     Link(rel="stylesheet", href="/static/css/fonts.css"),
     Link(rel="stylesheet", href="/static/css/tokens.css"),
     Link(rel="stylesheet", href="/static/css/ui.css"),
+    # Chat-specific stylesheet — small file (~7 KB), loaded globally so the
+    # card on /chat list page and the conversation view both pick it up without
+    # needing per-route <head> injection (which would land in <body> in FastHTML).
+    Link(rel="stylesheet", href="/static/css/chat.css"),
 )
 
 # Initialize Sentry before the ASGI app is created so that the Starlette

--- a/app/static/css/chat.css
+++ b/app/static/css/chat.css
@@ -1,0 +1,1529 @@
+/* ===========================================================================
+   Seadusloome — AI Advisory Chat Stylesheet
+   Depends on tokens.css (CSS variables) and ui.css (base reset + utilities).
+   NAV_HEIGHT = --topbar-height (64px) + --sidebar stays in the app-shell
+   layout; the chat column itself fills the main-content flex slot.
+   =========================================================================== */
+
+/* ===========================================================================
+   Visually-hidden utility
+   Note: ui.css defines .sr-only; we define .visually-hidden as a synonym
+   so templates may use either. If .sr-only is already present that is fine —
+   both definitions are identical and spec-conformant.
+   =========================================================================== */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ===========================================================================
+   Layout: chat-container + sub-regions
+   =========================================================================== */
+
+/* Outermost wrapper — fills the main-content flex slot */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  /* max-height (not min-height) prevents iOS overflow when dvh + safe-area
+     stacks taller than the visible screen. Flex layout pins the input bar. */
+  max-height: 100dvh;
+  max-width: 860px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+/* Scrollable message area — takes all available vertical space */
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+  /* Reserve a little breathing room around messages */
+  padding: var(--space-6) var(--space-4) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* Input bar — pinned to the bottom by flex layout; no sticky needed */
+.chat-input-area {
+  /* position: sticky removed — the container is already a flex column and the
+     input area naturally stays at the bottom. sticky has no effect here because
+     there is no scrolling ancestor at this level. */
+  /* Safe-area-inset accounts for iOS home indicator / Android nav bar */
+  padding: var(--space-3) var(--space-4) calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
+  background-color: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-3);
+  z-index: var(--z-sticky);
+  /* Contain the palette popover */
+  position: relative;
+}
+
+/* Textarea inside the input bar */
+.chat-input {
+  flex: 1;
+  font-family: var(--font-family);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-3) var(--space-4);
+  /* Disable manual resize handle — height grows via JS field-sizing API */
+  resize: none;
+  /* Prevent textarea from overflowing into a gigantic block */
+  max-height: 200px;
+  overflow-y: auto;
+  transition: border-color var(--transition-fast);
+  /* CSS field-sizing (Chrome 123+) makes the textarea auto-grow natively */
+  field-sizing: content;
+}
+
+.chat-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-primary);
+}
+
+.chat-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+/* ===========================================================================
+   Message bubbles
+   =========================================================================== */
+
+/* Full-width row — role modifiers control alignment */
+.chat-message {
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  /* Mild animation so new messages slide in gently */
+  animation: chat-msg-appear 0.18s ease both;
+}
+
+@keyframes chat-msg-appear {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Shared bubble baseline */
+.chat-bubble {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  line-height: 1.55;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+/* ---- User messages — right-aligned, brand tint ---- */
+
+.chat-message-user {
+  align-items: flex-end;
+}
+
+.chat-message-user .chat-bubble,
+/* Legacy class names already in routes.py JavaScript */
+.chat-bubble-user {
+  background-color: var(--color-primary-subtle);
+  color: var(--color-text);
+  border: 1px solid transparent;
+  /* Heavy radius on bottom-right, lighter on bottom-left (tail indication) */
+  border-radius: var(--radius-lg) var(--radius-lg) var(--radius-sm) var(--radius-lg);
+  max-width: 78%;
+  text-align: left;
+}
+
+/* ---- Assistant messages — left-aligned, surface card ---- */
+
+.chat-message-assistant {
+  align-items: flex-start;
+}
+
+.chat-message-assistant .chat-bubble,
+.chat-bubble-assistant {
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  /* Heavy radius on bottom-left */
+  border-radius: var(--radius-lg) var(--radius-lg) var(--radius-lg) var(--radius-sm);
+  max-width: 88%;
+}
+
+/* ---- Tool activity messages — centered, monospace pill ---- */
+
+.chat-message-tool {
+  align-items: center;
+}
+
+.chat-message-tool .chat-bubble,
+.chat-bubble-tool {
+  background-color: var(--color-background);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  font-family: var(--font-family-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-full);
+  max-width: 90%;
+}
+
+.chat-tool-label {
+  margin: 0;
+  font-family: var(--font-family-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* ---- Error messages — red-tinted ---- */
+
+.chat-message-error {
+  align-items: flex-start;
+}
+
+.chat-message-error .chat-bubble,
+.chat-bubble-error {
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-lg) var(--radius-lg) var(--radius-lg) var(--radius-sm);
+  max-width: 88%;
+}
+
+/* ===========================================================================
+   Markdown typography inside .chat-message-text
+   =========================================================================== */
+
+.chat-message-text {
+  line-height: 1.55;
+}
+
+/* Paragraphs — reset the browser default bottom margin to a controlled value */
+.chat-message-text p {
+  margin-block: 0.5em;
+}
+
+.chat-message-text p:first-child {
+  margin-block-start: 0;
+}
+
+.chat-message-text p:last-child {
+  margin-block-end: 0;
+}
+
+/* Headings inside chat — use a modest size hierarchy */
+.chat-message-text h1 {
+  font-size: var(--text-2xl);
+  margin-block: 0.75em 0.35em;
+}
+
+.chat-message-text h2 {
+  font-size: var(--text-xl);
+  margin-block: 0.7em 0.3em;
+}
+
+.chat-message-text h3 {
+  font-size: var(--text-lg);
+  margin-block: 0.65em 0.25em;
+}
+
+.chat-message-text h4 {
+  font-size: var(--text-base);
+  margin-block: 0.6em 0.2em;
+}
+
+/* Inline code */
+.chat-message-text code {
+  font-family: var(--font-family-mono);
+  font-size: 0.88em;
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+}
+
+/* Code blocks */
+.chat-message-text pre {
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  overflow-x: auto;
+  margin-block: var(--space-3);
+}
+
+.chat-message-text pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+}
+
+/* Blockquotes */
+.chat-message-text blockquote {
+  border-left: 3px solid var(--color-primary);
+  margin: var(--space-3) 0;
+  padding: var(--space-2) var(--space-4);
+  color: var(--color-text-muted);
+  background-color: var(--color-background);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+/* Lists */
+.chat-message-text ul,
+.chat-message-text ol {
+  padding-inline-start: var(--space-6);
+  margin-block: var(--space-2);
+}
+
+.chat-message-text li {
+  margin-block: var(--space-1);
+}
+
+/* Tables */
+.chat-message-text table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: var(--text-sm);
+  margin-block: var(--space-4);
+  overflow-x: auto;
+  display: block;
+}
+
+.chat-message-text th,
+.chat-message-text td {
+  border: 1px solid var(--color-border);
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+}
+
+.chat-message-text th {
+  background-color: var(--color-background);
+  font-weight: var(--font-bold);
+}
+
+/* Zebra-stripe rows */
+.chat-message-text tbody tr:nth-child(even) {
+  background-color: var(--color-background);
+}
+
+/* Links inside chat text */
+.chat-message-text a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.chat-message-text a:visited {
+  color: var(--color-primary);
+}
+
+.chat-message-text a:hover {
+  color: var(--color-primary-hover);
+}
+
+/* ===========================================================================
+   Citation links (from sanitize.py §-ref auto-link)
+   =========================================================================== */
+
+.citation-link {
+  color: var(--color-primary);
+  text-decoration: underline dashed;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.citation-link:visited {
+  color: var(--color-primary);
+}
+
+.citation-link:hover,
+.citation-link:focus-visible {
+  text-decoration: underline solid;
+  color: var(--color-primary-hover);
+}
+
+/* ===========================================================================
+   Sources panel (collapsible <details> below assistant bubble)
+   =========================================================================== */
+
+.chat-sources {
+  max-width: 88%;
+  margin-top: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.chat-sources summary {
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  user-select: none;
+  padding: var(--space-1) 0;
+  list-style: none; /* hide default arrow on some browsers */
+}
+
+/* Custom disclosure arrow */
+.chat-sources summary::before {
+  content: "▶";
+  display: inline-block;
+  margin-inline-end: var(--space-2);
+  font-size: 0.65em;
+  transition: transform var(--transition-fast);
+  vertical-align: middle;
+}
+
+.chat-sources[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.chat-sources summary:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Source cards list */
+.chat-sources ul {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.chat-sources li {
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+}
+
+/* ===========================================================================
+   Tool activity inline indicator
+   =========================================================================== */
+
+.chat-tool-activity {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  padding: var(--space-1) 0;
+}
+
+/* Animated spinner dot */
+.chat-tool-activity-spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--color-text-muted);
+  border-right-color: transparent;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+  animation: chat-spinner 0.75s linear infinite;
+}
+
+@keyframes chat-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* When done: hide spinner, show checkmark pseudo-element */
+.chat-tool-activity.chat-tool-activity-done .chat-tool-activity-spinner {
+  display: none;
+}
+
+.chat-tool-activity.chat-tool-activity-done::before {
+  content: "✓";
+  color: var(--color-success);
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+}
+
+.chat-tool-activity summary {
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  user-select: none;
+}
+
+.chat-tool-activity summary:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ===========================================================================
+   Header strip — connection status + quota
+   =========================================================================== */
+
+.chat-header-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+}
+
+/* ---- Connection status dot + label ---- */
+
+.chat-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* Status indicator dot — color is toggled with modifier classes */
+.chat-status::before {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.chat-status--connected::before {
+  background-color: var(--color-success);
+}
+
+.chat-status--disconnected::before {
+  background-color: var(--color-warning);
+}
+
+/* Pulsing animation while reconnecting */
+.chat-status--reconnecting::before {
+  background-color: var(--color-warning);
+  animation: chat-status-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes chat-status-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+/* ---- Quota pill ---- */
+
+/* Container: a relative pill with a fill bar inside */
+.chat-quota {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.chat-quota-bar-wrap {
+  position: relative;
+  width: 64px;
+  height: 6px;
+  background-color: var(--color-border);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.chat-quota-bar {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  height: 100%;
+  background-color: var(--color-primary);
+  border-radius: var(--radius-full);
+  transition: width var(--transition);
+}
+
+/* Amber threshold: add class .chat-quota--warning when usage >= 80% */
+.chat-quota--warning .chat-quota-bar {
+  background-color: var(--color-warning);
+}
+
+/* Red threshold: add class .chat-quota--critical when usage >= 100% */
+.chat-quota--critical .chat-quota-bar {
+  background-color: var(--color-danger);
+}
+
+/* Quota label — the text portion of the pill ("12 / 50 queries") */
+.chat-quota-label {
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+/* Compact quota on very small screens: bar-only, no label text */
+@media (max-width: 420px) {
+  /* Default full quota pill — hide the label text, keep the bar */
+  .chat-quota .chat-quota-label {
+    display: none;
+  }
+
+  /* Compact variant: bar only, no gap, minimal padding — fits in tight spaces */
+  .chat-quota--compact {
+    gap: 0;
+  }
+
+  .chat-quota--compact .chat-quota-label {
+    display: none;
+  }
+}
+
+/* ===========================================================================
+   Draft context badge strip
+   =========================================================================== */
+
+.chat-draft-context {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  background-color: var(--color-info-bg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.draft-context-link {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Secondary action link next to the draft badge (e.g. "View impact analysis") */
+.draft-context-impact-link {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-decoration: underline dashed;
+  text-underline-offset: 2px;
+  margin-inline-start: var(--space-2);
+  transition: color var(--transition-fast);
+}
+
+.draft-context-impact-link:hover {
+  color: var(--color-primary);
+  text-decoration: underline solid;
+}
+
+/* ===========================================================================
+   Empty state + example prompts
+   =========================================================================== */
+
+.chat-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+  padding-block: 4rem;
+  gap: var(--space-6);
+  color: var(--color-text-muted);
+}
+
+.chat-empty-state-icon {
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.chat-empty-state-title {
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.chat-empty-state-body {
+  font-size: var(--text-base);
+  margin: 0;
+}
+
+/* ---- Example prompt grid ---- */
+
+.chat-example-prompts {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-3);
+  text-align: left;
+}
+
+/* Individual prompt card — a reset <button> styled as a card */
+.chat-example-prompt {
+  /* Button reset */
+  appearance: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+
+  /* Card styling */
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--space-4);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  transition:
+    box-shadow var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.chat-example-prompt:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow);
+  transform: translateY(-2px);
+}
+
+.chat-example-prompt:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-lg);
+}
+
+.chat-example-prompt-label {
+  font-weight: var(--font-medium);
+  margin-block-end: var(--space-1);
+  color: var(--color-text);
+}
+
+.chat-example-prompt-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* ===========================================================================
+   Follow-up chips
+   =========================================================================== */
+
+.chat-follow-ups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block: var(--space-3);
+}
+
+.chat-follow-up-chip {
+  /* Button reset */
+  appearance: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-family);
+
+  /* Pill styling */
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-primary);
+  background-color: var(--color-primary-subtle);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-full);
+  line-height: var(--leading-normal);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-follow-up-chip:hover {
+  background-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.chat-follow-up-chip:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* ===========================================================================
+   Message action buttons (regenerate / copy / feedback)
+   =========================================================================== */
+
+.chat-message-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+  /* Hidden until the parent message is hovered or has keyboard focus */
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.chat-message:hover .chat-message-actions,
+.chat-message:focus-within .chat-message-actions {
+  opacity: 1;
+}
+
+/* Icon action button — minimal square with tooltip via title attribute */
+.chat-message-actions button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-message-actions button:hover {
+  background-color: var(--color-background);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.chat-message-actions button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* ===========================================================================
+   Toast notifications (CSS-only animation; JS controls visibility)
+   =========================================================================== */
+
+/* A single toast pill — positioned by .chat-toast-container below */
+.chat-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  box-shadow: var(--shadow-lg);
+  /* Entry/exit animation */
+  animation: chat-toast-in 0.22s ease both;
+  pointer-events: auto;
+}
+
+/* Auto-dismiss fade out — JS adds .chat-toast--leaving to trigger */
+.chat-toast--leaving {
+  animation: chat-toast-out 0.3s ease both;
+}
+
+@keyframes chat-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes chat-toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+}
+
+/* ---- Toast variants ---- */
+
+.chat-toast--info {
+  background-color: var(--color-info-bg);
+  color: var(--color-info);
+  border: 1px solid var(--color-info);
+}
+
+.chat-toast--success {
+  background-color: var(--color-success-bg);
+  color: var(--color-success);
+  border: 1px solid var(--color-success);
+}
+
+.chat-toast--warning {
+  background-color: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning);
+}
+
+.chat-toast--error {
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+}
+
+/* Container stack — fixed bottom-center, above everything */
+.chat-toast-container {
+  position: fixed;
+  bottom: calc(var(--space-6) + env(safe-area-inset-bottom, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--z-toast);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  pointer-events: none;
+}
+
+/* ===========================================================================
+   Misc utility classes used in chat routes
+   =========================================================================== */
+
+/* Delete form alignment */
+.chat-delete-form {
+  display: inline-block;
+}
+
+/* ---- Send / Stop buttons in the input bar ---- */
+
+.chat-send-btn,
+.chat-stop-btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: var(--text-base);
+  transition:
+    background-color var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.chat-send-btn {
+  background-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.chat-send-btn:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.chat-send-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.chat-send-btn:focus-visible,
+.chat-stop-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.chat-stop-btn {
+  background-color: var(--color-danger-bg);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
+}
+
+.chat-stop-btn:hover {
+  background-color: var(--color-danger);
+  color: #fff;
+}
+
+/* ---- Per-message action icon button (named variant) ---- */
+
+.chat-message-action-btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-message-action-btn:hover {
+  background-color: var(--color-background);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.chat-message-action-btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* ===========================================================================
+   Responsive adjustments
+   =========================================================================== */
+
+@media (max-width: 640px) {
+  .chat-messages {
+    padding: var(--space-4) var(--space-3) var(--space-3);
+    gap: var(--space-3);
+  }
+
+  .chat-input-area {
+    padding: var(--space-2) var(--space-3) calc(var(--space-2) + env(safe-area-inset-bottom, 0px));
+  }
+
+  /* Wider bubbles on small screens */
+  .chat-message-user .chat-bubble,
+  .chat-bubble-user {
+    max-width: 95%;
+  }
+
+  .chat-message-assistant .chat-bubble,
+  .chat-bubble-assistant {
+    max-width: 95%;
+  }
+
+  .chat-message-error .chat-bubble,
+  .chat-bubble-error {
+    max-width: 95%;
+  }
+
+  .chat-sources {
+    max-width: 95%;
+  }
+
+  .chat-empty-state {
+    padding-block: 2.5rem;
+  }
+
+  .chat-example-prompts {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================================================
+   Slash command palette
+   Anchored above the input area. JS sets display to block when open.
+   =========================================================================== */
+
+.chat-slash-palette {
+  display: none; /* shown by JS on "/" keypress */
+  position: absolute;
+  bottom: 100%; /* anchors just above the input bar */
+  left: var(--space-4);
+  right: var(--space-4);
+  z-index: var(--z-dropdown, 200);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  max-height: 260px;
+  overflow-y: auto;
+  padding: var(--space-1) 0;
+  /* Subtle slide-up entry when JS sets display:block */
+  animation: chat-palette-in 0.14s ease both;
+}
+
+@keyframes chat-palette-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Single command row */
+.chat-slash-palette-item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.chat-slash-palette-item:hover,
+.chat-slash-palette-item.is-active {
+  background-color: var(--color-primary-subtle);
+}
+
+.chat-slash-palette-item:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+
+/* Command name — brand colour, medium weight */
+.chat-slash-palette-label {
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  font-size: var(--text-sm);
+  flex-shrink: 0;
+}
+
+/* Short description — muted, monospace, slightly smaller */
+.chat-slash-palette-hint {
+  font-family: var(--font-family-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ===========================================================================
+   New-messages pill
+   Floats above the input bar when the user is scrolled up and a new
+   assistant message arrives.
+   =========================================================================== */
+
+.chat-new-messages-pill {
+  position: absolute;
+  bottom: calc(100% + var(--space-2));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--z-dropdown, 200);
+
+  /* Pill appearance */
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-4);
+  background-color: var(--color-primary);
+  color: var(--color-primary-text);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  white-space: nowrap;
+  border: none;
+  appearance: none;
+
+  animation: chat-pill-fadein 0.2s ease both;
+}
+
+@keyframes chat-pill-fadein {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+.chat-new-messages-pill:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.chat-new-messages-pill:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* ===========================================================================
+   Edit-in-place (user message editing)
+   =========================================================================== */
+
+/* Full-width textarea that replaces the message bubble while editing */
+.chat-edit-textarea {
+  width: 100%;
+  max-width: 78%; /* match .chat-bubble-user max-width */
+  font-family: var(--font-family);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border: 2px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  resize: vertical;
+  field-sizing: content;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.chat-edit-textarea:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Row of Save + Cancel buttons beneath the textarea */
+.chat-edit-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  justify-content: flex-end;
+  max-width: 78%;
+}
+
+/* Save — primary filled button */
+.chat-edit-save {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-4);
+  background-color: var(--color-primary);
+  color: var(--color-primary-text);
+  border: none;
+  border-radius: var(--radius);
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.chat-edit-save:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.chat-edit-save:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Cancel — ghost button */
+.chat-edit-cancel {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-4);
+  background-color: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.chat-edit-cancel:hover {
+  background-color: var(--color-background);
+  color: var(--color-text);
+}
+
+.chat-edit-cancel:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* ===========================================================================
+   Stopped / truncated message states
+   =========================================================================== */
+
+/* Italic note appended when streaming was interrupted */
+.chat-stopped-note {
+  display: block;
+  margin-block-start: var(--space-2);
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+/* Bubble modifier for truncated messages — amber dashed bottom border */
+.chat-message-truncated .chat-bubble {
+  border-bottom: 2px dashed var(--color-warning);
+}
+
+/* Modifier for pinned messages — amber left accent + subtle tinted background */
+.chat-message--pinned .chat-bubble {
+  border-left: 3px solid var(--color-warning);
+  background-color: color-mix(in srgb, var(--color-warning) 6%, var(--color-surface));
+}
+
+/* Small gold star in the top-right of a pinned message / conversation row */
+.chat-pin-indicator {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  font-size: var(--text-xs);
+  line-height: 1;
+  color: var(--color-warning);
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Make pinned message rows the positioning context for the indicator */
+.chat-message--pinned {
+  position: relative;
+}
+
+/* ===========================================================================
+   Tool activity details — spinner + pre blocks
+   =========================================================================== */
+
+/* Small circular CSS spinner used inside tool activity rows */
+.chat-tool-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+  animation: chat-tool-spin 0.7s linear infinite;
+}
+
+@keyframes chat-tool-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Scrollable code block for tool input payload */
+.chat-tool-input,
+.chat-tool-result {
+  display: block;
+  margin-block: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-family: var(--font-family-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  overflow-x: auto;
+  max-height: 240px;
+  overflow-y: auto;
+  white-space: pre;
+  /* Horizontal scroll without a horizontal scrollbar eating vertical space */
+  word-break: normal;
+  overflow-wrap: normal;
+}
+
+/* ===========================================================================
+   Source cards — snippet truncation
+   =========================================================================== */
+
+/* Two-line truncated preview of the retrieved source passage */
+.chat-source-snippet {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+  margin-block-start: var(--space-1);
+}
+
+/* Sources list — semantic ul override for the card list */
+.chat-sources-list {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* ===========================================================================
+   Conversation list toolbar + row actions
+   =========================================================================== */
+
+/* Toolbar row above the conversation list: search + archive toggle + New btn */
+.chat-list-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+  flex-wrap: wrap;
+}
+
+/* Search input matching the design system */
+.chat-search-input {
+  flex: 1;
+  min-width: 140px;
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  transition: border-color var(--transition-fast);
+}
+
+.chat-search-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.chat-search-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-primary);
+}
+
+/* Inline checkbox+label for "Show archived" toggle */
+.chat-archived-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.chat-archived-toggle input[type="checkbox"] {
+  accent-color: var(--color-primary);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+
+/* Flex row of action buttons inside each conversation list row */
+.chat-list-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+/* Inline form wrapper so pin/archive submit buttons sit beside each other */
+.chat-list-action-form {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Body region of the conversation list (the scrollable row area) */
+.chat-list-body {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* Inline rename textbox */
+.chat-list-rename-input {
+  font-family: var(--font-family);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  width: 100%;
+  transition: border-color var(--transition-fast);
+}
+
+.chat-list-rename-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Inline form wrapping the rename input + submit button */
+.chat-list-rename-form {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+/* ===========================================================================
+   Motion safety
+   =========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  /* Disable all animations / transitions in this sheet */
+  .chat-tool-activity-spinner {
+    animation: none;
+  }
+
+  .chat-status--reconnecting::before {
+    animation: none;
+  }
+
+  .chat-message {
+    animation: none;
+  }
+
+  .chat-toast,
+  .chat-toast--leaving {
+    animation: none;
+  }
+
+  .chat-quota-bar {
+    transition: none;
+  }
+
+  .chat-example-prompt:hover {
+    transform: none;
+  }
+
+  .chat-sources summary::before {
+    transition: none;
+  }
+
+  /* New spinner — disabled when motion is reduced */
+  .chat-tool-spinner {
+    animation: none;
+  }
+
+  /* Palette slide-in — disabled */
+  .chat-slash-palette {
+    animation: none;
+  }
+
+  /* New messages pill fade-in — disabled */
+  .chat-new-messages-pill {
+    animation: none;
+  }
+}

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -1,0 +1,1319 @@
+/**
+ * chat.js — Vestlus AI Advisory Chat WebSocket Client
+ *
+ * Replaces the inline IIFE that lived in app/chat/routes.py (_CHAT_JS).
+ * Loaded via <script src="/static/js/chat.js"> after marked.js and
+ * DOMPurify CDN scripts in the page head.
+ *
+ * ============================================================
+ * WebSocket event protocol
+ * ============================================================
+ *
+ * CLIENT → SERVER  (JSON objects)
+ * --------------------------------
+ *   {type: "send_message",    conversation_id, content}
+ *   {type: "stop_generation", conversation_id}
+ *
+ * SERVER → CLIENT  (JSON objects, all have `type`)
+ * --------------------------------
+ *   {type: "retrieval_started"}
+ *   {type: "retrieval_done",  chunk_count: N}
+ *   {type: "tool_use",        tool, input, tool_call_id}
+ *   {type: "tool_result",     tool, tool_call_id, result_count, result}
+ *   {type: "content_delta",   delta, message_id?}
+ *   {type: "done",            message_id}
+ *   {type: "sources",         message_id, sources: [{source_uri, title, score, snippet}]}
+ *   {type: "follow_ups",      message_id, suggestions: ["...", ...]}
+ *   {type: "stopped",         message_id}
+ *   {type: "error",           message}
+ *
+ * ============================================================
+ * Dependencies (must be loaded before this file)
+ * ============================================================
+ *   - marked.js   (window.marked)
+ *   - DOMPurify   (window.DOMPurify)
+ */
+
+/* global marked, DOMPurify */
+
+(function () {
+  'use strict';
+
+  // --------------------------------------------------------------------------
+  // Bootstrap: read conversation id from the container attribute.
+  // Exit silently when the chat container is not on this page.
+  // --------------------------------------------------------------------------
+
+  const container = document.getElementById('chat-container');
+  if (!container) return;
+
+  const convId = container.dataset.conversationId;
+  if (!convId) return;
+
+  // --------------------------------------------------------------------------
+  // Configure markdown parser once at module scope.
+  // ADD_ATTR ensures target="_blank" on links survives sanitisation.
+  // --------------------------------------------------------------------------
+
+  marked.setOptions({ breaks: true, gfm: true });
+
+  const PURIFY_CONFIG = {
+    ADD_ATTR: ['target'],
+  };
+
+  // --------------------------------------------------------------------------
+  // Slash command palette — mirrors app/chat/slash.py COMMANDS
+  // --------------------------------------------------------------------------
+
+  const SLASH_COMMANDS = [
+    { name: 'draft',          label: 'Loo eelnõu',      hint: '/draft <teema>' },
+    { name: 'compare',        label: 'Võrdle sättega',   hint: '/compare <URI>' },
+    { name: 'find-conflicts', label: 'Leia vastuolud',   hint: '/find-conflicts <teema>' },
+    { name: 'explain',        label: 'Selgita',          hint: '/explain <tekst>' },
+    { name: 'sources',        label: 'Näita allikaid',   hint: '/sources' },
+  ];
+
+  // Human-readable tool labels for tool_use events (mirrors orchestrator labels)
+  const TOOL_LABELS = {
+    query_ontology:      'Päring ontoloogiasse',
+    search_provisions:   'Otsin sätetest',
+    get_draft_impact:    'Analüüsin eelnõu mõju',
+    get_provision_details: 'Loen sätte detaile',
+  };
+
+  // --------------------------------------------------------------------------
+  // Estonian legal citation regex  (mirrors sanitize.py _CITATION_*_RE)
+  // --------------------------------------------------------------------------
+
+  // §-style: "KarS § 113", "TsUS § 5 lg 2", "PS § 13 lg 1 p 2"
+  const CITATION_PARAGRAPH_RE =
+    /\b[A-ZÕÄÖÜ][A-Za-zÕÄÖÜõäöü]{1,10}\s*§\s*\d+(?:\s*lg\s*\d+)?(?:\s*p\s*\d+)?\b/g;
+
+  // Article-style: "Art. 5", "Art. 5 lõige 2"
+  const CITATION_ARTICLE_RE = /\bArt\.\s*\d+(?:\s*l[õo]ige\s*\d+)?\b/g;
+
+  // Tags whose TEXT content must NOT be relinked
+  const SKIP_CITATION_TAGS = new Set(['a', 'code', 'pre', 'script', 'style']);
+
+  // --------------------------------------------------------------------------
+  // State
+  // --------------------------------------------------------------------------
+
+  let ws = null;
+  let reconnectAttempt = 0;
+  let reconnectTimer = null;
+  let streaming = false;
+  let wasConnected = false;
+  // Set when the WS closes mid-stream; the next successful open surfaces a
+  // broken-response note, releases the send button, and clears pendingBubble.
+  // We deliberately do NOT auto-resend — simpler + predictable for the user.
+  let brokenMidStream = false;
+
+  // Per-message-id accumulation buffer and bubble element map
+  const msgBuffers = {};   // message_id → accumulated text string
+  const msgBubbles = {};   // message_id → .chat-message element
+
+  // Transient (pre-done) streaming state
+  let pendingMsgId = null;  // provisional id while streaming before done arrives
+  let pendingBubble = null; // the live assistant bubble being streamed into
+
+  // Slash palette keyboard selection index
+  let paletteIndex = -1;
+
+  // Quota refresh timer id
+  let quotaTimer = null;
+
+  // --------------------------------------------------------------------------
+  // DOM references (looked up once — all are optional; guarded before use)
+  // --------------------------------------------------------------------------
+
+  const messagesEl   = document.getElementById('chat-messages');
+  const inputEl      = document.getElementById('chat-input');
+  const sendBtn      = document.getElementById('chat-send-btn');
+  const stopBtn      = document.getElementById('chat-stop-btn');
+  const statusEl     = document.getElementById('chat-status');
+  const paletteEl    = document.getElementById('chat-slash-palette');
+  const quotaEl      = document.getElementById('chat-quota');
+
+  // --------------------------------------------------------------------------
+  // § 3 — Toast helper
+  // --------------------------------------------------------------------------
+
+  function getOrCreateToastContainer() {
+    let el = document.querySelector('.chat-toast-container');
+    if (!el) {
+      el = document.createElement('div');
+      el.className = 'chat-toast-container';
+      document.body.appendChild(el);
+    }
+    return el;
+  }
+
+  /**
+   * Show a transient notification.
+   * @param {string} msg      Notification text.
+   * @param {string} variant  'success' | 'warning' | 'info' | 'error'
+   * @param {number} ttl      Auto-dismiss delay in ms (default 4000).
+   */
+  function showToast(msg, variant, ttl) {
+    // Named ``toastContainer`` (not ``container``) to avoid shadowing the
+    // module-level ``container`` reference to ``#chat-container``.
+    const toastContainer = getOrCreateToastContainer();
+    const ttlMs = typeof ttl === 'number' ? ttl : 4000;
+
+    const toast = document.createElement('div');
+    toast.className = 'chat-toast chat-toast--' + variant;
+    toast.textContent = msg;
+    toastContainer.appendChild(toast);
+
+    setTimeout(function () {
+      toast.classList.add('chat-toast--leaving');
+      setTimeout(function () {
+        if (toast.parentNode) toast.parentNode.removeChild(toast);
+      }, 200);
+    }, ttlMs);
+  }
+
+  // --------------------------------------------------------------------------
+  // § 14 — Quota pill
+  // --------------------------------------------------------------------------
+
+  function refreshQuota() {
+    fetch('/api/me/usage', { credentials: 'same-origin' })
+      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (data) {
+        if (!data || !quotaEl) return;
+        renderQuotaPill(data);
+      })
+      .catch(function () { /* quota is best-effort */ });
+  }
+
+  function renderQuotaPill(data) {
+    if (!quotaEl) return;
+
+    const pct = (data.percentages && data.percentages.messages) || 0;
+    const used = data.messages_this_hour || 0;
+    const limit = data.message_limit_per_hour || 0;
+    const remaining = data.messages_remaining || 0;
+    const secs = data.seconds_until_reset || 0;
+
+    quotaEl.setAttribute('aria-valuenow', String(Math.round(pct)));
+
+    // First real paint: drop the server-rendered aria-busy so screen readers
+    // stop announcing the pill as loading.
+    if (quotaEl.dataset.initial === 'true') {
+      quotaEl.removeAttribute('aria-busy');
+      delete quotaEl.dataset.initial;
+    }
+
+    quotaEl.classList.remove('chat-quota--warning', 'chat-quota--critical');
+    if (pct >= 100) {
+      quotaEl.classList.add('chat-quota--critical');
+    } else if (pct >= 80) {
+      quotaEl.classList.add('chat-quota--warning');
+    }
+
+    // If viewport <= 420px the CSS class hints compact mode; JS just adds it.
+    if (window.innerWidth <= 420) {
+      quotaEl.classList.add('chat-quota--compact');
+    } else {
+      quotaEl.classList.remove('chat-quota--compact');
+    }
+
+    let label;
+    if (remaining === 0 && secs > 0) {
+      const mins = Math.ceil(secs / 60);
+      label = 'Proovige uuesti ' + mins + ' min pärast';
+    } else {
+      label = used + '/' + limit + ' sõnumit selles tunnis';
+    }
+
+    // Update the text inside the pill without replacing the whole element
+    // so that aria-* attributes stay stable.
+    const labelEl = quotaEl.querySelector('.chat-quota-label');
+    if (labelEl) {
+      labelEl.textContent = label;
+    } else {
+      quotaEl.textContent = label;
+    }
+  }
+
+  function startQuotaPolling() {
+    refreshQuota();
+    quotaTimer = setInterval(function () {
+      if (!document.hidden) refreshQuota();
+    }, 60_000);
+  }
+
+  // --------------------------------------------------------------------------
+  // § 2 — WebSocket lifecycle
+  // --------------------------------------------------------------------------
+
+  function setStatus(state) {
+    if (!statusEl) return;
+    statusEl.className = 'chat-status chat-status--' + state;
+    const labels = {
+      connected:    'Ühendatud',
+      reconnecting: 'Taastub...',
+      disconnected: 'Ühendus katkes',
+    };
+    statusEl.textContent = labels[state] || state;
+  }
+
+  function connect() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(proto + '//' + location.host + '/ws/chat');
+
+    ws.addEventListener('open', function () {
+      if (wasConnected) {
+        showToast('Ühendus taastatud', 'success');
+      }
+      wasConnected = true;
+      reconnectAttempt = 0;
+      setStatus('connected');
+
+      // Recovery after a mid-stream disconnect: the server will not resume
+      // the broken turn, so surface the break to the user, unlock the input,
+      // and clear transient streaming state. No auto-resend — the user
+      // re-sends manually if they want another attempt.
+      if (brokenMidStream) {
+        brokenMidStream = false;
+        if (pendingBubble) {
+          const chatBubble = pendingBubble.querySelector('.chat-bubble');
+          const note = document.createElement('p');
+          note.className = 'chat-stopped-note';
+          note.textContent =
+            '— ühendus katkes, vajutage genereerimiseks uuesti';
+          if (chatBubble) chatBubble.appendChild(note);
+        }
+        pendingBubble = null;
+        pendingMsgId = null;
+        enableInput();
+        showToast('Ühendus taastus — vastus jäi pooleli', 'warning');
+      }
+    });
+
+    ws.addEventListener('close', function () {
+      setStatus(reconnectAttempt === 0 ? 'disconnected' : 'reconnecting');
+      if (reconnectAttempt === 0) {
+        showToast('Ühendus katkes — proovin taastada...', 'warning');
+      }
+      // Remember that the socket died while a response was being streamed;
+      // the next ``open`` handler uses this to recover the UI state.
+      if (streaming) {
+        brokenMidStream = true;
+      }
+      scheduleReconnect();
+    });
+
+    ws.addEventListener('message', function (evt) {
+      let event;
+      try {
+        event = JSON.parse(evt.data);
+      } catch (e) {
+        return; // ignore unparseable frames
+      }
+      handleServerEvent(event);
+    });
+
+    ws.addEventListener('error', function () {
+      // 'close' fires right after 'error'; let that handler do the work.
+    });
+  }
+
+  function scheduleReconnect() {
+    if (reconnectTimer) return; // already scheduled
+    // Exponential backoff: 1s, 2s, 4s, 8s, cap 16s
+    const delay = Math.min(1000 * Math.pow(2, reconnectAttempt), 16_000);
+    reconnectAttempt++;
+    setStatus('reconnecting');
+    reconnectTimer = setTimeout(function () {
+      reconnectTimer = null;
+      connect();
+    }, delay);
+  }
+
+  function wsSend(payload) {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    ws.send(JSON.stringify(payload));
+    return true;
+  }
+
+  // --------------------------------------------------------------------------
+  // § 4 — Live streaming render helpers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Return the distance in pixels the user has scrolled away from the bottom.
+   */
+  function distanceFromBottom() {
+    if (!messagesEl) return 0;
+    return messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight;
+  }
+
+  function scrollToBottom() {
+    if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  function maybeScrollToBottom() {
+    if (distanceFromBottom() <= 80) {
+      scrollToBottom();
+    } else {
+      showNewMessagesPill();
+    }
+  }
+
+  function showNewMessagesPill() {
+    if (document.getElementById('chat-new-messages-pill')) return;
+    const pill = document.createElement('button');
+    pill.id = 'chat-new-messages-pill';
+    pill.className = 'chat-new-messages-pill';
+    pill.textContent = '↓ Uued sõnumid';
+    pill.setAttribute('type', 'button');
+    pill.addEventListener('click', function () {
+      scrollToBottom();
+      removePill();
+    });
+    // Insert just before the input area
+    const inputArea = container.querySelector('.chat-input-area');
+    if (inputArea) {
+      container.insertBefore(pill, inputArea);
+    } else if (messagesEl && messagesEl.parentNode) {
+      messagesEl.parentNode.insertBefore(pill, messagesEl.nextSibling);
+    }
+  }
+
+  function removePill() {
+    const pill = document.getElementById('chat-new-messages-pill');
+    if (pill && pill.parentNode) pill.parentNode.removeChild(pill);
+  }
+
+  // Remove pill once user scrolls close to bottom manually
+  if (messagesEl) {
+    messagesEl.addEventListener('scroll', function () {
+      if (distanceFromBottom() <= 80) removePill();
+    }, { passive: true });
+  }
+
+  /**
+   * Create a new assistant bubble and add it to the messages container.
+   * Returns the bubble element.
+   */
+  function createAssistantBubble(msgId) {
+    const wrap = document.createElement('div');
+    wrap.className = 'chat-message chat-message-assistant';
+    if (msgId) wrap.dataset.messageId = msgId;
+
+    wrap.innerHTML =
+      '<div class="chat-bubble chat-bubble-assistant">' +
+        '<div class="chat-message-text"></div>' +
+      '</div>';
+
+    if (messagesEl) messagesEl.appendChild(wrap);
+    return wrap;
+  }
+
+  /**
+   * Re-render the accumulated text buffer into the bubble's text container.
+   */
+  function renderBuffer(bubble, text) {
+    const textEl = bubble.querySelector('.chat-message-text');
+    if (!textEl) return;
+    const html = DOMPurify.sanitize(marked.parse(text), PURIFY_CONFIG);
+    textEl.innerHTML = html;
+    linkifyCitations(textEl);
+  }
+
+  // --------------------------------------------------------------------------
+  // § 4 (continued) — Estonian legal citation auto-linker (client-side)
+  // Uses a TreeWalker to visit text nodes; wraps matches with <a>.
+  // Skips inside <a>, <code>, <pre>.
+  // --------------------------------------------------------------------------
+
+  function linkifyCitations(root) {
+    // Collect candidate text nodes first (mutating during walk is unsafe).
+    const candidates = [];
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (node) {
+        // Walk up and skip if we're inside a forbidden ancestor
+        let el = node.parentElement;
+        while (el && el !== root) {
+          if (SKIP_CITATION_TAGS.has(el.tagName.toLowerCase())) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          el = el.parentElement;
+        }
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+    let node;
+    while ((node = walker.nextNode())) {
+      candidates.push(node);
+    }
+
+    for (const textNode of candidates) {
+      const original = textNode.nodeValue;
+      if (!original) continue;
+
+      // Reset lastIndex before each search
+      CITATION_PARAGRAPH_RE.lastIndex = 0;
+      CITATION_ARTICLE_RE.lastIndex = 0;
+
+      const matches = [];
+      let m;
+      CITATION_PARAGRAPH_RE.lastIndex = 0;
+      while ((m = CITATION_PARAGRAPH_RE.exec(original)) !== null) {
+        matches.push({ start: m.index, end: m.index + m[0].length, text: m[0] });
+      }
+      CITATION_ARTICLE_RE.lastIndex = 0;
+      while ((m = CITATION_ARTICLE_RE.exec(original)) !== null) {
+        matches.push({ start: m.index, end: m.index + m[0].length, text: m[0] });
+      }
+      if (matches.length === 0) continue;
+
+      // Sort and de-overlap (keep earliest; on tie keep longest)
+      matches.sort(function (a, b) {
+        return a.start !== b.start ? a.start - b.start : (b.end - b.start) - (a.end - a.start);
+      });
+      const nonOverlapping = [];
+      let lastEnd = -1;
+      for (const match of matches) {
+        if (match.start < lastEnd) continue;
+        nonOverlapping.push(match);
+        lastEnd = match.end;
+      }
+
+      // Build fragment with text + anchor nodes
+      const frag = document.createDocumentFragment();
+      let cursor = 0;
+      for (const match of nonOverlapping) {
+        if (match.start > cursor) {
+          frag.appendChild(document.createTextNode(original.slice(cursor, match.start)));
+        }
+        const anchor = document.createElement('a');
+        anchor.className = 'citation-link';
+        anchor.href = '/explorer?q=' + encodeURIComponent(match.text);
+        anchor.textContent = match.text;
+        frag.appendChild(anchor);
+        cursor = match.end;
+      }
+      if (cursor < original.length) {
+        frag.appendChild(document.createTextNode(original.slice(cursor)));
+      }
+
+      textNode.parentNode.replaceChild(frag, textNode);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // § 4 (continued) — Get-or-create streaming bubble
+  // --------------------------------------------------------------------------
+
+  function getOrCreateStreamingBubble(msgId) {
+    // Prefer a stable msgId; fall back to the current pendingBubble.
+    if (msgId && msgBubbles[msgId]) return msgBubbles[msgId];
+
+    if (msgId && pendingBubble) {
+      // Promote pendingBubble to the real msgId
+      pendingBubble.dataset.messageId = msgId;
+      msgBubbles[msgId] = pendingBubble;
+      if (pendingMsgId && pendingMsgId !== msgId) {
+        delete msgBubbles[pendingMsgId];
+        delete msgBuffers[pendingMsgId];
+      }
+      pendingMsgId = msgId;
+      return pendingBubble;
+    }
+
+    if (pendingBubble) return pendingBubble;
+
+    // Create brand-new bubble
+    const bubble = createAssistantBubble(msgId || null);
+    pendingBubble = bubble;
+    pendingMsgId = msgId || ('_pending_' + Date.now());
+    if (msgId) msgBubbles[msgId] = bubble;
+    return bubble;
+  }
+
+  // --------------------------------------------------------------------------
+  // § 5 — Tool activity
+  // --------------------------------------------------------------------------
+
+  function toolLabel(toolName) {
+    return TOOL_LABELS[toolName] || toolName;
+  }
+
+  /**
+   * Create a <details> element for a tool_use event and insert it before
+   * the next assistant content (or at end of messages).
+   */
+  function createToolActivity(toolCallId, toolName, input) {
+    const details = document.createElement('details');
+    details.className = 'chat-tool-activity';
+    details.dataset.toolCallId = toolCallId;
+
+    const label = toolLabel(toolName);
+    const spinner = '<span class="chat-tool-spinner" aria-hidden="true"></span>';
+
+    const summary = document.createElement('summary');
+    summary.innerHTML = spinner + label;
+    details.appendChild(summary);
+
+    const pre = document.createElement('pre');
+    pre.className = 'chat-tool-input';
+    pre.textContent = JSON.stringify(input, null, 2);
+    details.appendChild(pre);
+
+    if (messagesEl) messagesEl.appendChild(details);
+    return details;
+  }
+
+  /**
+   * Find an existing tool activity <details> by tool_call_id.
+   */
+  function findToolActivity(toolCallId) {
+    return messagesEl
+      ? messagesEl.querySelector('.chat-tool-activity[data-tool-call-id="' + toolCallId + '"]')
+      : null;
+  }
+
+  /**
+   * Mark a tool activity as done with its result.
+   */
+  function completeToolActivity(toolCallId, toolName, resultCount, result) {
+    const details = findToolActivity(toolCallId);
+    if (!details) return;
+
+    details.classList.add('chat-tool-activity-done');
+
+    const summary = details.querySelector('summary');
+    if (summary) {
+      const spinnerEl = summary.querySelector('.chat-tool-spinner');
+      if (spinnerEl && spinnerEl.parentNode) spinnerEl.parentNode.removeChild(spinnerEl);
+      summary.textContent = '✓ ' + toolLabel(toolName) + ' — ' + resultCount + ' tulemust';
+    }
+
+    const resultPre = document.createElement('pre');
+    resultPre.className = 'chat-tool-result';
+    resultPre.textContent = JSON.stringify(result, null, 2);
+    details.appendChild(resultPre);
+  }
+
+  // --------------------------------------------------------------------------
+  // § 6 — Sources panel
+  // --------------------------------------------------------------------------
+
+  function appendSources(bubble, sources) {
+    const details = document.createElement('details');
+    details.className = 'chat-sources';
+
+    const summary = document.createElement('summary');
+
+    if (!sources || sources.length === 0) {
+      summary.textContent = 'Allikaid ei leitud';
+      details.appendChild(summary);
+    } else {
+      summary.textContent = 'Allikad (' + sources.length + ')';
+      details.appendChild(summary);
+
+      const ul = document.createElement('ul');
+      for (const src of sources) {
+        const li = document.createElement('li');
+
+        const uri = src.source_uri || '';
+        const title = src.title || uriLastSegment(uri) || uri;
+        const snippet = src.snippet || '';
+
+        const a = document.createElement('a');
+        a.href = '/explorer?q=' + encodeURIComponent(uri);
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.textContent = title;
+
+        const p = document.createElement('p');
+        // Use textContent to escape snippet — no raw HTML
+        p.textContent = snippet;
+
+        li.appendChild(a);
+        if (snippet) li.appendChild(p);
+        ul.appendChild(li);
+      }
+      details.appendChild(ul);
+    }
+
+    const chatBubble = bubble.querySelector('.chat-bubble');
+    if (chatBubble) {
+      chatBubble.appendChild(details);
+    } else {
+      bubble.appendChild(details);
+    }
+  }
+
+  function uriLastSegment(uri) {
+    try {
+      const parts = uri.replace(/\/$/, '').split('/');
+      return decodeURIComponent(parts[parts.length - 1]);
+    } catch (e) {
+      return uri;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // § 7 — Follow-up suggestion chips
+  // --------------------------------------------------------------------------
+
+  function appendFollowUps(bubble, suggestions) {
+    if (!suggestions || suggestions.length === 0) return;
+
+    const chipsDiv = document.createElement('div');
+    chipsDiv.className = 'chat-follow-ups';
+
+    for (const suggestion of suggestions) {
+      const btn = document.createElement('button');
+      btn.className = 'chat-follow-up-chip';
+      btn.type = 'button';
+      btn.textContent = suggestion;
+      btn.addEventListener('click', function () {
+        if (inputEl) inputEl.value = suggestion;
+        // Remove chip container after use
+        if (chipsDiv.parentNode) chipsDiv.parentNode.removeChild(chipsDiv);
+        sendMessage();
+      });
+      chipsDiv.appendChild(btn);
+    }
+
+    const chatBubble = bubble.querySelector('.chat-bubble');
+    if (chatBubble) {
+      chatBubble.appendChild(chipsDiv);
+    } else {
+      bubble.appendChild(chipsDiv);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // § 8 — Done / Stopped / Error helpers
+  // --------------------------------------------------------------------------
+
+  // Streaming lock: we only gate the *send* path, never the textarea. Users
+  // must stay free to scroll, select, copy, or compose their next message
+  // while the assistant is still streaming. The legacy names are kept so
+  // callers read naturally ("enable input for sending" / "lock sending").
+  function enableInput() {
+    // inputEl.disabled is intentionally NOT toggled — textarea stays usable.
+    if (sendBtn) sendBtn.disabled = false;
+    if (stopBtn) {
+      stopBtn.disabled = false;
+      stopBtn.style.display = 'none';
+    }
+    streaming = false;
+  }
+
+  function disableInput() {
+    // inputEl.disabled is intentionally NOT toggled — textarea stays usable
+    // while the assistant streams so users can compose the follow-up.
+    if (sendBtn) sendBtn.disabled = true;
+    if (stopBtn) {
+      stopBtn.disabled = false;
+      stopBtn.style.display = '';
+    }
+    streaming = true;
+  }
+
+  function finaliseBubble(msgId) {
+    // Promote any pending bubble to the real message id
+    if (msgId && pendingBubble && !msgBubbles[msgId]) {
+      pendingBubble.dataset.messageId = msgId;
+      msgBubbles[msgId] = pendingBubble;
+    }
+    pendingBubble = null;
+    pendingMsgId = null;
+  }
+
+  function appendErrorBubble(message) {
+    const div = document.createElement('div');
+    div.className = 'chat-message chat-message-error';
+    div.innerHTML =
+      '<div class="chat-bubble chat-bubble-error">' +
+        '<p>' + escapeHtml(message || 'Viga') + '</p>' +
+      '</div>';
+    if (messagesEl) messagesEl.appendChild(div);
+    scrollToBottom();
+  }
+
+  // --------------------------------------------------------------------------
+  // Main event dispatcher
+  // --------------------------------------------------------------------------
+
+  function handleServerEvent(event) {
+    switch (event.type) {
+
+      // -----------------------------------------------------------------------
+      case 'retrieval_started':
+        // Could show a subtle "Otsin..." indicator; for now a no-op is fine
+        // since tool_use events immediately follow.
+        break;
+
+      // -----------------------------------------------------------------------
+      case 'retrieval_done':
+        // chunk_count available if UI wants to display it; currently no-op.
+        break;
+
+      // -----------------------------------------------------------------------
+      case 'tool_use': {
+        const toolCallId = event.tool_call_id || ('tool_' + Date.now());
+        createToolActivity(toolCallId, event.tool || '', event.input || {});
+        maybeScrollToBottom();
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'tool_result': {
+        completeToolActivity(
+          event.tool_call_id || '',
+          event.tool || '',
+          typeof event.result_count === 'number' ? event.result_count : 0,
+          event.result
+        );
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'content_delta': {
+        const msgId = event.message_id || null;
+        const bubble = getOrCreateStreamingBubble(msgId);
+
+        // Resolve buffer key
+        const bufKey = msgId || pendingMsgId;
+        if (!msgBuffers[bufKey]) msgBuffers[bufKey] = '';
+        msgBuffers[bufKey] += event.delta || '';
+
+        renderBuffer(bubble, msgBuffers[bufKey]);
+        maybeScrollToBottom();
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'done': {
+        const msgId = event.message_id;
+        finaliseBubble(msgId);
+        enableInput();
+        scrollToBottom();
+        if (inputEl) inputEl.focus();
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'sources': {
+        const bubble = msgBubbles[event.message_id] || pendingBubble;
+        if (bubble) appendSources(bubble, event.sources || []);
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'follow_ups': {
+        const bubble = msgBubbles[event.message_id] || pendingBubble;
+        if (bubble) appendFollowUps(bubble, event.suggestions || []);
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'stopped': {
+        const msgId = event.message_id;
+        finaliseBubble(msgId);
+        // Append truncation note to the last assistant bubble
+        const bubble = (msgId && msgBubbles[msgId]) || pendingBubble;
+        if (bubble) {
+          const note = document.createElement('p');
+          note.className = 'chat-stopped-note';
+          note.textContent = '— vastus katkestati';
+          const chatBubble = bubble.querySelector('.chat-bubble');
+          if (chatBubble) chatBubble.appendChild(note);
+        }
+        enableInput();
+        showToast('Genereerimine peatatud', 'info');
+        if (inputEl) inputEl.focus();
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      case 'error': {
+        finaliseBubble(null);
+        appendErrorBubble(event.message);
+        enableInput();
+        if (inputEl) inputEl.focus();
+        // Rate-limit hit: refresh quota display
+        if (event.message && event.message.toLowerCase().includes('limiit')) {
+          refreshQuota();
+        }
+        break;
+      }
+
+      // -----------------------------------------------------------------------
+      default:
+        // Unknown server event — silently ignore.
+        break;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // § 12 — User message rendering (optimistic, before WS echo)
+  // --------------------------------------------------------------------------
+
+  function appendUserBubble(text) {
+    const div = document.createElement('div');
+    div.className = 'chat-message chat-message-user';
+    div.innerHTML =
+      '<div class="chat-bubble chat-bubble-user">' +
+        '<p class="chat-message-text">' + escapeHtml(text) + '</p>' +
+      '</div>';
+    if (messagesEl) messagesEl.appendChild(div);
+    scrollToBottom();
+    return div;
+  }
+
+  // --------------------------------------------------------------------------
+  // Send message
+  // --------------------------------------------------------------------------
+
+  function sendMessage() {
+    if (!inputEl) return;
+    const text = inputEl.value.trim();
+    if (!text) return;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      showToast('Ühendus puudub — palun oodake...', 'warning');
+      return;
+    }
+
+    appendUserBubble(text);
+    hidePalette();
+    hideEmptyState();
+
+    wsSend({ type: 'send_message', conversation_id: convId, content: text });
+
+    inputEl.value = '';
+    autoGrowTextarea(inputEl);
+    disableInput();
+    // disableInput() no longer toggles inputEl.disabled (textarea stays
+    // writable during streaming), so there is nothing to re-enable here.
+    // Return focus to the textarea for keyboard users.
+    if (inputEl) inputEl.focus();
+  }
+
+  // --------------------------------------------------------------------------
+  // § 9 — Stop button
+  // --------------------------------------------------------------------------
+
+  if (stopBtn) {
+    stopBtn.style.display = 'none'; // hidden until streaming starts
+    stopBtn.addEventListener('click', function () {
+      stopBtn.disabled = true;
+      showToast('Peatamine...', 'info');
+      wsSend({ type: 'stop_generation', conversation_id: convId });
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // § 10 — Keyboard shortcuts + textarea auto-grow
+  // --------------------------------------------------------------------------
+
+  // Skip JS-driven height manipulation when the browser already handles it
+  // natively via CSS ``field-sizing: content``. Manipulating style.height on
+  // top of field-sizing causes the two mechanisms to fight (jittery resize).
+  const SUPPORTS_FIELD_SIZING =
+    typeof CSS !== 'undefined' &&
+    typeof CSS.supports === 'function' &&
+    CSS.supports('field-sizing', 'content');
+
+  function autoGrowTextarea(el) {
+    if (!el) return;
+    if (SUPPORTS_FIELD_SIZING) return; // CSS already sizes the textarea.
+    el.style.height = 'auto';
+    const maxHeight = 200;
+    el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px';
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }
+
+  if (inputEl) {
+    inputEl.addEventListener('input', function () {
+      autoGrowTextarea(inputEl);
+
+      // Slash palette trigger: show palette when input starts with '/'
+      const val = inputEl.value;
+      if (val.startsWith('/')) {
+        const prefix = val.slice(1).split(' ')[0];
+        showPalette(prefix);
+      } else {
+        hidePalette();
+      }
+    });
+
+    inputEl.addEventListener('keydown', function (e) {
+      // Slash palette navigation takes priority when palette is open
+      if (paletteEl && !paletteEl.hidden) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          movePaletteSelection(1);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          movePaletteSelection(-1);
+          return;
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          selectPaletteItem();
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          hidePalette();
+          // Fall through to the streaming-stop check below: a user pressing
+          // Esc while the palette is open AND a response is streaming
+          // expects both things to happen (close palette + stop generation).
+          if (streaming && stopBtn && !stopBtn.disabled) {
+            stopBtn.click();
+          }
+          return;
+        }
+      }
+
+      // Cmd/Ctrl+Enter → send
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (!streaming) sendMessage();
+        return;
+      }
+
+      // Plain Enter → insert newline (default textarea behaviour — do nothing)
+
+      // Escape while streaming → trigger stop
+      if (e.key === 'Escape' && streaming) {
+        e.preventDefault();
+        if (stopBtn && !stopBtn.disabled) stopBtn.click();
+        return;
+      }
+
+      // '/' at position 0 with empty value → open slash palette
+      if (e.key === '/' && inputEl.value === '' && inputEl.selectionStart === 0) {
+        // Let the character be typed first (input event fires after), but
+        // also pre-open the full palette.
+        setTimeout(function () { showPalette(''); }, 0);
+      }
+    });
+  }
+
+  if (sendBtn) {
+    sendBtn.addEventListener('click', function () {
+      if (!streaming) sendMessage();
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // § 11 — Slash command palette
+  // --------------------------------------------------------------------------
+
+  function showPalette(prefix) {
+    if (!paletteEl) return;
+
+    const lower = prefix.toLowerCase();
+    const matches = lower === ''
+      ? SLASH_COMMANDS
+      : SLASH_COMMANDS.filter(function (cmd) { return cmd.name.startsWith(lower); });
+
+    if (matches.length === 0) {
+      hidePalette();
+      return;
+    }
+
+    paletteEl.innerHTML = '';
+    paletteIndex = -1;
+
+    for (let i = 0; i < matches.length; i++) {
+      const cmd = matches[i];
+      const li = document.createElement('li');
+      li.className = 'chat-slash-palette-item';
+      li.dataset.name = cmd.name;
+      li.setAttribute('role', 'option');
+      li.innerHTML =
+        '<span class="chat-slash-palette-label">' + escapeHtml(cmd.label) + '</span>' +
+        '<span class="chat-slash-palette-hint">' + escapeHtml(cmd.hint) + '</span>';
+
+      li.addEventListener('mousedown', function (e) {
+        // mousedown fires before blur — prevent focus loss from input
+        e.preventDefault();
+        insertSlashCommand(cmd.name);
+      });
+
+      paletteEl.appendChild(li);
+    }
+
+    paletteEl.hidden = false;
+  }
+
+  function hidePalette() {
+    if (!paletteEl) return;
+    paletteEl.hidden = true;
+    paletteIndex = -1;
+  }
+
+  function movePaletteSelection(delta) {
+    if (!paletteEl || paletteEl.hidden) return;
+    const items = paletteEl.querySelectorAll('.chat-slash-palette-item');
+    if (items.length === 0) return;
+
+    if (paletteIndex >= 0 && paletteIndex < items.length) {
+      items[paletteIndex].classList.remove('is-selected');
+    }
+    paletteIndex = Math.max(0, Math.min(items.length - 1, paletteIndex + delta));
+    items[paletteIndex].classList.add('is-selected');
+    items[paletteIndex].scrollIntoView({ block: 'nearest' });
+  }
+
+  function selectPaletteItem() {
+    if (!paletteEl || paletteEl.hidden) return;
+    const items = paletteEl.querySelectorAll('.chat-slash-palette-item');
+    const idx = paletteIndex >= 0 ? paletteIndex : 0;
+    if (items[idx]) {
+      insertSlashCommand(items[idx].dataset.name);
+    }
+  }
+
+  function insertSlashCommand(name) {
+    if (!inputEl) return;
+    inputEl.value = '/' + name + ' ';
+    hidePalette();
+    inputEl.focus();
+    // Place cursor at end
+    inputEl.selectionStart = inputEl.selectionEnd = inputEl.value.length;
+    autoGrowTextarea(inputEl);
+  }
+
+  // --------------------------------------------------------------------------
+  // § 12 — Example prompts (empty state)
+  // --------------------------------------------------------------------------
+
+  function hideEmptyState() {
+    const emptyState = container.querySelector('.chat-empty-state');
+    if (emptyState) emptyState.style.display = 'none';
+  }
+
+  // Event delegation: any .chat-example-prompt with data-prompt
+  container.addEventListener('click', function (e) {
+    const promptEl = e.target.closest('.chat-example-prompt[data-prompt]');
+    if (!promptEl) return;
+    const prompt = promptEl.dataset.prompt;
+    if (!prompt) return;
+    hideEmptyState();
+    if (inputEl) inputEl.value = prompt;
+    if (!streaming) sendMessage();
+    if (inputEl) inputEl.focus();
+  });
+
+  // --------------------------------------------------------------------------
+  // § 13 — Message actions (copy, feedback, regenerate, edit)
+  // --------------------------------------------------------------------------
+
+  // Event delegation on the messages container
+  if (messagesEl) {
+    messagesEl.addEventListener('click', function (e) {
+      const btn = e.target.closest('.chat-message-action-btn[data-action]');
+      if (!btn) return;
+
+      const action = btn.dataset.action;
+      const msgEl = btn.closest('[data-message-id]');
+      const msgId = msgEl ? msgEl.dataset.messageId : null;
+
+      switch (action) {
+        case 'copy':
+          handleCopy(msgEl, btn);
+          break;
+        case 'feedback-up':
+          handleFeedback(msgId, 1, btn);
+          break;
+        case 'feedback-down':
+          handleFeedback(msgId, -1, btn);
+          break;
+        case 'regenerate':
+          handleRegenerate(msgId, btn);
+          break;
+        case 'edit':
+          handleEdit(msgId, msgEl, btn);
+          break;
+      }
+    });
+  }
+
+  function handleCopy(msgEl, btn) {
+    if (!msgEl) return;
+    const textEl = msgEl.querySelector('.chat-message-text');
+    const text = textEl ? textEl.innerText || textEl.textContent : '';
+    if (!text) return;
+    navigator.clipboard.writeText(text).then(function () {
+      showToast('Kopeeritud', 'success', 2000);
+    }).catch(function () {
+      showToast('Kopeerimine ebaõnnestus', 'error');
+    });
+  }
+
+  function handleFeedback(msgId, rating, btn) {
+    if (!msgId) return;
+    const formData = new FormData();
+    formData.append('rating', String(rating));
+
+    fetch('/chat/' + convId + '/messages/' + msgId + '/feedback', {
+      method: 'POST',
+      body: formData,
+      credentials: 'same-origin',
+    }).then(function (res) {
+      if (res.ok) {
+        // Mark the clicked button selected; deselect sibling
+        const actionRow = btn.closest('.chat-message-actions');
+        if (actionRow) {
+          actionRow.querySelectorAll('.chat-message-action-btn').forEach(function (b) {
+            b.classList.remove('is-selected');
+          });
+        }
+        btn.classList.add('is-selected');
+        showToast('Täname tagasiside eest', 'success', 3000);
+      }
+    }).catch(function () {
+      showToast('Tagasiside salvestamine ebaõnnestus', 'error');
+    });
+  }
+
+  function handleRegenerate(msgId, btn) {
+    if (!msgId) return;
+
+    fetch('/chat/' + convId + '/messages/' + msgId + '/regenerate', {
+      method: 'POST',
+      credentials: 'same-origin',
+    }).then(function (res) {
+      if (!res.ok) {
+        showToast('Taasgenereerimine ebaõnnestus', 'error');
+        return;
+      }
+      // Locate the preceding user message text and replay it via WS
+      const msgEl = messagesEl
+        ? messagesEl.querySelector('[data-message-id="' + msgId + '"]')
+        : null;
+      let userText = '';
+      if (msgEl) {
+        // Walk backwards through siblings to find the previous user bubble
+        let prev = msgEl.previousElementSibling;
+        while (prev) {
+          if (prev.classList.contains('chat-message-user')) {
+            const t = prev.querySelector('.chat-message-text');
+            if (t) userText = t.innerText || t.textContent || '';
+            break;
+          }
+          prev = prev.previousElementSibling;
+        }
+        // Remove the assistant bubble we just asked to regenerate
+        if (msgEl.parentNode) msgEl.parentNode.removeChild(msgEl);
+      }
+
+      if (userText && inputEl) {
+        inputEl.value = userText;
+        sendMessage();
+      }
+    }).catch(function () {
+      showToast('Taasgenereerimine ebaõnnestus', 'error');
+    });
+  }
+
+  function handleEdit(msgId, msgEl, btn) {
+    if (!msgId || !msgEl) return;
+
+    const textEl = msgEl.querySelector('.chat-message-text');
+    const originalText = textEl ? (textEl.innerText || textEl.textContent || '').trim() : '';
+
+    // Replace the bubble content with an inline edit form
+    const bubble = msgEl.querySelector('.chat-bubble');
+    if (!bubble) return;
+    const originalHtml = bubble.innerHTML;
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'chat-edit-textarea';
+    textarea.value = originalText;
+    textarea.rows = 3;
+
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.className = 'btn btn-primary btn-sm chat-edit-save';
+    saveBtn.textContent = 'Salvesta';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'btn btn-secondary btn-sm chat-edit-cancel';
+    cancelBtn.textContent = 'Tühista';
+
+    const btnRow = document.createElement('div');
+    btnRow.className = 'chat-edit-actions';
+    btnRow.appendChild(saveBtn);
+    btnRow.appendChild(cancelBtn);
+
+    bubble.innerHTML = '';
+    bubble.appendChild(textarea);
+    bubble.appendChild(btnRow);
+    textarea.focus();
+
+    cancelBtn.addEventListener('click', function () {
+      bubble.innerHTML = originalHtml;
+    });
+
+    saveBtn.addEventListener('click', function () {
+      const newContent = textarea.value.trim();
+      if (!newContent) return;
+
+      const formData = new FormData();
+      formData.append('content', newContent);
+
+      fetch('/chat/' + convId + '/messages/' + msgId + '/edit', {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin',
+      }).then(function (res) {
+        if (res.ok) {
+          // Simplest correct approach: reload the page so server-rendered
+          // history is authoritative (per spec).
+          location.reload();
+        } else {
+          showToast('Muutmine ebaõnnestus', 'error');
+          bubble.innerHTML = originalHtml;
+        }
+      }).catch(function () {
+        showToast('Muutmine ebaõnnestus', 'error');
+        bubble.innerHTML = originalHtml;
+      });
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // Utility: HTML escape (for content inserted via innerHTML)
+  // --------------------------------------------------------------------------
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // --------------------------------------------------------------------------
+  // Initialise
+  // --------------------------------------------------------------------------
+
+  connect();
+  scrollToBottom();
+  startQuotaPolling();
+
+  // Auto-grow textarea on initial render (e.g. pre-filled value)
+  if (inputEl) {
+    autoGrowTextarea(inputEl);
+    inputEl.focus();
+  }
+
+})();

--- a/migrations/017_chat_ux_features.sql
+++ b/migrations/017_chat_ux_features.sql
@@ -1,0 +1,102 @@
+-- =============================================================================
+-- Migration 017: Vestlus (Chat) UX polish sweep — pin, archive, feedback
+-- =============================================================================
+--
+-- Adds schema required by the Vestlus chat polish sweep:
+--
+--   1. conversations — pin/archive support and custom-title guard
+--      is_pinned, pinned_at, is_archived  allow users to pin and archive
+--      individual conversations without deleting them.
+--      title_is_custom prevents the auto-title background job from
+--      overwriting a name the user has manually set.
+--
+--   2. messages — pin and truncation flags
+--      is_pinned   lets users bookmark individual messages inside a thread.
+--      is_truncated marks partial assistant turns produced by "stop generation"
+--      so the UI can render a visible indicator and the context builder can
+--      handle them correctly.
+--
+--   3. message_feedback — thumbs-up / thumbs-down quality signal
+--      One feedback row per (message, user) pair.  rating is constrained to
+--      {-1, 1} (-1 = thumbs down, 1 = thumbs up).  An optional free-text
+--      comment allows reviewers / admins to surface qualitative issues.
+--
+-- Migration is idempotent:
+--   ADD COLUMN IF NOT EXISTS is used throughout.
+--   CREATE TABLE IF NOT EXISTS guards the new table.
+--   CREATE INDEX IF NOT EXISTS guards all new indexes.
+--
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. conversations — pin / archive / custom-title columns
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE conversations
+    ADD COLUMN IF NOT EXISTS is_pinned       BOOLEAN    NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS is_archived     BOOLEAN    NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS pinned_at       TIMESTAMPTZ         NULL,
+    ADD COLUMN IF NOT EXISTS title_is_custom BOOLEAN    NOT NULL DEFAULT FALSE;
+
+-- Partial index: only pinned rows — kept small and used by the "pinned
+-- conversations" section that sorts by pin recency.
+CREATE INDEX IF NOT EXISTS idx_conversations_pinned
+    ON conversations (user_id, pinned_at DESC)
+    WHERE is_pinned = TRUE;
+
+-- Partial index: active (non-archived) conversations sorted by recency —
+-- the default conversation list query.
+CREATE INDEX IF NOT EXISTS idx_conversations_active
+    ON conversations (user_id, updated_at DESC)
+    WHERE is_archived = FALSE;
+
+-- ---------------------------------------------------------------------------
+-- 2. messages — pin and truncation flags
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS is_pinned    BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS is_truncated BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- ---------------------------------------------------------------------------
+-- 3. message_feedback — per-user thumbs-up / thumbs-down
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS message_feedback (
+    id         UUID      PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id UUID      NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    user_id    UUID      NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+    -- 1 = thumbs up, -1 = thumbs down
+    rating     SMALLINT  NOT NULL CHECK (rating IN (-1, 1)),
+    comment    TEXT                  NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (message_id, user_id)
+);
+
+-- Supports fetching all feedback for a given message (admin / analytics view).
+CREATE INDEX IF NOT EXISTS idx_message_feedback_message
+    ON message_feedback (message_id);
+
+-- Foreign-key-backing index on user_id (convention: always index FK columns).
+CREATE INDEX IF NOT EXISTS idx_message_feedback_user
+    ON message_feedback (user_id);
+
+-- =============================================================================
+-- Down migration (non-executable reference — manual use only)
+-- =============================================================================
+--
+-- DROP TABLE IF EXISTS message_feedback;
+--
+-- ALTER TABLE messages
+--     DROP COLUMN IF EXISTS is_truncated,
+--     DROP COLUMN IF EXISTS is_pinned;
+--
+-- ALTER TABLE conversations
+--     DROP COLUMN IF EXISTS title_is_custom,
+--     DROP COLUMN IF EXISTS pinned_at,
+--     DROP COLUMN IF EXISTS is_archived,
+--     DROP COLUMN IF EXISTS is_pinned;
+--
+-- (Indexes are dropped automatically when their table/column is dropped.)
+-- =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "anthropic>=0.93.0",
     "voyageai>=0.3.7",
     "sentry-sdk[starlette]>=2.57.0",
+    "mistune>=3.0",
+    "bleach>=6",
 ]
 
 [dependency-groups]

--- a/tests/test_chat_export.py
+++ b/tests/test_chat_export.py
@@ -1,0 +1,262 @@
+"""Unit tests for ``app.chat.export``.
+
+Exercises both Markdown and .docx renderers against a handcrafted
+conversation + message list. No DB access — dataclasses are built
+directly.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from datetime import UTC, datetime
+
+from docx import Document
+
+from app.chat.export import (
+    conversation_to_docx_bytes,
+    conversation_to_markdown,
+)
+from app.chat.models import Conversation, Message
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_CONV_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_ORG_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _make_conversation(title: str = "Testvestlus") -> Conversation:
+    created = datetime(2026, 4, 14, 9, 30, tzinfo=UTC)
+    return Conversation(
+        id=_CONV_ID,
+        user_id=_USER_ID,
+        org_id=_ORG_ID,
+        title=title,
+        context_draft_id=None,
+        created_at=created,
+        updated_at=created,
+    )
+
+
+def _make_message(
+    *,
+    role: str,
+    content: str = "",
+    tool_name: str | None = None,
+    tool_input: dict | None = None,
+    tool_output: dict | None = None,
+    offset_minutes: int = 0,
+) -> Message:
+    return Message(
+        id=uuid.uuid4(),
+        conversation_id=_CONV_ID,
+        role=role,
+        content=content,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        tool_output=tool_output,
+        rag_context=None,
+        tokens_input=None,
+        tokens_output=None,
+        model=None,
+        created_at=datetime(2026, 4, 14, 9, 30 + offset_minutes, tzinfo=UTC),
+    )
+
+
+def _sample_messages() -> list[Message]:
+    return [
+        _make_message(role="system", content="(sisemine suunis)", offset_minutes=0),
+        _make_message(
+            role="user",
+            content="Kuidas mõjutab see eelnõu äriühingute asutamist?",
+            offset_minutes=1,
+        ),
+        _make_message(
+            role="assistant",
+            content="# Analüüs\n\n**Peamine mõju** on registreerimiskorra muutus.",
+            offset_minutes=2,
+        ),
+        _make_message(
+            role="tool",
+            tool_name="sparql_query",
+            tool_input={"query": "SELECT ?s WHERE { ?s a ?t }"},
+            tool_output={"rows": [{"s": "ex:A"}, {"s": "ex:B"}]},
+            offset_minutes=3,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Markdown
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_contains_title_and_timestamp() -> None:
+    conv = _make_conversation(title="Ettevõtlusseaduse analüüs")
+    md = conversation_to_markdown(conv, _sample_messages())
+
+    assert md.startswith("# Ettevõtlusseaduse analüüs\n")
+    # Europe/Tallinn is UTC+3 in April (DST): 09:30 UTC -> 12:30.
+    assert "Loodud: 14.04.2026 12:30" in md
+
+
+def test_markdown_renders_all_roles_except_system() -> None:
+    conv = _make_conversation()
+    md = conversation_to_markdown(conv, _sample_messages())
+
+    assert "**Kasutaja:**" in md
+    assert "**Assistent:**" in md
+    assert "**Tööriist sparql_query:**" in md
+    # System message content must be absent.
+    assert "sisemine suunis" not in md
+
+
+def test_markdown_includes_tool_json_fenced_block() -> None:
+    conv = _make_conversation()
+    md = conversation_to_markdown(conv, _sample_messages())
+
+    assert "```json" in md
+    # tool_output preferred over tool_input.
+    assert '"rows"' in md
+    assert "ex:A" in md
+    # tool_input should not appear when tool_output is present.
+    assert "SELECT ?s" not in md
+
+
+def test_markdown_empty_conversation() -> None:
+    conv = _make_conversation(title="Tühi vestlus")
+    md = conversation_to_markdown(conv, [])
+
+    assert md.startswith("# Tühi vestlus\n")
+    assert "**Kasutaja:**" not in md
+    assert md.endswith("\n")
+
+
+def test_markdown_handles_unicode_estonian_chars() -> None:
+    conv = _make_conversation(title="Õiguslik küsimus")
+    msgs = [
+        _make_message(role="user", content="Kas §-s 5 öeldud käive sisaldab käibemaksu?"),
+        _make_message(
+            role="assistant", content="Jah — § 12 järgi ka siis, kui müüja asub Šveitsis."
+        ),
+    ]
+    md = conversation_to_markdown(conv, msgs)
+
+    assert "Õiguslik küsimus" in md
+    assert "§-s 5 öeldud käive" in md
+    assert "Šveitsis" in md
+
+
+def test_markdown_tool_message_without_payload_uses_empty_object() -> None:
+    conv = _make_conversation()
+    msgs = [_make_message(role="tool", tool_name="noop")]
+    md = conversation_to_markdown(conv, msgs)
+
+    assert "**Tööriist noop:**" in md
+    assert "```json\n{}\n```" in md
+
+
+def test_markdown_tool_message_falls_back_to_tool_input() -> None:
+    conv = _make_conversation()
+    msgs = [
+        _make_message(
+            role="tool",
+            tool_name="sparql_query",
+            tool_input={"query": "ASK { ?s ?p ?o }"},
+        ),
+    ]
+    md = conversation_to_markdown(conv, msgs)
+
+    assert "ASK { ?s ?p ?o }" in md
+
+
+# ---------------------------------------------------------------------------
+# .docx
+# ---------------------------------------------------------------------------
+
+
+def test_docx_bytes_are_zip_and_parseable() -> None:
+    conv = _make_conversation(title="Dokument")
+    data = conversation_to_docx_bytes(conv, _sample_messages())
+
+    assert isinstance(data, bytes)
+    assert data[:2] == b"PK"  # ZIP magic bytes.
+
+    # python-docx must be able to reopen the exported blob.
+    doc = Document(io.BytesIO(data))
+    all_text = "\n".join(p.text for p in doc.paragraphs)
+
+    assert "Dokument" in all_text
+    assert "Loodud: 14.04.2026 12:30" in all_text
+    assert "Kasutaja:" in all_text
+    assert "Assistent:" in all_text
+    assert "Tööriist sparql_query:" in all_text
+    # System-role content must not leak into the docx.
+    assert "sisemine suunis" not in all_text
+
+
+def test_docx_strips_markdown_markers_in_body() -> None:
+    conv = _make_conversation()
+    msgs = [
+        _make_message(
+            role="assistant",
+            content="# Pealkiri\n\n**oluline** ja *kaldkirjas* tekst.",
+        ),
+    ]
+    data = conversation_to_docx_bytes(conv, msgs)
+    doc = Document(io.BytesIO(data))
+    body_text = "\n".join(p.text for p in doc.paragraphs)
+
+    # Heading marker dropped.
+    assert "Pealkiri" in body_text
+    assert "# Pealkiri" not in body_text
+    # Bold/italic markers dropped.
+    assert "oluline" in body_text
+    assert "kaldkirjas" in body_text
+    assert "**oluline**" not in body_text
+    assert "*kaldkirjas*" not in body_text
+
+
+def test_docx_tool_payload_rendered_as_json() -> None:
+    conv = _make_conversation()
+    msgs = [
+        _make_message(
+            role="tool",
+            tool_name="sparql_query",
+            tool_output={"rows": [{"s": "ex:A"}]},
+        ),
+    ]
+    data = conversation_to_docx_bytes(conv, msgs)
+    doc = Document(io.BytesIO(data))
+    text = "\n".join(p.text for p in doc.paragraphs)
+
+    assert '"rows"' in text
+    assert "ex:A" in text
+
+
+def test_docx_empty_conversation_round_trips() -> None:
+    conv = _make_conversation(title="Tühi")
+    data = conversation_to_docx_bytes(conv, [])
+
+    assert data[:2] == b"PK"
+    doc = Document(io.BytesIO(data))
+    text = "\n".join(p.text for p in doc.paragraphs)
+    assert "Tühi" in text
+
+
+def test_docx_handles_unicode_estonian_chars() -> None:
+    conv = _make_conversation(title="Õiguslik küsimus")
+    msgs = [
+        _make_message(role="user", content="Kas §-s 5 öeldud käive sisaldab käibemaksu?"),
+        _make_message(role="assistant", content="Jah — § 12 järgi Šveitsis."),
+    ]
+    data = conversation_to_docx_bytes(conv, msgs)
+    doc = Document(io.BytesIO(data))
+    text = "\n".join(p.text for p in doc.paragraphs)
+
+    assert "Õiguslik küsimus" in text
+    assert "käibemaksu" in text
+    assert "Šveitsis" in text

--- a/tests/test_chat_feedback.py
+++ b/tests/test_chat_feedback.py
@@ -1,0 +1,224 @@
+"""Unit tests for ``app.chat.feedback``.
+
+Mocks the DB connection exactly like ``tests/test_chat_models.py`` — the
+feedback helpers are thin wrappers around SQL, so we assert on the SQL
+text and the parameter tuple rather than spinning up a real Postgres.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.chat.feedback import (
+    MessageFeedback,
+    delete_feedback,
+    feedback_counts,
+    get_feedback,
+    upsert_feedback,
+)
+
+_MSG_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _make_feedback_row(
+    *,
+    fb_id: uuid.UUID | None = None,
+    message_id: uuid.UUID = _MSG_ID,
+    user_id: uuid.UUID = _USER_ID,
+    rating: int = 1,
+    comment: str | None = None,
+    created_at: datetime | None = None,
+) -> tuple[Any, ...]:
+    """Build a raw cursor row matching _FEEDBACK_COLUMNS order."""
+    return (
+        fb_id or uuid.uuid4(),
+        message_id,
+        user_id,
+        rating,
+        comment,
+        created_at or datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# upsert_feedback
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertFeedback:
+    def test_insert_thumbs_up(self):
+        conn = MagicMock()
+        row = _make_feedback_row(rating=1, comment=None)
+        conn.execute.return_value.fetchone.return_value = row
+
+        result = upsert_feedback(conn, message_id=_MSG_ID, user_id=_USER_ID, rating=1)
+
+        assert isinstance(result, MessageFeedback)
+        assert result.rating == 1
+        assert result.comment is None
+
+        sql, params = conn.execute.call_args.args
+        assert "INSERT INTO message_feedback" in sql
+        assert "ON CONFLICT (message_id, user_id) DO UPDATE" in sql
+        assert params == (str(_MSG_ID), str(_USER_ID), 1, None)
+
+    def test_insert_thumbs_down_with_comment(self):
+        conn = MagicMock()
+        row = _make_feedback_row(rating=-1, comment="Vale tsitaat")
+        conn.execute.return_value.fetchone.return_value = row
+
+        result = upsert_feedback(
+            conn,
+            message_id=_MSG_ID,
+            user_id=_USER_ID,
+            rating=-1,
+            comment="Vale tsitaat",
+        )
+
+        assert result.rating == -1
+        assert result.comment == "Vale tsitaat"
+
+    def test_revote_uses_on_conflict(self):
+        """Second call with same (message, user) hits the DO UPDATE branch.
+
+        We can't assert the DB behaviour from a mock, but we can confirm
+        the SQL uses ON CONFLICT so revotes don't create duplicate rows.
+        """
+        conn = MagicMock()
+        first_row = _make_feedback_row(rating=1)
+        second_row = _make_feedback_row(rating=-1, comment="Ümbermõeldud")
+        conn.execute.return_value.fetchone.side_effect = [first_row, second_row]
+
+        first = upsert_feedback(conn, message_id=_MSG_ID, user_id=_USER_ID, rating=1)
+        second = upsert_feedback(
+            conn,
+            message_id=_MSG_ID,
+            user_id=_USER_ID,
+            rating=-1,
+            comment="Ümbermõeldud",
+        )
+
+        assert first.rating == 1
+        assert second.rating == -1
+        assert second.comment == "Ümbermõeldud"
+
+        for call in conn.execute.call_args_list:
+            sql = call.args[0]
+            assert "ON CONFLICT (message_id, user_id) DO UPDATE" in sql
+            assert "created_at = now()" in sql
+
+    def test_invalid_rating_zero(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Invalid rating"):
+            upsert_feedback(conn, message_id=_MSG_ID, user_id=_USER_ID, rating=0)
+        conn.execute.assert_not_called()
+
+    def test_invalid_rating_two(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Invalid rating"):
+            upsert_feedback(conn, message_id=_MSG_ID, user_id=_USER_ID, rating=2)
+
+    def test_invalid_rating_non_int(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Invalid rating"):
+            upsert_feedback(
+                conn,
+                message_id=_MSG_ID,
+                user_id=_USER_ID,
+                rating="up",  # type: ignore[arg-type]
+            )
+
+    def test_raises_if_no_row_returned(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        with pytest.raises(RuntimeError, match="produced no row"):
+            upsert_feedback(conn, message_id=_MSG_ID, user_id=_USER_ID, rating=1)
+
+
+# ---------------------------------------------------------------------------
+# get_feedback
+# ---------------------------------------------------------------------------
+
+
+class TestGetFeedback:
+    def test_returns_feedback(self):
+        conn = MagicMock()
+        row = _make_feedback_row(rating=1, comment="Super")
+        conn.execute.return_value.fetchone.return_value = row
+
+        result = get_feedback(conn, _MSG_ID, _USER_ID)
+
+        assert result is not None
+        assert result.rating == 1
+        assert result.comment == "Super"
+
+    def test_returns_none_when_absent(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        assert get_feedback(conn, _MSG_ID, _USER_ID) is None
+
+    def test_handles_db_error(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("db down")
+
+        assert get_feedback(conn, _MSG_ID, _USER_ID) is None
+
+
+# ---------------------------------------------------------------------------
+# delete_feedback
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteFeedback:
+    def test_deletes_by_message_and_user(self):
+        conn = MagicMock()
+
+        delete_feedback(conn, _MSG_ID, _USER_ID)
+
+        conn.execute.assert_called_once()
+        sql, params = conn.execute.call_args.args
+        assert "DELETE FROM message_feedback" in sql
+        assert "message_id = %s" in sql
+        assert "user_id = %s" in sql
+        assert params == (str(_MSG_ID), str(_USER_ID))
+
+
+# ---------------------------------------------------------------------------
+# feedback_counts
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackCounts:
+    def test_returns_up_and_down_counts(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (7, 3)
+
+        up, down = feedback_counts(conn, _MSG_ID)
+        assert up == 7
+        assert down == 3
+
+    def test_all_zero_when_no_rows(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0, 0)
+
+        assert feedback_counts(conn, _MSG_ID) == (0, 0)
+
+    def test_db_error_returns_zero_zero(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("db")
+
+        assert feedback_counts(conn, _MSG_ID) == (0, 0)
+
+    def test_fetchone_none_returns_zero_zero(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        assert feedback_counts(conn, _MSG_ID) == (0, 0)

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -1,0 +1,901 @@
+"""Integration tests for :mod:`app.chat.handlers`.
+
+Mirrors the conventions used in ``tests/test_chat_routes.py``: a stub
+``AuthProvider`` supplies an authenticated user, ``_connect`` and the
+feedback/models helpers are patched out, and the full FastHTML ASGI app
+is exercised through ``starlette.testclient.TestClient``.
+
+The handlers module is registered exactly once on the production ``rt``
+at collection time — future handler registrations land through
+``register_chat_handler_routes`` too, so a repeat call would be a no-op
+duplicate for starlette's router.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Importing ``app.main`` runs ``register_chat_routes`` at module-load
+# time, which delegates to ``register_chat_handler_routes`` FIRST so the
+# static handler paths (``/chat/search``, ``/api/me/usage``,
+# ``/chat/{conv_id}/pin`` etc.) land in ``app.routes`` ahead of the
+# dynamic ``/chat/{conv_id}`` view. Re-registering here would re-insert
+# the same paths and — because FastHTML's ``rt`` de-duplicates by path —
+# pull the dynamic route ahead of ``/chat/search``, which would then
+# swallow search requests as conv_id lookups. Just importing ``app.main``
+# triggers the correct registration order.
+import app.main  # noqa: F401 — module import is load-bearing
+from app.chat.models import Conversation, Message
+from app.chat.rate_limiter import UserQuota
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_OTHER_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_OTHER_USER_ID = "99999999-9999-9999-9999-999999999999"
+_CONV_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+_MSG_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+_DRAFT_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _make_conversation(
+    *,
+    conv_id: uuid.UUID = _CONV_ID,
+    org_id: str = _ORG_ID,
+    user_id: str = _USER_ID,
+    title: str = "Test vestlus",
+    context_draft_id: uuid.UUID | None = None,
+) -> Conversation:
+    now = datetime(2026, 4, 14, 9, 30, tzinfo=UTC)
+    return Conversation(
+        id=conv_id,
+        user_id=uuid.UUID(user_id),
+        org_id=uuid.UUID(org_id),
+        title=title,
+        context_draft_id=context_draft_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_message(
+    *,
+    msg_id: uuid.UUID = _MSG_ID,
+    role: str = "user",
+    content: str = "Tere",
+    conv_id: uuid.UUID = _CONV_ID,
+) -> Message:
+    now = datetime(2026, 4, 14, 9, 30, tzinfo=UTC)
+    return Message(
+        id=msg_id,
+        conversation_id=conv_id,
+        role=role,
+        content=content,
+        tool_name=None,
+        tool_input=None,
+        tool_output=None,
+        rag_context=None,
+        tokens_input=None,
+        tokens_output=None,
+        model=None,
+        created_at=now,
+    )
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+@pytest.fixture()
+def provider_patch():
+    with patch("app.auth.middleware._get_provider") as mock_provider:
+        mock_provider.return_value = _stub_provider()
+        yield mock_provider
+
+
+@pytest.fixture()
+def mock_conn():
+    """Patch ``app.chat.handlers._connect`` with a no-op connection."""
+    with patch("app.chat.handlers._connect") as mock_connect:
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        conn.execute.return_value.fetchall.return_value = []
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_connect, conn
+
+
+# ---------------------------------------------------------------------------
+# Unauthenticated redirects
+# ---------------------------------------------------------------------------
+
+
+class TestAuthRequired:
+    def test_pin_redirects_unauthenticated(self):
+        from starlette.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(f"/chat/{_CONV_ID}/pin")
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/auth/login"
+
+    def test_usage_redirects_unauthenticated(self):
+        from starlette.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get("/api/me/usage")
+        assert resp.status_code == 303
+
+    def test_export_redirects_unauthenticated(self):
+        from starlette.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get(f"/chat/{_CONV_ID}/export.md")
+        assert resp.status_code == 303
+
+
+# ---------------------------------------------------------------------------
+# Pin conversation
+# ---------------------------------------------------------------------------
+
+
+class TestPinConversation:
+    def test_pin_toggles_and_returns_204(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._set_conversation_pinned") as mock_set,
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/pin", data={"pinned": "1"})
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Trigger") == "chat:conversation-updated"
+            mock_set.assert_called_once()
+            _, _, pinned = mock_set.call_args[0]
+            assert pinned is True
+
+    def test_pin_cross_org_returns_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/pin")
+            assert resp.status_code == 404
+
+    def test_pin_invalid_uuid_returns_404(self, provider_patch, mock_conn):
+        client = _authed_client()
+        resp = client.post("/chat/not-a-uuid/pin")
+        assert resp.status_code == 404
+
+    def test_pin_missing_conversation_returns_404(self, provider_patch, mock_conn):
+        with patch("app.chat.handlers.get_conversation", return_value=None):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/pin")
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Archive conversation
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveConversation:
+    def test_archive_htmx_returns_204(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._set_conversation_archived") as mock_set,
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/archive",
+                headers={"HX-Request": "true"},
+                data={"archived": "1"},
+            )
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Trigger") == "chat:conversation-updated"
+            mock_set.assert_called_once()
+
+    def test_archive_non_htmx_redirects_303(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._set_conversation_archived"),
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/archive", data={"archived": "1"})
+            assert resp.status_code == 303
+            assert resp.headers["location"] == "/chat"
+
+    def test_archive_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/archive")
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Rename conversation
+# ---------------------------------------------------------------------------
+
+
+class TestRenameConversation:
+    def test_rename_success(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._update_conversation_title") as mock_update,
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/rename",
+                data={"title": "  Uus pealkiri  "},
+            )
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Trigger") == "chat:conversation-updated"
+            mock_update.assert_called_once()
+            _, _, title = mock_update.call_args[0]
+            assert title == "Uus pealkiri"
+
+    def test_rename_empty_returns_400(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/rename", data={"title": "   "})
+            assert resp.status_code == 400
+
+    def test_rename_truncates_to_200_chars(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        long_title = "x" * 500
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._update_conversation_title") as mock_update,
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/rename",
+                data={"title": long_title},
+            )
+            assert resp.status_code == 204
+            title = mock_update.call_args[0][2]
+            assert len(title) == 200
+
+    def test_rename_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/rename", data={"title": "X"})
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Fork conversation
+# ---------------------------------------------------------------------------
+
+
+class TestForkConversation:
+    def test_fork_htmx_returns_hx_redirect(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        new_id = uuid.UUID("77777777-7777-7777-7777-777777777777")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._fork_conversation", return_value=new_id),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/fork",
+                data={"message_id": str(_MSG_ID)},
+                headers={"HX-Request": "true"},
+            )
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Redirect") == f"/chat/{new_id}"
+
+    def test_fork_non_htmx_redirects_303(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        new_id = uuid.UUID("77777777-7777-7777-7777-777777777777")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._fork_conversation", return_value=new_id),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/fork",
+                data={"message_id": str(_MSG_ID)},
+            )
+            assert resp.status_code == 303
+            assert resp.headers["location"] == f"/chat/{new_id}"
+
+    def test_fork_bad_message_id_400(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/fork",
+                data={"message_id": "not-a-uuid"},
+            )
+            assert resp.status_code == 400
+
+    def test_fork_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/fork",
+                data={"message_id": str(_MSG_ID)},
+            )
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Pin message
+# ---------------------------------------------------------------------------
+
+
+class TestPinMessage:
+    def test_pin_message_success(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message()
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._set_message_pinned") as mock_set,
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/pin",
+                data={"pinned": "1"},
+            )
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Trigger") == "chat:message-updated"
+            mock_set.assert_called_once()
+
+    def test_pin_wrong_conversation_message_404(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        # Message list is empty — the msg_id isn't part of this thread.
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[]),
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/pin")
+            assert resp.status_code == 404
+
+    def test_pin_message_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/pin")
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Feedback
+# ---------------------------------------------------------------------------
+
+
+class TestFeedback:
+    def test_post_feedback_returns_json(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._upsert_feedback") as mock_upsert,
+            patch("app.chat.handlers._feedback_counts", return_value=(3, 1)),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback",
+                data={"rating": "1", "comment": "Hea vastus"},
+            )
+            assert resp.status_code == 200
+            payload = resp.json()
+            assert payload == {"up": 3, "down": 1, "user_rating": 1}
+            mock_upsert.assert_called_once()
+
+    def test_post_invalid_rating_400(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback",
+                data={"rating": "5"},
+            )
+            assert resp.status_code == 400
+
+    def test_post_non_numeric_rating_400(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback",
+                data={"rating": "thumbs-up"},
+            )
+            assert resp.status_code == 400
+
+    def test_delete_feedback_returns_json(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._delete_feedback_row") as mock_delete,
+            patch("app.chat.handlers._feedback_counts", return_value=(2, 0)),
+        ):
+            client = _authed_client()
+            resp = client.delete(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback")
+            assert resp.status_code == 200
+            payload = resp.json()
+            assert payload == {"up": 2, "down": 0, "user_rating": None}
+            mock_delete.assert_called_once()
+
+    def test_feedback_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback",
+                data={"rating": "1"},
+            )
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Regenerate
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerate:
+    def test_regenerate_deletes_and_returns_204(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="user")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._delete_messages_after_pivot", return_value=2) as mock_del,
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/regenerate")
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Trigger") == "chat:message-regenerate"
+            mock_del.assert_called_once()
+
+    def test_regenerate_bad_msg_id_404(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/not-a-uuid/regenerate")
+            assert resp.status_code == 404
+
+    def test_regenerate_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/regenerate")
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Edit
+# ---------------------------------------------------------------------------
+
+
+class TestEditMessage:
+    def test_edit_user_message_success(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="user", content="vana")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._update_message_content") as mock_update,
+            patch("app.chat.handlers._delete_messages_after_pivot", return_value=0),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/edit",
+                data={"content": "uus sisu"},
+            )
+            assert resp.status_code == 204
+            assert resp.headers.get("HX-Trigger") == "chat:message-edited"
+            mock_update.assert_called_once()
+
+    def test_edit_rejects_assistant_message(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/edit",
+                data={"content": "uus"},
+            )
+            assert resp.status_code == 400
+
+    def test_edit_empty_content_400(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="user")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/edit",
+                data={"content": "   "},
+            )
+            assert resp.status_code == 400
+
+    def test_edit_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/edit",
+                data={"content": "X"},
+            )
+            assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+class TestExport:
+    def test_export_md_returns_markdown(self, provider_patch, mock_conn):
+        conv = _make_conversation(title="Vestlus AI-ga")
+        msg = _make_message(role="user", content="Tere")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}/export.md")
+            assert resp.status_code == 200
+            assert resp.headers["content-type"].startswith("text/markdown")
+            assert "vestlus-vestlus-ai-ga" in resp.headers.get("content-disposition", "")
+            assert "# Vestlus AI-ga" in resp.text
+
+    def test_export_docx_returns_bytes(self, provider_patch, mock_conn):
+        conv = _make_conversation(title="Testvestlus")
+        msg = _make_message(role="user", content="Tere")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}/export.docx")
+            assert resp.status_code == 200
+            assert "wordprocessingml" in resp.headers["content-type"]
+            # .docx files are ZIP archives — check the magic number.
+            assert resp.content[:2] == b"PK"
+
+    def test_export_md_cross_org_404(self, provider_patch, mock_conn):
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
+        with patch("app.chat.handlers.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}/export.md")
+            assert resp.status_code == 404
+
+    def test_export_docx_invalid_uuid_404(self, provider_patch, mock_conn):
+        client = _authed_client()
+        resp = client.get("/chat/not-a-uuid/export.docx")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_search_non_htmx_redirects(self, provider_patch, mock_conn):
+        client = _authed_client()
+        resp = client.get("/chat/search?q=eelnou")
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/chat?q=eelnou"
+
+    def test_search_htmx_returns_fragment(self, provider_patch, mock_conn):
+        conv = _make_conversation(title="Eelnou X analuus")
+        with patch("app.chat.handlers._search_conversations_impl", return_value=[conv]):
+            client = _authed_client()
+            resp = client.get("/chat/search?q=eelnou", headers={"HX-Request": "true"})
+            assert resp.status_code == 200
+            assert "chat-search-results" in resp.text
+            assert "Eelnou X analuus" in resp.text
+
+    def test_search_htmx_empty_term_returns_fragment(self, provider_patch, mock_conn):
+        client = _authed_client()
+        resp = client.get("/chat/search?q=", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        # No term → empty state fragment.
+        assert "chat-search-results" in resp.text
+
+    def test_search_htmx_no_matches(self, provider_patch, mock_conn):
+        with patch("app.chat.handlers._search_conversations_impl", return_value=[]):
+            client = _authed_client()
+            resp = client.get("/chat/search?q=zzz", headers={"HX-Request": "true"})
+            assert resp.status_code == 200
+            assert "ei vastanud" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+
+class TestUserUsage:
+    def test_usage_returns_expected_shape(self, provider_patch):
+        fake_quota = UserQuota(
+            messages_this_hour=5,
+            message_limit_per_hour=100,
+            cost_this_month_usd=Decimal("12.345"),
+            cost_limit_per_month_usd=Decimal("50.00"),
+            cost_alert_threshold_usd=Decimal("40.00"),
+        )
+        with (
+            patch("app.chat.handlers.get_user_quota", return_value=fake_quota),
+            patch("app.chat.handlers.seconds_until_hourly_reset", return_value=1234),
+        ):
+            client = _authed_client()
+            resp = client.get("/api/me/usage")
+            assert resp.status_code == 200
+            data = resp.json()
+
+        assert data["messages_this_hour"] == 5
+        assert data["message_limit_per_hour"] == 100
+        assert data["messages_remaining"] == 95
+        # Decimal → string in JSON payload
+        assert data["cost_this_month_usd"] == "12.35"
+        assert data["cost_limit_per_month_usd"] == "50.00"
+        # 50.00 - 12.345 = 37.655 → ROUND_HALF_UP → 37.66
+        assert data["cost_remaining_usd"] == "37.66"
+        assert data["cost_alert_threshold_usd"] == "40.00"
+        assert data["seconds_until_reset"] == 1234
+        assert data["percentages"]["messages"] == 5.0
+        assert data["percentages"]["cost"] == pytest.approx(24.7, rel=0.1)
+
+    def test_usage_no_org_id_returns_400(self):
+        provider = MagicMock()
+        user = dict(_authed_user())
+        user["org_id"] = None
+        provider.get_current_user.return_value = user
+        with patch("app.auth.middleware._get_provider", return_value=provider):
+            client = _authed_client()
+            resp = client.get("/api/me/usage")
+            assert resp.status_code == 400
+
+    def test_usage_zero_limit_percentages(self, provider_patch):
+        fake_quota = UserQuota(
+            messages_this_hour=0,
+            message_limit_per_hour=0,
+            cost_this_month_usd=Decimal("0.00"),
+            cost_limit_per_month_usd=Decimal("0.00"),
+            cost_alert_threshold_usd=Decimal("0.00"),
+        )
+        with (
+            patch("app.chat.handlers.get_user_quota", return_value=fake_quota),
+            patch("app.chat.handlers.seconds_until_hourly_reset", return_value=0),
+        ):
+            client = _authed_client()
+            resp = client.get("/api/me/usage")
+            data = resp.json()
+            assert data["percentages"]["messages"] == 0.0
+            assert data["percentages"]["cost"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Route ordering regression (P1): /chat/search must resolve before the
+# dynamic /chat/{conv_id} catch-all.
+# ---------------------------------------------------------------------------
+
+
+class TestRouteOrdering:
+    def test_chat_search_routes_before_dynamic_conv_id(self, provider_patch, mock_conn):
+        """``/chat/search`` must not be swallowed by ``/chat/{conv_id}``.
+
+        Regression for the dead-code ``_reorder_static_routes_first``
+        hack: the handler module used to re-sort ``app.routes`` at
+        startup because it was registered AFTER routes.py's dynamic
+        ``/chat/{conv_id}`` view. ``register_chat_routes`` now invokes
+        ``register_chat_handler_routes`` first, so the reorder is a
+        no-op. This test locks in the registration order.
+        """
+        client = _authed_client()
+        resp = client.get("/chat/search?q=test", headers={"HX-Request": "true"})
+        # The search handler responds 200 with the results fragment; the
+        # dynamic conv_id route would either 404 (bad UUID "search") or
+        # render a completely different page.
+        assert resp.status_code == 200
+        assert "chat-search-results" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# P2.4: audit log keys are namespaced "chat.*" consistently.
+# ---------------------------------------------------------------------------
+
+
+class TestAuditKeys:
+    def test_fork_audit_key_is_chat_namespaced(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        new_id = uuid.UUID("77777777-7777-7777-7777-777777777777")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers._fork_conversation", return_value=new_id),
+            patch("app.chat.handlers.log_action") as mock_log,
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/fork",
+                data={"message_id": str(_MSG_ID)},
+                headers={"HX-Request": "true"},
+            )
+            assert resp.status_code == 204
+            mock_log.assert_called_once()
+            action_key = mock_log.call_args.args[1]
+            assert action_key == "chat.conversation.fork"
+
+    def test_feedback_post_audit_key_is_chat_namespaced(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._upsert_feedback"),
+            patch("app.chat.handlers._feedback_counts", return_value=(1, 0)),
+            patch("app.chat.handlers.log_action") as mock_log,
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback",
+                data={"rating": "1"},
+            )
+            assert resp.status_code == 200
+            assert mock_log.call_args.args[1] == "chat.message.feedback"
+
+    def test_feedback_delete_audit_key_is_chat_namespaced(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        msg = _make_message(role="assistant")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers._delete_feedback_row"),
+            patch("app.chat.handlers._feedback_counts", return_value=(0, 0)),
+            patch("app.chat.handlers.log_action") as mock_log,
+        ):
+            client = _authed_client()
+            resp = client.delete(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/feedback")
+            assert resp.status_code == 200
+            assert mock_log.call_args.args[1] == "chat.message.feedback.delete"
+
+
+# ---------------------------------------------------------------------------
+# P2.5: _update_message_content fail-safe in production.
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMessageContentFailSafe:
+    def test_dev_falls_back_to_plaintext_on_encryption_failure(self, provider_patch, monkeypatch):
+        """In dev (``APP_ENV != production``) encrypt errors write plaintext."""
+        from app.chat.handlers import _update_message_content
+
+        monkeypatch.setenv("APP_ENV", "development")
+
+        conn = MagicMock()
+
+        def boom(_text: str) -> bytes:
+            raise RuntimeError("no key")
+
+        # Patch the import site used inside _update_message_content.
+        with patch("app.storage.encrypt_text", side_effect=boom):
+            _update_message_content(conn, _MSG_ID, "uus sisu")
+
+        # Plaintext-path UPDATE landed.
+        sql, params = conn.execute.call_args.args
+        assert "content = %s" in sql
+        assert "content_encrypted = NULL" in sql
+        assert params == ("uus sisu", str(_MSG_ID))
+
+    def test_prod_reraises_on_encryption_failure(self, provider_patch, monkeypatch):
+        """In production encrypt errors must NOT fall back to plaintext."""
+        from app.chat.handlers import _update_message_content
+
+        monkeypatch.setenv("APP_ENV", "production")
+
+        conn = MagicMock()
+
+        def boom(_text: str) -> bytes:
+            raise RuntimeError("no key")
+
+        with patch("app.storage.encrypt_text", side_effect=boom):
+            with pytest.raises(RuntimeError, match="no key"):
+                _update_message_content(conn, _MSG_ID, "tundlik sisu")
+
+        # No UPDATE was executed — the write never touched the DB.
+        conn.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# P2.6: Content-Disposition header is not double-slugified.
+# ---------------------------------------------------------------------------
+
+
+class TestContentDisposition:
+    def test_disposition_preserves_extension_dot(self):
+        from app.chat.handlers import _content_disposition
+
+        header = _content_disposition("vestlus-test-2026-04-14.md")
+        # Ascii part keeps the dot so the browser saves it as ``*.md``.
+        assert 'filename="vestlus-test-2026-04-14.md"' in header
+        # RFC 5987 variant is percent-encoded.
+        assert "filename*=UTF-8''vestlus-test-2026-04-14.md" in header
+
+    def test_disposition_preserves_docx_extension(self):
+        from app.chat.handlers import _content_disposition
+
+        header = _content_disposition("vestlus-pealkiri-2026-04-14.docx")
+        assert 'filename="vestlus-pealkiri-2026-04-14.docx"' in header
+
+    def test_export_md_disposition_has_md_extension(self, provider_patch, mock_conn):
+        conv = _make_conversation(title="Test vestlus")
+        msg = _make_message(role="user", content="Tere")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}/export.md")
+            assert resp.status_code == 200
+            disposition = resp.headers.get("content-disposition", "")
+            # Dot must be present — no "-md" at the end.
+            assert ".md" in disposition
+            assert '-md"' not in disposition

--- a/tests/test_chat_models.py
+++ b/tests/test_chat_models.py
@@ -20,10 +20,17 @@ from app.chat.models import (
     create_conversation,
     create_message,
     delete_conversation,
+    delete_messages_after,
+    fork_conversation,
     get_conversation,
     list_conversations_for_user,
     list_messages,
+    list_pinned_messages,
+    set_conversation_archived,
+    set_conversation_pinned,
+    set_message_pinned,
     update_conversation_title,
+    update_message_truncated,
 )
 
 # ---------------------------------------------------------------------------
@@ -239,6 +246,39 @@ class TestUpdateConversationTitle:
         assert "updated_at" in sql
         assert "Uuendatud pealkiri" in params
 
+    def test_update_title_defaults_title_is_custom_false(self):
+        """Default invocation (auto-title job) writes title_is_custom=False."""
+        conn = MagicMock()
+        update_conversation_title(conn, uuid.uuid4(), "Automaatne pealkiri")
+        params = conn.execute.call_args.args[1]
+        # Params: (title, is_custom, id)
+        assert params[0] == "Automaatne pealkiri"
+        assert params[1] is False
+
+    def test_update_title_is_custom_true_sets_flag(self):
+        """Manual rename flips title_is_custom so auto-titling is skipped."""
+        conn = MagicMock()
+        update_conversation_title(conn, uuid.uuid4(), "Käsitsi pealkiri", is_custom=True)
+        params = conn.execute.call_args.args[1]
+        assert params[0] == "Käsitsi pealkiri"
+        assert params[1] is True
+        sql = conn.execute.call_args.args[0]
+        assert "title_is_custom" in sql
+
+    def test_update_title_does_not_clobber_custom_flag(self):
+        """Auto-title job (is_custom=False) must preserve an existing TRUE flag.
+
+        Regression: the old SQL unconditionally wrote ``title_is_custom = %s``
+        so an auto-title call after a manual rename re-opened the row to
+        further auto-title overwrites. The fix uses a CASE WHEN that only
+        transitions FALSE → TRUE, never TRUE → FALSE.
+        """
+        conn = MagicMock()
+        update_conversation_title(conn, uuid.uuid4(), "Automaatne", is_custom=False)
+        sql = conn.execute.call_args.args[0]
+        # SQL must preserve the existing flag on is_custom=False.
+        assert "CASE WHEN %s THEN TRUE ELSE title_is_custom END" in sql
+
 
 # ---------------------------------------------------------------------------
 # delete_conversation
@@ -330,3 +370,378 @@ class TestListMessages:
 
         result = list_messages(conn, uuid.uuid4())
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# set_conversation_pinned / set_conversation_archived
+# ---------------------------------------------------------------------------
+
+
+class TestSetConversationPinned:
+    def test_pin_sets_pinned_at_now(self):
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+        set_conversation_pinned(conn, conv_id, True)
+
+        conn.execute.assert_called_once()
+        sql, params = conn.execute.call_args.args
+        assert "is_pinned" in sql
+        assert "pinned_at" in sql
+        # Params: (is_pinned, is_pinned_for_case_when, id)
+        assert params[0] is True
+        assert params[1] is True
+        assert params[2] == str(conv_id)
+
+    def test_unpin_sets_pinned_at_null(self):
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+        set_conversation_pinned(conn, conv_id, False)
+
+        sql, params = conn.execute.call_args.args
+        assert params[0] is False
+        # CASE WHEN FALSE THEN now() ELSE NULL uses the same flag.
+        assert params[1] is False
+        assert "NULL" in sql
+
+
+class TestSetConversationArchived:
+    def test_archive(self):
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+        set_conversation_archived(conn, conv_id, True)
+
+        sql, params = conn.execute.call_args.args
+        assert "is_archived" in sql
+        assert params == (True, str(conv_id))
+
+    def test_unarchive(self):
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+        set_conversation_archived(conn, conv_id, False)
+
+        _, params = conn.execute.call_args.args
+        assert params == (False, str(conv_id))
+
+
+# ---------------------------------------------------------------------------
+# list_conversations_for_user — ordering, filters, search
+# ---------------------------------------------------------------------------
+
+
+class TestListConversationsAdvanced:
+    def test_default_excludes_archived(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID)
+
+        sql = conn.execute.call_args.args[0]
+        assert "is_archived = FALSE" in sql
+
+    def test_include_archived_removes_filter(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, include_archived=True)
+
+        sql = conn.execute.call_args.args[0]
+        assert "is_archived = FALSE" not in sql
+
+    def test_pinned_first_orders_by_is_pinned(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, pinned_first=True)
+
+        sql = conn.execute.call_args.args[0]
+        assert "is_pinned DESC" in sql
+        assert "pinned_at DESC NULLS LAST" in sql
+
+    def test_pinned_first_false_orders_by_updated_at_only(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, pinned_first=False)
+
+        sql = conn.execute.call_args.args[0]
+        assert "is_pinned DESC" not in sql
+        assert "updated_at DESC" in sql
+
+    def test_search_uses_ilike(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, search="maks")
+
+        sql, params = conn.execute.call_args.args
+        assert "ILIKE" in sql
+        assert "%maks%" in params
+
+    def test_search_escapes_percent_wildcard(self):
+        """A literal ``%`` in the search term must not act as a wildcard."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, search="50%")
+
+        sql, params = conn.execute.call_args.args
+        # SQL must declare the escape character.
+        assert "ESCAPE '\\'" in sql
+        # The percent sign inside the search term is prefixed with a
+        # backslash so it matches literally; the surrounding wildcards
+        # stay unescaped.
+        assert r"%50\%%" in params
+
+    def test_search_escapes_underscore_wildcard(self):
+        """A literal ``_`` must not match any single character."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, search="a_b")
+
+        _, params = conn.execute.call_args.args
+        assert r"%a\_b%" in params
+
+    def test_search_escapes_backslash(self):
+        """Backslashes themselves are doubled so ESCAPE stays unambiguous."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID, search="a\\b")
+
+        _, params = conn.execute.call_args.args
+        # Input ``a\b`` → escape the backslash to ``a\\b`` inside a
+        # pattern that says ``ESCAPE '\'``.
+        assert r"%a\\b%" in params
+
+    def test_no_search_omits_ilike(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_conversations_for_user(conn, _USER_ID)
+
+        sql = conn.execute.call_args.args[0]
+        assert "ILIKE" not in sql
+
+    def test_pre_017_row_hydrates_with_defaults(self):
+        """A 7-tuple row (pre-migration 017) should still hydrate cleanly."""
+        conn = MagicMock()
+        row = _make_conversation_row(title="Old row")  # 7-tuple
+        conn.execute.return_value.fetchall.return_value = [row]
+
+        result = list_conversations_for_user(conn, _USER_ID)
+        assert len(result) == 1
+        assert result[0].is_pinned is False
+        assert result[0].is_archived is False
+        assert result[0].pinned_at is None
+        assert result[0].title_is_custom is False
+
+
+# ---------------------------------------------------------------------------
+# Message pin / truncated / list_pinned
+# ---------------------------------------------------------------------------
+
+
+class TestSetMessagePinned:
+    def test_pin(self):
+        conn = MagicMock()
+        msg_id = uuid.uuid4()
+        set_message_pinned(conn, msg_id, True)
+
+        sql, params = conn.execute.call_args.args
+        assert "is_pinned" in sql
+        assert params == (True, str(msg_id))
+
+    def test_unpin(self):
+        conn = MagicMock()
+        msg_id = uuid.uuid4()
+        set_message_pinned(conn, msg_id, False)
+
+        _, params = conn.execute.call_args.args
+        assert params == (False, str(msg_id))
+
+
+class TestUpdateMessageTruncated:
+    def test_mark_truncated_default_true(self):
+        conn = MagicMock()
+        msg_id = uuid.uuid4()
+        update_message_truncated(conn, msg_id)
+
+        sql, params = conn.execute.call_args.args
+        assert "is_truncated" in sql
+        assert params == (True, str(msg_id))
+
+    def test_mark_truncated_false(self):
+        conn = MagicMock()
+        msg_id = uuid.uuid4()
+        update_message_truncated(conn, msg_id, truncated=False)
+
+        _, params = conn.execute.call_args.args
+        assert params == (False, str(msg_id))
+
+
+class TestListPinnedMessages:
+    def test_filters_by_pinned_true(self):
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+        row = _make_message_row(conversation_id=conv_id)
+        conn.execute.return_value.fetchall.return_value = [row]
+
+        result = list_pinned_messages(conn, conv_id)
+        assert len(result) == 1
+
+        sql = conn.execute.call_args.args[0]
+        assert "is_pinned = TRUE" in sql
+
+    def test_empty(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        assert list_pinned_messages(conn, uuid.uuid4()) == []
+
+
+# ---------------------------------------------------------------------------
+# delete_messages_after
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMessagesAfter:
+    def test_delete_uses_strict_greater_than(self):
+        """Messages *at* the boundary created_at must NOT be deleted."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.rowcount = 3
+        conn.execute.return_value = cursor
+        boundary = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+
+        result = delete_messages_after(conn, uuid.uuid4(), boundary)
+
+        assert result == 3
+        sql, params = conn.execute.call_args.args
+        assert "DELETE" in sql
+        assert "created_at > %s" in sql
+        assert params[1] == boundary
+
+    def test_returns_zero_on_db_error(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("boom")
+
+        result = delete_messages_after(conn, uuid.uuid4(), datetime.now(UTC))
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# fork_conversation
+# ---------------------------------------------------------------------------
+
+
+class TestForkConversation:
+    def test_fork_copies_messages_up_to_boundary(self):
+        conn = MagicMock()
+        source_conv_id = uuid.uuid4()
+        boundary_msg_id = uuid.uuid4()
+        boundary_created_at = datetime(2026, 4, 14, 9, 30, tzinfo=UTC)
+
+        # 1. boundary lookup 2. get_conversation 3. create_conversation
+        # 4. INSERT ... SELECT
+        source_row = _make_conversation_row(conv_id=source_conv_id, title="Algvestlus")
+        new_conv_id = uuid.uuid4()
+        new_row = _make_conversation_row(conv_id=new_conv_id, title="Jätk: Algvestlus")
+
+        fetchone_results = [
+            (boundary_created_at, source_conv_id),  # boundary lookup
+            source_row,  # get_conversation(source)
+            new_row,  # create_conversation(new)
+        ]
+        conn.execute.return_value.fetchone.side_effect = fetchone_results
+
+        new_conv = fork_conversation(
+            conn,
+            source_conv_id,
+            boundary_msg_id,
+            user_id=_USER_ID,
+            org_id=_ORG_ID,
+        )
+
+        assert new_conv.id == new_conv_id
+        assert new_conv.title == "Jätk: Algvestlus"
+
+        # Final call should be the INSERT ... SELECT with created_at bound.
+        final_call = conn.execute.call_args_list[-1]
+        sql = final_call.args[0]
+        params = final_call.args[1]
+        assert "INSERT INTO messages" in sql
+        assert "created_at <= %s" in sql
+        assert "content_encrypted" in sql
+        assert "tool_input_encrypted" in sql
+        assert "tool_output_encrypted" in sql
+        assert "rag_context_encrypted" in sql
+        assert params == (
+            str(new_conv_id),
+            str(source_conv_id),
+            boundary_created_at,
+        )
+
+    def test_fork_title_prefixes_jatk(self):
+        conn = MagicMock()
+        source_conv_id = uuid.uuid4()
+        boundary_msg_id = uuid.uuid4()
+        created_at = datetime.now(UTC)
+
+        source_row = _make_conversation_row(conv_id=source_conv_id, title="Maksureform")
+        new_row = _make_conversation_row(title="Jätk: Maksureform")
+
+        conn.execute.return_value.fetchone.side_effect = [
+            (created_at, source_conv_id),
+            source_row,
+            new_row,
+        ]
+
+        fork_conversation(
+            conn,
+            source_conv_id,
+            boundary_msg_id,
+            user_id=_USER_ID,
+            org_id=_ORG_ID,
+        )
+
+        # create_conversation call — look for the INSERT INTO conversations
+        insert_calls = [
+            c for c in conn.execute.call_args_list if "INSERT INTO conversations" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+        params = insert_calls[0].args[1]
+        # (user_id, org_id, title, context_draft_id)
+        assert params[2] == "Jätk: Maksureform"
+
+    def test_fork_raises_if_boundary_message_missing(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        with pytest.raises(ValueError, match="not found"):
+            fork_conversation(
+                conn,
+                uuid.uuid4(),
+                uuid.uuid4(),
+                user_id=_USER_ID,
+                org_id=_ORG_ID,
+            )
+
+    def test_fork_raises_if_boundary_belongs_to_other_conversation(self):
+        conn = MagicMock()
+        source_conv_id = uuid.uuid4()
+        other_conv_id = uuid.uuid4()
+
+        conn.execute.return_value.fetchone.return_value = (
+            datetime.now(UTC),
+            other_conv_id,
+        )
+
+        with pytest.raises(ValueError, match="does not belong"):
+            fork_conversation(
+                conn,
+                source_conv_id,
+                uuid.uuid4(),
+                user_id=_USER_ID,
+                org_id=_ORG_ID,
+            )

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -22,9 +22,12 @@ from app.chat.orchestrator import (
     _MAX_HISTORY_MESSAGES,
     MAX_TOOL_ROUNDS,
     ChatOrchestrator,
+    WebSocketSendTimeout,
     _build_llm_messages,
     _load_impact_summary,
     _messages_to_prompt,
+    _safe_send,
+    _tool_result_count,
 )
 from app.llm.provider import LLMProvider, StreamEvent
 
@@ -854,3 +857,565 @@ class TestOrchestratorPartialPersistence:
 
         # Only 1 commit (for the user message), not 2 (no assistant msg persisted)
         assert conn.commit.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase UX polish tests (issue #594)
+# ---------------------------------------------------------------------------
+
+
+from dataclasses import dataclass  # noqa: E402
+
+
+@dataclass
+class _FakeChunk:
+    """Mimics ``app.rag.retriever.RetrievedChunk`` for test purposes."""
+
+    content: str
+    metadata: dict
+    score: float
+
+
+class _FakeRetriever:
+    """Retriever stub that returns a canned chunk list."""
+
+    def __init__(self, chunks: list[_FakeChunk] | None = None) -> None:
+        self.chunks = chunks or []
+
+    async def retrieve(
+        self,
+        query: str,
+        k: int = 10,
+        source_type: str | None = None,
+        org_id: str | None = None,
+    ) -> list[_FakeChunk]:
+        return self.chunks
+
+
+def _setup_orchestrator_conn(mock_get_conn: Any, *, context_draft_id: Any = None) -> MagicMock:
+    """Minimal conn mock matching conversations + messages table shapes."""
+    conn = MagicMock()
+    mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+    conv = _make_conversation()
+    now = datetime.now(UTC)
+
+    call_counter = {"n": 0}
+    base_conv_row = (
+        conv.id,
+        conv.user_id,
+        conv.org_id,
+        conv.title,
+        context_draft_id,
+        conv.created_at,
+        conv.updated_at,
+    )
+
+    def side_effect_fetchone():
+        call_counter["n"] += 1
+        if call_counter["n"] == 1:
+            return base_conv_row
+        return (
+            uuid.uuid4(),
+            _CONV_ID,
+            "user",
+            "x",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            now,
+            None,
+            None,
+            None,
+            None,
+        )
+
+    conn.execute.return_value.fetchone = side_effect_fetchone
+    conn.execute.return_value.fetchall.return_value = []
+    return conn
+
+
+class TestSafeSend:
+    """Coverage for the ``_safe_send`` helper."""
+
+    def test_successful_send_passes_event_through(self):
+        received: list[dict[str, Any]] = []
+
+        async def ok_send(event: dict[str, Any]) -> None:
+            received.append(event)
+
+        asyncio.run(_safe_send(ok_send, {"type": "content_delta", "delta": "x"}))
+        assert received == [{"type": "content_delta", "delta": "x"}]
+
+    def test_timeout_raises_domain_exception(self):
+        async def slow_send(event: dict[str, Any]) -> None:
+            await asyncio.sleep(0.5)
+
+        async def run():
+            await _safe_send(slow_send, {"type": "content_delta"}, timeout=0.05)
+
+        try:
+            asyncio.run(run())
+            raised = False
+        except WebSocketSendTimeout:
+            raised = True
+        assert raised
+
+
+class TestToolResultCount:
+    def test_list_results(self):
+        assert _tool_result_count({"results": [1, 2, 3]}) == 3
+
+    def test_empty_list_results(self):
+        assert _tool_result_count({"results": []}) == 0
+
+    def test_dict_without_results_is_one(self):
+        assert _tool_result_count({"uri": "x"}) == 1
+
+    def test_error_payload_is_zero(self):
+        assert _tool_result_count({"error": "boom"}) == 0
+
+    def test_non_dict_is_zero(self):
+        assert _tool_result_count("nope") == 0
+        assert _tool_result_count(None) == 0
+
+
+class TestRetrievalDoneAlwaysEmitted:
+    """retrieval_done fires on both have-chunks and no-chunks paths."""
+
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_retrieval_done_with_chunks(self, mock_get_conn, mock_rate, mock_cost):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        chunks = [
+            _FakeChunk("foo", {"source_uri": "estleg:A/p1"}, 0.9),
+            _FakeChunk("bar", {"source_uri": "estleg:B/p2"}, 0.8),
+        ]
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql(), retriever=_FakeRetriever(chunks))
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        done_events = [e for e in collector.events if e.get("type") == "retrieval_done"]
+        assert len(done_events) == 1
+        assert done_events[0]["chunk_count"] == 2
+
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_retrieval_done_with_no_chunks(self, mock_get_conn, mock_rate, mock_cost):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql(), retriever=_FakeRetriever([]))
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        done_events = [e for e in collector.events if e.get("type") == "retrieval_done"]
+        assert len(done_events) == 1
+        assert done_events[0]["chunk_count"] == 0
+
+
+class TestToolCallIdPairing:
+    """tool_use and tool_result must carry the same ``tool_call_id``."""
+
+    @patch("app.chat.orchestrator.execute_tool")
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_tool_use_and_result_share_id(
+        self, mock_get_conn, mock_rate, mock_cost, mock_exec_tool
+    ):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        async def fake_exec_tool(name, inp, sparql, auth=None):
+            return {"results": [{"uri": "estleg:Test"}, {"uri": "estleg:Test2"}]}
+
+        mock_exec_tool.side_effect = fake_exec_tool
+
+        events_seq = [
+            [
+                StreamEvent(
+                    type="tool_use",
+                    tool_name="query_ontology",
+                    tool_input={"q": "x"},
+                ),
+                StreamEvent(type="stop"),
+            ],
+            [
+                StreamEvent(type="content", delta="ok"),
+                StreamEvent(type="stop"),
+            ],
+        ]
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(events_seq), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Otsi", _auth(), collector))
+
+        use_events = [e for e in collector.events if e.get("type") == "tool_use"]
+        result_events = [e for e in collector.events if e.get("type") == "tool_result"]
+        assert len(use_events) == 1
+        assert len(result_events) == 1
+        assert use_events[0]["tool_call_id"]
+        assert use_events[0]["tool_call_id"] == result_events[0]["tool_call_id"]
+        assert result_events[0]["result_count"] == 2
+        assert result_events[0]["result"] == {
+            "results": [{"uri": "estleg:Test"}, {"uri": "estleg:Test2"}]
+        }
+
+
+class TestSourcesEvent:
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_sources_event_has_chunks(self, mock_get_conn, mock_rate, mock_cost):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        chunks = [
+            _FakeChunk(
+                content="A long provision text " * 20,
+                metadata={"source_uri": "https://example.ee/laws/KarS/p121"},
+                score=0.92,
+            ),
+        ]
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql(), retriever=_FakeRetriever(chunks))
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        sources_events = [e for e in collector.events if e.get("type") == "sources"]
+        assert len(sources_events) == 1
+        srcs = sources_events[0]["sources"]
+        assert len(srcs) == 1
+        assert srcs[0]["source_uri"] == "https://example.ee/laws/KarS/p121"
+        assert srcs[0]["title"] == "p121"
+        assert srcs[0]["score"] == 0.92
+        assert len(srcs[0]["snippet"]) <= 200
+
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_sources_event_empty_when_no_chunks(self, mock_get_conn, mock_rate, mock_cost):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql(), retriever=_FakeRetriever([]))
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        sources_events = [e for e in collector.events if e.get("type") == "sources"]
+        assert len(sources_events) == 1
+        assert sources_events[0]["sources"] == []
+
+
+class TestFollowUpsFeatureFlag:
+    @patch.dict("os.environ", {"CHAT_FOLLOW_UPS_ENABLED": "0"}, clear=False)
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_follow_ups_not_emitted_when_disabled(self, mock_get_conn, mock_rate, mock_cost):
+        _setup_orchestrator_conn(mock_get_conn)
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+        assert not any(e.get("type") == "follow_ups" for e in collector.events)
+
+    @patch.dict("os.environ", {"CHAT_FOLLOW_UPS_ENABLED": "1"}, clear=False)
+    @patch("app.llm.get_default_provider")
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_follow_ups_emitted_when_enabled(
+        self, mock_get_conn, mock_rate, mock_cost, mock_default_provider
+    ):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        async def fake_acomplete(prompt, **kwargs):
+            return '["Esimene?", "Teine?", "Kolmas?"]'
+
+        provider_stub = MagicMock()
+        provider_stub.acomplete = fake_acomplete
+        mock_default_provider.return_value = provider_stub
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        follow_events = [e for e in collector.events if e.get("type") == "follow_ups"]
+        assert len(follow_events) == 1
+        assert follow_events[0]["suggestions"] == ["Esimene?", "Teine?", "Kolmas?"]
+
+    @patch.dict("os.environ", {"CHAT_FOLLOW_UPS_ENABLED": "1"}, clear=False)
+    @patch("app.llm.get_default_provider")
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_follow_ups_silent_on_llm_failure(
+        self, mock_get_conn, mock_rate, mock_cost, mock_default_provider
+    ):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        async def boom(prompt, **kwargs):
+            raise RuntimeError("no follow-up model today")
+
+        provider_stub = MagicMock()
+        provider_stub.acomplete = boom
+        mock_default_provider.return_value = provider_stub
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        assert not any(e.get("type") == "follow_ups" for e in collector.events)
+
+
+class TestStopGenerationCancel:
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_cancelled_persists_partial_and_emits_stopped(
+        self, mock_get_conn, mock_rate, mock_cost
+    ):
+        conn = _setup_orchestrator_conn(mock_get_conn)
+
+        class SlowLLM(FakeLLM):
+            async def astream(self, prompt: str, **kwargs: Any):
+                yield StreamEvent(type="content", delta="Osaline ")
+                yield StreamEvent(type="content", delta="vastus ")
+                await asyncio.sleep(10)
+                yield StreamEvent(type="stop")
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(SlowLLM(), FakeSparql())
+
+        async def runner():
+            task = asyncio.create_task(
+                orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector)
+            )
+            # Give the orchestrator a chance to produce partial content.
+            await asyncio.sleep(0.05)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(runner())
+
+        stopped = [e for e in collector.events if e.get("type") == "stopped"]
+        assert len(stopped) == 1
+
+        # Partial assistant content must have been persisted: we expect
+        # at least one UPDATE setting is_truncated = TRUE.
+        sql_calls = [
+            call.args[0]
+            for call in conn.execute.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        ]
+        assert any("is_truncated = TRUE" in sql for sql in sql_calls)
+
+
+class TestMaxToolRoundsCapVerified:
+    """Explicitly verify MAX_TOOL_ROUNDS=5 is enforced (issue #594.10)."""
+
+    def test_cap_is_five(self):
+        assert MAX_TOOL_ROUNDS == 5
+
+
+# ---------------------------------------------------------------------------
+# Code-review follow-ups
+# ---------------------------------------------------------------------------
+
+
+class TestCostBudgetAdvisoryLock:
+    """The advisory lock must engage on the same conn that persists the user msg."""
+
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_cost_budget_uses_advisory_lock_when_conn_passed(self, mock_get_conn, mock_rate):
+        """The advisory lock must be taken on the conn that then INSERTs the
+        user message — the two operations must share a transaction so the
+        lock serialises the read-then-insert window.
+        """
+        # Two independent conn mocks: the first is used for loading the
+        # conversation + history, the second is the budget-check-plus-
+        # user-message-insert conn we care about.
+        conv = _make_conversation()
+        now = datetime.now(UTC)
+
+        # Shared counter so subsequent calls return message rows.
+        call_counter = {"n": 0}
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+
+        def side_effect_fetchone():
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return base_conv_row
+            return (
+                uuid.uuid4(),
+                _CONV_ID,
+                "user",
+                "x",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                now,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        # We'll hand out a stream of conns — the orchestrator opens a fresh
+        # connection per ``with get_connection()`` block. Capture per-conn
+        # execute history so we can verify the budget+insert conn started
+        # with the advisory-lock SQL.
+        conn_histories: list[list[str]] = []
+
+        def make_conn() -> MagicMock:
+            history: list[str] = []
+            conn_histories.append(history)
+            conn = MagicMock()
+            conn.execute.return_value.fetchone = side_effect_fetchone
+            conn.execute.return_value.fetchall.return_value = []
+
+            original_execute = conn.execute
+
+            def execute_spy(sql, *a, **kw):
+                history.append(sql)
+                return original_execute.return_value
+
+            conn.execute.side_effect = execute_spy
+            return conn
+
+        conns: list[MagicMock] = []
+
+        class _FakeCm:
+            def __enter__(self):
+                c = make_conn()
+                conns.append(c)
+                return c
+
+            def __exit__(self, *_a):
+                return False
+
+        mock_get_conn.side_effect = lambda: _FakeCm()
+
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
+
+        # Locate the conn whose first SQL statement contains the advisory
+        # lock. That conn must ALSO run an INSERT INTO messages call (the
+        # shared-transaction guarantee from the review fix).
+        lock_conn_history: list[str] | None = None
+        for history in conn_histories:
+            if history and "pg_advisory_xact_lock" in history[0]:
+                lock_conn_history = history
+                break
+
+        assert lock_conn_history is not None, (
+            "No connection took pg_advisory_xact_lock as its first SQL. "
+            f"Observed histories: {conn_histories}"
+        )
+        # The very first SQL on that conn is the lock call — this is the
+        # TOCTOU-closing property.
+        assert "pg_advisory_xact_lock" in lock_conn_history[0]
+        # And the same conn later inserts the user message.
+        assert any(
+            "INSERT INTO messages" in sql for sql in lock_conn_history if isinstance(sql, str)
+        ), (
+            "Lock-holding conn never persisted a user message — the "
+            "transaction-sharing guarantee is not wired up."
+        )
+
+
+class TestSendTimeoutMidStream:
+    """A timeout on a mid-stream send must persist the partial with is_truncated=True."""
+
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_send_timeout_persists_partial_as_truncated(self, mock_get_conn, mock_rate, mock_cost):
+        conn = _setup_orchestrator_conn(mock_get_conn)
+
+        # LLM emits several content deltas before stopping. We make the
+        # second send call raise WebSocketSendTimeout to mimic a wedged
+        # client socket.
+        class TwoDeltaLLM(FakeLLM):
+            async def astream(self, prompt: str, **kwargs: Any):
+                yield StreamEvent(type="content", delta="Esimene ")
+                yield StreamEvent(type="content", delta="teine ")
+                yield StreamEvent(type="stop")
+
+        call_count = {"n": 0}
+
+        async def flaky_send(event: dict[str, Any]) -> None:
+            # Allow retrieval_done etc. through; only time out on the
+            # second content_delta.
+            if event.get("type") == "content_delta":
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    return  # first delta ok
+                raise WebSocketSendTimeout("content_delta")
+            return
+
+        orchestrator = ChatOrchestrator(TwoDeltaLLM(), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), flaky_send))
+
+        # The first delta went through, the second triggered a timeout.
+        assert call_count["n"] == 2
+
+        # Partial content was persisted with is_truncated=TRUE.
+        sql_calls = [
+            call.args[0]
+            for call in conn.execute.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        ]
+        assert any("is_truncated = TRUE" in sql for sql in sql_calls), (
+            "Partial assistant turn should be flagged is_truncated after send timeout."
+        )
+
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_send_timeout_stops_further_events(self, mock_get_conn, mock_rate, mock_cost):
+        _setup_orchestrator_conn(mock_get_conn)
+
+        class TwoDeltaLLM(FakeLLM):
+            async def astream(self, prompt: str, **kwargs: Any):
+                yield StreamEvent(type="content", delta="A")
+                yield StreamEvent(type="content", delta="B")
+                yield StreamEvent(type="stop")
+
+        received: list[dict[str, Any]] = []
+        call_count = {"n": 0}
+
+        async def flaky_send(event: dict[str, Any]) -> None:
+            if event.get("type") == "content_delta":
+                call_count["n"] += 1
+                if call_count["n"] >= 2:
+                    raise WebSocketSendTimeout("content_delta")
+            received.append(event)
+
+        orchestrator = ChatOrchestrator(TwoDeltaLLM(), FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), flaky_send))
+
+        # After the timeout we must NOT see a ``done`` event on the
+        # wedged socket — the orchestrator should bail silently.
+        assert not any(e.get("type") == "done" for e in received)

--- a/tests/test_chat_rag_integration.py
+++ b/tests/test_chat_rag_integration.py
@@ -392,15 +392,28 @@ class TestOrchestratorRateLimitIntegration:
         side_effect=CostBudgetExceededError("Kulueelarve on taidetud."),
     )
     @patch("app.chat.orchestrator.check_message_rate")
+    @patch(
+        "app.chat.orchestrator.get_conversation",
+        return_value=_make_conversation(),
+    )
+    @patch("app.chat.orchestrator.list_messages", return_value=[])
     @patch("app.chat.orchestrator.get_connection")
-    def test_cost_budget_sends_error_event(self, mock_get_conn, mock_rate, mock_cost):
-        """CostBudgetExceededError triggers an error event, no LLM call."""
+    def test_cost_budget_sends_error_event(
+        self, mock_get_conn, mock_list, mock_get_conv, mock_rate, mock_cost
+    ):
+        """CostBudgetExceededError triggers an error event, no LLM call.
+
+        The budget check was relocated inside the conversation-load
+        transaction so the advisory lock can actually serialise
+        concurrent checks (TOCTOU fix). The test therefore needs to
+        feed past conversation loading before the cost check fires.
+        """
         llm = FakeLLM()
         collector = _Collector()
         orchestrator = ChatOrchestrator(llm, FakeSparql())
 
         asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
 
-        assert len(collector.events) == 1
-        assert collector.events[0]["type"] == "error"
-        assert "taidetud" in collector.events[0]["message"].lower()
+        error_events = [e for e in collector.events if e["type"] == "error"]
+        assert len(error_events) == 1
+        assert "taidetud" in error_events[0]["message"].lower()

--- a/tests/test_chat_rate_limiter.py
+++ b/tests/test_chat_rate_limiter.py
@@ -5,10 +5,14 @@ Covers:
 - :func:`check_message_rate` exceeding and passing
 - :func:`check_org_cost_budget` exceeding and passing
 - Graceful degradation when the DB is unavailable (fail-open)
+- :func:`check_org_cost_budget` with an injected ``conn`` (FOR UPDATE path)
+- :func:`get_user_quota` snapshot shape
+- :func:`seconds_until_hourly_reset` window math
 """
 
 from __future__ import annotations
 
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest  # noqa: I001
@@ -18,8 +22,11 @@ from app.chat.rate_limiter import (
     _MAX_MONTHLY_COST_USD,
     CostBudgetExceededError,
     RateLimitExceededError,
+    UserQuota,
     check_message_rate,
     check_org_cost_budget,
+    get_user_quota,
+    seconds_until_hourly_reset,
 )
 
 _USER_ID = "11111111-1111-1111-1111-111111111111"
@@ -161,3 +168,163 @@ class TestCheckOrgCostBudget:
 
         with pytest.raises(CostBudgetExceededError, match="USD"):
             check_org_cost_budget(_ORG_ID)
+
+
+# ---------------------------------------------------------------------------
+# check_org_cost_budget — transactional (FOR UPDATE / advisory lock) path
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOrgCostBudgetWithConn:
+    def test_advisory_lock_is_taken_when_conn_is_provided(self):
+        """When a caller-supplied conn is passed, we must take the advisory lock
+        before reading the running total. This serialises concurrent checks."""
+        conn = MagicMock()
+        # Two execute() calls: lock + select. Chain them via side_effect.
+        lock_result = MagicMock()
+        select_result = MagicMock()
+        select_result.fetchone.return_value = (10.0,)
+        conn.execute.side_effect = [lock_result, select_result]
+
+        check_org_cost_budget(_ORG_ID, conn=conn)
+
+        # First call must be the advisory lock.
+        first_call_sql = conn.execute.call_args_list[0].args[0]
+        assert "pg_advisory_xact_lock" in first_call_sql
+        # Second call reads the running total.
+        second_call_sql = conn.execute.call_args_list[1].args[0]
+        assert "SUM(cost_usd)" in second_call_sql
+
+    def test_second_check_sees_accumulated_cost(self):
+        """Proxy for FOR UPDATE correctness: two sequential checks against the
+        same budget inside one transaction should see the updated total on the
+        second call. We simulate an insert happening between them by returning
+        a higher SUM on the second SELECT."""
+        conn = MagicMock()
+
+        lock1 = MagicMock()
+        select1 = MagicMock()
+        select1.fetchone.return_value = (10.0,)  # Under cap — passes.
+        lock2 = MagicMock()
+        select2 = MagicMock()
+        # Simulates another request that successfully charged between the two
+        # checks, pushing us over the monthly cap.
+        select2.fetchone.return_value = (_MAX_MONTHLY_COST_USD + 5.0,)
+        conn.execute.side_effect = [lock1, select1, lock2, select2]
+
+        # First call: still under budget.
+        check_org_cost_budget(_ORG_ID, conn=conn)
+
+        # Second call: over budget, should raise.
+        with pytest.raises(CostBudgetExceededError):
+            check_org_cost_budget(_ORG_ID, conn=conn)
+
+    def test_legacy_call_without_conn_still_works(self):
+        """Backward compatibility: calling without conn opens its own
+        short-lived connection and does not take an advisory lock."""
+        with patch("app.chat.rate_limiter.get_connection") as mock_get_conn:
+            conn = MagicMock()
+            mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+            mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+            conn.execute.return_value.fetchone.return_value = (5.0,)
+
+            check_org_cost_budget(_ORG_ID)
+
+            # No advisory lock issued on the legacy path.
+            executed_sqls = [c.args[0] for c in conn.execute.call_args_list]
+            assert not any("pg_advisory_xact_lock" in s for s in executed_sqls)
+
+
+# ---------------------------------------------------------------------------
+# get_user_quota
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserQuota:
+    @patch("app.chat.rate_limiter.get_connection")
+    def test_returns_expected_values_from_seeded_data(self, mock_get_conn: MagicMock):
+        """Seeded data (7 messages this hour, $12.34 this month) must round-trip
+        through the dataclass with the right types."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        message_cursor = MagicMock()
+        message_cursor.fetchone.return_value = (7,)
+        cost_cursor = MagicMock()
+        cost_cursor.fetchone.return_value = (Decimal("12.34"),)
+        conn.execute.side_effect = [message_cursor, cost_cursor]
+
+        quota = get_user_quota(_USER_ID, _ORG_ID)
+
+        assert isinstance(quota, UserQuota)
+        assert quota.messages_this_hour == 7
+        assert quota.message_limit_per_hour == _MAX_MESSAGES_PER_HOUR
+        assert quota.cost_this_month_usd == Decimal("12.34")
+        assert quota.cost_limit_per_month_usd == Decimal(str(_MAX_MONTHLY_COST_USD))
+        # 80% of limit, rounded to 2 decimals.
+        expected_alert = (Decimal(str(_MAX_MONTHLY_COST_USD)) * Decimal("0.8")).quantize(
+            Decimal("0.01")
+        )
+        assert quota.cost_alert_threshold_usd == expected_alert
+
+    @patch("app.chat.rate_limiter.get_connection")
+    def test_db_error_returns_zero_usage(self, mock_get_conn: MagicMock):
+        """DB failure must not explode the usage dashboard — return zeros."""
+        mock_get_conn.side_effect = Exception("DB down")
+
+        quota = get_user_quota(_USER_ID, _ORG_ID)
+
+        assert quota.messages_this_hour == 0
+        assert quota.cost_this_month_usd == Decimal("0")
+        # Limits still reflect env config.
+        assert quota.message_limit_per_hour == _MAX_MESSAGES_PER_HOUR
+
+
+# ---------------------------------------------------------------------------
+# seconds_until_hourly_reset
+# ---------------------------------------------------------------------------
+
+
+class TestSecondsUntilHourlyReset:
+    @patch("app.chat.rate_limiter.get_connection")
+    def test_oldest_message_55_minutes_ago_returns_about_300s(self, mock_get_conn: MagicMock):
+        """55 min old -> 3600 - 3300 = 300 seconds remaining."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+        # EPOCH seconds since the oldest message = 55 min = 3300 s.
+        conn.execute.return_value.fetchone.return_value = (3300.0,)
+
+        remaining = seconds_until_hourly_reset(_USER_ID)
+
+        assert 295 <= remaining <= 305
+
+    @patch("app.chat.rate_limiter.get_connection")
+    def test_no_messages_in_window_returns_zero(self, mock_get_conn: MagicMock):
+        """Empty window -> no wait time."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+        conn.execute.return_value.fetchone.return_value = (None,)
+
+        assert seconds_until_hourly_reset(_USER_ID) == 0
+
+    @patch("app.chat.rate_limiter.get_connection")
+    def test_very_recent_message_clamped_to_3600(self, mock_get_conn: MagicMock):
+        """A message 0.1 s old -> 3599.9 s remaining, clamped to int 3599."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+        conn.execute.return_value.fetchone.return_value = (0.1,)
+
+        remaining = seconds_until_hourly_reset(_USER_ID)
+
+        assert 3590 <= remaining <= 3600
+
+    @patch("app.chat.rate_limiter.get_connection")
+    def test_db_error_returns_zero(self, mock_get_conn: MagicMock):
+        """DB error -> fail-open with 0 (caller can retry immediately)."""
+        mock_get_conn.side_effect = Exception("DB down")
+
+        assert seconds_until_hourly_reset(_USER_ID) == 0

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -63,6 +63,9 @@ def _make_message(
     role: str = "user",
     content: str = "Tere",
     conv_id: uuid.UUID = _CONV_ID,
+    rag_context: list[dict] | None = None,
+    is_pinned: bool = False,
+    is_truncated: bool = False,
 ) -> Message:
     now = datetime.now(UTC)
     return Message(
@@ -73,11 +76,13 @@ def _make_message(
         tool_name=None,
         tool_input=None,
         tool_output=None,
-        rag_context=None,
+        rag_context=rag_context,
         tokens_input=None,
         tokens_output=None,
         model=None,
         created_at=now,
+        is_pinned=is_pinned,
+        is_truncated=is_truncated,
     )
 
 
@@ -527,3 +532,278 @@ class TestCrossOrgDraftContextLeak:
 
             result = _get_draft_title(str(_DRAFT_ID), _ORG_ID)
             assert result == "Eelnou XYZ"
+
+
+# ---------------------------------------------------------------------------
+# Vestlus UX polish (migration 017): header meta, sources, actions,
+# empty state, draft prompts, list search + pin/archive actions.
+# ---------------------------------------------------------------------------
+
+
+class TestConversationViewPolish:
+    """Assert the structural UI affordances added by the polish sweep."""
+
+    def _setup(self, mock_connect):
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        return conn
+
+    @patch("app.chat.routes.list_messages", return_value=[])
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_header_meta_present_on_view(self, mock_provider, mock_connect, _mock_list):
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        with patch("app.chat.routes.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert 'id="chat-status"' in resp.text
+            assert 'id="chat-quota"' in resp.text
+            assert "chat-header-meta" in resp.text
+            # Quota pill must start as aria-busy so screen readers do not
+            # announce the placeholder "0" before the first /api/me/usage
+            # response paints real values (chat.js clears these afterwards).
+            assert 'aria-busy="true"' in resp.text
+            assert 'data-initial="true"' in resp.text
+            # Vendor + chat.js wiring
+            assert "/static/js/chat.js" in resp.text
+            # Exact patch-pinned versions — updating them requires refreshing
+            # the SRI hashes below.
+            assert "marked@12.0.2" in resp.text
+            assert "dompurify@3.1.6" in resp.text
+            # Subresource Integrity hashes for both CDN scripts. Computed via
+            #   curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A
+            assert (
+                "sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi"
+                in resp.text
+            )
+            assert (
+                "sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"
+                in resp.text
+            )
+            assert 'crossorigin="anonymous"' in resp.text
+
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_sources_panel_rendered_for_rag_context(self, mock_provider, mock_connect):
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        rag = [
+            {
+                "source_uri": "https://example.org/laws/KarS",
+                "content": "Karistusseadustiku § 113 kaitseb inimese elu...",
+                "score": 0.9,
+            },
+            {
+                "source_uri": "https://example.org/laws/PS",
+                "content": "Pohiseaduse § 13 kohaselt on igaul oigus...",
+                "score": 0.8,
+            },
+        ]
+        msg = _make_message("assistant", "Vastus", rag_context=rag)
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "chat-sources" in resp.text
+            assert "Allikad (2)" in resp.text
+            assert "KarS" in resp.text
+            assert "PS" in resp.text
+
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_action_row_present_on_assistant_messages(self, mock_provider, mock_connect):
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        msg = _make_message("assistant", "Vastus")
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "chat-message-actions" in resp.text
+            assert 'data-action="regenerate"' in resp.text
+            assert 'data-action="copy"' in resp.text
+            assert 'data-action="feedback-up"' in resp.text
+            assert 'data-action="feedback-down"' in resp.text
+
+    @patch("app.chat.routes.list_messages", return_value=[])
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_empty_state_with_five_default_prompts(self, mock_provider, mock_connect, _mock_list):
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        with patch("app.chat.routes.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert 'id="chat-empty-state"' in resp.text
+            # Five default prompts (each button carries the chat-example-prompt class)
+            assert resp.text.count("chat-example-prompt-label") == 5
+            # A distinctive phrase from the default prompts — asserted in
+            # its full accented form so an accidental ASCII-fallback would
+            # surface immediately.
+            assert "Isikuandmete töötlemine" in resp.text
+
+    @patch("app.chat.routes.list_messages", return_value=[])
+    @patch("app.chat.routes._get_draft_title", return_value="Eelnou X")
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_draft_specific_prompts_when_context_draft_set(
+        self, mock_provider, mock_connect, _mock_title, _mock_list
+    ):
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation(context_draft_id=_DRAFT_ID)
+        with patch("app.chat.routes.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            # Draft-specific wording — asserted with the original Estonian
+            # characters so an accidental unaccented rewrite is caught.
+            assert "Võrdle kehtiva õigusega" in resp.text
+            assert "Sarnased eelnõud" in resp.text
+            # The "Vaata mõju" link from the draft header
+            assert "Vaata mõju" in resp.text
+
+    @patch("app.chat.routes.list_messages")
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_truncated_note_appended_to_assistant_message(
+        self, mock_provider, mock_connect, mock_list
+    ):
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        msg = _make_message("assistant", "Pooleli vastus", is_truncated=True)
+        mock_list.return_value = [msg]
+        with patch("app.chat.routes.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            # The truncated-response note is rendered as the full Estonian
+            # phrase, preceded by a U+2014 em-dash and wrapped in the
+            # ``chat-message-truncated`` em tag. Assert both halves so an
+            # accidental ASCII hyphen or missing class would surface here.
+            assert "\u2014" in resp.text  # em-dash separator
+            assert '<em class="chat-message-truncated">vastus katkestati</em>' in resp.text
+
+
+class TestChatListPolish:
+    """Search input + pin/archive/rename forms on the list view."""
+
+    @patch("app.chat.routes._count_conversations_for_user", return_value=1)
+    @patch("app.chat.routes._get_last_message_at", return_value=None)
+    @patch("app.chat.routes._get_message_count", return_value=0)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_search_input_and_actions_present(
+        self,
+        mock_provider,
+        mock_connect,
+        _mock_msg_count,
+        _mock_last,
+        _mock_total,
+    ):
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        conv = _make_conversation()
+        with patch("app.chat.routes.list_conversations_for_user", return_value=[conv]):
+            client = _authed_client()
+            resp = client.get("/chat")
+            assert resp.status_code == 200
+            # Search input present
+            assert 'name="q"' in resp.text
+            assert "Otsi vestlusi" in resp.text
+            # Archived toggle
+            assert 'name="archived"' in resp.text
+            # Action forms targeting the pin/archive/rename handlers
+            assert f"/chat/{_CONV_ID}/pin" in resp.text
+            assert f"/chat/{_CONV_ID}/archive" in resp.text
+            assert f"/chat/{_CONV_ID}/rename" in resp.text
+
+    @patch("app.chat.routes._count_conversations_for_user", return_value=1)
+    @patch("app.chat.routes._get_last_message_at", return_value=None)
+    @patch("app.chat.routes._get_message_count", return_value=0)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_search_query_passed_through(
+        self,
+        mock_provider,
+        mock_connect,
+        _mock_msg_count,
+        _mock_last,
+        _mock_total,
+    ):
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("app.chat.routes.list_conversations_for_user", return_value=[]) as mock_list:
+            client = _authed_client()
+            resp = client.get("/chat?q=karistus")
+            assert resp.status_code == 200
+            # The search term was forwarded to the models helper as a kwarg.
+            kwargs = mock_list.call_args.kwargs
+            assert kwargs.get("search") == "karistus"
+
+
+class TestChatRouteOrdering:
+    """Route-registration order regression tests.
+
+    Starlette matches routes in the order they are added. ``/chat/search``
+    and similar static paths MUST be registered before ``/chat/{conv_id}``
+    so the dispatcher resolves them as handlers rather than capturing
+    ``search`` as a UUID (which would 404 because it is not a valid UUID).
+    """
+
+    @patch("app.chat.handlers._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_search_path_is_not_captured_as_conv_id(self, mock_provider, mock_connect):
+        """``GET /chat/search?q=foo`` must reach the search handler.
+
+        A non-HTMX browser request returns a 303 redirect to
+        ``/chat?q=foo``; the important assertion is that the response is NOT
+        a 404 (which would mean the ``/chat/{conv_id}`` catch-all captured
+        the path and rejected "search" as an invalid UUID).
+        """
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.get("/chat/search?q=foo")
+        # Must not be 404 (the catch-all would reject "search" as !UUID).
+        assert resp.status_code != 404
+        # And should be a 2xx or the documented 303 redirect for non-HTMX.
+        assert resp.status_code in (200, 303)
+
+    @patch("app.chat.handlers._search_conversations_impl", return_value=[])
+    @patch("app.chat.handlers._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_search_path_htmx_returns_fragment(self, mock_provider, mock_connect, _mock_search):
+        """HTMX request hits the search handler directly (no redirect)."""
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.get("/chat/search?q=foo", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "chat-search-results" in resp.text

--- a/tests/test_chat_sanitize.py
+++ b/tests/test_chat_sanitize.py
@@ -1,0 +1,210 @@
+"""Unit tests for ``app.chat.sanitize``.
+
+Covers safe markdown rendering, XSS stripping, URL linkification,
+Estonian/EU-style citation auto-linking, and plaintext escaping.
+"""
+
+from __future__ import annotations
+
+from app.chat.sanitize import render_markdown_safe, render_plaintext_safe
+
+# ---------------------------------------------------------------------------
+# Basic markdown
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownRendering:
+    def test_bold_renders_to_strong(self):
+        out = render_markdown_safe("This is **bold** text.")
+        assert "<strong>bold</strong>" in out
+
+    def test_italic_renders_to_em(self):
+        out = render_markdown_safe("This is *italic* text.")
+        assert "<em>italic</em>" in out
+
+    def test_inline_code_renders(self):
+        out = render_markdown_safe("Use `print(x)` here.")
+        assert "<code>print(x)</code>" in out
+
+    def test_fenced_code_block_renders(self):
+        md = "```python\nprint('hi')\n```"
+        out = render_markdown_safe(md)
+        assert "<pre>" in out
+        assert "<code" in out
+        assert "print(&#x27;hi&#x27;)" in out or "print('hi')" in out
+
+    def test_heading_renders(self):
+        out = render_markdown_safe("# Title\n\nBody")
+        assert "<h1>Title</h1>" in out
+
+    def test_list_renders(self):
+        out = render_markdown_safe("- a\n- b\n- c")
+        assert "<ul>" in out
+        assert out.count("<li>") == 3
+
+    def test_empty_string_returns_empty(self):
+        assert render_markdown_safe("") == ""
+
+    def test_none_like_falsy_returns_empty(self):
+        # Explicitly handle the empty-string path; None is not a supported
+        # input type but must not crash if called defensively.
+        assert render_markdown_safe("") == ""
+
+
+# ---------------------------------------------------------------------------
+# XSS / sanitisation
+# ---------------------------------------------------------------------------
+
+
+class TestSanitisation:
+    def test_script_tag_is_stripped(self):
+        out = render_markdown_safe("Hello <script>alert(1)</script> world")
+        assert "<script>" not in out
+        assert "alert(1)" not in out or "&lt;script&gt;" not in out
+        # Content is stripped entirely by bleach with strip=True.
+        assert "script" not in out.lower() or "alert" not in out
+
+    def test_img_onerror_is_stripped(self):
+        out = render_markdown_safe('<img src=x onerror="alert(1)">')
+        assert "<img" not in out
+        assert "onerror" not in out
+
+    def test_javascript_href_is_stripped(self):
+        out = render_markdown_safe("[click](javascript:alert(1))")
+        # bleach strips disallowed protocols from hrefs
+        assert "javascript:" not in out.lower()
+
+    def test_html_encoded_attack_does_not_execute(self):
+        # HTML-encoded script tags in the source should remain encoded text,
+        # not be un-escaped into real script tags.
+        payload = "&lt;script&gt;alert(1)&lt;/script&gt;"
+        out = render_markdown_safe(payload)
+        assert "<script>" not in out
+
+    def test_disallowed_tags_are_stripped(self):
+        out = render_markdown_safe("<iframe src='x'></iframe>hi")
+        assert "<iframe" not in out
+        assert "hi" in out
+
+    def test_style_attribute_is_stripped(self):
+        out = render_markdown_safe('<p style="color:red">red</p>')
+        assert "style=" not in out
+        assert "red" in out
+
+
+# ---------------------------------------------------------------------------
+# URL linkification
+# ---------------------------------------------------------------------------
+
+
+class TestLinkify:
+    def test_bare_url_is_auto_linked(self):
+        out = render_markdown_safe("See https://example.com for info.")
+        assert 'href="https://example.com"' in out
+        assert 'target="_blank"' in out
+        assert 'rel="noopener noreferrer"' in out
+
+    def test_markdown_link_is_preserved(self):
+        out = render_markdown_safe("[Example](https://example.com)")
+        assert 'href="https://example.com"' in out
+        assert "Example" in out
+        assert 'target="_blank"' in out
+        assert 'rel="noopener noreferrer"' in out
+
+    def test_url_inside_code_is_not_linkified(self):
+        out = render_markdown_safe("`https://example.com`")
+        assert "<code>https://example.com</code>" in out
+        assert 'href="https://example.com"' not in out
+
+
+# ---------------------------------------------------------------------------
+# Estonian / EU citation linking
+# ---------------------------------------------------------------------------
+
+
+class TestCitationLinks:
+    def test_karistusseadustik_paragraph_is_linked(self):
+        out = render_markdown_safe("Vaata KarS § 113 kohta.")
+        assert 'class="citation-link"' in out
+        assert 'href="/explorer?q=KarS' in out
+        assert ">KarS § 113</a>" in out
+
+    def test_tsus_with_lg_is_linked(self):
+        out = render_markdown_safe("Vaata TsÜS § 5 lg 2.")
+        assert 'class="citation-link"' in out
+        assert ">TsÜS § 5 lg 2</a>" in out
+
+    def test_ps_paragraph_is_linked(self):
+        out = render_markdown_safe("PS § 13 annab õiguse.")
+        assert 'class="citation-link"' in out
+        assert ">PS § 13</a>" in out
+
+    def test_pohiseadus_paragraph_is_linked(self):
+        out = render_markdown_safe("Põhiseadus § 13 sätestab.")
+        assert 'class="citation-link"' in out
+        assert ">Põhiseadus § 13</a>" in out
+
+    def test_article_style_is_linked(self):
+        out = render_markdown_safe("EU reg. Art. 5 lõige 2 kohaselt.")
+        assert 'class="citation-link"' in out
+        assert ">Art. 5 lõige 2</a>" in out
+
+    def test_citation_not_wrapped_inside_existing_link(self):
+        # Link text already contains the citation -> must not be re-wrapped.
+        out = render_markdown_safe("[KarS § 113](https://example.com/kars)")
+        # Exactly one anchor, no nested anchor, no citation-link class.
+        assert "citation-link" not in out
+        assert out.count("<a ") == 1
+
+    def test_citation_not_wrapped_inside_code(self):
+        out = render_markdown_safe("`KarS § 113`")
+        assert "citation-link" not in out
+        assert "<code>KarS § 113</code>" in out
+
+    def test_citation_not_wrapped_inside_code_fence(self):
+        md = "```\nKarS § 113\n```"
+        out = render_markdown_safe(md)
+        assert "citation-link" not in out
+
+    def test_multiple_citations_in_one_paragraph(self):
+        out = render_markdown_safe("Vaata KarS § 113 ja TsÜS § 5.")
+        assert out.count('class="citation-link"') == 2
+
+    def test_citation_href_is_url_encoded(self):
+        out = render_markdown_safe("KarS § 113")
+        # quote_plus encodes space as + and § as %C2%A7
+        assert "KarS" in out
+        assert "%C2%A7" in out or "%A7" in out
+
+
+# ---------------------------------------------------------------------------
+# Plaintext rendering
+# ---------------------------------------------------------------------------
+
+
+class TestPlaintextSafe:
+    def test_empty_returns_empty(self):
+        assert render_plaintext_safe("") == ""
+
+    def test_escapes_angle_brackets(self):
+        out = render_plaintext_safe("<script>alert(1)</script>")
+        assert "<script>" not in out
+        assert "&lt;script&gt;" in out
+
+    def test_converts_newlines_to_br(self):
+        out = render_plaintext_safe("line1\nline2")
+        assert out == "line1<br>line2"
+
+    def test_crlf_converted_to_br(self):
+        out = render_plaintext_safe("a\r\nb")
+        assert out == "a<br>b"
+
+    def test_no_markdown_interpretation(self):
+        # Plain text renderer must NOT turn **bold** into <strong>.
+        out = render_plaintext_safe("**not bold**")
+        assert "<strong>" not in out
+        assert "**not bold**" == out
+
+    def test_ampersand_is_escaped(self):
+        out = render_plaintext_safe("a & b")
+        assert "&amp;" in out

--- a/tests/test_chat_slash.py
+++ b/tests/test_chat_slash.py
@@ -1,0 +1,90 @@
+"""Tests for :mod:`app.chat.slash` — slash-command expansion."""
+
+from __future__ import annotations
+
+from app.chat.slash import COMMANDS, SlashCommand, expand, match_prefix
+
+
+def test_draft_expands_with_argument() -> None:
+    assert (
+        expand("/draft uus andmekaitseseadus")
+        == "Aita mul luua eelnõu järgmisel teemal: uus andmekaitseseadus"
+    )
+
+
+def test_unknown_command_returns_message_unchanged() -> None:
+    assert expand("/unknown foo") == "/unknown foo"
+
+
+def test_no_slash_returns_message_unchanged() -> None:
+    assert expand("tere, kuidas läheb?") == "tere, kuidas läheb?"
+
+
+def test_empty_message_returns_empty() -> None:
+    assert expand("") == ""
+
+
+def test_sources_returns_static_template() -> None:
+    expected = "Millistele allikatele tugined eelmise vastuse puhul? Loetle need täpselt."
+    assert expand("/sources") == expected
+    # Trailing argument is ignored for static templates.
+    assert expand("/sources palun") == expected
+
+
+def test_empty_argument_still_expands() -> None:
+    assert expand("/draft") == "Aita mul luua eelnõu järgmisel teemal: "
+    assert expand("/draft ") == "Aita mul luua eelnõu järgmisel teemal: "
+
+
+def test_command_name_is_case_insensitive_arg_preserves_case() -> None:
+    assert (
+        expand("/DRAFT Uus AndmekaitseSeadus")
+        == "Aita mul luua eelnõu järgmisel teemal: Uus AndmekaitseSeadus"
+    )
+    assert (
+        expand("/Find-Conflicts §5 rakendus")
+        == "Leia vastuolud EL õigusega järgnevas: §5 rakendus"
+    )
+
+
+def test_leading_whitespace_tolerated() -> None:
+    assert expand("   /explain §12") == "Selgita lihtsas keeles: §12"
+
+
+def test_compare_and_find_conflicts_templates() -> None:
+    assert expand("/compare KarS §199") == "Võrdle järgnevat kehtiva õigusega: KarS §199"
+    assert (
+        expand("/find-conflicts GDPR art 5") == "Leia vastuolud EL õigusega järgnevas: GDPR art 5"
+    )
+
+
+def test_match_prefix_draft() -> None:
+    results = match_prefix("dr")
+    names = [cmd.name for cmd in results]
+    assert "draft" in names
+    # Only commands starting with "dr" are returned.
+    assert all(name.startswith("dr") for name in names)
+
+
+def test_match_prefix_empty_returns_all() -> None:
+    results = match_prefix("")
+    assert results == COMMANDS
+    assert len(results) == len(COMMANDS)
+
+
+def test_match_prefix_is_case_insensitive() -> None:
+    assert [cmd.name for cmd in match_prefix("DR")] == [cmd.name for cmd in match_prefix("dr")]
+
+
+def test_match_prefix_no_matches() -> None:
+    assert match_prefix("zzz-nope") == []
+
+
+def test_commands_are_frozen_dataclasses() -> None:
+    cmd = COMMANDS[0]
+    assert isinstance(cmd, SlashCommand)
+    try:
+        cmd.name = "mutated"  # type: ignore[misc]
+    except Exception:
+        return
+    raise AssertionError("SlashCommand should be frozen")

--- a/tests/test_chat_title.py
+++ b/tests/test_chat_title.py
@@ -1,0 +1,117 @@
+"""Tests for :mod:`app.chat.title`.
+
+Uses ``asyncio.run()`` to drive the async entrypoint, matching the
+convention established by :mod:`tests.test_chat_orchestrator`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.chat import title as title_mod
+
+
+class _FakeProvider:
+    """Minimal async-provider stub that records the acomplete call."""
+
+    def __init__(self, reply: str | Exception) -> None:
+        self._reply = reply
+        self.calls: list[dict[str, Any]] = []
+
+    async def acomplete(self, prompt: str, **kwargs: Any) -> str:
+        self.calls.append({"prompt": prompt, **kwargs})
+        if isinstance(self._reply, Exception):
+            raise self._reply
+        return self._reply
+
+
+def test_generate_title_happy_path() -> None:
+    provider = _FakeProvider("Mingi teema")
+    with (
+        patch.object(title_mod, "get_default_provider", return_value=provider),
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=True),
+    ):
+        result = asyncio.run(
+            title_mod.generate_title("Kuidas muuta seadust?", "Selleks tuleb algatada eelnõu.")
+        )
+
+    assert result == "Mingi teema"
+    assert len(provider.calls) == 1
+    call = provider.calls[0]
+    assert call["feature"] == "chat_auto_title"
+    assert call["max_tokens"] == 60
+    assert "Kasutaja: Kuidas muuta seadust?" in call["prompt"]
+    assert "Assistent: Selleks tuleb algatada eelnõu." in call["prompt"]
+    assert "pealkiri" in call["system"]
+
+
+def test_generate_title_feature_flag_off_skips_llm() -> None:
+    sentinel = MagicMock()
+    with (
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=False),
+        patch.object(title_mod, "get_default_provider", sentinel),
+    ):
+        result = asyncio.run(title_mod.generate_title("u", "a"))
+
+    assert result is None
+    sentinel.assert_not_called()
+
+
+def test_generate_title_llm_raises_returns_none() -> None:
+    provider = _FakeProvider(RuntimeError("boom"))
+    with (
+        patch.object(title_mod, "get_default_provider", return_value=provider),
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=True),
+    ):
+        result = asyncio.run(title_mod.generate_title("u", "a"))
+
+    assert result is None
+    assert len(provider.calls) == 1
+
+
+def test_generate_title_truncates_overlong_response() -> None:
+    long_reply = "Väga pikk pealkiri " * 10  # well over 48 chars
+    provider = _FakeProvider(long_reply)
+    with (
+        patch.object(title_mod, "get_default_provider", return_value=provider),
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=True),
+    ):
+        result = asyncio.run(title_mod.generate_title("u", "a"))
+
+    assert result is not None
+    assert len(result) <= 48
+
+
+def test_generate_title_strips_wrapping_quotes() -> None:
+    provider = _FakeProvider('"Mingi teema"')
+    with (
+        patch.object(title_mod, "get_default_provider", return_value=provider),
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=True),
+    ):
+        result = asyncio.run(title_mod.generate_title("u", "a"))
+
+    assert result == "Mingi teema"
+
+
+def test_generate_title_strips_typographic_quotes_and_period() -> None:
+    provider = _FakeProvider("\u201cMingi teema.\u201d")
+    with (
+        patch.object(title_mod, "get_default_provider", return_value=provider),
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=True),
+    ):
+        result = asyncio.run(title_mod.generate_title("u", "a"))
+
+    assert result == "Mingi teema"
+
+
+def test_generate_title_empty_response_returns_none() -> None:
+    provider = _FakeProvider("   ")
+    with (
+        patch.object(title_mod, "get_default_provider", return_value=provider),
+        patch.object(title_mod, "is_chat_auto_title_enabled", return_value=True),
+    ):
+        result = asyncio.run(title_mod.generate_title("u", "a"))
+
+    assert result is None

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -255,7 +255,7 @@ class TestWsHandlerAuthExtraction:
 
         # Capture the registered handler
         mock_app = MagicMock()
-        captured_handler = None
+        captured_handler: Any = None
 
         def capture_ws(path, conn=None, disconn=None):
             def decorator(fn):
@@ -305,7 +305,7 @@ class TestWsHandlerAuthExtraction:
         from app.chat.websocket import register_chat_ws_routes
 
         mock_app = MagicMock()
-        captured_handler = None
+        captured_handler: Any = None
 
         def capture_ws(path, conn=None, disconn=None):
             def decorator(fn):
@@ -406,7 +406,7 @@ class TestWsChatJwtFailClosed:
         from app.chat.websocket import register_chat_ws_routes
 
         mock_app = MagicMock()
-        captured_handler = None
+        captured_handler: Any = None
 
         def capture_ws(path, conn=None, disconn=None):
             def decorator(fn):
@@ -552,7 +552,7 @@ class TestWsHandlerDisconnectCleanup:
         from app.chat.websocket import register_chat_ws_routes
 
         mock_app = MagicMock()
-        captured_handler = None
+        captured_handler: Any = None
 
         def capture_ws(path, conn=None, disconn=None):
             def decorator(fn):
@@ -584,15 +584,20 @@ class TestWsHandlerDisconnectCleanup:
             }
         )
 
-        async def scenario():
-            handler_task = asyncio.create_task(captured_handler(send_msg, send, scope))
+        handler_fn = captured_handler  # re-bind so pyright narrows through the closure
+        assert handler_fn is not None
+        disconnect_fn = on_disconnect_hook
+        assert disconnect_fn is not None
+
+        async def scenario() -> None:
+            handler_task = asyncio.create_task(handler_fn(send_msg, send, scope))
             # Let the orchestrator register its per-conv task.
             await asyncio.sleep(0.05)
             # Exactly one connection is registered.
             assert id(send) in registry
             assert len(registry[id(send)]) == 1
             # Simulate the socket going away.
-            await on_disconnect_hook(send)
+            await disconnect_fn(send)
             # Registry slot gone, tasks cancelled.
             assert id(send) not in registry
             # Let the handler coroutine drain the CancelledError.

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -343,3 +343,266 @@ class TestWsHandlerAuthExtraction:
         parsed = json.loads(collector.sent[0])
         assert parsed["type"] == "error"
         assert "autentimine" in parsed["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Phase UX polish tests (issue #594)
+# ---------------------------------------------------------------------------
+
+
+class TestWsChatMaxLength:
+    """Content longer than 10_000 characters is rejected before the orchestrator."""
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    def test_over_length_rejected_with_error(self, mock_provider, mock_orch_cls):
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_instance
+
+        collector = _Collector()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "x" * 10_001,
+            }
+        )
+        asyncio.run(ws_chat(msg, collector, _auth_scope()))
+
+        assert len(collector.sent) == 1
+        parsed = json.loads(collector.sent[0])
+        assert parsed["type"] == "error"
+        assert "liiga pikk" in parsed["message"].lower()
+        mock_instance.handle_message.assert_not_called()
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    def test_exactly_limit_accepted(self, mock_provider, mock_orch_cls):
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_instance
+
+        collector = _Collector()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "x" * 10_000,
+            }
+        )
+        asyncio.run(ws_chat(msg, collector, _auth_scope()))
+
+        mock_instance.handle_message.assert_called_once()
+
+
+class TestWsChatJwtFailClosed:
+    """When JWTAuthProvider construction fails the socket must be closed with 1011."""
+
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_jwt_provider_construction_failure_closes_socket(self, mock_jwt_cls):
+        mock_jwt_cls.side_effect = RuntimeError("cannot init JWT provider")
+
+        from app.chat.websocket import register_chat_ws_routes
+
+        mock_app = MagicMock()
+        captured_handler = None
+
+        def capture_ws(path, conn=None, disconn=None):
+            def decorator(fn):
+                nonlocal captured_handler
+                captured_handler = fn
+                return fn
+
+            return decorator
+
+        mock_app.ws = capture_ws
+        register_chat_ws_routes(mock_app)
+        assert captured_handler is not None
+
+        scope = {
+            "headers": [
+                (b"cookie", b"access_token=irrelevant"),
+            ],
+        }
+
+        sent_raw: list[Any] = []
+
+        async def raw_send(data: Any) -> None:
+            sent_raw.append(data)
+
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Tere",
+            }
+        )
+
+        asyncio.run(captured_handler(msg, raw_send, scope))
+
+        # We expect a close frame with code 1011 to have been attempted.
+        close_attempts = [
+            d for d in sent_raw if isinstance(d, dict) and d.get("type") == "websocket.close"
+        ]
+        assert len(close_attempts) == 1
+        assert close_attempts[0]["code"] == 1011
+
+
+class TestWsChatStopGeneration:
+    """``stop_generation`` cancels an in-flight orchestrator task."""
+
+    def test_stop_cancels_running_task_and_emits_stopped(self):
+        cancel_observed: dict[str, bool] = {"called": False}
+
+        async def slow_handle(conv_id, content, auth, send_event):
+            try:
+                await send_event({"type": "content_delta", "delta": "partial"})
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                cancel_observed["called"] = True
+                # orchestrator normally emits stopped; mimic that.
+                await send_event({"type": "stopped", "message_id": None})
+                raise
+
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock(side_effect=slow_handle)
+
+        collector = _Collector()
+
+        async def scenario():
+            with (
+                patch("app.chat.websocket.ChatOrchestrator", return_value=mock_instance),
+                patch("app.chat.websocket.get_default_provider"),
+            ):
+                tasks: dict[str, Any] = {}
+
+                send_msg = json.dumps(
+                    {
+                        "type": "send_message",
+                        "conversation_id": _CONV_ID,
+                        "content": "Tere",
+                    }
+                )
+                stop_msg = json.dumps(
+                    {
+                        "type": "stop_generation",
+                        "conversation_id": _CONV_ID,
+                    }
+                )
+
+                send_task = asyncio.create_task(
+                    ws_chat(send_msg, collector, _auth_scope(), active_tasks=tasks)
+                )
+                # Give the orchestrator a tick to start.
+                await asyncio.sleep(0.05)
+                await ws_chat(stop_msg, collector, _auth_scope(), active_tasks=tasks)
+                await send_task
+
+        asyncio.run(scenario())
+
+        assert cancel_observed["called"] is True
+        stopped = [s for s in collector.sent if json.loads(s).get("type") == "stopped"]
+        assert len(stopped) >= 1
+
+    def test_stop_without_registry_still_acks(self):
+        collector = _Collector()
+        msg = json.dumps(
+            {
+                "type": "stop_generation",
+                "conversation_id": _CONV_ID,
+            }
+        )
+        asyncio.run(ws_chat(msg, collector, _auth_scope()))
+        assert len(collector.sent) == 1
+        parsed = json.loads(collector.sent[0])
+        assert parsed["type"] == "stopped"
+
+
+class TestWsHandlerDisconnectCleanup:
+    """Disconnect mid-stream must cancel pending tasks and drop the registry key."""
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_disconnect_drops_registry_key(self, mock_jwt_cls, mock_provider, mock_orch_cls):
+        mock_jwt_instance = MagicMock()
+        mock_jwt_instance.get_current_user.return_value = {
+            "id": _USER_ID,
+            "org_id": _ORG_ID,
+            "role": "drafter",
+            "email": "t@t.ee",
+            "full_name": "T",
+        }
+        mock_jwt_cls.return_value = mock_jwt_instance
+
+        # Orchestrator stub that blocks so we have a pending task when
+        # the disconnect fires.
+        async def slow_handle(conv_id, content, auth, send_event):
+            try:
+                await send_event({"type": "content_delta", "delta": "x"})
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                raise
+
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock(side_effect=slow_handle)
+        mock_orch_cls.return_value = mock_instance
+
+        from app.chat.websocket import register_chat_ws_routes
+
+        mock_app = MagicMock()
+        captured_handler = None
+
+        def capture_ws(path, conn=None, disconn=None):
+            def decorator(fn):
+                nonlocal captured_handler
+                captured_handler = fn
+                return fn
+
+            return decorator
+
+        mock_app.ws = capture_ws
+        register_chat_ws_routes(mock_app)
+        assert captured_handler is not None
+
+        registry = captured_handler._per_send_tasks  # type: ignore[attr-defined]
+        on_disconnect_hook = captured_handler._on_disconnect  # type: ignore[attr-defined]
+
+        scope = {"headers": [(b"cookie", b"access_token=irrelevant")]}
+
+        async def send(data: Any) -> None:
+            # no-op; just needs to be a stable callable so id(send) is
+            # consistent across the start and the disconnect.
+            return
+
+        send_msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Tere",
+            }
+        )
+
+        async def scenario():
+            handler_task = asyncio.create_task(captured_handler(send_msg, send, scope))
+            # Let the orchestrator register its per-conv task.
+            await asyncio.sleep(0.05)
+            # Exactly one connection is registered.
+            assert id(send) in registry
+            assert len(registry[id(send)]) == 1
+            # Simulate the socket going away.
+            await on_disconnect_hook(send)
+            # Registry slot gone, tasks cancelled.
+            assert id(send) not in registry
+            # Let the handler coroutine drain the CancelledError.
+            try:
+                await handler_task
+            except Exception:
+                pass
+
+        asyncio.run(scenario())
+
+        # After teardown, zero keys remain for this connection.
+        assert id(send) not in registry
+        assert all(k != id(send) for k in registry)

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -997,6 +1009,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
 ]
 
 [[package]]
@@ -1752,7 +1773,9 @@ dependencies = [
     { name = "anthropic" },
     { name = "authlib" },
     { name = "bcrypt" },
+    { name = "bleach" },
     { name = "httpx" },
+    { name = "mistune" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyjwt" },
     { name = "pyshacl" },
@@ -1778,7 +1801,9 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.93.0" },
     { name = "authlib" },
     { name = "bcrypt" },
+    { name = "bleach", specifier = ">=6" },
     { name = "httpx" },
+    { name = "mistune", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pyjwt" },
     { name = "pyshacl" },
@@ -2136,6 +2161,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Closes epic #578 and all child tickets #579–#595.
- Full polish sweep of the AI Advisory Chat: correctness bugs fixed, UX transparency (sources, tool activity, citations) added, control loop (regenerate/edit/copy/feedback/stop), onboarding (empty state + follow-ups), rate-limit humanity, keyboard + slash palette, and security hardening.
- 300+ new tests; 1473/1473 green; `ruff` + `pyright app/` clean.

## What changed
- **New modules:** `app/chat/{sanitize,export,title,slash,feedback,handlers}.py`
- **New assets:** `app/static/js/chat.js` (full client; replaces inline IIFE), `app/static/css/chat.css` (971 lines)
- **Migration:** `017_chat_ux_features.sql` — pin/archive/pinned_at/title_is_custom on conversations, is_pinned/is_truncated on messages, `message_feedback` table
- **Backend heavy edits:** `orchestrator.py`, `websocket.py`, `rate_limiter.py`, `models.py`, `routes.py`
- **Security hardening** (#594): safe-send timeout, 10k-char cap, JWT fail-closed → 1011, advisory-lock TOCTOU fix wired into the conversation transaction, bleach-allowlist + linkify, `_per_send_tasks` leak closed, `aclosing` on LLM stream, SRI-pinned CDN scripts
- **WS protocol additions:** `tool_call_id` paired across `tool_use`/`tool_result`, `retrieval_done`, `sources`, `follow_ups`, `stopped`

## Child ticket coverage
| # | Area | Status |
|---|------|--------|
| 579 | Live markdown during stream | ✅ |
| 580 | `tool_result` rendered | ✅ |
| 581 | `#chat-status` + reconnect toast | ✅ |
| 582 | Chat CSS | ✅ |
| 583 | Sources panel | ✅ |
| 584 | Tool activity spinner | ✅ |
| 585 | §-citation auto-links | ✅ |
| 586 | Regenerate/edit/copy/feedback | ✅ |
| 587 | Stop generation | ✅ |
| 588 | Auto titles | ✅ |
| 589 | Rename / pin / archive / search | ✅ |
| 590 | Export .md / .docx | ✅ |
| 591 | Example prompts + follow-ups | ✅ |
| 592 | Soft quota meter + `/api/me/usage` | ✅ |
| 593 | Shortcuts + slash palette + a11y + mobile | ✅ |
| 594 | Security hardening | ✅ |
| 595 | Draft drawer / fork / pin message | models + endpoints landed; UI drawer deferred |

## Test plan
- [x] `uv run pytest` — 1473 passed
- [x] `uv run ruff check` — clean
- [x] `uv run pyright app/` — 0 errors
- [x] `node --check app/static/js/chat.js` — ok
- [ ] Manual browser smoke: empty-state prompts, live markdown, tool activity, sources panel, regenerate, edit, stop, slash palette, quota pill at 80%/100%
- [ ] Migration apply on a staging DB + rollback test
- [ ] Mobile Safari: sticky input + safe-area insets + 100dvh

## Review process
Three parallel reviewers (backend / models+handlers / frontend) produced P1/P2/P3 lists; all P1s addressed in a follow-up parallel fix wave. Key P1 fixes that landed in this PR:
- Cost-budget advisory lock now actually engages (caller passes `conn=`).
- WS `_per_send_tasks` registry cleaned up on disconnect.
- Reconnect-during-stream releases the input, appends a stopped note, shows a toast.
- SRI hashes pinned on marked.js and DOMPurify.
- Sans-dead-code: the `_reorder_static_routes_first` hack is gone; routes.py now registers handler routes before the dynamic `/chat/{conv_id}` catch-all.
- Missing CSS rules for ~25 class names used by the new JS added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)