### PR TITLE
Auth: block org-admin from demoting / deactivating admin & org_admin (#634)

### DIFF
--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -593,7 +593,13 @@ def org_user_create(req: Request, email: str, password: str, full_name: str, rol
 
 
 def org_user_role_form(req: Request, user_id: str):
-    """GET /org/users/{user_id}/role — change role form (org admin)."""
+    """GET /org/users/{user_id}/role — change role form (org admin).
+
+    Targets whose current role is outside ``ORG_ASSIGNABLE_ROLES``
+    (i.e. ``admin`` or ``org_admin``) are protected: the form is
+    replaced by an 'ei saa muuta' state without any action buttons,
+    so the UI never exposes a way to mutate their role (#634).
+    """
     auth = req.scope.get("auth", {})
     theme = get_theme_from_request(req)
     org_id = auth.get("org_id")
@@ -601,6 +607,36 @@ def org_user_role_form(req: Request, user_id: str):
     user = get_user(user_id)
     if user is None or user.get("org_id") != org_id:
         return _error_page(req, "Kasutajat ei leitud.", "/org/users", "/org/users")
+
+    # #634 — refuse to render the mutating form for protected targets.
+    if user["role"] not in ORG_ASSIGNABLE_ROLES:
+        return PageShell(
+            H1("Muuda rolli", cls="page-title"),
+            Card(
+                CardHeader(
+                    P(
+                        f"Kasutaja: {user['full_name']} ({user['email']})",
+                        cls="card-subtitle",
+                    )
+                ),
+                CardBody(
+                    Alert(
+                        "Selle kasutaja rolli ei saa muuta: "
+                        "administraatori ja organisatsiooni admin kasutajaid "
+                        "saab hallata ainult süsteemi administraator.",
+                        variant="warning",
+                    ),
+                    Div(
+                        A("Tagasi", href="/org/users", cls="btn btn-ghost btn-md"),
+                        cls="form-actions",
+                    ),
+                ),
+            ),
+            title="Muuda rolli",
+            user=auth or None,
+            theme=theme,
+            active_nav="/org/users",
+        )
 
     role_options = [(r, _ROLE_LABELS.get(r, r)) for r in ORG_ASSIGNABLE_ROLES]
 
@@ -634,13 +670,30 @@ def org_user_role_form(req: Request, user_id: str):
 
 
 def org_user_role_update(req: Request, user_id: str, role: str):
-    """POST /org/users/{user_id}/role — update user role (org admin)."""
+    """POST /org/users/{user_id}/role — update user role (org admin).
+
+    Refuses to mutate targets whose current role is outside
+    ``ORG_ASSIGNABLE_ROLES`` (#634). An org_admin must never be able
+    to demote another org_admin or the seeded system admin through
+    the org-scoped UI.
+    """
     auth = req.scope.get("auth", {})
     org_id = auth.get("org_id")
 
     user = get_user(user_id)
     if user is None or user.get("org_id") != org_id:
         return _error_page(req, "Kasutajat ei leitud.", "/org/users", "/org/users")
+
+    # #634 — block demoting admins / org_admins via the org UI.
+    if user["role"] not in ORG_ASSIGNABLE_ROLES:
+        return _error_page(
+            req,
+            "Selle kasutaja rolli ei saa muuta: "
+            "administraatori ja organisatsiooni admin kasutajaid "
+            "saab hallata ainult süsteemi administraator.",
+            "/org/users",
+            "/org/users",
+        )
 
     if role not in ORG_ASSIGNABLE_ROLES:
         return _error_page(
@@ -658,13 +711,40 @@ def org_user_role_update(req: Request, user_id: str, role: str):
 
 
 def org_user_deactivate(req: Request, user_id: str):
-    """POST /org/users/{user_id}/deactivate — deactivate user (org admin)."""
+    """POST /org/users/{user_id}/deactivate — deactivate user (org admin).
+
+    Blocks two escalation paths (#634):
+
+    1. An org_admin cannot deactivate another org_admin or the seeded
+       system admin (whose row also carries the org_id).
+    2. An org_admin cannot deactivate themselves.
+    """
     auth = req.scope.get("auth", {})
     org_id = auth.get("org_id")
+
+    # #634 — self-deactivation is never allowed.
+    if str(user_id) == str(auth.get("id")):
+        return _error_page(
+            req,
+            "Te ei saa ennast deaktiveerida.",
+            "/org/users",
+            "/org/users",
+        )
 
     user = get_user(user_id)
     if user is None or user.get("org_id") != org_id:
         return _error_page(req, "Kasutajat ei leitud.", "/org/users", "/org/users")
+
+    # #634 — protect admins / org_admins from the org UI.
+    if user["role"] not in ORG_ASSIGNABLE_ROLES:
+        return _error_page(
+            req,
+            "Seda kasutajat ei saa deaktiveerida: "
+            "administraatori ja organisatsiooni admin kasutajaid "
+            "saab hallata ainult süsteemi administraator.",
+            "/org/users",
+            "/org/users",
+        )
 
     success = deactivate_user(user_id)
     if not success:

--- a/tests/test_auth_org_admin_guards.py
+++ b/tests/test_auth_org_admin_guards.py
@@ -1,0 +1,221 @@
+"""Tests for org-admin guards on same-org admin / org_admin targets (#634).
+
+Pre-fix, ``org_user_role_update``, ``org_user_deactivate`` and
+``org_user_role_form`` only validated the **new** role against
+``ORG_ASSIGNABLE_ROLES`` — they never inspected the target user's
+**current** role. An org_admin could therefore demote or deactivate
+another org_admin (or even the seeded system admin, which has an org_id
+per ``migrations/004_admin_seed_fix.sql``). Self-deactivation was also
+unguarded.
+
+These tests exercise the three handlers by stubbing ``get_user`` so no
+DB is required and checking for the refusal path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from starlette.responses import RedirectResponse
+
+from app.auth.users import (
+    org_user_deactivate,
+    org_user_role_form,
+    org_user_role_update,
+)
+
+_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_ORG_ADMIN_ID = "11111111-1111-1111-1111-111111111111"
+_TARGET_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _make_request(auth: dict[str, Any] | None = None) -> MagicMock:
+    req = MagicMock()
+    # PageShell (used by _error_page) reads ``full_name`` off the auth dict
+    # to render the user menu — always include it.
+    default = {
+        "id": _ORG_ADMIN_ID,
+        "role": "org_admin",
+        "org_id": _ORG_ID,
+        "email": "admin@org.ee",
+        "full_name": "Org Admin",
+    }
+    req.scope = {"auth": auth or default}
+    # Mimic Starlette's Request.cookies (used by the theme helper).
+    req.cookies = {}
+    return req
+
+
+def _target(*, role: str, user_id: str = _TARGET_ID, org_id: str = _ORG_ID) -> dict:  # type: ignore[type-arg]
+    return {
+        "id": user_id,
+        "email": "t@t.ee",
+        "full_name": "T",
+        "role": role,
+        "org_id": org_id,
+        "is_active": True,
+        "org_name": "org",
+    }
+
+
+# ---------------------------------------------------------------------------
+# org_user_role_update — must refuse protected targets
+# ---------------------------------------------------------------------------
+
+
+class TestOrgUserRoleUpdateRefusesProtectedTargets:
+    @patch("app.auth.users.update_user_role")
+    @patch("app.auth.users.get_user")
+    def test_refuses_to_update_org_admin_target(
+        self, mock_get_user: MagicMock, mock_update: MagicMock
+    ):
+        mock_get_user.return_value = _target(role="org_admin")
+
+        req = _make_request()
+        result = org_user_role_update(req, _TARGET_ID, "drafter")
+
+        # Handler must NOT call update_user_role.
+        mock_update.assert_not_called()
+        # Must render an error page (not a 303 redirect to /org/users).
+        assert not isinstance(result, RedirectResponse), (
+            "org_admin target must not be updated — handler redirected as if it succeeded"
+        )
+
+    @patch("app.auth.users.update_user_role")
+    @patch("app.auth.users.get_user")
+    def test_refuses_to_update_admin_target(
+        self, mock_get_user: MagicMock, mock_update: MagicMock
+    ):
+        mock_get_user.return_value = _target(role="admin")
+
+        req = _make_request()
+        result = org_user_role_update(req, _TARGET_ID, "drafter")
+
+        mock_update.assert_not_called()
+        assert not isinstance(result, RedirectResponse), (
+            "admin target must not be updated — handler redirected as if it succeeded"
+        )
+
+    @patch("app.auth.users.log_action")
+    @patch("app.auth.users.update_user_role")
+    @patch("app.auth.users.get_user")
+    def test_allows_updating_drafter_target(
+        self,
+        mock_get_user: MagicMock,
+        mock_update: MagicMock,
+        mock_log: MagicMock,
+    ):
+        """Existing allowed path must still work — drafter -> reviewer."""
+        mock_get_user.return_value = _target(role="drafter")
+        mock_update.return_value = True
+
+        req = _make_request()
+        result = org_user_role_update(req, _TARGET_ID, "reviewer")
+
+        mock_update.assert_called_once_with(_TARGET_ID, "reviewer")
+        assert isinstance(result, RedirectResponse)
+
+
+# ---------------------------------------------------------------------------
+# org_user_deactivate — must refuse protected targets and self
+# ---------------------------------------------------------------------------
+
+
+class TestOrgUserDeactivateGuards:
+    @patch("app.auth.users.deactivate_user")
+    @patch("app.auth.users.get_user")
+    def test_refuses_to_deactivate_org_admin_target(
+        self, mock_get_user: MagicMock, mock_deactivate: MagicMock
+    ):
+        mock_get_user.return_value = _target(role="org_admin")
+
+        req = _make_request()
+        result = org_user_deactivate(req, _TARGET_ID)
+
+        mock_deactivate.assert_not_called()
+        assert not isinstance(result, RedirectResponse), (
+            "org_admin target must not be deactivated — handler redirected as if it succeeded"
+        )
+
+    @patch("app.auth.users.deactivate_user")
+    @patch("app.auth.users.get_user")
+    def test_refuses_to_deactivate_admin_target(
+        self, mock_get_user: MagicMock, mock_deactivate: MagicMock
+    ):
+        mock_get_user.return_value = _target(role="admin")
+
+        req = _make_request()
+        result = org_user_deactivate(req, _TARGET_ID)
+
+        mock_deactivate.assert_not_called()
+        assert not isinstance(result, RedirectResponse), (
+            "admin target must not be deactivated — handler redirected as if it succeeded"
+        )
+
+    @patch("app.auth.users.deactivate_user")
+    @patch("app.auth.users.get_user")
+    def test_refuses_self_deactivation(self, mock_get_user: MagicMock, mock_deactivate: MagicMock):
+        """Org admin tries to deactivate themselves."""
+        # The get_user for caller returns an org_admin in their own org.
+        mock_get_user.return_value = _target(
+            role="org_admin",
+            user_id=_ORG_ADMIN_ID,
+        )
+
+        req = _make_request()
+        result = org_user_deactivate(req, _ORG_ADMIN_ID)
+
+        mock_deactivate.assert_not_called()
+        assert not isinstance(result, RedirectResponse), (
+            "Self-deactivation must not be allowed — handler redirected as if it succeeded"
+        )
+
+    @patch("app.auth.users.log_action")
+    @patch("app.auth.users.deactivate_user")
+    @patch("app.auth.users.get_user")
+    def test_allows_deactivating_drafter_target(
+        self,
+        mock_get_user: MagicMock,
+        mock_deactivate: MagicMock,
+        mock_log: MagicMock,
+    ):
+        mock_get_user.return_value = _target(role="drafter")
+        mock_deactivate.return_value = True
+
+        req = _make_request()
+        result = org_user_deactivate(req, _TARGET_ID)
+
+        mock_deactivate.assert_called_once_with(_TARGET_ID)
+        assert isinstance(result, RedirectResponse)
+
+
+# ---------------------------------------------------------------------------
+# org_user_role_form — must NOT render the role-picker for protected targets
+# ---------------------------------------------------------------------------
+
+
+class TestOrgUserRoleFormProtectedTargets:
+    @patch("app.auth.users.get_user")
+    def test_protected_target_rendered_without_select_action(self, mock_get_user: MagicMock):
+        """A protected target must NOT receive a form with role select +
+        Salvesta button. The page should render an 'ei saa muuta' state."""
+        mock_get_user.return_value = _target(role="org_admin")
+
+        req = _make_request()
+        result = org_user_role_form(req, _TARGET_ID)
+
+        # Convert the FT result to HTML text
+        from fasthtml.common import to_xml
+
+        html = to_xml(result) if result is not None else ""
+
+        # The Estonian refusal message must be present.
+        assert "ei saa muuta" in html.lower() or "keelatud" in html.lower(), (
+            "Form must show a 'ei saa muuta' / 'keelatud' state for protected targets"
+        )
+        # The POST action to actually update the role must NOT be present
+        # (or the form must be rendered read-only / disabled).
+        assert f'action="/org/users/{_TARGET_ID}/role"' not in html, (
+            "Protected-target form must not expose an active POST action"
+        )


### PR DESCRIPTION
## Summary

The `/org/users/{id}/role` and `/org/users/{id}/deactivate` handlers
previously only validated the **new** role against
`ORG_ASSIGNABLE_ROLES = ('drafter', 'reviewer')`. They never inspected
the target's **current** role, and there was no self-deactivation
protection. An org_admin could therefore:

- demote another same-org org_admin to drafter/reviewer;
- demote or deactivate the seeded system admin (whose row carries an
  org_id per `migrations/004_admin_seed_fix.sql`);
- deactivate themselves.

This PR adds three guards in `app/auth/users.py`:

1. `org_user_role_update()` refuses targets whose *current* role is
   outside `ORG_ASSIGNABLE_ROLES`.
2. `org_user_deactivate()` refuses the same targets and refuses when
   the target id matches the caller id (self-deactivation).
3. `org_user_role_form()` renders a clear Estonian "ei saa muuta"
   state for protected targets — no form, no POST action.

## Definition of Done

- [x] `org_user_role_update()` rejects targets currently holding `admin` / `org_admin`
- [x] `org_user_deactivate()` rejects targets currently holding `admin` / `org_admin` and rejects self
- [x] `org_user_role_form()` shows a clear "not allowed" state for these targets (no exposed action buttons)
- [x] Regression tests cover same-org `org_admin` and `admin` targets, plus self-deactivation
- [x] `uv run pytest -q` and `uv run ruff check` pass

## Test plan

- [x] 8 new tests in `tests/test_auth_org_admin_guards.py` covering
      every refusal path + the happy-path "demote a drafter to reviewer"
      allow path.
- [x] Full auth suite still green (`tests/test_auth*.py`).

Closes #634.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>