### PR TITLE
Fix #660: off-load sync partial-persist out of async cancel handlers

### DIFF
--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -1089,7 +1089,10 @@ class ChatOrchestrator:
                 conversation_id,
             )
             if stream_state["full_content"]:
-                _persist_partial_assistant(
+                # #660: psycopg is sync; offload the partial-persist so a
+                # cancellation handler doesn't block the event loop.
+                await asyncio.to_thread(
+                    _persist_partial_assistant,
                     conversation_id,
                     stream_state["full_content"],
                     getattr(self.llm, "_model", None),
@@ -1113,12 +1116,19 @@ class ChatOrchestrator:
             # as truncated, emit a stopped event, then re-raise so the
             # caller's task.cancel() propagates correctly.
             cancelled = True
-            assistant_msg_id = _persist_partial_assistant(
-                conversation_id,
-                stream_state["full_content"],
-                getattr(self.llm, "_model", None),
-                rag_context_json,
-                is_truncated=True,
+            # #660: shield the partial-persist from a second cancel — we
+            # already chose to record the partial; let it complete. Also
+            # offload to a thread so psycopg I/O doesn't block the event
+            # loop during the cancellation path.
+            assistant_msg_id = await asyncio.shield(
+                asyncio.to_thread(
+                    _persist_partial_assistant,
+                    conversation_id,
+                    stream_state["full_content"],
+                    getattr(self.llm, "_model", None),
+                    rag_context_json,
+                    is_truncated=True,
+                )
             )
             # #661: shield the stopped-event send from a second cancel so
             # the UI still receives the stop acknowledgement even if the
@@ -1143,7 +1153,10 @@ class ChatOrchestrator:
         except WebSocketSendTimeout:
             # Client socket is unresponsive — persist whatever we have and
             # bail without sending further events.
-            _persist_partial_assistant(
+            # #660: offload the sync persist so the event loop is free
+            # to drain other connections while we save the partial.
+            await asyncio.to_thread(
+                _persist_partial_assistant,
                 conversation_id,
                 stream_state["full_content"],
                 getattr(self.llm, "_model", None),
@@ -1155,7 +1168,10 @@ class ChatOrchestrator:
             logger.exception("LLM streaming failed for conversation %s", conversation_id)
             # M1: persist partial content with error suffix when streaming fails
             if stream_state["full_content"]:
-                _persist_partial_assistant(
+                # #660: offload the sync persist so the cancellation/error
+                # path doesn't block the event loop.
+                await asyncio.to_thread(
+                    _persist_partial_assistant,
                     conversation_id,
                     stream_state["full_content"],
                     getattr(self.llm, "_model", None),


### PR DESCRIPTION
## Summary

Closes #660.

\`_persist_partial_assistant\` runs sync psycopg INSERT + commit. It was called directly from the orchestrator's \`TimeoutError\`, \`CancelledError\`, \`WebSocketSendTimeout\`, and \`Exception\` handlers — 10-50ms of blocking I/O on the event loop every time a turn was cancelled or timed out. Under load (many concurrent cancellations) this stalled every other coroutine briefly.

## Changes

- \`app/chat/orchestrator.py\`: wrap each of the 4 call sites in \`asyncio.to_thread(...)\` so the sync DB work runs in the default executor.
- The \`CancelledError\` path additionally uses \`asyncio.shield(asyncio.to_thread(...))\` so a second cancel can't abort the partial persist we already chose to record.

No behavioural change otherwise: the same row lands with the same \`is_truncated\` flag and (where applicable) error_suffix.

## Verification

- \`uv run ruff check\` clean.
- \`uv run pyright app/chat/orchestrator.py\` clean.
- \`uv run pytest tests/test_chat_*.py\` — 384 passed, 2 skipped.

## Test plan

- [ ] CI: lint-and-test green
- [ ] Existing partial-persist behavioural tests cover the four code paths (timeout, cancellation, ws-send-timeout, generic exception); all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)