### PR TITLE
Auth: invalidate access tokens on role change / deactivation (#635)

### DIFF
--- a/app/auth/jwt_provider.py
+++ b/app/auth/jwt_provider.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import bcrypt
 import jwt
@@ -95,27 +96,72 @@ class JWTAuthProvider(AuthProvider):
         )
 
     def get_current_user(self, token: str) -> UserDict | None:
-        """Decode a JWT *token* and return the user payload.
+        """Decode a JWT *token* and rehydrate the user from the database.
 
-        Returns ``None`` when the token is expired, tampered, or malformed.
+        Returns ``None`` when the token is expired, tampered, malformed, or
+        when the server-side state invalidates it:
+
+        - the user no longer exists;
+        - ``is_active`` is ``FALSE``;
+        - the token's ``tv`` claim does not match ``users.token_version``
+          (i.e. the token was issued before the latest role change /
+          deactivation / forced logout);
+        - the token's ``role`` or ``org_id`` claims disagree with the DB
+          (defence-in-depth: should not happen if ``tv`` is maintained,
+          but cheap to verify).
+
+        Cost: one indexed ``SELECT`` per authenticated request. At the
+        5–50 concurrent user scale this is negligible. See #635.
         """
         try:
-            payload: dict[str, str] = jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM])
+            payload: dict[str, Any] = jwt.decode(token, SECRET_KEY, algorithms=[JWT_ALGORITHM])
         except jwt.PyJWTError:
             return None
 
         sub = payload.get("sub")
         email = payload.get("email")
         role = payload.get("role")
-        if not (sub and email and role):
+        tv_claim = payload.get("tv")
+        # Legacy tokens issued before the #635 fix have no ``tv`` claim.
+        # Reject them so users re-login through the refresh path and
+        # receive a versioned token.
+        if not (sub and email and role) or tv_claim is None:
+            return None
+
+        try:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT token_version, is_active, role, org_id FROM users WHERE id = %s",
+                    (sub,),
+                ).fetchone()
+        except Exception:
+            # Defensive: a DB outage must not silently grant access.
+            return None
+
+        if row is None:
+            return None
+
+        db_tv, db_active, db_role, db_org_id = row
+        if not db_active:
+            return None
+        if db_tv != tv_claim:
+            return None
+        # Role / org_id drift beyond what ``tv`` should already catch —
+        # defensive check in case someone updates those columns without
+        # bumping ``token_version``.
+        if db_role != role:
+            return None
+        db_org_id_str = str(db_org_id) if db_org_id is not None else None
+        claim_org_id = payload.get("org_id")
+        if db_org_id_str != claim_org_id:
             return None
 
         return UserDict(
             id=sub,
             email=email,
             full_name=payload.get("full_name", ""),
-            role=role,
-            org_id=payload.get("org_id"),
+            role=db_role,
+            org_id=db_org_id_str,
         )
 
     def logout(self, session_id: str) -> None:
@@ -129,34 +175,47 @@ class JWTAuthProvider(AuthProvider):
     def create_tokens(self, user: UserDict) -> tuple[str, str]:
         """Create a JWT access token and a refresh token for *user*.
 
+        The access token embeds the user's current ``token_version`` as
+        the ``tv`` claim (#635) so that future role changes or
+        deactivations can invalidate it in O(1) DB work.
+
         The refresh token is persisted in the ``sessions`` table.
         Returns ``(access_token, refresh_token)``.
         """
         now = datetime.now(UTC)
 
-        # Access token (stateless JWT)
-        access_payload = {
-            "sub": user["id"],
-            "email": user["email"],
-            "role": user["role"],
-            "full_name": user["full_name"],
-            "org_id": user.get("org_id"),
-            "exp": now + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
-            "iat": now,
-        }
-        access_token = jwt.encode(access_payload, SECRET_KEY, algorithm=JWT_ALGORITHM)
-
-        # Refresh token (opaque, stored hashed in DB)
+        # Fetch current token_version and create the session in one
+        # short-lived connection. We do the SELECT before the INSERT so
+        # a concurrent role change that bumped the counter does not
+        # silently issue us a stale tv.
         refresh_token = uuid.uuid4().hex + uuid.uuid4().hex
         token_hash = _hash_token(refresh_token)
         expires_at = now + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
 
         with self._connect() as conn:
+            row = conn.execute(
+                "SELECT token_version FROM users WHERE id = %s",
+                (user["id"],),
+            ).fetchone()
+            token_version = row[0] if row is not None else 0
             conn.execute(
                 "INSERT INTO sessions (user_id, token_hash, expires_at) VALUES (%s, %s, %s)",
                 (user["id"], token_hash, expires_at),
             )
             conn.commit()
+
+        # Access token (stateless JWT, with tv)
+        access_payload: dict[str, Any] = {
+            "sub": user["id"],
+            "email": user["email"],
+            "role": user["role"],
+            "full_name": user["full_name"],
+            "org_id": user.get("org_id"),
+            "tv": token_version,
+            "exp": now + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+            "iat": now,
+        }
+        access_token = jwt.encode(access_payload, SECRET_KEY, algorithm=JWT_ALGORITHM)
 
         return access_token, refresh_token
 

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -169,13 +169,20 @@ def create_user(
 
 
 def update_user_role(user_id: str, role: str) -> bool:
-    """Update a user's role. Returns True on success."""
+    """Update a user's role. Returns True on success.
+
+    Bumps ``token_version`` in the same UPDATE so every previously-issued
+    access token is invalidated immediately (#635).
+    """
     if role not in VALID_ROLES:
         logger.error("Invalid role: %s", role)
         return False
     try:
         with _connect() as conn:
-            conn.execute("UPDATE users SET role = %s WHERE id = %s", (role, user_id))
+            conn.execute(
+                "UPDATE users SET role = %s, token_version = token_version + 1 WHERE id = %s",
+                (role, user_id),
+            )
             conn.commit()
         return True
     except Exception:
@@ -187,11 +194,19 @@ def update_user_role(user_id: str, role: str) -> bool:
 def deactivate_user(user_id: str) -> bool:
     """Deactivate a user by setting is_active to false and revoking sessions.
 
+    Bumps ``token_version`` so any outstanding access token is rejected
+    on its next use (#635), and deletes the user's refresh sessions.
+
     Returns True on success.
     """
     try:
         with _connect() as conn:
-            conn.execute("UPDATE users SET is_active = FALSE WHERE id = %s", (user_id,))
+            conn.execute(
+                "UPDATE users "
+                "SET is_active = FALSE, token_version = token_version + 1 "
+                "WHERE id = %s",
+                (user_id,),
+            )
             conn.execute("DELETE FROM sessions WHERE user_id = %s", (user_id,))
             conn.commit()
         return True

--- a/migrations/020_add_users_token_version.sql
+++ b/migrations/020_add_users_token_version.sql
@@ -1,0 +1,13 @@
+-- #635 — Token-version column for access-token revocation.
+--
+-- The JWT access token embeds the user's current ``token_version`` as the
+-- ``tv`` claim. On every authenticated request the middleware rehydrates
+-- the user from the DB and rejects the token when ``tv`` != ``token_version``
+-- (or when ``is_active`` is FALSE, or when ``role`` / ``org_id`` have drifted).
+--
+-- Role updates and deactivations bump ``token_version`` in the same UPDATE,
+-- which invalidates every previously-issued access token for that user in
+-- O(1) DB work.
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS token_version INTEGER NOT NULL DEFAULT 0;

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -159,11 +159,13 @@ class TestJWTTokens:
 
 
 class TestGetCurrentUser:
-    """Test JWTAuthProvider.get_current_user without a database.
+    """Test JWTAuthProvider.get_current_user.
 
-    We instantiate the provider but only call get_current_user which is
-    purely stateless (JWT decode).  We pass a dummy DB URL since the
-    constructor requires one, but no connection is made.
+    Post-#635 ``get_current_user`` rehydrates the user from the DB to
+    enforce token-version revocation. The happy-path test therefore
+    mocks ``_connect`` to return a matching ``token_version`` /
+    ``is_active`` / ``role`` row. Failure-mode tests exercise the
+    early JWT-decode exits where no DB lookup happens.
     """
 
     def _provider(self):  # noqa: ANN202
@@ -172,6 +174,8 @@ class TestGetCurrentUser:
         return JWTAuthProvider(database_url="postgresql://fake:fake@localhost/fake")
 
     def test_valid_token_returns_user(self):
+        from unittest.mock import MagicMock, patch
+
         provider = self._provider()
         now = datetime.now(UTC)
         payload = {
@@ -180,11 +184,23 @@ class TestGetCurrentUser:
             "role": "drafter",
             "full_name": "A B",
             "org_id": None,
+            "tv": 0,
             "exp": now + timedelta(hours=1),
             "iat": now,
         }
         token = jwt.encode(payload, SECRET_KEY, algorithm=JWT_ALGORITHM)
-        user = provider.get_current_user(token)
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0, True, "drafter", None)
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=conn)
+        ctx.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "app.auth.jwt_provider.JWTAuthProvider._connect",
+            return_value=ctx,
+        ):
+            user = provider.get_current_user(token)
 
         assert user is not None
         assert user["id"] == "uid"

--- a/tests/test_auth_token_version.py
+++ b/tests/test_auth_token_version.py
@@ -1,0 +1,213 @@
+"""Tests for token-version based access-token revocation (#635).
+
+Access tokens trust JWT claims alone in the pre-fix implementation, so
+role updates and deactivations do not take effect until the token
+expires (up to 60 minutes). The fix embeds a ``tv`` (token version)
+claim in the access token and verifies it — along with ``is_active``,
+``role`` and ``org_id`` — against the DB on every authenticated request.
+
+These tests exercise ``JWTAuthProvider.get_current_user`` with
+``_connect`` mocked so they never touch a real database.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import jwt
+
+from app.auth.jwt_provider import (
+    JWT_ALGORITHM,
+    SECRET_KEY,
+)
+
+
+def _jwt_provider_cls():
+    """Re-fetch ``JWTAuthProvider`` after any module reloads performed
+    by neighbouring tests in ``tests/test_auth.py``."""
+    import app.auth.jwt_provider as mod
+
+    return mod.JWTAuthProvider
+
+
+def _make_token(
+    *,
+    sub: str = "uid-1",
+    email: str = "a@b.ee",
+    role: str = "drafter",
+    org_id: str | None = None,
+    tv: int | None = 0,
+    exp_delta: timedelta = timedelta(hours=1),
+    full_name: str = "A B",
+) -> str:
+    now = datetime.now(UTC)
+    payload: dict[str, Any] = {
+        "sub": sub,
+        "email": email,
+        "role": role,
+        "full_name": full_name,
+        "org_id": org_id,
+        "exp": now + exp_delta,
+        "iat": now,
+    }
+    if tv is not None:
+        payload["tv"] = tv
+    return jwt.encode(payload, SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+
+def _patch_connect(conn_ctx: MagicMock):
+    """Return a context-manager mock whose __enter__ returns *conn_ctx*."""
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn_ctx)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+class TestTokenVersionVerification:
+    """get_current_user must reject tokens whose ``tv`` claim is stale."""
+
+    def _provider(self):
+        return _jwt_provider_cls()(database_url="postgresql://fake:fake@localhost/fake")
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_matching_token_version_accepted(self, mock_connect: MagicMock):
+        conn = MagicMock()
+        # (token_version, is_active, role, org_id)
+        conn.execute.return_value.fetchone.return_value = (0, True, "drafter", None)
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = self._provider()
+        token = _make_token(tv=0, role="drafter")
+        user = provider.get_current_user(token)
+
+        assert user is not None
+        assert user["id"] == "uid-1"
+        assert user["role"] == "drafter"
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_stale_token_version_rejected(self, mock_connect: MagicMock):
+        """After role change, tv increments; old token must 401."""
+        conn = MagicMock()
+        # DB says token_version is now 1 (incremented after role change).
+        conn.execute.return_value.fetchone.return_value = (1, True, "drafter", None)
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = self._provider()
+        # Old token still carries tv=0.
+        token = _make_token(tv=0, role="admin")  # stale elevated role
+        assert provider.get_current_user(token) is None
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_deactivated_user_rejected_even_with_valid_token(self, mock_connect: MagicMock):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0, False, "drafter", None)
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = self._provider()
+        token = _make_token(tv=0)
+        assert provider.get_current_user(token) is None
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_user_not_in_db_rejected(self, mock_connect: MagicMock):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = self._provider()
+        token = _make_token(tv=0)
+        assert provider.get_current_user(token) is None
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_role_mismatch_between_token_and_db_rejected(self, mock_connect: MagicMock):
+        """If DB role differs from JWT role the token is stale."""
+        conn = MagicMock()
+        # DB role is drafter, token still claims admin.
+        conn.execute.return_value.fetchone.return_value = (0, True, "drafter", None)
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = self._provider()
+        token = _make_token(tv=0, role="admin")
+        assert provider.get_current_user(token) is None
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_missing_tv_claim_rejected(self, mock_connect: MagicMock):
+        """Legacy tokens without tv must be rejected after migration."""
+        # No DB call expected; the early validation trips first.
+        conn = MagicMock()
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = self._provider()
+        token = _make_token(tv=None)
+        assert provider.get_current_user(token) is None
+
+
+class TestCreateTokensEmbedsTokenVersion:
+    """create_tokens must fetch and embed the current token_version."""
+
+    @patch("app.auth.jwt_provider.JWTAuthProvider._connect")
+    def test_access_token_contains_tv_claim(self, mock_connect: MagicMock):
+        conn = MagicMock()
+        # Two sequential execute calls: SELECT token_version, then INSERT session.
+        # The SELECT returns (5,); the INSERT has no meaningful return.
+        select_cursor = MagicMock()
+        select_cursor.fetchone.return_value = (5,)
+        insert_cursor = MagicMock()
+        conn.execute.side_effect = [select_cursor, insert_cursor]
+        mock_connect.return_value = _patch_connect(conn)
+
+        provider = _jwt_provider_cls()(database_url="postgresql://fake:fake@localhost/fake")
+        user: dict[str, Any] = {
+            "id": "uid-1",
+            "email": "a@b.ee",
+            "full_name": "A B",
+            "role": "drafter",
+            "org_id": None,
+        }
+        access_token, _refresh_token = provider.create_tokens(user)  # type: ignore[arg-type]
+
+        decoded = jwt.decode(access_token, SECRET_KEY, algorithms=[JWT_ALGORITHM])
+        assert decoded["tv"] == 5
+
+
+class TestUpdateUserRoleIncrementsTokenVersion:
+    """update_user_role must bump token_version atomically."""
+
+    @patch("app.auth.users._connect")
+    def test_update_role_bumps_token_version(self, mock_connect: MagicMock):
+        from app.auth.users import update_user_role
+
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        ok = update_user_role("some-uid", "reviewer")
+        assert ok is True
+
+        # The UPDATE must touch both role and token_version.
+        sql = conn.execute.call_args[0][0]
+        assert "UPDATE users" in sql
+        assert "token_version" in sql
+        assert "role" in sql
+
+
+class TestDeactivateUserIncrementsTokenVersion:
+    """deactivate_user must bump token_version atomically."""
+
+    @patch("app.auth.users._connect")
+    def test_deactivate_bumps_token_version(self, mock_connect: MagicMock):
+        from app.auth.users import deactivate_user
+
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        ok = deactivate_user("some-uid")
+        assert ok is True
+
+        # First call = UPDATE users (is_active + token_version).
+        first_sql = conn.execute.call_args_list[0][0][0]
+        assert "UPDATE users" in first_sql
+        assert "is_active" in first_sql
+        assert "token_version" in first_sql


### PR DESCRIPTION
## Summary

Access tokens previously trusted their JWT claims alone, which meant role
updates and deactivations took effect only after the access token expired
(up to `ACCESS_TOKEN_EXPIRE_MINUTES = 60`). Deactivated users kept valid
sessions, demoted admins kept hitting admin routes.

This PR adds a ``tv`` (token-version) claim to the access token and a
``token_version`` column to ``users``. On every authenticated request,
``get_current_user`` rehydrates the user row and rejects tokens whose
``tv`` does not match the DB, whose ``is_active`` is FALSE, or whose
``role`` / ``org_id`` have drifted. ``update_user_role`` and
``deactivate_user`` bump ``token_version`` in the same UPDATE, so every
previously-issued access token is invalidated at the next request.

## Definition of Done

- [x] Demoted user loses elevated route access immediately
- [x] Deactivated user loses authenticated access immediately
- [x] Mechanism is documented (token-version approach, in docstrings + migration)
- [x] Regression tests cover both "demoted" and "deactivated" against a still-valid access token
- [x] `uv run pytest -q` and `uv run ruff check` pass

## Test plan

- [x] 9 new tests in `tests/test_auth_token_version.py`, including stale-`tv`
      rejection, deactivated-user rejection, role-mismatch defensive check,
      and `create_tokens` embedding `tv`.
- [x] Existing `TestGetCurrentUser.test_valid_token_returns_user` updated
      to reflect the DB-rehydration contract.
- [x] Full auth suite passes (`tests/test_auth*.py` = 83 tests).

## Notes / trade-offs

- Adds **one indexed SELECT per authenticated HTTP request**. At the
  5-50 concurrent user scale this is negligible; noted in the
  `get_current_user` docstring.
- Legacy tokens (no `tv` claim) are rejected; users will be bounced
  through the refresh endpoint to receive a versioned token.

Closes #635.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>