### PR TITLE
Fix #658: chat user-msg lost when pre-RAG DB calls hang

### DIFF
--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -55,6 +55,8 @@ from typing import Any
 
 from app.auth.policy import can_access_conversation
 from app.chat.models import (
+    Conversation,
+    Message,
     create_message,
     get_conversation,
     list_messages,
@@ -482,6 +484,26 @@ def _check_budget_in_own_tx(org_id: uuid.UUID | str) -> None:
         conn.commit()
 
 
+def _load_conversation(conversation_id: uuid.UUID) -> Conversation | None:
+    """Load a conversation row in a sync ``with get_connection()`` block.
+
+    Wrapped by :func:`asyncio.to_thread` in ``handle_message`` so the
+    sync psycopg call doesn't block the event loop (#658).
+    """
+    with get_connection() as conn:
+        return get_conversation(conn, conversation_id)
+
+
+def _load_history(conversation_id: uuid.UUID) -> list[Message]:
+    """Load message history for a conversation.
+
+    Wrapped by :func:`asyncio.to_thread` in ``handle_message`` so the
+    sync psycopg call doesn't block the event loop (#658).
+    """
+    with get_connection() as conn:
+        return list_messages(conn, conversation_id)
+
+
 # ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
@@ -571,28 +593,66 @@ class ChatOrchestrator:
         org_id = auth.get("org_id")
 
         # 0. Per-user message rate limit (cheap pre-check, fail-open on DB
-        # error). The per-org cost budget is checked in step 3 inside the
-        # same transaction that persists the user message so the advisory
-        # lock covers the read-then-insert window (see below).
+        # error). Bounded by _PRE_STREAM_DB_TIMEOUT_SECONDS via
+        # asyncio.wait_for so a stuck pool can't hang the turn here (#658).
+        logger.info(
+            "chat.handle_message step=0-rate-check conv=%s user=%s",
+            conversation_id,
+            user_id,
+        )
         try:
             if user_id:
-                check_message_rate(user_id)
+                await asyncio.wait_for(
+                    asyncio.to_thread(check_message_rate, user_id),
+                    timeout=_PRE_STREAM_DB_TIMEOUT_SECONDS,
+                )
         except RateLimitExceededError as exc:
             try:
                 await _safe_send(send, {"type": "error", "message": str(exc)})
             except WebSocketSendTimeout:
                 pass
             return
+        except TimeoutError:
+            logger.warning(
+                "Rate-limit check timed out after %.1fs for user=%s; failing open",
+                _PRE_STREAM_DB_TIMEOUT_SECONDS,
+                user_id,
+            )
+            # Fail open — let the turn through; a stuck rate-limit DB
+            # call shouldn't block a paying user from chatting.
 
-        # 1. Load conversation
+        # 1. Load conversation. Bounded for the same reason as step 0.
+        logger.info(
+            "chat.handle_message step=1-load-conv conv=%s",
+            conversation_id,
+        )
         try:
-            with get_connection() as conn:
-                conversation = get_conversation(conn, conversation_id)
+            conversation = await asyncio.wait_for(
+                asyncio.to_thread(_load_conversation, conversation_id),
+                timeout=_PRE_STREAM_DB_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Conversation load timed out after %.1fs for conv=%s",
+                _PRE_STREAM_DB_TIMEOUT_SECONDS,
+                conversation_id,
+            )
+            try:
+                await _safe_send(
+                    send,
+                    {
+                        "type": "error",
+                        "message": "Andmebaas vastab aeglaselt. Palun proovi uuesti.",
+                    },
+                )
+            except WebSocketSendTimeout:
+                pass
+            return
         except Exception:
             logger.exception("Failed to load conversation %s", conversation_id)
             try:
                 await _safe_send(
-                    send, {"type": "error", "message": "Vestluse laadimine ebaonnestus."}
+                    send, {"type": "error", "message": "Vestluse laadimine ebaõnnestus."}
                 )
             except WebSocketSendTimeout:
                 pass
@@ -617,12 +677,26 @@ class ChatOrchestrator:
                 pass
             return
 
-        # Load message history
+        # 2. Load message history. Bounded; on error or timeout we
+        # proceed with empty history so the turn can still happen.
+        logger.info(
+            "chat.handle_message step=2-load-history conv=%s",
+            conversation_id,
+        )
         try:
-            with get_connection() as conn:
-                history = list_messages(conn, conversation_id)
+            history = await asyncio.wait_for(
+                asyncio.to_thread(_load_history, conversation_id),
+                timeout=_PRE_STREAM_DB_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "History load timed out after %.1fs for conv=%s; using empty",
+                _PRE_STREAM_DB_TIMEOUT_SECONDS,
+                conversation_id,
+            )
+            history = []
         except Exception:
-            logger.exception("Failed to load messages for conversation %s", conversation_id)
+            logger.exception("Failed to load messages for conv=%s", conversation_id)
             history = []
 
         history_length_before = len(history)

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -95,6 +95,14 @@ _FOLLOW_UPS_MAX_TOKENS = 180
 _RAG_RETRIEVE_TIMEOUT_SECONDS = 15.0
 _TURN_DEADLINE_SECONDS = 120.0
 
+# #658 — pre-stream DB-call deadline. Each sync DB op (rate check,
+# conversation load, history load, user-msg persist, budget check)
+# is wrapped in ``asyncio.wait_for(... , _PRE_STREAM_DB_TIMEOUT_SECONDS)``
+# so a stalled connection pool surfaces as a friendly error event
+# instead of an indefinite "thinking" spinner. 8 seconds is generous
+# for a healthy DB and short enough that the user notices.
+_PRE_STREAM_DB_TIMEOUT_SECONDS = 8.0
+
 # Module-level registry of fire-and-forget background tasks (e.g. the
 # auto-title job). Holding a strong reference prevents asyncio from
 # GC'ing the task mid-flight and logging the noisy "Task was destroyed
@@ -444,6 +452,37 @@ async def _maybe_generate_title(
 
 
 # ---------------------------------------------------------------------------
+# Pre-stream DB helpers (#658)
+# ---------------------------------------------------------------------------
+
+
+def _persist_user_message(conversation_id: uuid.UUID, user_message: str) -> None:
+    """Insert the user message in a tiny standalone transaction.
+
+    Decoupled from the budget transaction (#658) so a stuck advisory
+    lock cannot lose user input. Runs in a thread via
+    ``asyncio.to_thread`` because psycopg is sync.
+    """
+    with get_connection() as conn:
+        create_message(conn, conversation_id, "user", user_message)
+        conn.commit()
+
+
+def _check_budget_in_own_tx(org_id: uuid.UUID | str) -> None:
+    """Run the per-org cost-budget check in its own short-lived tx.
+
+    The advisory lock taken inside ``check_org_cost_budget`` is bounded
+    by ``SET LOCAL lock_timeout = '3s'`` (set inside the function),
+    so a stuck lock raises ``LockNotAvailable`` which the function's
+    own except catches and fails open. Raises
+    :class:`CostBudgetExceededError` if the org is over budget.
+    """
+    with get_connection() as conn:
+        check_org_cost_budget(org_id, conn=conn)
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -600,35 +639,82 @@ class ChatOrchestrator:
             impact_summary=impact_summary,
         )
 
-        # 3. Budget check + persist user message BEFORE RAG retrieval (#652).
-        # RAG and the LLM can stall for minutes; if we wait until after them
-        # to persist, a timeout means the user's message is silently lost
-        # and they can't see it after a reload. The advisory lock taken in
-        # ``check_org_cost_budget`` still covers the read-then-insert window
-        # because it runs in the same transaction as ``create_message``.
+        # 3a. Persist the user message FIRST in its own transaction (#658).
+        # Decoupled from the budget check so a stuck pg_advisory_xact_lock
+        # or any downstream failure cannot lose user input. Bounded by an
+        # 8s deadline so a stalled pool surfaces as an error instead of a
+        # silent hang. The persist runs in a thread because psycopg is
+        # sync; ``asyncio.to_thread`` keeps the event loop responsive.
+        logger.info(
+            "chat.handle_message step=3a-persist-user conv=%s user=%s",
+            conversation_id,
+            user_id,
+        )
         try:
-            with get_connection() as conn:
-                if org_id:
-                    check_org_cost_budget(org_id, conn=conn)
-                create_message(conn, conversation_id, "user", user_message)
-                conn.commit()
-        except CostBudgetExceededError as exc:
+            await asyncio.wait_for(
+                asyncio.to_thread(_persist_user_message, conversation_id, user_message),
+                timeout=_PRE_STREAM_DB_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "User-message persist timed out after %.1fs for conv=%s",
+                _PRE_STREAM_DB_TIMEOUT_SECONDS,
+                conversation_id,
+            )
             try:
-                await _safe_send(send, {"type": "error", "message": str(exc)})
+                await _safe_send(
+                    send,
+                    {
+                        "type": "error",
+                        "message": "Andmebaas vastab aeglaselt. Palun proovi uuesti.",
+                    },
+                )
             except WebSocketSendTimeout:
                 pass
             return
         except Exception:
-            logger.exception("Failed to persist user message")
+            logger.exception("Failed to persist user message for conv=%s", conversation_id)
             try:
                 await _safe_send(
-                    send, {"type": "error", "message": "Sonum salvestamine ebaonnestus."}
+                    send, {"type": "error", "message": "Sõnumi salvestamine ebaõnnestus."}
                 )
             except WebSocketSendTimeout:
                 pass
             return
 
-        # 3b. RAG retrieval — now that the user message is safely persisted,
+        # 3b. Budget check in a separate transaction. The user message is
+        # already safely persisted; if the budget is over the user simply
+        # sees an error (and can see what they tried to ask on reload).
+        if org_id:
+            logger.info(
+                "chat.handle_message step=3b-budget conv=%s org=%s",
+                conversation_id,
+                org_id,
+            )
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(_check_budget_in_own_tx, org_id),
+                    timeout=_PRE_STREAM_DB_TIMEOUT_SECONDS,
+                )
+            except CostBudgetExceededError as exc:
+                try:
+                    await _safe_send(send, {"type": "error", "message": str(exc)})
+                except WebSocketSendTimeout:
+                    pass
+                return
+            except TimeoutError:
+                logger.warning(
+                    "Budget check timed out after %.1fs for conv=%s; failing open",
+                    _PRE_STREAM_DB_TIMEOUT_SECONDS,
+                    conversation_id,
+                )
+                # Fail open — user message already persisted; better to
+                # let this turn through than to lose data.
+            except Exception:
+                logger.exception("Budget check failed for conv=%s", conversation_id)
+                # Fail open
+
+        # 3c. RAG retrieval — now that the user message is safely persisted,
         # we can afford to have RAG fail or time out without losing data.
         # Tenant scoping landed in #576: retriever filters by caller's org_id
         # (public NULL-scoped rows + caller's own private rows).

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -701,12 +701,31 @@ class ChatOrchestrator:
 
         history_length_before = len(history)
 
-        # 2. Build system prompt
+        # 2b. Build system prompt. The impact-summary load is a sync DB
+        # call; wrap it in the same wait_for+to_thread pattern as the
+        # other pre-stream loads so a stalled pool can't hang the turn
+        # before persist (#658). Fail-open with no summary on timeout —
+        # the chat still works, it just won't reference impact details.
         impact_summary: str | None = None
         draft_context_id: str | None = None
         if conversation.context_draft_id:
             draft_context_id = str(conversation.context_draft_id)
-            impact_summary = _load_impact_summary(draft_context_id, str(org_id))
+            try:
+                impact_summary = await asyncio.wait_for(
+                    asyncio.to_thread(_load_impact_summary, draft_context_id, str(org_id)),
+                    timeout=_PRE_STREAM_DB_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Impact summary load timed out after %.1fs for draft=%s; "
+                    "proceeding without context",
+                    _PRE_STREAM_DB_TIMEOUT_SECONDS,
+                    draft_context_id,
+                )
+                impact_summary = None
+            except Exception:
+                logger.exception("Failed to load impact summary for draft=%s", draft_context_id)
+                impact_summary = None
 
         system_prompt = build_system_prompt(
             draft_context_id=draft_context_id,

--- a/app/chat/rate_limiter.py
+++ b/app/chat/rate_limiter.py
@@ -145,12 +145,25 @@ def check_org_cost_budget(
     its own short-lived connection and performs the plain SELECT with
     no locking. This mode is intentionally kept for non-critical paths
     (status/usage display) where a momentary race is acceptable.
+
+    The advisory-lock acquire is bounded by ``SET LOCAL lock_timeout =
+    '3s'``: if a stale connection holds the lock for longer than that,
+    psycopg raises ``LockNotAvailable``, the outer ``except`` catches
+    it, and we fail-open for this turn (the org will simply have a
+    momentary unmetered spend; the next turn will see the corrected
+    sum). Trade-off: brief budget-check skew during lock contention vs.
+    indefinite hangs that lose user data (#658).
     """
     max_cost = _get_max_monthly_cost_usd()
     total_cost = 0.0
 
     try:
         if conn is not None:
+            # Bound the advisory-lock acquire so a stuck pre-deploy
+            # connection holding the lock can't hang the whole turn
+            # (#658). On lock_timeout, psycopg raises LockNotAvailable
+            # which the outer except catches and we fail-open.
+            conn.execute("SET LOCAL lock_timeout = '3s'")
             # Serialise concurrent budget checks for this org inside the
             # caller's transaction. The lock is released on commit/rollback.
             conn.execute(

--- a/app/chat/websocket.py
+++ b/app/chat/websocket.py
@@ -36,16 +36,58 @@ logger = logging.getLogger(__name__)
 
 _MAX_MESSAGE_LENGTH = 10_000
 
+# #658 — server-side WS heartbeat. Emit a tiny ping every N seconds for
+# the lifetime of the connection so NAT idle timeouts / proxy idle-cuts
+# can't silently kill the socket during long RAG / LLM rounds.
+_WS_HEARTBEAT_INTERVAL_SECONDS = 25.0
+
+# #658 — per-connection heartbeat task registry. Keyed by id(send) so
+# we can cancel the heartbeat when the WS disconnects. ``id(send)`` is
+# stable for the lifetime of one connection (same pattern as the
+# existing ``_per_send_tasks`` registry below).
+_heartbeat_tasks: dict[int, asyncio.Task[None]] = {}
+
+
+def _start_heartbeat(send: Any) -> asyncio.Task[None]:
+    """Spawn a background task that emits ``{"type": "ping"}`` every
+    ``_WS_HEARTBEAT_INTERVAL_SECONDS``.
+
+    Returns the task so the caller can cancel it on disconnect. Send
+    errors are logged at DEBUG and swallowed — the task keeps ticking
+    so a transient send failure doesn't take down the heartbeat.
+    """
+
+    async def _beat() -> None:
+        while True:
+            try:
+                await asyncio.sleep(_WS_HEARTBEAT_INTERVAL_SECONDS)
+                await send(json.dumps({"type": "ping"}))
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("WS heartbeat send failed (continuing)", exc_info=True)
+
+    task = asyncio.create_task(_beat())
+    return task
+
 
 async def on_connect(send: Any) -> None:
     """Called when a WebSocket client connects to /ws/chat."""
     logger.info("Chat WS client connected")
     await send(json.dumps({"type": "connected"}))
+    _heartbeat_tasks[id(send)] = _start_heartbeat(send)
 
 
 async def on_disconnect(send: Any) -> None:
     """Called when a WebSocket client disconnects."""
     logger.info("Chat WS client disconnected")
+    task = _heartbeat_tasks.pop(id(send), None)
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
 
 
 async def ws_chat(

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -825,6 +825,14 @@
     switch (event.type) {
 
       // -----------------------------------------------------------------------
+      case 'ping':
+        // Server-side heartbeat (#658) — keeps WS alive through NAT idle
+        // timeouts / proxy idle-cuts during long RAG / LLM rounds. No UI
+        // effect; drop silently so it doesn't hit the default branch (or
+        // any future "unknown event type" log).
+        return;
+
+      // -----------------------------------------------------------------------
       case 'retrieval_started':
         updateThinkingStatus('Otsin allikaid ontoloogiast...');
         break;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ select = ["E", "F", "I", "N", "W", "UP"]
 # UI component functions follow FastHTML's PascalCase convention for FT builders
 "app/ui/**/*.py" = ["F403", "F405", "N802"]
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: integration tests that require a live database (skipped without DATABASE_URL)",
+]
+
 [tool.pyright]
 pythonVersion = "3.13"
 typeCheckingMode = "basic"

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -856,8 +856,11 @@ class TestOrchestratorPartialPersistence:
         error_events = [e for e in collector.events if e.get("type") == "error"]
         assert len(error_events) == 1
 
-        # Only 1 commit (for the user message), not 2 (no assistant msg persisted)
-        assert conn.commit.call_count == 1
+        # #658: user-msg persist and budget check now run in separate
+        # transactions, so we expect 2 commits (one per tx) — neither is
+        # the assistant message, since the LLM exploded before producing
+        # any content.
+        assert conn.commit.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -1470,18 +1473,18 @@ class TestMaxToolRoundsCapVerified:
 
 
 class TestCostBudgetAdvisoryLock:
-    """The advisory lock must engage on the same conn that persists the user msg."""
+    """User-msg INSERT and advisory lock must run on SEPARATE conns (#658)."""
 
     @patch("app.chat.orchestrator.check_message_rate")
     @patch("app.chat.orchestrator.get_connection")
-    def test_cost_budget_uses_advisory_lock_when_conn_passed(self, mock_get_conn, mock_rate):
-        """The advisory lock must be taken on the conn that then INSERTs the
-        user message — the two operations must share a transaction so the
-        lock serialises the read-then-insert window.
+    def test_cost_budget_lock_and_user_msg_insert_are_decoupled(self, mock_get_conn, mock_rate):
+        """The advisory lock and the user-msg INSERT must run on DIFFERENT
+        connections (#658). A stuck advisory lock must not be able to hold
+        up the user-message persist, so the two operations live in
+        independent short-lived transactions. This test asserts that
+        separation: the conn that takes ``pg_advisory_xact_lock`` does not
+        also run ``INSERT INTO messages``.
         """
-        # Two independent conn mocks: the first is used for loading the
-        # conversation + history, the second is the budget-check-plus-
-        # user-message-insert conn we care about.
         conv = _make_conversation()
         now = datetime.now(UTC)
 
@@ -1522,8 +1525,8 @@ class TestCostBudgetAdvisoryLock:
 
         # We'll hand out a stream of conns — the orchestrator opens a fresh
         # connection per ``with get_connection()`` block. Capture per-conn
-        # execute history so we can verify the budget+insert conn started
-        # with the advisory-lock SQL.
+        # execute history so we can verify the lock-holding conn never
+        # performs the user-msg INSERT.
         conn_histories: list[list[str]] = []
 
         def make_conn() -> MagicMock:
@@ -1559,28 +1562,39 @@ class TestCostBudgetAdvisoryLock:
         orchestrator = ChatOrchestrator(FakeLLM(), FakeSparql())
         asyncio.run(orchestrator.handle_message(_CONV_ID, "Tere", _auth(), collector))
 
-        # Locate the conn whose first SQL statement contains the advisory
-        # lock. That conn must ALSO run an INSERT INTO messages call (the
-        # shared-transaction guarantee from the review fix).
+        # Locate the conn that took the advisory lock and the conn that
+        # inserted the user message. They MUST be different conns now (#658).
         lock_conn_history: list[str] | None = None
+        user_insert_conn_history: list[str] | None = None
         for history in conn_histories:
-            if history and "pg_advisory_xact_lock" in history[0]:
+            if any(isinstance(sql, str) and "pg_advisory_xact_lock" in sql for sql in history):
                 lock_conn_history = history
-                break
+            if any(isinstance(sql, str) and "INSERT INTO messages" in sql for sql in history):
+                # Take the FIRST INSERT-using conn as the user-msg conn; that
+                # is the step-3a persist (assistant-msg persistence happens
+                # later on a different conn).
+                if user_insert_conn_history is None:
+                    user_insert_conn_history = history
 
         assert lock_conn_history is not None, (
-            "No connection took pg_advisory_xact_lock as its first SQL. "
+            f"No connection took pg_advisory_xact_lock. Observed histories: {conn_histories}"
+        )
+        assert user_insert_conn_history is not None, (
+            "No connection ran INSERT INTO messages for the user message. "
             f"Observed histories: {conn_histories}"
         )
-        # The very first SQL on that conn is the lock call — this is the
-        # TOCTOU-closing property.
-        assert "pg_advisory_xact_lock" in lock_conn_history[0]
-        # And the same conn later inserts the user message.
-        assert any(
-            "INSERT INTO messages" in sql for sql in lock_conn_history if isinstance(sql, str)
+        # The user-msg INSERT and the advisory lock must NOT live on the
+        # same conn — that decoupling is the #658 fix.
+        assert lock_conn_history is not user_insert_conn_history, (
+            "Advisory lock and user-msg INSERT shared a connection. The "
+            "#658 fix requires them to run in independent transactions."
+        )
+        # Sanity: the lock-holding conn must not contain a user-msg INSERT.
+        assert not any(
+            isinstance(sql, str) and "INSERT INTO messages" in sql for sql in lock_conn_history
         ), (
-            "Lock-holding conn never persisted a user message — the "
-            "transaction-sharing guarantee is not wired up."
+            "Lock-holding conn ran INSERT INTO messages — that re-couples "
+            "the user-msg persist with the budget tx (regression on #658)."
         )
 
 

--- a/tests/test_chat_orchestrator_prerag_hang.py
+++ b/tests/test_chat_orchestrator_prerag_hang.py
@@ -1,0 +1,129 @@
+"""Regression: ChatOrchestrator must persist the user message before
+RAG retrieval, and an unresponsive retriever must NOT lose user input.
+
+Closes #658.
+
+Spins up a synthetic conversation, patches the retriever to hang
+forever, runs the orchestrator with a short outer deadline, then
+verifies the user-message row is in the DB. This is the data-loss
+guarantee the rest of #658 ships.
+
+Uses sync ``def test_X()`` with ``asyncio.run(_inner())`` for the
+async portions, matching the convention in
+``tests/test_chat_orchestrator.py`` (the project doesn't have
+pytest-asyncio installed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def test_user_message_persists_when_retriever_hangs() -> None:
+    """If the embedder/retriever hangs forever, the user's message
+    must already be in the DB by the time RAG starts, and the turn
+    must surface a timeout / error instead of silently swallowing the
+    message.
+    """
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("integration test — DATABASE_URL not set")
+
+    from app.chat.orchestrator import ChatOrchestrator
+    from app.db import get_connection
+
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    conv_id = uuid.uuid4()
+
+    # Bootstrap synthetic org / user / conversation. The schema uses
+    # ``organizations`` (not ``orgs``) and requires ``slug`` + ``name``
+    # to both be UNIQUE NOT NULL. ``users`` requires ``password_hash``,
+    # ``full_name`` and a CHECK-constrained ``role``.
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO organizations (id, name, slug) VALUES (%s, %s, %s)",
+            (org_id, f"test-org-658-{org_id}", f"test-org-658-{org_id}"),
+        )
+        conn.execute(
+            "INSERT INTO users (id, email, password_hash, full_name, role, org_id) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            (user_id, f"user-{user_id}@example.com", "x", "Test", "drafter", org_id),
+        )
+        conn.execute(
+            "INSERT INTO conversations (id, user_id, org_id, title) VALUES (%s, %s, %s, %s)",
+            (conv_id, user_id, org_id, "test conv 658"),
+        )
+        conn.commit()
+
+    try:
+
+        async def _run() -> list[dict[str, Any]]:
+            hanging_retriever = MagicMock()
+
+            async def _never_returns(*args: Any, **kwargs: Any) -> None:
+                await asyncio.sleep(3600)
+
+            hanging_retriever.retrieve = AsyncMock(side_effect=_never_returns)
+
+            # MagicMock LLM is fine — once RAG times out, the orchestrator
+            # tries to call ``llm.astream`` which will raise (MagicMock's
+            # astream is not an async iterator). The orchestrator catches
+            # that in its broad ``except Exception`` and emits an error
+            # event. By then the user message is already persisted —
+            # which is the whole point of this test.
+            orchestrator = ChatOrchestrator(MagicMock(), MagicMock())
+            events: list[dict[str, Any]] = []
+
+            async def collect(event: dict[str, Any]) -> None:
+                events.append(event)
+
+            with patch.object(orchestrator, "_get_retriever", return_value=hanging_retriever):
+                # The RAG retrieve has its own 15s deadline; we expect
+                # the orchestrator to either time out RAG (proceed
+                # without context) or hit the outer deadline. Either
+                # way the user message must already be in the DB.
+                try:
+                    await asyncio.wait_for(
+                        orchestrator.handle_message(
+                            conv_id,
+                            "Tere, see on test 658.",
+                            {"id": str(user_id), "org_id": str(org_id)},
+                            collect,
+                        ),
+                        timeout=20.0,  # > 15s RAG deadline, < 120s turn
+                    )
+                except TimeoutError:
+                    pass  # Expected if downstream wedges
+
+            return events
+
+        events = asyncio.run(_run())
+
+        # Verify: user message IS in the DB regardless of what
+        # happened downstream. This is the data-loss guarantee #658
+        # ships.
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE conversation_id = %s AND role = 'user'",
+                (conv_id,),
+            ).fetchone()
+        assert row is not None
+        assert row[0] == 1, (
+            f"User message must persist even when RAG hangs; got {row[0]} "
+            f"messages instead. Events emitted: "
+            f"{[e.get('type') for e in events]}"
+        )
+    finally:
+        # Cleanup — always run even if the assertion failed.
+        with get_connection() as conn:
+            conn.execute("DELETE FROM messages WHERE conversation_id = %s", (conv_id,))
+            conn.execute("DELETE FROM conversations WHERE id = %s", (conv_id,))
+            conn.execute("DELETE FROM users WHERE id = %s", (user_id,))
+            conn.execute("DELETE FROM organizations WHERE id = %s", (org_id,))
+            conn.commit()

--- a/tests/test_chat_rag_integration.py
+++ b/tests/test_chat_rag_integration.py
@@ -387,6 +387,7 @@ class TestOrchestratorRateLimitIntegration:
         assert collector.events[0]["type"] == "error"
         assert "100" in collector.events[0]["message"]
 
+    @patch("app.chat.orchestrator._persist_user_message")
     @patch(
         "app.chat.orchestrator.check_org_cost_budget",
         side_effect=CostBudgetExceededError("Kulueelarve on taidetud."),
@@ -399,14 +400,20 @@ class TestOrchestratorRateLimitIntegration:
     @patch("app.chat.orchestrator.list_messages", return_value=[])
     @patch("app.chat.orchestrator.get_connection")
     def test_cost_budget_sends_error_event(
-        self, mock_get_conn, mock_list, mock_get_conv, mock_rate, mock_cost
+        self,
+        mock_get_conn,
+        mock_list,
+        mock_get_conv,
+        mock_rate,
+        mock_cost,
+        mock_persist,
     ):
         """CostBudgetExceededError triggers an error event, no LLM call.
 
-        The budget check was relocated inside the conversation-load
-        transaction so the advisory lock can actually serialise
-        concurrent checks (TOCTOU fix). The test therefore needs to
-        feed past conversation loading before the cost check fires.
+        The user-message persist runs in its own transaction (#658) before
+        the budget check, so we patch it to a no-op to focus this test
+        purely on the budget-error path. The persist step is exercised
+        elsewhere in ``test_chat_orchestrator.py``.
         """
         llm = FakeLLM()
         collector = _Collector()

--- a/tests/test_chat_rate_limiter.py
+++ b/tests/test_chat_rate_limiter.py
@@ -178,22 +178,32 @@ class TestCheckOrgCostBudget:
 class TestCheckOrgCostBudgetWithConn:
     def test_advisory_lock_is_taken_when_conn_is_provided(self):
         """When a caller-supplied conn is passed, we must take the advisory lock
-        before reading the running total. This serialises concurrent checks."""
+        before reading the running total. This serialises concurrent checks.
+
+        After the #658 fix the call order is:
+          1. ``SET LOCAL lock_timeout`` (bounds the lock acquire)
+          2. ``pg_advisory_xact_lock`` (the actual lock)
+          3. ``SELECT SUM(cost_usd)`` (the running-total read)
+        """
         conn = MagicMock()
-        # Two execute() calls: lock + select. Chain them via side_effect.
+        # Three execute() calls: lock_timeout + lock + select. Chain via side_effect.
+        timeout_result = MagicMock()
         lock_result = MagicMock()
         select_result = MagicMock()
         select_result.fetchone.return_value = (10.0,)
-        conn.execute.side_effect = [lock_result, select_result]
+        conn.execute.side_effect = [timeout_result, lock_result, select_result]
 
         check_org_cost_budget(_ORG_ID, conn=conn)
 
-        # First call must be the advisory lock.
+        # First call must set the lock_timeout (#658 hang fix).
         first_call_sql = conn.execute.call_args_list[0].args[0]
-        assert "pg_advisory_xact_lock" in first_call_sql
-        # Second call reads the running total.
+        assert "lock_timeout" in first_call_sql
+        # Second call must be the advisory lock.
         second_call_sql = conn.execute.call_args_list[1].args[0]
-        assert "SUM(cost_usd)" in second_call_sql
+        assert "pg_advisory_xact_lock" in second_call_sql
+        # Third call reads the running total.
+        third_call_sql = conn.execute.call_args_list[2].args[0]
+        assert "SUM(cost_usd)" in third_call_sql
 
     def test_second_check_sees_accumulated_cost(self):
         """Proxy for FOR UPDATE correctness: two sequential checks against the
@@ -202,15 +212,25 @@ class TestCheckOrgCostBudgetWithConn:
         a higher SUM on the second SELECT."""
         conn = MagicMock()
 
+        # Each call now emits 3 execute()s: lock_timeout, advisory lock, select.
+        timeout1 = MagicMock()
         lock1 = MagicMock()
         select1 = MagicMock()
         select1.fetchone.return_value = (10.0,)  # Under cap — passes.
+        timeout2 = MagicMock()
         lock2 = MagicMock()
         select2 = MagicMock()
         # Simulates another request that successfully charged between the two
         # checks, pushing us over the monthly cap.
         select2.fetchone.return_value = (_MAX_MONTHLY_COST_USD + 5.0,)
-        conn.execute.side_effect = [lock1, select1, lock2, select2]
+        conn.execute.side_effect = [
+            timeout1,
+            lock1,
+            select1,
+            timeout2,
+            lock2,
+            select2,
+        ]
 
         # First call: still under budget.
         check_org_cost_budget(_ORG_ID, conn=conn)

--- a/tests/test_chat_rate_limiter_lock_timeout.py
+++ b/tests/test_chat_rate_limiter_lock_timeout.py
@@ -1,0 +1,62 @@
+"""Regression: check_org_cost_budget must time out on a stuck advisory lock.
+
+Before the #658 fix, a pre-deploy connection holding
+``pg_advisory_xact_lock('cost_budget:<org>')`` could block every new
+chat turn for that org indefinitely because the orchestrator's user-msg
+persist transaction reused that lock.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+
+import pytest
+
+from app.chat.rate_limiter import check_org_cost_budget
+
+
+@pytest.mark.integration
+def test_check_org_cost_budget_returns_within_5s_when_lock_is_held():
+    """If another connection holds the cost-budget advisory lock,
+    ``check_org_cost_budget`` must return (fail-open) within 5 seconds
+    instead of hanging forever."""
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("integration test — DATABASE_URL not set")
+
+    import psycopg
+
+    org_id = uuid.uuid4()
+    holder_started = threading.Event()
+    release_holder = threading.Event()
+
+    def hold_lock() -> None:
+        with psycopg.connect(os.environ["DATABASE_URL"]) as holder:
+            holder.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended('cost_budget:' || %s::text, 0))",
+                (str(org_id),),
+            )
+            holder_started.set()
+            while not release_holder.wait(timeout=0.1):
+                pass
+            holder.rollback()  # release the advisory lock
+
+    thread = threading.Thread(target=hold_lock, daemon=True)
+    thread.start()
+    assert holder_started.wait(timeout=5.0), "lock-holder thread did not start"
+
+    started = time.monotonic()
+    with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+        check_org_cost_budget(org_id, conn=conn)
+        conn.rollback()
+    elapsed = time.monotonic() - started
+
+    release_holder.set()
+    thread.join(timeout=2.0)
+
+    assert elapsed < 5.0, (
+        f"check_org_cost_budget hung for {elapsed:.1f}s with a stuck advisory "
+        f"lock (must time out and fail-open in <5s)"
+    )

--- a/tests/test_chat_websocket_heartbeat.py
+++ b/tests/test_chat_websocket_heartbeat.py
@@ -1,0 +1,72 @@
+"""WebSocket heartbeat — server emits {'type': 'ping'} every ~25s.
+
+Closes part of #658: NAT idle timeouts and proxy idle-cuts can silently
+kill the WS during long RAG/LLM rounds. A periodic ping keeps the path
+warm.
+
+Uses ``asyncio.run()`` to drive async test bodies, matching the project
+convention established by :mod:`tests.test_chat_orchestrator`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from app.chat import websocket as ws_mod
+from app.chat.websocket import _start_heartbeat
+
+
+def test_heartbeat_emits_ping_on_interval(monkeypatch) -> None:
+    """The heartbeat task emits at least one ping per interval and
+    exits cleanly on cancel."""
+    # Override the interval so the test is fast.
+    monkeypatch.setattr(ws_mod, "_WS_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+    received: list[dict] = []
+
+    async def fake_send(payload: str) -> None:
+        received.append(json.loads(payload))
+
+    async def _run() -> None:
+        task = _start_heartbeat(fake_send)
+        try:
+            await asyncio.sleep(0.18)  # allow ~3 ticks
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(_run())
+
+    pings = [e for e in received if e.get("type") == "ping"]
+    assert len(pings) >= 2, f"expected at least 2 pings in 180ms, got {len(pings)}: {received}"
+
+
+def test_heartbeat_swallows_send_errors(monkeypatch) -> None:
+    """Heartbeat survives a transient send failure without crashing."""
+    monkeypatch.setattr(ws_mod, "_WS_HEARTBEAT_INTERVAL_SECONDS", 0.02)
+
+    calls: list[int] = []
+
+    async def flaky_send(payload: str) -> None:
+        calls.append(len(calls))
+        if len(calls) == 2:
+            raise RuntimeError("transient")
+
+    async def _run() -> None:
+        task = _start_heartbeat(flaky_send)
+        try:
+            await asyncio.sleep(0.1)
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(_run())
+
+    assert len(calls) >= 3, "heartbeat must keep ticking after a send error"


### PR DESCRIPTION
## Summary

Fixes the production data-loss bug where chat WebSocket turns hang past 215s with no error event and user messages disappear on reload (#658).

**Root cause:** the user-message INSERT lived inside the same transaction as \`check_org_cost_budget\`'s \`pg_advisory_xact_lock\`. A pre-deploy connection still holding that lock blocked every new turn for that org indefinitely — the persist never committed, the WS kept "thinking" past 215s, and on reload the user message was gone.

## Changes

### Smoking-gun fixes
- **\`app/chat/rate_limiter.py\`**: bound the advisory-lock acquire with \`SET LOCAL lock_timeout = '3s'\`. A stuck lock now raises \`LockNotAvailable\`; the existing \`except Exception\` fail-open path takes over.
- **\`app/chat/orchestrator.py\`**: persist user message in its OWN transaction first, then run the budget check in a separate short-lived tx. Wrap each pre-stream sync DB call (rate check, conv load, history load, impact-summary load, persist, budget) in \`asyncio.wait_for(asyncio.to_thread(...), 8s)\` so a stalled pool surfaces as a friendly error event instead of an indefinite spinner.

### Diagnostics
- Step-level \`logger.info\` markers (\`step=0-rate-check\`, \`step=1-load-conv\`, \`step=2-load-history\`, \`step=3a-persist-user\`, \`step=3b-budget\`) so future hangs are visible in logs.

### WS heartbeat
- **\`app/chat/websocket.py\`**: emit \`{\"type\": \"ping\"}\` every 25s for the connection lifetime so NAT idle timeouts and proxy idle-cuts can't silently kill the socket during long RAG / LLM rounds.
- **\`app/static/js/chat.js\`**: drop ping events silently in the WS event-type dispatcher (no UI effect).

## Tests added
- \`tests/test_chat_orchestrator_prerag_hang.py\` — patches the retriever to hang forever; asserts the user-message row IS in the DB by the time the orchestrator returns. **This is the data-loss regression guard.**
- \`tests/test_chat_rate_limiter_lock_timeout.py\` — holds the cost-budget advisory lock from a second connection and asserts the budget check returns within 5s.
- \`tests/test_chat_websocket_heartbeat.py\` — asserts heartbeat cadence + resilience to transient send errors.

Plus minimal adaptations to two existing tests (\`test_chat_orchestrator.py\`, \`test_chat_rag_integration.py\`) to assert the new two-tx shape.

## Verification
- \`uv run ruff check\` clean across all changed files.
- \`uv run pyright\` clean across all changed files.
- \`uv run pytest tests/test_chat_*.py\` — **384 passed, 2 skipped** (the 2 skips are integration tests that need \`DATABASE_URL\`; CI runs them).
- Plan: \`docs/superpowers/plans/2026-05-01-chat-prerag-hang-fix.md\`.

## Out of scope (separate follow-ups)
- #660 (sync psycopg in \`_persist_partial_assistant\` cancel handlers) — small standalone fix.
- #655 client \"Peatamine…\" UI feedback — the underlying cancellation issue is largely fixed by removing uninterruptible sync blocks; the UX polish is a follow-up.
- #654 / #663 chat-list HTMX feedback — different files, different bug.

## Manual test plan
- [ ] CI: lint-and-test green
- [ ] Manual on staging: hold cost-budget advisory lock from \`psql\` against the staging org id; send chat message → errors within ~3-8s instead of hanging
- [ ] Manual on staging: open DevTools WS view; observe \`ping\` frames every ~25s during a long RAG round
- [ ] Manual on staging: send a message during a deliberate Voyage-AI block (firewall block) → user msg appears in DB on reload, error event shown to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)