### PR TITLE
Auth: /ws/chat silent-refreshes expired access tokens (#637)

### DIFF
--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -53,6 +53,43 @@ SKIP_PATHS: list[str] = [
 ]
 
 
+def verify_refresh_token_user(
+    refresh_token: str,
+    provider: JWTAuthProvider | None = None,
+) -> dict[str, Any] | None:
+    """Verify a refresh token without consuming it (#637, review).
+
+    Verify the refresh token's signature, confirm the DB session row
+    exists and is not expired, and confirm the user is still active.
+    Return the associated user dict on success, ``None`` otherwise.
+
+    Unlike :func:`try_refresh_access_token`, this helper does **not**
+    mutate session state — the session row is not deleted and no new
+    tokens are minted. It exists for transports that cannot persist
+    rotated cookies on their response, most notably the ``/ws/chat``
+    WebSocket handshake: the upgrade response has no Set-Cookie hook,
+    so consuming the refresh token would leave the browser with a
+    dead cookie and break the next HTTP request's silent-refresh.
+
+    Security note: refresh-token rotation defends against reuse by
+    ensuring every refresh mints a brand-new pair and invalidates the
+    old one. The rotation only matters when NEW tokens are minted
+    (HTTP middleware does that). Read-only verification of a
+    presented refresh token does not enable reuse attacks because no
+    new token is minted here; the refresh token still gets rotated
+    atomically on the next HTTP request that goes through
+    :func:`auth_before`.
+    """
+    if not refresh_token:
+        return None
+
+    provider = provider or _get_provider()
+    user = provider.verify_refresh_token(refresh_token)
+    if user is None:
+        return None
+    return dict(user)
+
+
 def try_refresh_access_token(
     refresh_token: str,
     provider: JWTAuthProvider | None = None,
@@ -67,6 +104,13 @@ def try_refresh_access_token(
     Factored out of :func:`auth_before` (#637) so non-HTTP transports
     — notably the ``/ws/chat`` WebSocket handshake — can mirror the
     HTTP silent-refresh contract without re-implementing it.
+
+    Note: the ``/ws/chat`` handshake uses
+    :func:`verify_refresh_token_user` (verify-only) instead of this
+    function because it cannot persist rotated cookies on the upgrade
+    response. Consuming the refresh token there without being able to
+    set replacement cookies would break the browser's subsequent HTTP
+    silent-refresh (#637, review).
     """
     if not refresh_token:
         return None

--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
@@ -53,6 +53,35 @@ SKIP_PATHS: list[str] = [
 ]
 
 
+def try_refresh_access_token(
+    refresh_token: str,
+    provider: JWTAuthProvider | None = None,
+) -> tuple[str, str, dict[str, Any]] | None:
+    """Rotate a refresh token and mint a fresh access/refresh pair.
+
+    Returns ``(new_access, new_refresh, user_dict)`` on success,
+    ``None`` when the refresh token is absent, expired, or the user
+    has been deactivated. The old refresh session is removed from the
+    DB so it cannot be replayed.
+
+    Factored out of :func:`auth_before` (#637) so non-HTTP transports
+    — notably the ``/ws/chat`` WebSocket handshake — can mirror the
+    HTTP silent-refresh contract without re-implementing it.
+    """
+    if not refresh_token:
+        return None
+
+    provider = provider or _get_provider()
+    user = provider.verify_refresh_token(refresh_token)
+    if user is None:
+        return None
+
+    # Rotate: invalidate the old refresh session, mint a fresh pair.
+    provider.delete_refresh_token(refresh_token)
+    new_access, new_refresh = provider.create_tokens(user)
+    return new_access, new_refresh, dict(user)
+
+
 def auth_before(req: Request) -> Response | None:
     """Beforeware: authenticate via JWT cookies, redirect to login if needed.
 
@@ -77,11 +106,9 @@ def auth_before(req: Request) -> Response | None:
 
     # Access token missing or invalid -- attempt silent refresh.
     if refresh_token:
-        user = provider.verify_refresh_token(refresh_token)
-        if user is not None:
-            # Rotate tokens: delete old refresh session, create new pair.
-            provider.delete_refresh_token(refresh_token)
-            new_access, new_refresh = provider.create_tokens(user)
+        rotated = try_refresh_access_token(refresh_token, provider=provider)
+        if rotated is not None:
+            new_access, new_refresh, _user = rotated
 
             # We cannot simply set cookies on the current response because the
             # Beforeware runs *before* the handler and the response object does

--- a/app/chat/websocket.py
+++ b/app/chat/websocket.py
@@ -333,13 +333,23 @@ def register_chat_ws_routes(app: Any) -> None:
 
                 if user is None and refresh_token:
                     # #637 — silent refresh for long-lived chat sessions.
-                    # Import here so the chat module has no side-effect-y
-                    # dependency on the HTTP middleware at import time.
-                    from app.auth.middleware import try_refresh_access_token
+                    # The WS upgrade response cannot set replacement
+                    # cookies, so we use the verify-only helper here
+                    # (see #637, review). Consuming the refresh token
+                    # without being able to persist the rotated
+                    # cookies would leave the browser with a dead
+                    # refresh_token and break the next HTTP request's
+                    # silent-refresh. The refresh token still rotates
+                    # atomically on the next HTTP call through
+                    # ``auth_before``.
+                    #
+                    # Import here so the chat module has no
+                    # side-effect-y dependency on the HTTP middleware
+                    # at import time.
+                    from app.auth.middleware import verify_refresh_token_user
 
-                    rotated = try_refresh_access_token(refresh_token, provider=provider)
-                    if rotated is not None:
-                        _new_access, _new_refresh, refreshed_user = rotated
+                    refreshed_user = verify_refresh_token_user(refresh_token, provider=provider)
+                    if refreshed_user is not None:
                         user = refreshed_user
 
                 if user is not None:

--- a/app/chat/websocket.py
+++ b/app/chat/websocket.py
@@ -296,15 +296,27 @@ def register_chat_ws_routes(app: Any) -> None:
     _per_send_tasks: dict[int, dict[str, asyncio.Task[Any]]] = {}
 
     async def _ws_handler(msg: str, send: Any, scope: dict[str, Any] | None = None) -> None:
-        """Extract JWT from WS handshake cookies and pass auth scope to ws_chat."""
+        """Extract JWT from WS handshake cookies and pass auth scope to ws_chat.
+
+        Mirrors the HTTP middleware's silent-refresh contract (#637): if
+        the ``access_token`` cookie is missing or invalid but a valid
+        ``refresh_token`` is present, verify the refresh token, mint a
+        new pair, and proceed with the authenticated user. The new
+        cookies cannot be set on the WS upgrade response here (we only
+        have the ASGI send callable), so the next HTTP request the
+        client makes will go through the Beforeware which will do the
+        same rotation and persist the cookies. This keeps long-lived
+        chat sessions alive past the 60-minute access-token expiry.
+        """
         auth_scope: dict[str, Any] = {}
 
         if scope is not None:
             # Try to extract the access_token from handshake headers.
             raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
             access_token = _extract_cookie_from_headers(raw_headers, "access_token")
+            refresh_token = _extract_cookie_from_headers(raw_headers, "refresh_token")
 
-            if access_token:
+            if access_token or refresh_token:
                 provider = _get_jwt_provider()
                 if provider is None:
                     # Fail-closed: we cannot verify tokens, so reject
@@ -313,9 +325,25 @@ def register_chat_ws_routes(app: Any) -> None:
                     await _ws_close(send, 1011, "auth provider unavailable")
                     return
 
-                user = provider.get_current_user(access_token)
+                user: dict[str, Any] | None = None
+                if access_token:
+                    verified = provider.get_current_user(access_token)
+                    if verified is not None:
+                        user = dict(verified)
+
+                if user is None and refresh_token:
+                    # #637 — silent refresh for long-lived chat sessions.
+                    # Import here so the chat module has no side-effect-y
+                    # dependency on the HTTP middleware at import time.
+                    from app.auth.middleware import try_refresh_access_token
+
+                    rotated = try_refresh_access_token(refresh_token, provider=provider)
+                    if rotated is not None:
+                        _new_access, _new_refresh, refreshed_user = rotated
+                        user = refreshed_user
+
                 if user is not None:
-                    auth_scope["auth"] = dict(user)
+                    auth_scope["auth"] = user
 
         key = id(send)
         tasks = _per_send_tasks.setdefault(key, {})

--- a/tests/test_chat_websocket_refresh.py
+++ b/tests/test_chat_websocket_refresh.py
@@ -5,13 +5,33 @@ the refresh_token is still valid. The WebSocket handshake bypasses the
 Beforeware, so pre-fix it would reject chats for up to 60 minutes past
 access-token expiry even when the user still had a valid refresh cookie.
 
+Design note (#637, review)
+--------------------------
+
+The WS upgrade response has no Set-Cookie hook, so the WS handshake
+MUST NOT consume the refresh token (i.e. delete the old session row
+and mint a new pair). If it did, the browser would keep sending the
+now-dead refresh cookie, the next HTTP request's Beforeware silent-
+refresh would fail, and the user would be redirected to /auth/login
+on the very next navigation or quota poll.
+
+The WS handshake therefore uses the verify-only helper
+``verify_refresh_token_user`` which checks signature + DB session
+row + user active, but leaves session state untouched. The refresh
+token still gets rotated atomically on the next HTTP request that
+goes through ``auth_before``.
+
 These tests pin the behaviour:
 
 - When only ``refresh_token`` (no valid access_token) is present, the WS
-  handshake must verify the refresh token, mint a new pair, and proceed
-  with the authenticated user.
-- When neither cookie is usable, the handshake must fail-closed (existing
-  behaviour, preserved).
+  handshake must verify the refresh token and proceed with the
+  authenticated user, WITHOUT deleting the session row or minting a
+  new pair.
+- A subsequent HTTP request with the SAME cookies must still be able
+  to rotate via the normal Beforeware path (regression for the P1
+  finding on PR #648).
+- When neither cookie is usable, the handshake must fail-closed
+  (existing behaviour, preserved).
 
 The JWT provider is mocked so no real DB is needed.
 """
@@ -62,10 +82,16 @@ class TestWsChatSilentRefresh:
     @patch("app.chat.websocket.ChatOrchestrator")
     @patch("app.chat.websocket.get_default_provider")
     @patch("app.chat.websocket.JWTAuthProvider")
-    def test_expired_access_valid_refresh_rotates_and_authenticates(
+    def test_expired_access_valid_refresh_authenticates_without_consuming(
         self, mock_jwt_cls, mock_provider, mock_orch_cls
     ):
-        """Expired access + valid refresh → WS authenticates."""
+        """Expired access + valid refresh -> WS authenticates, session preserved.
+
+        The WS handshake must verify the refresh token but MUST NOT
+        delete the old session or mint new tokens (#637, review). That
+        work happens later, on the next HTTP request through the
+        Beforeware.
+        """
         user_payload: dict[str, Any] = {
             "id": _USER_ID,
             "email": "a@b.ee",
@@ -79,10 +105,6 @@ class TestWsChatSilentRefresh:
         mock_jwt_instance.get_current_user.return_value = None
         # Refresh token verifies cleanly.
         mock_jwt_instance.verify_refresh_token.return_value = user_payload
-        mock_jwt_instance.create_tokens.return_value = (
-            "new-access-xyz",
-            "new-refresh-xyz",
-        )
         mock_jwt_cls.return_value = mock_jwt_instance
 
         mock_orch_instance = MagicMock()
@@ -108,11 +130,14 @@ class TestWsChatSilentRefresh:
 
         asyncio.run(handler(msg, send, scope))
 
-        # Refresh verified and new tokens minted.
+        # Refresh token verified.
         mock_jwt_instance.verify_refresh_token.assert_called_once_with("valid-refresh")
-        mock_jwt_instance.create_tokens.assert_called_once_with(user_payload)
-        # Old refresh removed so it cannot be reused.
-        mock_jwt_instance.delete_refresh_token.assert_called_once_with("valid-refresh")
+        # CRITICAL: session row NOT deleted and NO new tokens minted.
+        # The HTTP Beforeware owns rotation — the WS handshake must not
+        # consume the refresh token because it cannot persist the
+        # replacement cookies.
+        mock_jwt_instance.delete_refresh_token.assert_not_called()
+        mock_jwt_instance.create_tokens.assert_not_called()
         # Orchestrator received the authenticated auth dict.
         mock_orch_instance.handle_message.assert_called_once()
         call_args = mock_orch_instance.handle_message.call_args
@@ -123,7 +148,8 @@ class TestWsChatSilentRefresh:
     @patch("app.chat.websocket.JWTAuthProvider")
     def test_no_access_cookie_only_refresh_works(self, mock_jwt_cls, mock_provider, mock_orch_cls):
         """Even without an access_token cookie at all, a valid refresh
-        cookie must authenticate the WS handshake."""
+        cookie must authenticate the WS handshake — and still not
+        consume the refresh session."""
         user_payload: dict[str, Any] = {
             "id": _USER_ID,
             "email": "a@b.ee",
@@ -134,7 +160,6 @@ class TestWsChatSilentRefresh:
 
         mock_jwt_instance = MagicMock()
         mock_jwt_instance.verify_refresh_token.return_value = user_payload
-        mock_jwt_instance.create_tokens.return_value = ("a", "r")
         mock_jwt_cls.return_value = mock_jwt_instance
 
         mock_orch_instance = MagicMock()
@@ -161,6 +186,8 @@ class TestWsChatSilentRefresh:
         asyncio.run(handler(msg, send, scope))
 
         mock_jwt_instance.verify_refresh_token.assert_called_once_with("only-refresh")
+        mock_jwt_instance.delete_refresh_token.assert_not_called()
+        mock_jwt_instance.create_tokens.assert_not_called()
         mock_orch_instance.handle_message.assert_called_once()
 
     @patch("app.chat.websocket.ChatOrchestrator")
@@ -230,3 +257,110 @@ class TestWsChatSilentRefresh:
             e.get("type") == "error" and "autentimine" in e.get("message", "").lower()
             for e in error_events
         )
+
+
+class TestWsFollowedByHttpStillRotates:
+    """Regression test for the P1 review finding on PR #648.
+
+    Before the fix, the WS handshake called ``try_refresh_access_token``
+    which *consumed* the refresh token: the old session row was deleted
+    and a new pair was minted — but the new tokens were thrown away
+    because the upgrade response could not set them as cookies. The
+    browser kept the stale refresh cookie, and the next HTTP request's
+    ``auth_before`` could not rotate it (session row gone), so the user
+    was redirected to /auth/login.
+
+    This test drives both code paths against the same stub provider and
+    asserts that after the WS handshake, the follow-up HTTP request can
+    still complete the silent refresh.
+    """
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_ws_handshake_then_http_request_same_refresh_still_rotates(
+        self, mock_jwt_cls, mock_provider, mock_orch_cls
+    ):
+        from app.auth import middleware as mw
+        from app.auth.middleware import auth_before
+
+        user_payload: dict[str, Any] = {
+            "id": _USER_ID,
+            "email": "a@b.ee",
+            "full_name": "A B",
+            "role": "drafter",
+            "org_id": _ORG_ID,
+        }
+
+        # Shared mock provider used by both transports. Both
+        # ``get_current_user`` (access-token validator) returns None
+        # (expired access token); ``verify_refresh_token`` returns a
+        # valid user both times the refresh cookie is presented — which
+        # is what a real provider would do because the WS handshake
+        # must NOT delete the session row.
+        mock_jwt_instance = MagicMock()
+        mock_jwt_instance.get_current_user.return_value = None
+        mock_jwt_instance.verify_refresh_token.return_value = user_payload
+        mock_jwt_instance.create_tokens.return_value = ("new-access", "new-refresh")
+        mock_jwt_cls.return_value = mock_jwt_instance
+
+        mock_orch_instance = MagicMock()
+        mock_orch_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_orch_instance
+
+        # --- step 1: WS handshake with expired access + valid refresh ---
+        handler = _capture_handler()
+        assert handler is not None
+
+        scope = {
+            "headers": [
+                (b"cookie", b"access_token=expired; refresh_token=shared-refresh"),
+            ],
+        }
+        send = _FreshSend()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Tere!",
+            }
+        )
+
+        asyncio.run(handler(msg, send, scope))
+
+        # WS authenticated (handle_message called).
+        mock_orch_instance.handle_message.assert_called_once()
+        # And — the important part — the WS handshake did NOT consume
+        # the refresh session.  ``verify_refresh_token`` runs, but
+        # ``delete_refresh_token`` and ``create_tokens`` do NOT.
+        assert mock_jwt_instance.verify_refresh_token.call_count == 1
+        mock_jwt_instance.delete_refresh_token.assert_not_called()
+        mock_jwt_instance.create_tokens.assert_not_called()
+
+        # --- step 2: follow-up HTTP request with the SAME cookies ----
+        # ``auth_before`` must still be able to rotate the refresh
+        # token because the WS handshake left the session row intact.
+        mw._provider = mock_jwt_instance  # inject stub into middleware
+        try:
+            req = MagicMock()
+            req.cookies = {"access_token": "expired", "refresh_token": "shared-refresh"}
+            req.url = "http://testserver/dashboard"
+            req.scope = {}
+
+            result = auth_before(req)
+        finally:
+            mw._provider = None
+
+        # HTTP path rotated the refresh cookie (307 redirect with
+        # Set-Cookie headers for both new tokens).
+        assert result is not None
+        assert getattr(result, "status_code", None) == 307
+        mock_jwt_instance.delete_refresh_token.assert_called_once_with("shared-refresh")
+        mock_jwt_instance.create_tokens.assert_called_once_with(user_payload)
+
+        set_cookies = [
+            h for h in getattr(result, "raw_headers", []) if h[0].lower() == b"set-cookie"
+        ]
+        cookie_blob = b"\n".join(v for _, v in set_cookies).decode()
+        assert "access_token=new-access" in cookie_blob
+        assert "refresh_token=new-refresh" in cookie_blob

--- a/tests/test_chat_websocket_refresh.py
+++ b/tests/test_chat_websocket_refresh.py
@@ -1,0 +1,232 @@
+"""Regression tests for /ws/chat silent refresh (#637).
+
+The HTTP Beforeware rotates tokens when the access_token is expired but
+the refresh_token is still valid. The WebSocket handshake bypasses the
+Beforeware, so pre-fix it would reject chats for up to 60 minutes past
+access-token expiry even when the user still had a valid refresh cookie.
+
+These tests pin the behaviour:
+
+- When only ``refresh_token`` (no valid access_token) is present, the WS
+  handshake must verify the refresh token, mint a new pair, and proceed
+  with the authenticated user.
+- When neither cookie is usable, the handshake must fail-closed (existing
+  behaviour, preserved).
+
+The JWT provider is mocked so no real DB is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_USER_ID = "11111111-1111-1111-1111-111111111111"
+_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_CONV_ID = "33333333-3333-3333-3333-333333333333"
+
+
+class _FreshSend:
+    """A stable send callable that records every ASGI message sent."""
+
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def __call__(self, data: Any) -> None:
+        self.sent.append(data)
+
+
+def _capture_handler():
+    from app.chat.websocket import register_chat_ws_routes
+
+    mock_app = MagicMock()
+    captured: dict[str, Any] = {"handler": None}
+
+    def capture_ws(path: str, conn: Any = None, disconn: Any = None) -> Any:
+        def decorator(fn: Any) -> Any:
+            captured["handler"] = fn
+            return fn
+
+        return decorator
+
+    mock_app.ws = capture_ws
+    register_chat_ws_routes(mock_app)
+    return captured["handler"]
+
+
+class TestWsChatSilentRefresh:
+    """Only a refresh_token cookie — handshake must refresh and proceed."""
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_expired_access_valid_refresh_rotates_and_authenticates(
+        self, mock_jwt_cls, mock_provider, mock_orch_cls
+    ):
+        """Expired access + valid refresh → WS authenticates."""
+        user_payload: dict[str, Any] = {
+            "id": _USER_ID,
+            "email": "a@b.ee",
+            "full_name": "A B",
+            "role": "drafter",
+            "org_id": _ORG_ID,
+        }
+
+        mock_jwt_instance = MagicMock()
+        # Access token is present but invalid (expired or stale).
+        mock_jwt_instance.get_current_user.return_value = None
+        # Refresh token verifies cleanly.
+        mock_jwt_instance.verify_refresh_token.return_value = user_payload
+        mock_jwt_instance.create_tokens.return_value = (
+            "new-access-xyz",
+            "new-refresh-xyz",
+        )
+        mock_jwt_cls.return_value = mock_jwt_instance
+
+        mock_orch_instance = MagicMock()
+        mock_orch_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_orch_instance
+
+        handler = _capture_handler()
+        assert handler is not None
+
+        scope = {
+            "headers": [
+                (b"cookie", b"access_token=expired; refresh_token=valid-refresh"),
+            ],
+        }
+        send = _FreshSend()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Tere!",
+            }
+        )
+
+        asyncio.run(handler(msg, send, scope))
+
+        # Refresh verified and new tokens minted.
+        mock_jwt_instance.verify_refresh_token.assert_called_once_with("valid-refresh")
+        mock_jwt_instance.create_tokens.assert_called_once_with(user_payload)
+        # Old refresh removed so it cannot be reused.
+        mock_jwt_instance.delete_refresh_token.assert_called_once_with("valid-refresh")
+        # Orchestrator received the authenticated auth dict.
+        mock_orch_instance.handle_message.assert_called_once()
+        call_args = mock_orch_instance.handle_message.call_args
+        assert call_args[0][2]["id"] == _USER_ID
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_no_access_cookie_only_refresh_works(self, mock_jwt_cls, mock_provider, mock_orch_cls):
+        """Even without an access_token cookie at all, a valid refresh
+        cookie must authenticate the WS handshake."""
+        user_payload: dict[str, Any] = {
+            "id": _USER_ID,
+            "email": "a@b.ee",
+            "full_name": "A B",
+            "role": "drafter",
+            "org_id": _ORG_ID,
+        }
+
+        mock_jwt_instance = MagicMock()
+        mock_jwt_instance.verify_refresh_token.return_value = user_payload
+        mock_jwt_instance.create_tokens.return_value = ("a", "r")
+        mock_jwt_cls.return_value = mock_jwt_instance
+
+        mock_orch_instance = MagicMock()
+        mock_orch_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_orch_instance
+
+        handler = _capture_handler()
+        assert handler is not None
+
+        scope = {
+            "headers": [
+                (b"cookie", b"refresh_token=only-refresh"),
+            ],
+        }
+        send = _FreshSend()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Hei",
+            }
+        )
+
+        asyncio.run(handler(msg, send, scope))
+
+        mock_jwt_instance.verify_refresh_token.assert_called_once_with("only-refresh")
+        mock_orch_instance.handle_message.assert_called_once()
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_neither_cookie_rejects_with_auth_error(
+        self, mock_jwt_cls, mock_provider, mock_orch_cls
+    ):
+        mock_jwt_instance = MagicMock()
+        mock_jwt_cls.return_value = mock_jwt_instance
+
+        handler = _capture_handler()
+        assert handler is not None
+
+        scope = {"headers": [(b"host", b"localhost")]}
+        send = _FreshSend()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Hei",
+            }
+        )
+
+        asyncio.run(handler(msg, send, scope))
+
+        # verify_refresh_token must not even be attempted with no cookie.
+        mock_jwt_instance.verify_refresh_token.assert_not_called()
+        # The existing "autentimine nõutav" error path is preserved.
+        error_events = [json.loads(m) for m in send.sent if isinstance(m, str)]
+        assert any(
+            e.get("type") == "error" and "autentimine" in e.get("message", "").lower()
+            for e in error_events
+        )
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    @patch("app.chat.websocket.JWTAuthProvider")
+    def test_invalid_refresh_rejects(self, mock_jwt_cls, mock_provider, mock_orch_cls):
+        mock_jwt_instance = MagicMock()
+        mock_jwt_instance.get_current_user.return_value = None
+        mock_jwt_instance.verify_refresh_token.return_value = None  # invalid
+        mock_jwt_cls.return_value = mock_jwt_instance
+
+        handler = _capture_handler()
+        assert handler is not None
+
+        scope = {"headers": [(b"cookie", b"refresh_token=dead")]}
+        send = _FreshSend()
+        msg = json.dumps(
+            {
+                "type": "send_message",
+                "conversation_id": _CONV_ID,
+                "content": "Hei",
+            }
+        )
+
+        asyncio.run(handler(msg, send, scope))
+
+        mock_jwt_instance.verify_refresh_token.assert_called_once_with("dead")
+        # Must not touch delete/create on invalid refresh.
+        mock_jwt_instance.delete_refresh_token.assert_not_called()
+        mock_jwt_instance.create_tokens.assert_not_called()
+        # And must emit an auth-required error.
+        error_events = [json.loads(m) for m in send.sent if isinstance(m, str)]
+        assert any(
+            e.get("type") == "error" and "autentimine" in e.get("message", "").lower()
+            for e in error_events
+        )


### PR DESCRIPTION
## Summary

The HTTP Beforeware transparently rotates tokens when the access_token
is expired but the refresh_token is still valid. The `/ws/chat`
WebSocket handshake bypassed that middleware and only consulted the
`access_token` cookie, so chats broke for up to 60 minutes past
access-token expiry even when the user still had a valid refresh cookie.

## What changed

1. **`app/auth/middleware.py`** — factored the refresh logic out of
   `auth_before()` into a reusable helper
   `try_refresh_access_token(refresh_token, provider=None) -> tuple | None`.
   It verifies the refresh token, deletes the old session, mints a fresh
   `(access, refresh, user)` triple.

2. **`app/chat/websocket.py`** — the WS handshake now also reads the
   `refresh_token` cookie. When `access_token` is missing/invalid but a
   valid `refresh_token` is present, it calls
   `try_refresh_access_token()` and proceeds with the authenticated
   user. The new cookies cannot be set on the ASGI WS upgrade response
   from inside the send callable, but the next HTTP request the
   client makes goes through the Beforeware which will re-rotate and
   persist the cookies. That is enough to keep long-lived chat
   sessions alive past the 60-minute expiry.

## Definition of Done

- [x] WS handshake successfully authenticates when only the refresh token is valid
- [x] Fresh cookies are set (on the next HTTP request) so subsequent HTTP requests benefit from the rotation
- [x] Regression test for "expired access token + valid refresh token" against `/ws/chat`
- [ ] Manually verified: leaving a chat tab open >60 min still works after reconnect
- [x] `uv run pytest -q` and `uv run ruff check` pass

## Test plan

- [x] 4 new tests in `tests/test_chat_websocket_refresh.py`:
  expired-access + valid-refresh, refresh-only, neither cookie, invalid
  refresh.
- [x] Existing `tests/test_chat_websocket.py` and
  `tests/test_auth_middleware.py` still green.

Closes #637.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>