### PR TITLE
Fix #663: HX-Refresh on archive/delete keeps pagination honest

### DIFF
--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -385,13 +385,20 @@ async def archive_conversation_handler(req: Request, conv_id: str):
     )
 
     if _is_htmx(req):
-        # Empty body + 200 collapses the row out of the list. We trigger
-        # ``chat:conversation-updated`` so any sidebar counters listening
-        # for the event can still refresh.
+        # #663: a row-only outerHTML swap collapsed the <tr> but left
+        # the toolbar/pagination counts stale, which was confusing on
+        # the archived-filter view in particular. HX-Refresh: true does
+        # a full page reload so the row vanishes AND the counts are
+        # always honest. Slight scroll-loss cost is acceptable since
+        # the row leaves view anyway. The HX-Trigger event is kept so
+        # any sidebar counters listening for it refresh too.
         return Response(
             "",
             status_code=200,
-            headers={"HX-Trigger": "chat:conversation-updated"},
+            headers={
+                "HX-Refresh": "true",
+                "HX-Trigger": "chat:conversation-updated",
+            },
         )
     return RedirectResponse(url="/chat", status_code=303)
 

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -1117,9 +1117,14 @@ async def delete_conversation_handler(req: Request, conv_id: str):
 
     is_htmx = req.headers.get("HX-Request") == "true"
     if is_htmx and from_list:
-        # Empty body + 200 — htmx replaces the <tr> with nothing, so the
-        # row vanishes from the list without touching pagination.
-        return Response("", status_code=200)
+        # #663: a row-only swap leaves pagination/counts stale. Use
+        # HX-Refresh so the row vanishes AND the counts/pagination
+        # refresh, matching what the user sees after a manual reload.
+        return Response(
+            "",
+            status_code=200,
+            headers={"HX-Refresh": "true"},
+        )
     if is_htmx:
         return Response(
             status_code=204,

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -249,11 +249,12 @@ class TestPinConversation:
 
 
 class TestArchiveConversation:
-    def test_archive_htmx_returns_empty_row_swap(self, provider_patch, mock_conn):
-        """Bug #654: htmx archive removes the row in place (empty 200).
-
+    def test_archive_htmx_returns_hx_refresh(self, provider_patch, mock_conn):
+        """Bug #663: htmx archive returns HX-Refresh so the row removal
+        AND the toolbar/pagination counts refresh atomically. Slight
+        scroll-loss cost is acceptable since the row leaves view anyway.
         The HX-Trigger event is preserved so sidebar counters listening
-        for ``chat:conversation-updated`` still refresh.
+        for ``chat:conversation-updated`` still refresh too.
         """
         conv = _make_conversation()
         with (
@@ -268,6 +269,7 @@ class TestArchiveConversation:
             )
             assert resp.status_code == 200
             assert resp.text == ""
+            assert resp.headers.get("HX-Refresh") == "true"
             assert resp.headers.get("HX-Trigger") == "chat:conversation-updated"
             mock_set.assert_called_once()
 

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -414,12 +414,13 @@ class TestChatDelete:
     @patch("app.chat.routes.delete_conversation")
     @patch("app.chat.routes._connect")
     @patch("app.auth.middleware._get_provider")
-    def test_delete_from_list_returns_empty_row_swap(
+    def test_delete_from_list_returns_hx_refresh(
         self, mock_provider, mock_connect, mock_delete, mock_audit
     ):
-        """Bug #654: the ``/chat`` list delete form posts ``from_list=1``
-        so htmx can swap the row out in place (empty 200 body, no
-        HX-Redirect).
+        """Bug #663: the ``/chat`` list delete form posts ``from_list=1``;
+        the response uses ``HX-Refresh: true`` so the row vanishes AND
+        the toolbar/pagination counts refresh (a row-only swap left
+        counts stale).
         """
         mock_provider.return_value = _stub_provider()
         conn = MagicMock()
@@ -436,7 +437,8 @@ class TestChatDelete:
             )
             assert resp.status_code == 200
             assert resp.text == ""
-            # No HX-Redirect — row just disappears from the list.
+            assert resp.headers.get("HX-Refresh") == "true"
+            # No HX-Redirect — the refresh handles the page change.
             assert "HX-Redirect" not in resp.headers
         mock_delete.assert_called_once()
 


### PR DESCRIPTION
## Summary

Closes #663.

The row-only \`outerHTML\` swap on archive/delete left the toolbar / pagination counts stale because htmx only replaced the \`<tr>\`. On the archived-filter view this was particularly confusing — the user saw the row vanish but the count was unchanged.

## Changes

- \`app/chat/handlers.py\` — archive handler returns \`HX-Refresh: true\` (still emits \`HX-Trigger: chat:conversation-updated\` for sidebar listeners).
- \`app/chat/routes.py\` — \`from_list=1\` delete branch returns \`HX-Refresh: true\`.
- \`tests/test_chat_handlers.py::test_archive_htmx_returns_hx_refresh\` — updated assertion.
- \`tests/test_chat_routes.py::test_delete_from_list_returns_hx_refresh\` — updated assertion.

The row vanishes AND counts / pagination refresh atomically. Slight scroll-loss is acceptable: the row leaves view anyway, so re-orienting after the action is normal.

## Verification

- \`uv run ruff check\` clean.
- \`uv run pyright app/chat\` clean.
- \`uv run pytest tests/test_chat_*.py\` — 384 passed, 2 skipped.

## Test plan

- [ ] CI: lint-and-test green
- [ ] Manual on staging: open \`/chat\`, archive a row → page refreshes, count drops by one
- [ ] Manual on staging: open \`/chat?archived=1\`, archive a row (which un-archives in this view) → page refreshes, count drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)