### PR TITLE
Eelnõud A5: detail-page additions — Tüüp column + child eelnõud card (#643)

### DIFF
--- a/app/docs/draft_model.py
+++ b/app/docs/draft_model.py
@@ -596,12 +596,18 @@ def list_vtks_for_org(
     return [_row_to_draft(row) for row in rows]
 
 
-def list_eelnous_for_vtk(vtk_id: uuid.UUID | str) -> list[Draft]:
+def list_eelnous_for_vtk(vtk_id: uuid.UUID | str, *, org_id: uuid.UUID | str) -> list[Draft]:
     """Return eelnõud whose ``parent_vtk_id`` is *vtk_id* (#643).
 
     Newest-first so the most recent follow-on draft surfaces at the top
     of the "Sellest VTKst tulenevad eelnõud" card on the VTK detail
     page. Manages its own connection. On DB error returns ``[]``.
+
+    ``org_id`` is required and enforced at the SQL layer — matches the
+    org-scoping convention of every other reader in this module
+    (``list_vtks_for_org``, ``fetch_drafts_for_org``, etc.). Callers
+    pass the VTK's own org so cross-org leaks are impossible by design,
+    not by post-filter.
     """
     try:
         with _connect() as conn:
@@ -610,10 +616,11 @@ def list_eelnous_for_vtk(vtk_id: uuid.UUID | str) -> list[Draft]:
                 select {_DRAFT_COLUMNS}
                 from drafts
                 where parent_vtk_id = %s
+                  and org_id = %s
                   and doc_type = 'eelnou'
                 order by created_at desc
                 """,
-                (str(vtk_id),),
+                (str(vtk_id), str(org_id)),
             ).fetchall()
     except Exception:
         logger.exception("Failed to list eelnõud for VTK=%s", vtk_id)

--- a/app/docs/draft_model.py
+++ b/app/docs/draft_model.py
@@ -596,6 +596,31 @@ def list_vtks_for_org(
     return [_row_to_draft(row) for row in rows]
 
 
+def list_eelnous_for_vtk(vtk_id: uuid.UUID | str) -> list[Draft]:
+    """Return eelnõud whose ``parent_vtk_id`` is *vtk_id* (#643).
+
+    Newest-first so the most recent follow-on draft surfaces at the top
+    of the "Sellest VTKst tulenevad eelnõud" card on the VTK detail
+    page. Manages its own connection. On DB error returns ``[]``.
+    """
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                f"""
+                select {_DRAFT_COLUMNS}
+                from drafts
+                where parent_vtk_id = %s
+                  and doc_type = 'eelnou'
+                order by created_at desc
+                """,
+                (str(vtk_id),),
+            ).fetchall()
+    except Exception:
+        logger.exception("Failed to list eelnõud for VTK=%s", vtk_id)
+        return []
+    return [_row_to_draft(row) for row in rows]
+
+
 # ---------------------------------------------------------------------------
 # Convenience wrappers that manage their own connection
 # ---------------------------------------------------------------------------

--- a/app/docs/routes.py
+++ b/app/docs/routes.py
@@ -32,7 +32,7 @@ from starlette.responses import HTMLResponse, RedirectResponse, Response
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_delete_draft, can_edit_draft, can_view_draft
-from app.auth.users import get_user, list_users
+from app.auth.users import list_users
 from app.db import get_connection as _connect
 from app.docs.audit import (
     log_draft_delete,
@@ -1757,14 +1757,20 @@ def _link_vtk_modal(
     ]
 
 
-def _vtk_children_card(vtk: Draft, *, children: list[Draft]) -> Any:
+def _vtk_children_card(
+    vtk: Draft,
+    *,
+    children: list[Draft],
+    uploader_index: dict[str, dict[str, Any]] | None = None,
+) -> Any:
     """#643: render the "Sellest VTKst tulenevad eelnõud" card on VTK detail.
 
     Lists eelnõud whose ``parent_vtk_id`` equals this VTK, newest-first.
     Each row links to the child eelnõu's detail page and shows status
-    badge, uploader name (best-effort lookup), and upload date. Empty
-    state surfaces the EmptyState primitive so the card matches the
-    rest of the design system.
+    badge, uploader name (resolved from the bulk ``uploader_index``
+    dict so we don't N+1 a per-child user lookup), and upload date.
+    Empty state surfaces the EmptyState primitive so the card matches
+    the rest of the design system.
     """
     if not children:
         body: Any = EmptyState(
@@ -1776,9 +1782,10 @@ def _vtk_children_card(vtk: Draft, *, children: list[Draft]) -> Any:
             icon="📄",
         )
     else:
+        index = uploader_index or {}
         rows: list[Any] = []
         for child in children:
-            uploader = get_user(str(child.user_id)) if child.user_id else None
+            uploader = index.get(str(child.user_id)) if child.user_id else None
             uploader_label = (
                 str(uploader.get("full_name") or uploader.get("email") or "—") if uploader else "—"
             )
@@ -2008,19 +2015,18 @@ def draft_detail_page(req: Request, draft_id: str):
     if can_edit_draft(auth, draft) and draft.doc_type == "eelnou":
         org_vtks = list_vtks_for_org(draft.org_id)
 
-    # #643: VTK detail surfaces a "Sellest VTKst tulenevad eelnõud" card.
-    # The query is org-scoped indirectly through parent_vtk_id (VTK already
-    # in the caller's org), but we still defensively filter on org_id to
-    # rule out cross-org leakage if an eelnõu in another org somehow
-    # references this VTK (shouldn't happen — A2 validates same-org on
-    # link — but defence in depth costs us nothing).
+    # #643: VTK detail surfaces a "Sellest VTKst tulenevad eelnõud"
+    # card. Org-scoping is enforced inside `list_eelnous_for_vtk` at
+    # the SQL layer — no post-filter needed.
     vtk_children: list[Draft] = []
+    uploader_index: dict[str, dict[str, Any]] = {}
     if draft.doc_type == "vtk":
-        vtk_children = [
-            child
-            for child in list_eelnous_for_vtk(draft.id)
-            if str(child.org_id) == str(draft.org_id)
-        ]
+        vtk_children = list_eelnous_for_vtk(draft.id, org_id=draft.org_id)
+        # Bulk-resolve uploader names for the children card so we
+        # don't fan out N+1 `get_user` calls. One org-scoped lookup
+        # gives us every uploader we could possibly need to render.
+        if vtk_children:
+            uploader_index = {str(u["id"]): u for u in list_users(org_id=str(draft.org_id))}
 
     detail_body = _draft_detail_body(
         draft,
@@ -2062,7 +2068,9 @@ def draft_detail_page(req: Request, draft_id: str):
         # #643: VTK-only card listing follow-on eelnõud. Skipped on
         # eelnõu detail since VTKs are the only doc_type that can have
         # children in our model.
-        _vtk_children_card(draft, children=vtk_children) if draft.doc_type == "vtk" else "",
+        _vtk_children_card(draft, children=vtk_children, uploader_index=uploader_index)
+        if draft.doc_type == "vtk"
+        else "",
         title=draft.title,
         user=auth,
         theme=theme,

--- a/app/docs/routes.py
+++ b/app/docs/routes.py
@@ -32,7 +32,7 @@ from starlette.responses import HTMLResponse, RedirectResponse, Response
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_delete_draft, can_edit_draft, can_view_draft
-from app.auth.users import list_users
+from app.auth.users import get_user, list_users
 from app.db import get_connection as _connect
 from app.docs.audit import (
     log_draft_delete,
@@ -45,6 +45,7 @@ from app.docs.draft_model import (
     delete_draft,
     fetch_draft,
     list_drafts_for_org_filtered,
+    list_eelnous_for_vtk,
     list_vtks_for_org,
     touch_draft_access,
     touch_draft_access_conn,
@@ -454,6 +455,7 @@ def _draft_rows(drafts: list[Draft]) -> list[dict[str, Any]]:
         rows.append(
             {
                 "id": str(draft.id),
+                "doc_type_raw": draft.doc_type,
                 "title": draft.title,
                 "filename": draft.filename,
                 "status_raw": draft.status,
@@ -461,6 +463,16 @@ def _draft_rows(drafts: list[Draft]) -> list[dict[str, Any]]:
             }
         )
     return rows
+
+
+# #643: badge variant per doc_type for the Tüüp column on the drafts
+# list. Eelnõu = subtle "default" pill (it's the dominant case, no
+# need to draw attention); VTK = "primary" so it stands out at a
+# glance — VTKs are rarer and operationally distinct.
+_DOC_TYPE_BADGE: dict[str, tuple[str, BadgeVariant]] = {
+    "eelnou": ("Eelnõu", "default"),
+    "vtk": ("VTK", "primary"),
+}
 
 
 def _draft_list_columns() -> list[Column]:
@@ -483,7 +495,12 @@ def _draft_list_columns() -> list[Column]:
             cls="btn btn-secondary btn-sm",
         )
 
+    def _doc_type_cell(row: dict[str, Any]):
+        label, variant = _DOC_TYPE_BADGE.get(row["doc_type_raw"], ("Eelnõu", "default"))
+        return Badge(label, variant=variant, cls=f"doc-type doc-type-{row['doc_type_raw']}")
+
     return [
+        Column(key="doc_type", label="Tüüp", sortable=False, render=_doc_type_cell),
         Column(key="title", label="Pealkiri", sortable=False, render=_title_cell),
         Column(key="filename", label="Failinimi", sortable=False),
         Column(
@@ -1740,6 +1757,64 @@ def _link_vtk_modal(
     ]
 
 
+def _vtk_children_card(vtk: Draft, *, children: list[Draft]) -> Any:
+    """#643: render the "Sellest VTKst tulenevad eelnõud" card on VTK detail.
+
+    Lists eelnõud whose ``parent_vtk_id`` equals this VTK, newest-first.
+    Each row links to the child eelnõu's detail page and shows status
+    badge, uploader name (best-effort lookup), and upload date. Empty
+    state surfaces the EmptyState primitive so the card matches the
+    rest of the design system.
+    """
+    if not children:
+        body: Any = EmptyState(
+            "VTKga pole veel eelnõusid seotud.",
+            message=(
+                "Kui sellele VTK-le järgneb eelnõu, valige üleslaadimisel "
+                "'Seotud VTK' väljas see VTK — siia tekib siis vastav rida."
+            ),
+            icon="📄",
+        )
+    else:
+        rows: list[Any] = []
+        for child in children:
+            uploader = get_user(str(child.user_id)) if child.user_id else None
+            uploader_label = (
+                str(uploader.get("full_name") or uploader.get("email") or "—") if uploader else "—"
+            )
+            rows.append(
+                Tr(  # noqa: F405
+                    Td(  # noqa: F405
+                        A(  # noqa: F405
+                            child.title,
+                            href=f"/drafts/{child.id}",
+                            cls="data-table-link",
+                        ),
+                        data_label="Pealkiri",
+                    ),
+                    Td(_status_badge(child.status), data_label="Staatus"),  # noqa: F405
+                    Td(uploader_label, data_label="Üleslaadija"),  # noqa: F405
+                    Td(_format_timestamp(child.created_at), data_label="Üles laaditud"),  # noqa: F405
+                )
+            )
+        body = Table(  # noqa: F405
+            Thead(  # noqa: F405
+                Tr(  # noqa: F405
+                    Th("Pealkiri"),  # noqa: F405
+                    Th("Staatus"),  # noqa: F405
+                    Th("Üleslaadija"),  # noqa: F405
+                    Th("Üles laaditud"),  # noqa: F405
+                )
+            ),
+            Tbody(*rows),  # noqa: F405
+            cls="data-table vtk-children-table",
+        )
+    return Card(
+        CardHeader(H3("Sellest VTKst tulenevad eelnõud", cls="card-title")),  # noqa: F405
+        CardBody(body),
+    )
+
+
 def _draft_detail_body(
     draft: Draft,
     auth: Mapping[str, Any] | None = None,
@@ -1933,6 +2008,20 @@ def draft_detail_page(req: Request, draft_id: str):
     if can_edit_draft(auth, draft) and draft.doc_type == "eelnou":
         org_vtks = list_vtks_for_org(draft.org_id)
 
+    # #643: VTK detail surfaces a "Sellest VTKst tulenevad eelnõud" card.
+    # The query is org-scoped indirectly through parent_vtk_id (VTK already
+    # in the caller's org), but we still defensively filter on org_id to
+    # rule out cross-org leakage if an eelnõu in another org somehow
+    # references this VTK (shouldn't happen — A2 validates same-org on
+    # link — but defence in depth costs us nothing).
+    vtk_children: list[Draft] = []
+    if draft.doc_type == "vtk":
+        vtk_children = [
+            child
+            for child in list_eelnous_for_vtk(draft.id)
+            if str(child.org_id) == str(draft.org_id)
+        ]
+
     detail_body = _draft_detail_body(
         draft,
         auth=auth,
@@ -1970,6 +2059,10 @@ def draft_detail_page(req: Request, draft_id: str):
             # user-facing detail page omits it.
             CardBody(*detail_body),
         ),
+        # #643: VTK-only card listing follow-on eelnõud. Skipped on
+        # eelnõu detail since VTKs are the only doc_type that can have
+        # children in our model.
+        _vtk_children_card(draft, children=vtk_children) if draft.doc_type == "vtk" else "",
         title=draft.title,
         user=auth,
         theme=theme,

--- a/tests/test_docs_draft_model.py
+++ b/tests/test_docs_draft_model.py
@@ -32,6 +32,7 @@ from app.docs.draft_model import (
     fetch_draft,
     get_draft,
     list_drafts_for_org,
+    list_eelnous_for_vtk,
     list_vtks_for_org,
     update_draft_parent_vtk,
 )
@@ -877,3 +878,53 @@ class TestListDraftsForOrgFiltered:
         assert drafts == []
         assert total == 0
         mock_connect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #643: list_eelnous_for_vtk — children of a VTK on its detail page
+# ---------------------------------------------------------------------------
+
+
+class TestListEelnousForVtk:
+    @patch("app.docs.draft_model._connect")
+    def test_filters_on_parent_vtk_id_and_doc_type(self, mock_connect):
+        """SQL must restrict to eelnõud (not other VTKs) referencing this VTK."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [
+            _make_raw_row(
+                draft_id=uuid.uuid4(),
+                doc_type="eelnou",
+                parent_vtk_id=_VTK_ID,
+                title="Child A",
+            ),
+        ]
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        children = list_eelnous_for_vtk(_VTK_ID)
+
+        assert len(children) == 1
+        assert children[0].doc_type == "eelnou"
+        assert children[0].parent_vtk_id == _VTK_ID
+        sql: str = conn.execute.call_args.args[0]
+        assert "parent_vtk_id = %s" in sql
+        assert "doc_type = 'eelnou'" in sql
+        assert "order by created_at desc" in sql.lower()
+
+    @patch("app.docs.draft_model._connect")
+    def test_db_error_returns_empty_list(self, mock_connect):
+        """A DB outage must not crash the VTK detail page."""
+        mock_connect.side_effect = RuntimeError("db unavailable")
+
+        children = list_eelnous_for_vtk(_VTK_ID)
+
+        assert children == []
+
+    @patch("app.docs.draft_model._connect")
+    def test_no_children_returns_empty_list(self, mock_connect):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        assert list_eelnous_for_vtk(_VTK_ID) == []

--- a/tests/test_docs_draft_model.py
+++ b/tests/test_docs_draft_model.py
@@ -887,8 +887,8 @@ class TestListDraftsForOrgFiltered:
 
 class TestListEelnousForVtk:
     @patch("app.docs.draft_model._connect")
-    def test_filters_on_parent_vtk_id_and_doc_type(self, mock_connect):
-        """SQL must restrict to eelnõud (not other VTKs) referencing this VTK."""
+    def test_filters_on_parent_vtk_id_and_org_id_and_doc_type(self, mock_connect):
+        """SQL enforces parent + org + doc_type at the data-access layer."""
         conn = MagicMock()
         conn.execute.return_value.fetchall.return_value = [
             _make_raw_row(
@@ -901,22 +901,36 @@ class TestListEelnousForVtk:
         mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        children = list_eelnous_for_vtk(_VTK_ID)
+        children = list_eelnous_for_vtk(_VTK_ID, org_id=_ORG_ID)
 
         assert len(children) == 1
         assert children[0].doc_type == "eelnou"
         assert children[0].parent_vtk_id == _VTK_ID
         sql: str = conn.execute.call_args.args[0]
+        params: tuple = conn.execute.call_args.args[1]
         assert "parent_vtk_id = %s" in sql
+        assert "org_id = %s" in sql
         assert "doc_type = 'eelnou'" in sql
         assert "order by created_at desc" in sql.lower()
+        # SQL params: (vtk_id, org_id) — both stringified UUIDs.
+        assert params == (str(_VTK_ID), str(_ORG_ID))
+
+    def test_org_id_is_keyword_only(self):
+        """org_id is required and keyword-only — callers cannot forget it.
+
+        This is the contract guarantee that lets every other reader rely
+        on `list_eelnous_for_vtk` for org-scoped reads without their own
+        post-filter.
+        """
+        with pytest.raises(TypeError):
+            list_eelnous_for_vtk(_VTK_ID)  # type: ignore[call-arg]
 
     @patch("app.docs.draft_model._connect")
     def test_db_error_returns_empty_list(self, mock_connect):
         """A DB outage must not crash the VTK detail page."""
         mock_connect.side_effect = RuntimeError("db unavailable")
 
-        children = list_eelnous_for_vtk(_VTK_ID)
+        children = list_eelnous_for_vtk(_VTK_ID, org_id=_ORG_ID)
 
         assert children == []
 
@@ -927,4 +941,4 @@ class TestListEelnousForVtk:
         mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        assert list_eelnous_for_vtk(_VTK_ID) == []
+        assert list_eelnous_for_vtk(_VTK_ID, org_id=_ORG_ID) == []

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -1841,3 +1841,205 @@ class TestLinkVtkModalOnDetailPage:
         assert 'id="link-vtk-modal"' in resp.text
         assert "Maantee VTK" in resp.text
         assert 'hx-post="/drafts/44444444-4444-4444-4444-444444444444/link-vtk"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# #643: Tüüp column on the drafts list + VTK detail children card
+# ---------------------------------------------------------------------------
+
+
+class TestDocTypeColumn:
+    """Drafts list now renders a Tüüp badge as the leftmost column."""
+
+    @patch("app.docs.routes.list_users")
+    @patch("app.docs.routes.list_drafts_for_org_filtered")
+    @patch("app.auth.middleware._get_provider")
+    def test_doc_type_badge_per_row(
+        self,
+        mock_get_provider: MagicMock,
+        mock_list_filtered: MagicMock,
+        mock_list_users: MagicMock,
+    ):
+        """Mixed-type listing shows the Eelnõu badge AND the VTK badge."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_list_users.return_value = []
+        eelnou = _make_draft(title="Eelnõu A", status="ready")
+        vtk = _make_vtk(title="VTK A")
+        mock_list_filtered.return_value = ([eelnou, vtk], 2)
+
+        client = _authed_client()
+        resp = client.get("/drafts")
+
+        assert resp.status_code == 200
+        # Header for the new column is present
+        assert "Tüüp" in resp.text
+        # Two badge cells, one per row (different variants)
+        assert "doc-type-eelnou" in resp.text
+        assert "doc-type-vtk" in resp.text
+        # And the labels themselves
+        assert ">Eelnõu<" in resp.text
+        assert ">VTK<" in resp.text
+
+
+class TestVtkDetailChildrenCard:
+    """VTK detail page surfaces its follow-on eelnõud."""
+
+    @patch("app.docs.routes.list_eelnous_for_vtk")
+    @patch("app.docs.routes.list_vtks_for_org")
+    @patch("app.docs.routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_vtk_detail_does_not_show_seotud_vtk_row(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_list_vtks: MagicMock,
+        mock_list_children: MagicMock,
+    ):
+        """VTKs cannot have parents — the metadata row must be omitted."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_vtk(title="My VTK", status="ready")
+        mock_list_vtks.return_value = []
+        mock_list_children.return_value = []
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_VTK_ID}")
+
+        assert resp.status_code == 200
+        # The "Seotud VTK" metadata row is the eelnõu-only widget; for
+        # a VTK we render neither the <dt> label nor the picker trigger.
+        # (The literal phrase "Seotud VTK" can still appear in the
+        # children-card empty-state helper text — that's fine.)
+        assert "<dt>Seotud VTK</dt>" not in resp.text
+        assert "Seo VTKga" not in resp.text
+
+    @patch("app.docs.routes.get_user")
+    @patch("app.docs.routes.list_eelnous_for_vtk")
+    @patch("app.docs.routes.list_vtks_for_org")
+    @patch("app.docs.routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_vtk_detail_lists_children_newest_first(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_list_vtks: MagicMock,
+        mock_list_children: MagicMock,
+        mock_get_user: MagicMock,
+    ):
+        """Children render in the order returned by the helper, with
+        title link, status badge, uploader name, and upload date."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_vtk(title="My VTK", status="ready")
+        mock_list_vtks.return_value = []
+        # Helper already orders newest-first; route must preserve order.
+        newer = _make_draft(
+            draft_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            title="Newer eelnõu",
+            status="ready",
+        )
+        older = _make_draft(
+            draft_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            title="Older eelnõu",
+            status="parsing",
+        )
+        mock_list_children.return_value = [newer, older]
+        mock_get_user.return_value = {"full_name": "Jaan Tamm", "email": "jaan@example.ee"}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_VTK_ID}")
+
+        assert resp.status_code == 200
+        assert "Sellest VTKst tulenevad eelnõud" in resp.text
+        assert "Newer eelnõu" in resp.text
+        assert "Older eelnõu" in resp.text
+        assert "Jaan Tamm" in resp.text
+        # Newest first — find both substrings, assert ordering.
+        assert resp.text.index("Newer eelnõu") < resp.text.index("Older eelnõu")
+        # Status badges for both children rendered.
+        assert "draft-status-ok" in resp.text  # ready -> ok
+        assert "draft-status-running" in resp.text  # parsing -> running
+
+    @patch("app.docs.routes.list_eelnous_for_vtk")
+    @patch("app.docs.routes.list_vtks_for_org")
+    @patch("app.docs.routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_vtk_detail_with_no_children_shows_empty_state(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_list_vtks: MagicMock,
+        mock_list_children: MagicMock,
+    ):
+        """Empty-children state renders the EmptyState primitive copy."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_vtk(title="My VTK", status="ready")
+        mock_list_vtks.return_value = []
+        mock_list_children.return_value = []
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_VTK_ID}")
+
+        assert resp.status_code == 200
+        assert "Sellest VTKst tulenevad eelnõud" in resp.text
+        assert "VTKga pole veel eelnõusid seotud." in resp.text
+
+    @patch("app.docs.routes.list_eelnous_for_vtk")
+    @patch("app.docs.routes.list_vtks_for_org")
+    @patch("app.docs.routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_eelnou_detail_does_not_render_children_card(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_list_vtks: MagicMock,
+        mock_list_children: MagicMock,
+    ):
+        """Children card is VTK-only — eelnõu detail must not render it."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft(status="ready")
+        mock_list_vtks.return_value = []
+
+        client = _authed_client()
+        resp = client.get("/drafts/44444444-4444-4444-4444-444444444444")
+
+        assert resp.status_code == 200
+        assert "Sellest VTKst tulenevad eelnõud" not in resp.text
+        # And we never even called list_eelnous_for_vtk on the eelnõu path.
+        mock_list_children.assert_not_called()
+
+
+class TestListEelnousForVtkHelper:
+    """Sanity smoke for the new draft_model helper, exercised via routes."""
+
+    @patch("app.docs.routes.list_eelnous_for_vtk")
+    @patch("app.docs.routes.list_vtks_for_org")
+    @patch("app.docs.routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_cross_org_children_filtered_out(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_list_vtks: MagicMock,
+        mock_list_children: MagicMock,
+    ):
+        """Defence-in-depth: any child whose org_id differs from the VTK's
+        is silently filtered before render. (A2 already validates same-org
+        on link, but the detail page is the user-facing safety net.)"""
+        mock_get_provider.return_value = _stub_provider()
+        vtk = _make_vtk(title="My VTK", status="ready")
+        mock_fetch.return_value = vtk
+        mock_list_vtks.return_value = []
+        same_org = _make_draft(title="Same-org eelnõu", status="ready")
+        cross_org = _make_draft(
+            draft_id=uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            org_id="22222222-2222-2222-2222-222222222222",
+            title="Cross-org eelnõu",
+            status="ready",
+        )
+        mock_list_children.return_value = [same_org, cross_org]
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_VTK_ID}")
+
+        assert resp.status_code == 200
+        assert "Same-org eelnõu" in resp.text
+        assert "Cross-org eelnõu" not in resp.text

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -1912,7 +1912,7 @@ class TestVtkDetailChildrenCard:
         assert "<dt>Seotud VTK</dt>" not in resp.text
         assert "Seo VTKga" not in resp.text
 
-    @patch("app.docs.routes.get_user")
+    @patch("app.docs.routes.list_users")
     @patch("app.docs.routes.list_eelnous_for_vtk")
     @patch("app.docs.routes.list_vtks_for_org")
     @patch("app.docs.routes.fetch_draft")
@@ -1923,10 +1923,14 @@ class TestVtkDetailChildrenCard:
         mock_fetch: MagicMock,
         mock_list_vtks: MagicMock,
         mock_list_children: MagicMock,
-        mock_get_user: MagicMock,
+        mock_list_users: MagicMock,
     ):
         """Children render in the order returned by the helper, with
-        title link, status badge, uploader name, and upload date."""
+        title link, status badge, uploader name, and upload date.
+
+        Uploader resolution must be a single bulk lookup, NOT N+1
+        per-child get_user calls.
+        """
         mock_get_provider.return_value = _stub_provider()
         mock_fetch.return_value = _make_vtk(title="My VTK", status="ready")
         mock_list_vtks.return_value = []
@@ -1942,7 +1946,11 @@ class TestVtkDetailChildrenCard:
             status="parsing",
         )
         mock_list_children.return_value = [newer, older]
-        mock_get_user.return_value = {"full_name": "Jaan Tamm", "email": "jaan@example.ee"}
+        # Bulk uploader resolution — one call returns every user in the
+        # org. Both children share the same uploader id (_USER_ID).
+        mock_list_users.return_value = [
+            {"id": _USER_ID, "full_name": "Jaan Tamm", "email": "jaan@example.ee"}
+        ]
 
         client = _authed_client()
         resp = client.get(f"/drafts/{_VTK_ID}")
@@ -1957,6 +1965,14 @@ class TestVtkDetailChildrenCard:
         # Status badges for both children rendered.
         assert "draft-status-ok" in resp.text  # ready -> ok
         assert "draft-status-running" in resp.text  # parsing -> running
+        # No-N+1 invariant: list_users called exactly once, regardless
+        # of child count.
+        assert mock_list_users.call_count == 1
+        # And it was scoped to the VTK's org_id.
+        assert mock_list_users.call_args.kwargs["org_id"] == _ORG_ID
+        # list_eelnous_for_vtk now requires keyword org_id at the SQL
+        # layer — no post-filter in the route.
+        assert mock_list_children.call_args.kwargs["org_id"] == uuid.UUID(_ORG_ID)
 
     @patch("app.docs.routes.list_eelnous_for_vtk")
     @patch("app.docs.routes.list_vtks_for_org")
@@ -2008,38 +2024,33 @@ class TestVtkDetailChildrenCard:
 
 
 class TestListEelnousForVtkHelper:
-    """Sanity smoke for the new draft_model helper, exercised via routes."""
+    """Route-level wiring of the children helper."""
 
     @patch("app.docs.routes.list_eelnous_for_vtk")
     @patch("app.docs.routes.list_vtks_for_org")
     @patch("app.docs.routes.fetch_draft")
     @patch("app.auth.middleware._get_provider")
-    def test_cross_org_children_filtered_out(
+    def test_route_passes_org_id_to_helper(
         self,
         mock_get_provider: MagicMock,
         mock_fetch: MagicMock,
         mock_list_vtks: MagicMock,
         mock_list_children: MagicMock,
     ):
-        """Defence-in-depth: any child whose org_id differs from the VTK's
-        is silently filtered before render. (A2 already validates same-org
-        on link, but the detail page is the user-facing safety net.)"""
+        """The route must call ``list_eelnous_for_vtk(vtk_id, org_id=...)``
+        — primary defence is at the SQL layer, not in the route. Any
+        future caller of the helper that forgets ``org_id`` will fail
+        loudly (kw-only required) rather than silently leaking."""
         mock_get_provider.return_value = _stub_provider()
         vtk = _make_vtk(title="My VTK", status="ready")
         mock_fetch.return_value = vtk
         mock_list_vtks.return_value = []
-        same_org = _make_draft(title="Same-org eelnõu", status="ready")
-        cross_org = _make_draft(
-            draft_id=uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
-            org_id="22222222-2222-2222-2222-222222222222",
-            title="Cross-org eelnõu",
-            status="ready",
-        )
-        mock_list_children.return_value = [same_org, cross_org]
+        mock_list_children.return_value = []
 
         client = _authed_client()
         resp = client.get(f"/drafts/{_VTK_ID}")
 
         assert resp.status_code == 200
-        assert "Same-org eelnõu" in resp.text
-        assert "Cross-org eelnõu" not in resp.text
+        # Helper called with the VTK's own org_id at the SQL boundary.
+        assert mock_list_children.call_args.args[0] == uuid.UUID(_VTK_ID)
+        assert mock_list_children.call_args.kwargs["org_id"] == uuid.UUID(_ORG_ID)


### PR DESCRIPTION
## Summary
- Drafts list gets a leftmost **Tüüp** column with a Badge per row (Eelnõu / VTK)
- VTK detail page gets a new **Sellest VTKst tulenevad eelnõud** card listing follow-on eelnõud
- New `list_eelnous_for_vtk(vtk_id)` helper in `app/docs/draft_model.py`
- Defence-in-depth org-scoping when rendering children (on top of A2's same-org link validation)

## Spec
[`docs/superpowers/specs/2026-04-16-drafts-metadata-discovery-design.md`](https://github.com/henrikaavik/Seadusloome/blob/main/docs/superpowers/specs/2026-04-16-drafts-metadata-discovery-design.md) §6

## What A2 already shipped vs. what's new
A2 already wired `_seotud_vtk_row` into the metadata block, the link-vtk Modal, and the picker — so nothing changed for the eelnõu detail's "Seotud VTK" row. This PR is strictly the Tüüp column + the VTK-side children card.

## Tests
- 8 new tests added across `test_docs_routes.py` (`TestDocTypeColumn`, `TestVtkDetailChildrenCard`, `TestListEelnousForVtkHelper`) and `test_docs_draft_model.py` (`TestListEelnousForVtk`)
- Full `tests/test_docs_*.py` suite: **332 passed** (was 324)
- ruff + pyright clean

## Notes
- Empty-state copy: "VTKga pole veel eelnõusid seotud."
- Badge variant choice: Eelnõu = default (subtle, the dominant case), VTK = primary (calls attention since it's rarer + operationally distinct)

Closes #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)