### PR TITLE
UI: detailed welcome InfoBox on /drafts and expanded one on /chat

### DIFF
--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -392,8 +392,31 @@ def chat_list_page(req: Request):
     header_children.append(
         InfoBox(
             P(
-                "AI n\u00f5ustaja vastab k\u00fcsimustele Eesti \u00f5iguse kohta. "
-                "Vestlused on privaatsed ja seotud teie organisatsiooniga."
+                "AI \u00f5igusn\u00f5ustaja Claude vastab teie k\u00fcsimustele "
+                "Eesti \u00f5iguse kohta. Vastused tuginevad ontoloogiale "
+                "(50\u202f000+ kehtivat s\u00e4tet, 615 seadust, "
+                "22\u202f832 eeln\u00f5ud, 12\u202f137 Riigikohtu lahendit, "
+                "33\u202f242 EL \u00f5igusakti, 22\u202f290 EL kohtulahendit) "
+                "ning RAG-s\u00fcsteemile, mis leiab semantiliselt sarnaseid "
+                "\u00f5igusakti l\u00f5ike."
+            ),
+            P(
+                "Saate k\u00fcsida konkreetsete s\u00e4tete t\u00e4henduse "
+                "kohta, v\u00f5rrelda eeln\u00f5ud kehtiva regulatsiooniga, "
+                "otsida pretsedente, paluda EL direktiivide "
+                "transponeerimisanal\u00fc\u00fcsi v\u00f5i arutada "
+                "eeln\u00f5u m\u00f5ju. AI kasutab vajadusel t\u00f6\u00f6riistu "
+                "(ontoloogiap\u00e4ringud, s\u00e4tete otsing, m\u00f5juanal\u00fc\u00fcs, "
+                "s\u00e4tte detailid) ja viitab vastustes alusallikatele, et "
+                "saaksite v\u00e4ited kontrollida."
+            ),
+            P(
+                "Vestlused on privaatsed ja seotud teie organisatsiooniga. "
+                "Saate vestluse siduda konkreetse eeln\u00f5uga "
+                "(kontekst paneb AI vastused selle dokumendi suhtes), "
+                "kinnitada olulised vestlused t\u00e4hekesega, otsida "
+                "vanadest vestlustest ja vajadusel arhiveerida l\u00f5petatud "
+                "vestlused. Vajutage \u201eUus vestlus\u201c, et alustada."
             ),
             variant="info",
             dismissible=True,

--- a/app/docs/routes.py
+++ b/app/docs/routes.py
@@ -982,6 +982,36 @@ def drafts_list_page(req: Request):
 
     header_children: list = [H1("Eelnõud", cls="page-title")]  # noqa: F405
     header_children.append(
+        InfoBox(
+            P(
+                "See on teie organisatsiooni eelnõude töölaud. Siin saate "
+                "üles laadida uusi eelnõu kavandeid (.docx või .pdf) ja "
+                "väljatöötamiskavatsusi (VTK), jälgida nende töötlust "
+                "(parsimine → entiteetide ekstraktimine → mõjuanalüüs) "
+                "ning vaadata ja eksportida valmis mõjuaruandeid."
+            ),
+            P(
+                "Iga üleslaaditud eelnõu kohta süsteem tuvastab "
+                "automaatselt viited (õigusaktidele, sätetele, EL "
+                "direktiividele, Riigikohtu lahenditele), võrdleb seda "
+                "kehtiva õiguskorraga, leiab võimalikud konfliktid ja "
+                "katmata regulatsioonialad ning koostab .docx "
+                "mõjuaruande. Saate nimekirja filtreerida tüübi, staatuse, "
+                "üleslaadija ja kuupäeva järgi ning otsida pealkirjast, "
+                "failinimest või eelnõus mainitud viidete tekstist."
+            ),
+            P(
+                "Vajutage „Laadi üles uus eelnõu“, et alustada. "
+                "Maksimaalne failisuurus on 50 MB. Eelnõud säilivad kuni "
+                "nende kustutamiseni; tundlikud failid on krüpteeritud "
+                "puhkeolekus ja nähtavad ainult teie organisatsiooni "
+                "liikmetele."
+            ),
+            variant="info",
+            dismissible=True,
+        )
+    )
+    header_children.append(
         Div(
             A(
                 "Laadi üles uus eelnõu",


### PR DESCRIPTION
## Summary

User feedback: the dashboard welcome InfoBox is helpful — please add the same kind of contextual help to **Eelnõud** and **Vestlus** views. They can be longer and more detailed, explaining what the menu does and what's possible there.

This PR adds a detailed three-paragraph InfoBox to `/drafts` (which had none) and replaces the one-liner on `/chat` with an equally detailed three-paragraph version.

### /drafts InfoBox covers
- Purpose: workspace for uploading eelnõud + VTKd, tracking the parse → extract → analyze pipeline, viewing & exporting impact reports
- Capabilities: automatic detection of references (laws, provisions, EU directives, court decisions), conflict detection, gap analysis, .docx export, filter & search
- Tip: how to start, the 50 MB cap, encryption + retention model

### /chat InfoBox covers
- Scale: ontology numbers (50k+ provisions, 615 laws, 22 832 drafts, 12 137 SC decisions, 33 242 EU acts, 22 290 EU court decisions) + RAG semantic retrieval
- Capabilities: compare drafts, find precedents, EU transposition analysis, tool-use (ontology queries, provision search, impact analysis), source citations
- Conversation features: draft context binding, pinning, archiving, search

## Verification

- `uv run ruff check` — clean
- `uv run pyright app/docs/routes.py app/chat/routes.py` — 0 errors
- `uv run pytest -q tests/test_docs_routes.py tests/test_chat_routes.py` — 92 passed