### PR TITLE
Notifications: fix clickthrough + dead links (#638)

### DIFF
--- a/app/notifications/models.py
+++ b/app/notifications/models.py
@@ -170,6 +170,34 @@ def list_notifications_for_user(
     return [_row_to_notification(row) for row in rows]
 
 
+def get_notification(
+    conn: Any,
+    notification_id: uuid.UUID | str,
+    user_id: uuid.UUID | str | None = None,
+) -> Notification | None:
+    """Return a single notification by id, or ``None``.
+
+    When *user_id* is provided, the SELECT also filters on ownership so
+    that one user cannot fetch another user's notification.
+    """
+    try:
+        if user_id is not None:
+            row = conn.execute(
+                f"SELECT {_NOTIFICATION_COLUMNS} FROM notifications "
+                "WHERE id = %s AND user_id = %s",
+                (str(notification_id), str(user_id)),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                f"SELECT {_NOTIFICATION_COLUMNS} FROM notifications WHERE id = %s",
+                (str(notification_id),),
+            ).fetchone()
+    except Exception:
+        logger.exception("Failed to fetch notification id=%s", notification_id)
+        return None
+    return _row_to_notification(row) if row else None
+
+
 def count_unread(conn: Any, user_id: uuid.UUID | str) -> int:
     """Return the number of unread notifications for a user."""
     try:

--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -109,19 +109,31 @@ def NotificationItem(notif: Any, *, compact: bool = False):  # noqa: ANN201, N80
         )
     if notif.link:
         return A(content, href=notif.link, cls="notification-link")  # noqa: F405
+    # Non-link notifications always render inside a wrapper with a stable
+    # ID. The unread variant has a "Loe" button; the read variant does
+    # not. The button (and the mark-read response) target this wrapper so
+    # HTMX's ``outerHTML`` swap replaces the entire wrapper - if we only
+    # swapped the inner ``#notification-{id}`` row the stale "Loe" button
+    # would remain in the DOM after mark-read. See PR #645 review.
+    wrapper_id = f"notification-wrapper-{notif.id}"
     if not notif.read:
         return Div(  # noqa: F405
             content,
             Button(  # noqa: F405
                 "Loe",
                 hx_post=f"/notifications/{notif.id}/read",
-                hx_target=f"#notification-{notif.id}",
+                hx_target=f"#{wrapper_id}",
                 hx_swap="outerHTML",
                 cls="notification-mark-btn btn-sm",
             ),
             cls="notification-item-wrapper",
+            id=wrapper_id,
         )
-    return content
+    return Div(  # noqa: F405
+        content,
+        cls="notification-item-wrapper",
+        id=wrapper_id,
+    )
 
 
 def NotificationList(notifications: list[Any], *, compact: bool = False):  # noqa: ANN201, N802
@@ -220,10 +232,11 @@ def mark_single_read(req: Request, id: str):
        return an empty 200 with an ``HX-Redirect`` header so the browser
        navigates after the POST.
     2. Unread non-link notifications render a "Loe" button whose target
-       is ``#notification-{id}`` with ``hx-swap="outerHTML"``. For these
-       we re-render the full notification row in its read state so the
-       row visibly flips from unread-style to read-style (previously the
-       row collapsed into a bare dot).
+       is ``#notification-wrapper-{id}`` with ``hx-swap="outerHTML"``.
+       For these we re-render the full wrapper in its read state so the
+       row visibly flips from unread-style to read-style AND the stale
+       "Loe" button is removed from the DOM (previously the swap hit the
+       inner row only, leaving the button behind; see PR #645 review).
     """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
@@ -264,15 +277,21 @@ def mark_single_read(req: Request, id: str):
         fresh = None
 
     if fresh is None:
-        # DB error or notification vanished — fall back to a minimal but
-        # non-collapsing read-state row so the UI doesn't break.
+        # DB error or notification vanished - fall back to a minimal but
+        # non-collapsing read-state wrapper so the UI doesn't break and
+        # the outerHTML swap against #notification-wrapper-{id} lands on
+        # matching markup.
         return Div(  # noqa: F405
             Div(  # noqa: F405
-                Span("", cls="notification-title"),  # noqa: F405
-                cls="notification-header",
+                Div(  # noqa: F405
+                    Span("", cls="notification-title"),  # noqa: F405
+                    cls="notification-header",
+                ),
+                cls="notification-item notification-item--read",
+                id=f"notification-{id}",
             ),
-            cls="notification-item notification-item--read",
-            id=f"notification-{id}",
+            cls="notification-item-wrapper",
+            id=f"notification-wrapper-{id}",
         )
 
     return NotificationItem(fresh)

--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import quote, urlparse
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
@@ -25,6 +26,7 @@ from app.auth.provider import UserDict
 from app.db import get_connection as _connect
 from app.notifications.models import (
     count_unread,
+    get_notification,
     list_notifications_for_user,
     mark_all_read,
     mark_read,
@@ -93,11 +95,15 @@ def NotificationItem(notif: Any, *, compact: bool = False):  # noqa: ANN201, N80
     )
 
     if notif.link and not notif.read:
-        # Wrap in a link and mark as read on click
+        # Wrap in a link and mark as read on click. The raw <a href> is
+        # swallowed by HTMX's hx-post, so we pipe the destination through
+        # a ``?redirect=`` query param — the handler validates same-origin
+        # and returns HX-Redirect so the browser navigates after the POST.
+        redirect_qp = quote(notif.link, safe="")
         return A(  # noqa: F405
             content,
             href=notif.link,
-            hx_post=f"/notifications/{notif.id}/read",
+            hx_post=f"/notifications/{notif.id}/read?redirect={redirect_qp}",
             hx_swap="none",
             cls="notification-link",
         )
@@ -184,8 +190,41 @@ def notifications_page(req: Request):
     )
 
 
+def _is_safe_redirect(target: str) -> bool:
+    """Return True if *target* is a safe, same-origin path to redirect to.
+
+    We only allow relative paths beginning with a single ``/`` so the
+    browser cannot be sent to an attacker-controlled host. ``//host`` is
+    a protocol-relative URL and must be rejected.
+    """
+    if not target or not target.startswith("/"):
+        return False
+    if target.startswith("//"):
+        return False
+    parsed = urlparse(target)
+    # urlparse of a relative path should yield empty scheme and netloc.
+    if parsed.scheme or parsed.netloc:
+        return False
+    return True
+
+
 def mark_single_read(req: Request, id: str):
-    """POST /notifications/{id}/read -- mark one notification as read (HTMX)."""
+    """POST /notifications/{id}/read -- mark one notification as read (HTMX).
+
+    Two call sites:
+
+    1. Unread linked notifications render as ``<a href hx-post=...>``. The
+       click is consumed by HTMX's POST and the native ``<a>`` navigation
+       is suppressed. For these, the caller encodes the destination as a
+       ``?redirect=<link>`` query param; when present and same-origin we
+       return an empty 200 with an ``HX-Redirect`` header so the browser
+       navigates after the POST.
+    2. Unread non-link notifications render a "Loe" button whose target
+       is ``#notification-{id}`` with ``hx-swap="outerHTML"``. For these
+       we re-render the full notification row in its read state so the
+       row visibly flips from unread-style to read-style (previously the
+       row collapsed into a bare dot).
+    """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
         return auth_or_redirect
@@ -205,9 +244,38 @@ def mark_single_read(req: Request, id: str):
     except Exception:
         logger.exception("Failed to mark notification %s as read", id)
 
-    # Return an empty response -- the HTMX swap will handle UI update.
-    # If hx_target was the item itself, return a minimal read-state item.
-    return Span(cls="notification-dot--read")  # noqa: F405
+    # Path 1: linked notification -> HX-Redirect after the POST.
+    redirect_target = req.query_params.get("redirect")
+    if redirect_target and _is_safe_redirect(redirect_target):
+        return Response(
+            content="",
+            status_code=200,
+            headers={"HX-Redirect": redirect_target},
+        )
+
+    # Path 2: non-link notification -> re-render the whole row in its
+    # read state so HTMX's ``outerHTML`` swap against ``#notification-{id}``
+    # replaces the item with a properly rendered read-state row.
+    try:
+        with _connect() as conn:
+            fresh = get_notification(conn, notif_id, user_id=auth["id"])
+    except Exception:
+        logger.exception("Failed to refetch notification %s after mark-read", id)
+        fresh = None
+
+    if fresh is None:
+        # DB error or notification vanished — fall back to a minimal but
+        # non-collapsing read-state row so the UI doesn't break.
+        return Div(  # noqa: F405
+            Div(  # noqa: F405
+                Span("", cls="notification-title"),  # noqa: F405
+                cls="notification-header",
+            ),
+            cls="notification-item notification-item--read",
+            id=f"notification-{id}",
+        )
+
+    return NotificationItem(fresh)
 
 
 def mark_all_read_handler(req: Request):

--- a/app/notifications/wire.py
+++ b/app/notifications/wire.py
@@ -20,6 +20,38 @@ from app.notifications.notify import notify
 logger = logging.getLogger(__name__)
 
 
+def _annotation_target_link(annotation: Any) -> str:
+    """Return a real GET page for an annotation target.
+
+    Notifications used to link to ``/annotations/{id}`` but that route
+    does not exist — the only routes under ``/api/annotations`` are
+    POST/DELETE endpoints. Each annotation carries a ``target_type``
+    and ``target_id`` pointing at the resource it's attached to, so the
+    notification link should navigate to the target's detail page
+    (where the user can see the annotation in context).
+
+    Falls back to the notification inbox (``/notifications``) when the
+    target type is unknown or fields are missing, which always renders
+    a 200 GET page.
+    """
+    target_type = getattr(annotation, "target_type", None)
+    target_id = getattr(annotation, "target_id", None)
+    if not target_type or not target_id:
+        return "/notifications"
+
+    # Known target types map to existing GET pages. If a future target
+    # type is added without a matching GET route, we still return a
+    # safe fallback rather than a dead link.
+    if target_type == "draft":
+        return f"/drafts/{target_id}"
+    if target_type == "conversation":
+        return f"/chat/{target_id}"
+    # Provisions and entities don't yet have a dedicated standalone
+    # GET detail page; point the user at the inbox as the safest
+    # existing 200-GET destination. (Follow-up: route for those.)
+    return "/notifications"
+
+
 def notify_annotation_reply(annotation: Any, reply: Any) -> None:
     """Notify the annotation author when someone replies to their annotation.
 
@@ -37,11 +69,13 @@ def notify_annotation_reply(annotation: Any, reply: Any) -> None:
             type="annotation_reply",
             title="Uus vastus teie margistusele",
             body=reply.content[:200] if reply.content else None,
-            link=f"/annotations/{annotation.id}",
+            link=_annotation_target_link(annotation),
             metadata={
                 "annotation_id": str(annotation.id),
                 "reply_id": str(reply.id),
                 "reply_user_id": str(reply.user_id),
+                "target_type": getattr(annotation, "target_type", None),
+                "target_id": getattr(annotation, "target_id", None),
             },
         )
     except Exception:
@@ -127,7 +161,9 @@ def notify_sync_failed(error_message: str) -> None:
                 type="sync_failed",
                 title="Ontoloogia sunkroonimine ebaonnestus",
                 body=error_message[:300] if error_message else None,
-                link="/admin/sync",
+                # /admin/sync is POST-only; anchor on the sync card on
+                # the admin dashboard, which is a real GET page.
+                link="/admin#sync-card",
                 metadata={"error": error_message[:500] if error_message else None},
             )
     except Exception:

--- a/tests/test_notifications_routes.py
+++ b/tests/test_notifications_routes.py
@@ -280,6 +280,43 @@ class TestNotificationItemRendering:
         assert "redirect=" in html
         assert "%2Fdrafts%2Fabc" in html or "/drafts/abc" in html
 
+    def test_unread_non_link_wrapper_has_stable_id_and_button_targets_wrapper(self):
+        """Review fix (PR #645): the unread non-link row renders as a
+        wrapper containing the inner row + a "Loe" button. The button
+        must target the WRAPPER (not the inner row) with ``outerHTML``
+        so the mark-read response can replace the whole wrapper -
+        otherwise the stale "Loe" button would remain in the DOM after
+        mark-read completes."""
+        notif = _make_notification(read=False, link=None)
+
+        html = to_xml(NotificationItem(notif))
+
+        # Wrapper must carry a stable ID so the button can target it.
+        assert f'id="notification-wrapper-{_NOTIF_ID}"' in html
+        # "Loe" button must target the wrapper, not the inner item.
+        assert f'hx-target="#notification-wrapper-{_NOTIF_ID}"' in html
+        assert f'hx-target="#notification-{_NOTIF_ID}"' not in html
+        # Button must still request outerHTML swap.
+        assert 'hx-swap="outerHTML"' in html
+        # Sanity: the button is present in the unread state.
+        assert "Loe" in html
+
+    def test_read_non_link_item_has_no_loe_button_and_is_wrapper_rooted(self):
+        """Review fix (PR #645): after mark-read, the response markup
+        must (a) be rooted at an element carrying the wrapper ID so
+        HTMX's ``outerHTML`` swap against the wrapper lands cleanly,
+        and (b) contain no stale "Loe" button."""
+        notif = _make_notification(read=True, link=None)
+
+        html = to_xml(NotificationItem(notif))
+
+        # The response root must carry the wrapper ID so the outerHTML
+        # swap against #notification-wrapper-{id} has a matching target.
+        assert f'id="notification-wrapper-{_NOTIF_ID}"' in html
+        # No stale "Loe" button must remain.
+        assert "Loe" not in html
+        assert "notification-mark-btn" not in html
+
 
 # ---------------------------------------------------------------------------
 # Tests: POST /notifications/read-all

--- a/tests/test_notifications_routes.py
+++ b/tests/test_notifications_routes.py
@@ -19,6 +19,7 @@ from starlette.responses import RedirectResponse, Response
 
 from app.notifications.models import Notification
 from app.notifications.routes import (
+    NotificationItem,
     api_notifications_partial,
     api_unread_count,
     mark_all_read_handler,
@@ -170,6 +171,114 @@ class TestMarkSingleRead:
         result = mark_single_read(req, str(_NOTIF_ID))
 
         assert isinstance(result, RedirectResponse)
+
+    @patch("app.notifications.routes._require_auth")
+    @patch("app.notifications.routes._connect")
+    def test_returns_hx_redirect_when_redirect_query_param_present(self, mock_connect, mock_auth):
+        """Bug 1: clicking an unread linked notification must navigate.
+
+        The `<a href>` click is swallowed by HTMX's POST and the native
+        navigation is suppressed. The handler must emit ``HX-Redirect``
+        so the browser navigates after the mark-read POST.
+        """
+        mock_auth.return_value = _AUTH
+        conn = MagicMock()
+        mock_connect.return_value = _ConnectCM(conn)
+
+        with patch("app.notifications.routes.mark_read"):
+            req = _make_request(
+                path=f"/notifications/{_NOTIF_ID}/read",
+                method="POST",
+                query_string=b"redirect=/drafts/abc",
+            )
+            result = mark_single_read(req, str(_NOTIF_ID))
+
+        assert isinstance(result, Response)
+        assert result.headers.get("HX-Redirect") == "/drafts/abc"
+
+    @patch("app.notifications.routes._require_auth")
+    @patch("app.notifications.routes._connect")
+    def test_rejects_external_redirect_target(self, mock_connect, mock_auth):
+        """The redirect target must stay same-origin."""
+        mock_auth.return_value = _AUTH
+        conn = MagicMock()
+        mock_connect.return_value = _ConnectCM(conn)
+
+        fresh_notif = _make_notification(read=True)
+        with (
+            patch("app.notifications.routes.mark_read"),
+            patch(
+                "app.notifications.routes.get_notification",
+                return_value=fresh_notif,
+            ),
+        ):
+            req = _make_request(
+                path=f"/notifications/{_NOTIF_ID}/read",
+                method="POST",
+                query_string=b"redirect=https%3A%2F%2Fevil.example%2Fpwn",
+            )
+            result = mark_single_read(req, str(_NOTIF_ID))
+
+        # Must NOT forward an off-site redirect. Either the result is
+        # not a Response (it's the re-rendered item) or its HX-Redirect
+        # header is absent.
+        if isinstance(result, Response):
+            assert result.headers.get("HX-Redirect") is None
+        else:
+            html = to_xml(result)
+            assert "evil.example" not in html
+
+    @patch("app.notifications.routes._require_auth")
+    @patch("app.notifications.routes._connect")
+    def test_returns_rendered_read_state_item_when_no_redirect(self, mock_connect, mock_auth):
+        """Bug 2: marking a non-link notification must return a re-rendered
+        read-state notification item — not a bare Span that collapses the
+        HTMX ``outerHTML`` swap target into a single dot."""
+        mock_auth.return_value = _AUTH
+        conn = MagicMock()
+        mock_connect.return_value = _ConnectCM(conn)
+
+        fresh_notif = _make_notification(read=True, link=None)
+
+        with (
+            patch("app.notifications.routes.mark_read"),
+            patch(
+                "app.notifications.routes.get_notification",
+                return_value=fresh_notif,
+            ),
+        ):
+            req = _make_request(
+                path=f"/notifications/{_NOTIF_ID}/read",
+                method="POST",
+            )
+            result = mark_single_read(req, str(_NOTIF_ID))
+
+        html = to_xml(result)
+        # Must render a full notification item wrapper, not just a dot.
+        assert f'id="notification-{_NOTIF_ID}"' in html
+        assert "notification-item--read" in html
+        # It must not be the bare standalone dot.
+        assert not html.strip().startswith("<span")
+
+
+# ---------------------------------------------------------------------------
+# Tests: NotificationItem rendering
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationItemRendering:
+    def test_unread_linked_item_embeds_redirect_query_param(self):
+        """Bug 1 (rendering side): the hx_post URL must carry the
+        destination in a ``redirect`` query param so the handler can
+        issue ``HX-Redirect`` and navigate after marking read."""
+        notif = _make_notification(read=False, link="/drafts/abc")
+
+        html = to_xml(NotificationItem(notif))
+
+        # The hx-post endpoint must encode the target link in the URL.
+        assert "hx-post=" in html
+        assert "redirect=" in html
+        assert "%2Fdrafts%2Fabc" in html or "/drafts/abc" in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notifications_wire.py
+++ b/tests/test_notifications_wire.py
@@ -32,10 +32,16 @@ _REPLY_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
 _SESSION_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
 
 
-def _make_annotation(user_id: uuid.UUID = _USER_A) -> MagicMock:
+def _make_annotation(
+    user_id: uuid.UUID = _USER_A,
+    target_type: str = "draft",
+    target_id: str | None = None,
+) -> MagicMock:
     ann = MagicMock()
     ann.id = _ANN_ID
     ann.user_id = user_id
+    ann.target_type = target_type
+    ann.target_id = target_id or str(_DRAFT_ID)
     return ann
 
 
@@ -89,6 +95,43 @@ class TestNotifyAnnotationReply:
         notify_annotation_reply(ann, reply)
 
         mock_notify.assert_not_called()
+
+    @patch("app.notifications.wire.notify")
+    def test_link_points_at_real_get_page_for_draft_target(self, mock_notify):
+        """Bug 3: `link=f"/annotations/{id}"` is a dead route.
+
+        When the annotation is on a draft, the notification link must
+        navigate to the draft's detail page (a 200 GET), not a
+        non-existent ``/annotations/{id}`` URL.
+        """
+        ann = _make_annotation(_USER_A, target_type="draft", target_id=str(_DRAFT_ID))
+        reply = _make_reply(_USER_B)
+
+        notify_annotation_reply(ann, reply)
+
+        call_kwargs = mock_notify.call_args[1]
+        link = call_kwargs.get("link") or ""
+        # Must not use the dead /annotations/{id} route.
+        assert not link.startswith("/annotations/")
+        # Must point at the draft detail page for a draft-target annotation.
+        assert str(_DRAFT_ID) in link
+        assert link.startswith("/drafts/")
+
+    @patch("app.notifications.wire.notify")
+    def test_link_points_at_chat_for_conversation_target(self, mock_notify):
+        ann = _make_annotation(
+            _USER_A,
+            target_type="conversation",
+            target_id="11111111-2222-3333-4444-555555555555",
+        )
+        reply = _make_reply(_USER_B)
+
+        notify_annotation_reply(ann, reply)
+
+        call_kwargs = mock_notify.call_args[1]
+        link = call_kwargs.get("link") or ""
+        assert not link.startswith("/annotations/")
+        assert link.startswith("/chat/")
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +204,30 @@ class TestNotifySyncFailed:
         user_ids = [call[1]["user_id"] for call in mock_notify.call_args_list]
         assert admin1 in user_ids
         assert admin2 in user_ids
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_link_points_at_real_get_page(self, mock_connect, mock_notify):
+        """Bug 4: `/admin/sync` is a POST-only route — sending admins
+        there yields a 405. The link must target a real GET page.
+        """
+        admin1 = uuid.uuid4()
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [(admin1,)]
+        mock_connect.return_value = _ConnectCM(conn)
+
+        notify_sync_failed("Connection refused")
+
+        call_kwargs = mock_notify.call_args[1]
+        link = call_kwargs.get("link") or ""
+        # Must not be the POST-only /admin/sync route.
+        assert link != "/admin/sync"
+        # Must resolve to a real GET admin page. The admin dashboard
+        # (/admin) exposes a sync-card section we can anchor to.
+        assert link.startswith("/admin")
+        # Must not be any other POST-only admin route either.
+        assert not link.startswith("/admin/sync?")
+        assert not link == "/admin/sync/"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #638.

## Summary

Four small but user-visible fixes to the notification inbox flow:

1. **Clickthrough on unread linked notifications** (routes.py): the `<a href hx-post=...>` click was swallowed by HTMX's POST and the native navigation never fired. The mark-read endpoint now accepts a `?redirect=<path>` query param and returns `HX-Redirect` (after a strict same-origin check) so the browser navigates after the POST.
2. **Non-link mark-read collapsed the row** (routes.py): `mark_single_read` returned a bare `<span>` against an `hx_swap="outerHTML"` target, leaving the row as a dot. It now re-renders the full notification item in its read state, via a new `get_notification()` helper in `models.py`.
3. **`annotation_reply` dead link** (wire.py): `/annotations/{id}` has no GET handler. Notifications now navigate to the annotation's target (`/drafts/{id}` for drafts, `/chat/{id}` for conversations). Provisions and entity targets fall back to the notification inbox until their dedicated detail pages exist (see Follow-ups below).
4. **`sync_failed` dead link** (wire.py): `/admin/sync` is POST-only. Changed to `/admin#sync-card`, which is a real GET page that scrolls to the sync status card.

## Definition of Done

- [x] Clicking an unread linked notification both marks it read and navigates to the link
- [x] Marking an unread non-link notification read leaves a properly rendered read-state row
- [x] `annotation_reply` notification link resolves to a 200 GET page
- [x] `sync_failed` notification link resolves to a 200 GET page
- [x] Regression tests cover all four behaviors
- [x] `uv run pytest -q` and `uv run ruff check` pass

## Follow-ups

- Provision and entity target annotations currently fall back to `/notifications`. When/if a GET detail page is added for provisions (`/provisions/{id}`) and entities (`/explorer?entity=...`), update `_annotation_target_link()` in `app/notifications/wire.py`.
- Consider a more visible in-page anchor for `#sync-card` on the admin dashboard (e.g. highlight flash on arrival).

## Test plan

- [x] `uv run pytest -q tests/test_notifications_routes.py tests/test_notifications_wire.py tests/test_notifications_models.py` — 34 passed
- [x] `uv run pytest -q tests/test_annotations_routes.py tests/test_annotations_models.py tests/test_dashboard.py` — 66 passed (regression check)
- [x] `uv run ruff check` — clean
- [x] `uv run pyright app/notifications/ tests/test_notifications_*.py` — clean

Generated with [Claude Code](https://claude.com/claude-code)