### PR TITLE
CI: fix migration 019 column + pyright errors in test_ui_feedback

### DIFF
--- a/app/docs/draft_model.py
+++ b/app/docs/draft_model.py
@@ -421,7 +421,7 @@ def list_drafts_for_org_filtered(
     * ``q`` (title/filename/entity-label) runs a two-phase candidate
       lookup powered by ``pg_trgm`` GIN indexes from migration 019.
       Phase 1 scans ``drafts`` for title + filename matches.  Phase 2
-      pulls distinct draft IDs whose ``draft_entities.label`` matches.
+      pulls distinct draft IDs whose ``draft_entities.ref_text`` matches.
       The union is capped at :data:`_CANDIDATE_CAP` IDs before the
       final ``id = any(...)`` filter runs.
     * ``doc_types`` / ``statuses`` default to "all" when ``None`` or
@@ -472,15 +472,15 @@ def list_drafts_for_org_filtered(
                     (org_str, pattern, pattern, _CANDIDATE_CAP),
                 ).fetchall()
 
-                # Phase 2 -- entity-label trigram match, scoped to the
-                # caller's org via a sub-select.  Scoping at the SQL
+                # Phase 2 -- entity-ref_text trigram match, scoped to
+                # the caller's org via a sub-select.  Scoping at the SQL
                 # level means a stray draft_id leak is impossible even
                 # if pg_trgm surfaces an unexpected row.
                 phase2 = conn.execute(
                     """
                     select distinct draft_id
                       from draft_entities
-                     where label ilike %s
+                     where ref_text ilike %s
                        and draft_id in (
                            select id from drafts where org_id = %s
                        )

--- a/migrations/019_draft_doc_type_and_vtk_lineage.sql
+++ b/migrations/019_draft_doc_type_and_vtk_lineage.sql
@@ -30,7 +30,7 @@
 --      Hot path for "child eelnoud of this VTK" on the VTK detail page.
 --
 --   6. pg_trgm extension + trigram indexes on title, filename, and
---      draft_entities.label to power ILIKE %q% search without seqscans.
+--      draft_entities.ref_text to power ILIKE %q% search without seqscans.
 -- =============================================================================
 
 -- ---------------------------------------------------------------------------
@@ -72,7 +72,7 @@ CREATE INDEX idx_drafts_parent_vtk
 -- ---------------------------------------------------------------------------
 -- pg_trgm is a stable in-tree PostgreSQL extension; safe to add without
 -- downtime. The three GIN indexes below make ILIKE '%q%' index-supported
--- on title, filename, and draft_entities.label respectively.
+-- on title, filename, and draft_entities.ref_text respectively.
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
@@ -82,5 +82,5 @@ CREATE INDEX idx_drafts_title_trgm
 CREATE INDEX idx_drafts_filename_trgm
     ON drafts USING gin (filename gin_trgm_ops);
 
-CREATE INDEX idx_draft_entities_label_trgm
-    ON draft_entities USING gin (label gin_trgm_ops);
+CREATE INDEX idx_draft_entities_ref_text_trgm
+    ON draft_entities USING gin (ref_text gin_trgm_ops);

--- a/tests/test_ui_feedback.py
+++ b/tests/test_ui_feedback.py
@@ -1,9 +1,11 @@
 """Smoke tests for feedback components: Toast, Spinner, Skeleton, EmptyState."""
 
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from fasthtml.common import Button, to_xml
+from starlette.requests import Request
 
 from app.ui.feedback import (
     EmptyState,
@@ -110,13 +112,14 @@ def test_empty_state_with_action():
 # ---- Flash messages (#598) ------------------------------------------------
 
 
-def _fake_request_with_session() -> SimpleNamespace:
+def _fake_request_with_session() -> Request:
     """Build a stand-in Request object exposing a ``.session`` dict.
 
     ``push_flash`` / ``pop_flashes`` only touch ``request.session``, so
     any object with that attribute is sufficient for unit testing.
+    The cast keeps pyright quiet at the call sites.
     """
-    return SimpleNamespace(session={})
+    return cast(Request, SimpleNamespace(session={}))
 
 
 def test_push_flash_queues_entry():


### PR DESCRIPTION
## Summary

Two pre-existing CI failures making `main` red on every push. Both predate the auth/chat/notifications fixes in #644-#648 but became visible after the recent series of pushes re-triggered CI.

### 1. Migration 019 references a non-existent column

`migrations/019_draft_doc_type_and_vtk_lineage.sql` (added by #639) tried to create a trigram GIN index on `draft_entities.label`. That column doesn't exist — the actual column is `ref_text` (defined in migration 005). The same wrong name leaked into the phase-2 search query added by #642 in `app/docs/draft_model.py`.

Fix:
- Renamed `label` → `ref_text` in the migration's `CREATE INDEX` and in the SQL of `list_drafts_for_org_filtered()`.
- Renamed the index from `idx_draft_entities_label_trgm` to `idx_draft_entities_ref_text_trgm`.
- Safe to edit migration 019 in place because it has never successfully applied in any environment — it errored on this exact line in CI.

### 2. Pyright errors in `tests/test_ui_feedback.py`

10 errors of the form `Argument of type "SimpleNamespace" cannot be assigned to parameter "request" of type "Request[State]"`. The helper `_fake_request_with_session()` was returning a `SimpleNamespace`.

Fix: helper now `cast`s the namespace to `Request` so all 10 call sites typecheck without per-line ignores.

## Verification

- `uv run ruff check` — clean
- `uv run pyright tests/test_ui_feedback.py` — 0 errors
- `uv run pytest -q tests/test_ui_feedback.py tests/test_docs_draft_model.py` — 74 passed