### PR TITLE
Vestlus UX hotfix: thinking indicator + historical messages recovery

### DIFF
--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -92,6 +92,29 @@ _CONVERSATION_COLUMNS = (
     "is_pinned, is_archived, pinned_at, title_is_custom"
 )
 
+# Legacy 7-column list used when migration 017 is not yet applied. Mirrors
+# the same fallback pattern as _MESSAGE_COLUMNS_PRE017 below.
+_CONVERSATION_COLUMNS_PRE017 = (
+    "id, user_id, org_id, title, context_draft_id, created_at, updated_at"
+)
+
+
+def _is_missing_v017_column_error(exc: BaseException) -> bool:
+    """Return True if the exception looks like psycopg's UndefinedColumn
+    raised by a reference to a migration-017 column."""
+    msg = str(exc).lower()
+    return "does not exist" in msg and any(
+        col in msg
+        for col in (
+            "is_pinned",
+            "is_archived",
+            "pinned_at",
+            "title_is_custom",
+            "is_truncated",
+        )
+    )
+
+
 # NOTE (#570): SELECT returns both the plaintext and the ``*_encrypted``
 # columns. ``_row_to_message`` prefers the encrypted column when set and
 # falls back to the plaintext column for rows that predate the backfill
@@ -102,6 +125,18 @@ _MESSAGE_COLUMNS = (
     "tool_output, rag_context, tokens_input, tokens_output, model, created_at, "
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
     "rag_context_encrypted, is_pinned, is_truncated"
+)
+
+# Legacy SELECT list used when migration 017 has not yet applied (the
+# ``is_pinned`` / ``is_truncated`` columns are absent). Without this
+# fallback, loading any conversation raises ``UndefinedColumn`` and the
+# conversation view silently renders the empty state — users then see
+# the example-prompt cards instead of their history. See #596 follow-up.
+_MESSAGE_COLUMNS_PRE017 = (
+    "id, conversation_id, role, content, tool_name, tool_input, "
+    "tool_output, rag_context, tokens_input, tokens_output, model, created_at, "
+    "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
+    "rag_context_encrypted"
 )
 
 
@@ -289,9 +324,27 @@ def get_conversation(
             f"SELECT {_CONVERSATION_COLUMNS} FROM conversations WHERE id = %s",
             (str(conv_id),),
         ).fetchone()
-    except Exception:
-        logger.exception("Failed to fetch conversation id=%s", conv_id)
-        return None
+    except Exception as exc:
+        if _is_missing_v017_column_error(exc):
+            logger.warning(
+                "get_conversation: migration 017 columns missing — fallback for id=%s",
+                conv_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                row = conn.execute(
+                    f"SELECT {_CONVERSATION_COLUMNS_PRE017} FROM conversations WHERE id = %s",
+                    (str(conv_id),),
+                ).fetchone()
+            except Exception:
+                logger.exception("Fallback get_conversation failed for id=%s", conv_id)
+                return None
+        else:
+            logger.exception("Failed to fetch conversation id=%s", conv_id)
+            return None
     return _row_to_conversation(row) if row else None
 
 
@@ -348,23 +401,48 @@ def list_conversations_for_user(
     where_sql = " AND ".join(where_clauses)
     params.extend([limit, max(0, offset)])
 
-    try:
-        rows = conn.execute(
+    def _run(cols: str, where: str, order: str) -> list[tuple[Any, ...]]:
+        return conn.execute(
             f"""
-            SELECT {_CONVERSATION_COLUMNS}
+            SELECT {cols}
             FROM conversations
-            WHERE {where_sql}
-            ORDER BY {order_by}
+            WHERE {where}
+            ORDER BY {order}
             LIMIT %s OFFSET %s
             """,
             tuple(params),
         ).fetchall()
-    except Exception:
-        logger.exception(
-            "Failed to list conversations for user=%s",
-            user_id,
-        )
-        return []
+
+    try:
+        rows = _run(_CONVERSATION_COLUMNS, where_sql, order_by)
+    except Exception as exc:
+        if _is_missing_v017_column_error(exc):
+            logger.warning(
+                "list_conversations_for_user: migration 017 columns missing —"
+                " falling back to pre-017 SELECT for user=%s",
+                user_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            # Strip pre-017 unsafe predicates / ordering.
+            legacy_where = " AND ".join(c for c in where_clauses if "is_archived" not in c)
+            legacy_order = "updated_at DESC"
+            try:
+                rows = _run(_CONVERSATION_COLUMNS_PRE017, legacy_where, legacy_order)
+            except Exception:
+                logger.exception(
+                    "Fallback list_conversations_for_user failed for user=%s",
+                    user_id,
+                )
+                return []
+        else:
+            logger.exception(
+                "Failed to list conversations for user=%s",
+                user_id,
+            )
+            return []
     return [_row_to_conversation(row) for row in rows]
 
 
@@ -535,7 +613,15 @@ def list_messages(
     conn: Any,
     conversation_id: uuid.UUID | str,
 ) -> list[Message]:
-    """Return all messages in a conversation, ordered by ``created_at`` ASC."""
+    """Return all messages in a conversation, ordered by ``created_at`` ASC.
+
+    Falls back to a SELECT without the migration-017 columns if those
+    columns do not yet exist on the target database. This keeps the
+    conversation view functional during a window where the app image
+    was deployed but migration 017 has not yet been applied — otherwise
+    users open a historical conversation and see the empty-state prompt
+    cards instead of their history (reported after #596 rolled out).
+    """
     try:
         rows = conn.execute(
             f"""
@@ -546,12 +632,44 @@ def list_messages(
             """,
             (str(conversation_id),),
         ).fetchall()
-    except Exception:
-        logger.exception(
-            "Failed to list messages for conversation=%s",
-            conversation_id,
-        )
-        return []
+    except Exception as exc:
+        # Psycopg raises ``UndefinedColumn`` (SQLSTATE 42703) when the
+        # new columns are missing. Matching by message text keeps us
+        # compatible with psycopg2 and psycopg3 without importing
+        # driver-specific exception classes.
+        msg = str(exc).lower()
+        if "is_pinned" in msg or "is_truncated" in msg or "does not exist" in msg:
+            logger.warning(
+                "list_messages: migration 017 columns missing — falling back"
+                " to pre-017 SELECT for conversation=%s",
+                conversation_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT {_MESSAGE_COLUMNS_PRE017}
+                    FROM messages
+                    WHERE conversation_id = %s
+                    ORDER BY created_at ASC
+                    """,
+                    (str(conversation_id),),
+                ).fetchall()
+            except Exception:
+                logger.exception(
+                    "Fallback list_messages also failed for conversation=%s",
+                    conversation_id,
+                )
+                return []
+        else:
+            logger.exception(
+                "Failed to list messages for conversation=%s",
+                conversation_id,
+            )
+            return []
     return [_row_to_message(row) for row in rows]
 
 

--- a/app/static/css/chat.css
+++ b/app/static/css/chat.css
@@ -1309,6 +1309,63 @@
    Tool activity details — spinner + pre blocks
    =========================================================================== */
 
+/* ===========================================================================
+   Thinking indicator (bridges send → first content_delta)
+   =========================================================================== */
+
+.chat-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}
+
+.chat-thinking-status {
+  font-style: italic;
+}
+
+.chat-thinking-elapsed {
+  color: var(--color-text-subtle, var(--color-text-muted));
+  font-variant-numeric: tabular-nums;
+  font-size: var(--font-size-xs);
+}
+
+.chat-thinking-dots {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.chat-thinking-dots > span {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-primary);
+  opacity: 0.3;
+  animation: chat-thinking-pulse 1.2s ease-in-out infinite;
+}
+
+.chat-thinking-dots > span:nth-child(2) { animation-delay: 0.15s; }
+.chat-thinking-dots > span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes chat-thinking-pulse {
+  0%, 60%, 100% { opacity: 0.25; transform: scale(1); }
+  30%           { opacity: 1;    transform: scale(1.3); }
+}
+
+/* While the bubble is still in thinking-only state, hide the empty
+   .chat-message-text container so there is no visible gap. */
+.chat-message-thinking .chat-message-text:empty {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-thinking-dots > span { animation: none; opacity: 0.6; }
+}
+
 /* Small circular CSS spinner used inside tool activity rows */
 .chat-tool-spinner {
   display: inline-block;

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -117,6 +117,14 @@
   let pendingMsgId = null;  // provisional id while streaming before done arrives
   let pendingBubble = null; // the live assistant bubble being streamed into
 
+  // Thinking-indicator state (bridges send → first content_delta so the UI
+  // never sits silent while the server does RAG retrieval + LLM first-token
+  // latency, which commonly takes 3-10s and sometimes longer).
+  let thinkingStartTs = 0;
+  let thinkingElapsedTimer = null;
+  let thinkingWatchdogA = null;  // 15s "võtab kauem kui tavaliselt"
+  let thinkingWatchdogB = null;  // 45s "server vastab aeglaselt"
+
   // Slash palette keyboard selection index
   let paletteIndex = -1;
 
@@ -406,11 +414,80 @@
 
     wrap.innerHTML =
       '<div class="chat-bubble chat-bubble-assistant">' +
+        '<div class="chat-thinking" aria-live="polite">' +
+          '<span class="chat-thinking-dots" aria-hidden="true">' +
+            '<span></span><span></span><span></span>' +
+          '</span>' +
+          '<span class="chat-thinking-status">Mõtlen...</span>' +
+          '<span class="chat-thinking-elapsed" aria-hidden="true"></span>' +
+        '</div>' +
         '<div class="chat-message-text"></div>' +
       '</div>';
 
     if (messagesEl) messagesEl.appendChild(wrap);
     return wrap;
+  }
+
+  /**
+   * Update the thinking-status text inside the current pending bubble.
+   * Safe to call even if no thinking state is active — it becomes a no-op.
+   */
+  function updateThinkingStatus(text) {
+    const bubble = pendingBubble;
+    if (!bubble) return;
+    const statusEl = bubble.querySelector('.chat-thinking-status');
+    if (statusEl && text) statusEl.textContent = text;
+  }
+
+  /**
+   * Start the per-request "thinking" state: opens an assistant bubble with
+   * animated dots, an elapsed-seconds ticker, and two watchdog toasts that
+   * fire at 15s and 45s so the user always has a signal that work is alive.
+   */
+  function startThinking() {
+    thinkingStartTs = Date.now();
+    const bubble = getOrCreateStreamingBubble(null);
+    bubble.classList.add('chat-message-thinking');
+    const elapsedEl = bubble.querySelector('.chat-thinking-elapsed');
+
+    // Tick the elapsed counter every second.
+    if (thinkingElapsedTimer) clearInterval(thinkingElapsedTimer);
+    thinkingElapsedTimer = setInterval(function () {
+      if (!elapsedEl) return;
+      const secs = Math.floor((Date.now() - thinkingStartTs) / 1000);
+      elapsedEl.textContent = secs > 2 ? (' (' + secs + 's)') : '';
+    }, 1000);
+
+    // Watchdogs.
+    if (thinkingWatchdogA) clearTimeout(thinkingWatchdogA);
+    thinkingWatchdogA = setTimeout(function () {
+      if (!streaming) return;
+      updateThinkingStatus('Võtab kauem kui tavaliselt...');
+      showToast('Päring on endiselt pooleli', 'info', 5000);
+    }, 15000);
+
+    if (thinkingWatchdogB) clearTimeout(thinkingWatchdogB);
+    thinkingWatchdogB = setTimeout(function () {
+      if (!streaming) return;
+      updateThinkingStatus('Server vastab aeglaselt, oodake veel hetk...');
+      showToast('Server vastab aeglaselt', 'warning', 6000);
+    }, 45000);
+
+    scrollToBottom();
+  }
+
+  /**
+   * Drop the thinking visuals without removing the bubble (it becomes the
+   * streaming bubble). Always clears timers + watchdogs.
+   */
+  function clearThinking() {
+    if (thinkingElapsedTimer) { clearInterval(thinkingElapsedTimer); thinkingElapsedTimer = null; }
+    if (thinkingWatchdogA)    { clearTimeout(thinkingWatchdogA);    thinkingWatchdogA = null; }
+    if (thinkingWatchdogB)    { clearTimeout(thinkingWatchdogB);    thinkingWatchdogB = null; }
+    if (!pendingBubble) return;
+    pendingBubble.classList.remove('chat-message-thinking');
+    const thinkingEl = pendingBubble.querySelector('.chat-thinking');
+    if (thinkingEl && thinkingEl.parentNode) thinkingEl.parentNode.removeChild(thinkingEl);
   }
 
   /**
@@ -749,19 +826,23 @@
 
       // -----------------------------------------------------------------------
       case 'retrieval_started':
-        // Could show a subtle "Otsin..." indicator; for now a no-op is fine
-        // since tool_use events immediately follow.
+        updateThinkingStatus('Otsin allikaid ontoloogiast...');
         break;
 
       // -----------------------------------------------------------------------
-      case 'retrieval_done':
-        // chunk_count available if UI wants to display it; currently no-op.
+      case 'retrieval_done': {
+        const n = typeof event.chunk_count === 'number' ? event.chunk_count : 0;
+        updateThinkingStatus(
+          n > 0 ? ('Leidsin ' + n + ' allikat, koostan vastust...') : 'Koostan vastust...'
+        );
         break;
+      }
 
       // -----------------------------------------------------------------------
       case 'tool_use': {
         const toolCallId = event.tool_call_id || ('tool_' + Date.now());
         createToolActivity(toolCallId, event.tool || '', event.input || {});
+        updateThinkingStatus(toolLabel(event.tool || '') + '...');
         maybeScrollToBottom();
         break;
       }
@@ -781,6 +862,8 @@
       case 'content_delta': {
         const msgId = event.message_id || null;
         const bubble = getOrCreateStreamingBubble(msgId);
+        // First real token: drop thinking animation / watchdogs.
+        if (bubble.classList.contains('chat-message-thinking')) clearThinking();
 
         // Resolve buffer key
         const bufKey = msgId || pendingMsgId;
@@ -795,6 +878,7 @@
       // -----------------------------------------------------------------------
       case 'done': {
         const msgId = event.message_id;
+        clearThinking();
         finaliseBubble(msgId);
         enableInput();
         scrollToBottom();
@@ -819,6 +903,7 @@
       // -----------------------------------------------------------------------
       case 'stopped': {
         const msgId = event.message_id;
+        clearThinking();
         finaliseBubble(msgId);
         // Append truncation note to the last assistant bubble
         const bubble = (msgId && msgBubbles[msgId]) || pendingBubble;
@@ -837,6 +922,15 @@
 
       // -----------------------------------------------------------------------
       case 'error': {
+        clearThinking();
+        // If the pending bubble was still in pure-thinking state (no deltas
+        // arrived), replace it with the error bubble instead of leaving an
+        // empty assistant shell.
+        if (pendingBubble && pendingBubble.classList.contains('chat-message-thinking')) {
+          if (pendingBubble.parentNode) pendingBubble.parentNode.removeChild(pendingBubble);
+          pendingBubble = null;
+          pendingMsgId = null;
+        }
         finaliseBubble(null);
         appendErrorBubble(event.message);
         enableInput();
@@ -893,9 +987,10 @@
     inputEl.value = '';
     autoGrowTextarea(inputEl);
     disableInput();
-    // disableInput() no longer toggles inputEl.disabled (textarea stays
-    // writable during streaming), so there is nothing to re-enable here.
-    // Return focus to the textarea for keyboard users.
+    // Open a "thinking" bubble immediately so the user has visual feedback
+    // during the seconds before the first content_delta arrives (RAG + LLM
+    // first-token latency typically adds 3-10s; can occasionally be longer).
+    startThinking();
     if (inputEl) inputEl.focus();
   }
 


### PR DESCRIPTION
Two regressions reported on the #596 deploy:

### 1. UI sits silent after \"Saada\"
LLM first-token latency is 3-10s (often longer with RAG). No visual feedback existed between click and the first content_delta → users assumed a crash.

**Fix:** open a thinking bubble immediately with animated dots, elapsed-seconds counter (appears from 3s), and watchdog toasts at 15s / 45s. The status label updates per event:
- \`retrieval_started\` → \"Otsin allikaid ontoloogiast...\"
- \`retrieval_done\` → \"Leidsin N allikat, koostan vastust...\"
- \`tool_use\` → tool-specific label
- first \`content_delta\` → drops animation, streams content into the same bubble
- \`error\` / \`stopped\` → clears thinking (error path removes the empty shell)

### 2. Historical conversations showed empty-state prompts instead of messages
Root cause: migration 017 adds \`is_pinned\`/\`is_truncated\`/\`is_archived\`/\`title_is_custom\`/\`pinned_at\` referenced in every chat SELECT. If the app image deploys but migration 017 has not yet applied, every SELECT raises \`UndefinedColumn\`, the \`except\` path returns \`[]\`, and the empty state renders.

**Fix:** \`list_messages\`, \`get_conversation\`, and \`list_conversations_for_user\` now detect the UndefinedColumn error (by message substring — driver-agnostic between psycopg2/3), roll back the poisoned transaction, and re-run against the pre-017 column list. Defaults for missing flags come from the existing defensive row-to-dataclass mappers. Once migration 017 lands the fast path is the only path.

## Test plan
- [x] \`uv run pytest tests/test_chat_*.py\` — 366 passed
- [x] \`ruff\` + \`pyright app/chat/models.py\` clean
- [x] \`node --check app/static/js/chat.js\` ok
- [ ] Manual browser: send a message, confirm dots appear instantly, watchdog toast fires at 15s
- [ ] Manual browser: open an old conversation, confirm history loads even if migration 017 is not applied yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)