### PR TITLE
Fix #662: persist per-turn token counts on assistant messages

### DIFF
--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -991,7 +991,17 @@ class ChatOrchestrator:
                                 },
                             )
                         elif event.type == "stop":
-                            pass  # handled after loop
+                            # #662: capture per-turn token counts so the
+                            # assistant message row records them. The
+                            # provider tallies these from message_start /
+                            # message_delta usage events; this is the
+                            # final hand-off to persistence.
+                            if event.tokens_input is not None:
+                                stream_state["tokens_in"] += event.tokens_input
+                            if event.tokens_output is not None:
+                                stream_state["tokens_out"] += event.tokens_output
+                            # Continue — the post-loop logic decides
+                            # whether we're truly done (no pending tools).
 
                 # If no tool use requested, we're done
                 if not pending_tools:

--- a/app/llm/claude.py
+++ b/app/llm/claude.py
@@ -516,7 +516,16 @@ class ClaudeProvider(LLMProvider):
             org_id=org_id,
         )
 
-        yield StreamEvent(type="stop")
+        # #662: emit the per-turn token counts on the terminal stop
+        # event so the orchestrator can persist them on the assistant
+        # message row. The cost-tracker call above writes a separate
+        # llm_usage row; the message-level counts here are what the
+        # chat history shows in the UI ("input: 1234, output: 567").
+        yield StreamEvent(
+            type="stop",
+            tokens_input=tokens_input,
+            tokens_output=tokens_output,
+        )
 
 
 _default_provider: ClaudeProvider | None = None

--- a/app/llm/provider.py
+++ b/app/llm/provider.py
@@ -28,6 +28,12 @@ class StreamEvent:
             Forward-compatibility hook so orchestrators can echo the id
             back in a follow-up ``tool_result`` message; the current
             orchestrator still mints its own opaque ``tool_call_id``.
+        tokens_input: Total prompt-token count for the turn, set on the
+            terminal ``stop`` event so the orchestrator can persist it
+            alongside the assistant message (#662). ``None`` for non-stop
+            events and for providers that don't report usage.
+        tokens_output: Total completion-token count for the turn, set on
+            the terminal ``stop`` event (#662). ``None`` otherwise.
     """
 
     type: str  # "content", "tool_use", "stop"
@@ -35,6 +41,8 @@ class StreamEvent:
     tool_name: str | None = None
     tool_input: dict | None = field(default=None)
     tool_use_id: str | None = None
+    tokens_input: int | None = None
+    tokens_output: int | None = None
 
 
 class LLMProvider(ABC):

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -719,6 +719,160 @@ class TestOrchestratorPersistence:
         assert conn.commit.call_count >= 1
 
 
+class TestAssistantTokensPersistence:
+    """#662: token counts from the LLM stream's terminal stop event must be
+    persisted on the assistant message row. Before the fix the orchestrator
+    initialised tokens_in/out to 0 and never read them off StreamEvent, so
+    every assistant row landed with NULL tokens."""
+
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_stop_event_tokens_propagate_to_create_message(self, mock_get_conn, mock_create_msg):
+        """When astream emits a terminal ``stop`` carrying tokens_input
+        and tokens_output, the orchestrator must pass those values to
+        ``create_message`` for the assistant message row."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        now = datetime.now(UTC)
+        call_counter = {"n": 0}
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+
+        def side_effect_fetchone():
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return base_conv_row
+            return (
+                uuid.uuid4(),
+                _CONV_ID,
+                "user",
+                "x",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                now,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        conn.execute.return_value.fetchone = side_effect_fetchone
+        conn.execute.return_value.fetchall.return_value = []
+        mock_create_msg.return_value = MagicMock(id=_MSG_ID)
+
+        events = [
+            [
+                StreamEvent(type="content", delta="Tere!"),
+                StreamEvent(type="stop", tokens_input=1234, tokens_output=567),
+            ]
+        ]
+        llm = FakeLLM(events)
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(llm, FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Test", _auth(), collector))
+
+        # Find the create_message call for the assistant role and assert
+        # its tokens_input / tokens_output kwargs were passed through.
+        assistant_calls = [
+            c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
+        ]
+        assert assistant_calls, "expected at least one assistant create_message call"
+        assistant_call = assistant_calls[-1]
+        assert assistant_call.kwargs.get("tokens_input") == 1234, (
+            f"expected tokens_input=1234, got {assistant_call.kwargs.get('tokens_input')}"
+        )
+        assert assistant_call.kwargs.get("tokens_output") == 567, (
+            f"expected tokens_output=567, got {assistant_call.kwargs.get('tokens_output')}"
+        )
+
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_stop_event_without_tokens_persists_none(self, mock_get_conn, mock_create_msg):
+        """When astream emits a terminal ``stop`` without token counts
+        (legacy provider, stub mode, etc.), the orchestrator must persist
+        NULL rather than 0 — matches the pre-fix falsy-check semantics for
+        backwards compatibility."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        now = datetime.now(UTC)
+        call_counter = {"n": 0}
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+
+        def side_effect_fetchone():
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return base_conv_row
+            return (
+                uuid.uuid4(),
+                _CONV_ID,
+                "user",
+                "x",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                now,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        conn.execute.return_value.fetchone = side_effect_fetchone
+        conn.execute.return_value.fetchall.return_value = []
+        mock_create_msg.return_value = MagicMock(id=_MSG_ID)
+
+        events = [
+            [
+                StreamEvent(type="content", delta="Tere!"),
+                StreamEvent(type="stop"),  # no tokens
+            ]
+        ]
+        llm = FakeLLM(events)
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(llm, FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Test", _auth(), collector))
+
+        assistant_calls = [
+            c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
+        ]
+        assert assistant_calls, "expected at least one assistant create_message call"
+        assistant_call = assistant_calls[-1]
+        # The orchestrator's falsy-check stores None for 0 totals so
+        # legacy stub providers don't pollute analytics with fake zeroes.
+        assert assistant_call.kwargs.get("tokens_input") is None
+        assert assistant_call.kwargs.get("tokens_output") is None
+
+
 class TestOrchestratorPartialPersistence:
     """M1: Partial message should be persisted with error suffix on LLM failure."""
 


### PR DESCRIPTION
## Summary

Closes #662.

\`ClaudeProvider.astream\` tallied input/output tokens from \`message_start\` and \`message_delta\` usage events and recorded them via \`_log_cost\` (the analytics path), but the terminal \`StreamEvent(type='stop')\` carried no token fields. The orchestrator's \`stream_state['tokens_in'/'tokens_out']\` were initialised to 0 and never updated, so the falsy guard at the assistant-message persist call always stored NULL. Result: every \`assistant\` row in \`messages.tokens_input\` / \`messages.tokens_output\` was NULL even though the cost-tracker had the right numbers.

## Changes

- \`app/llm/provider.py\` — \`StreamEvent\` gains optional \`tokens_input\` / \`tokens_output\` fields, populated only on terminal \`stop\` events.
- \`app/llm/claude.py\` — \`ClaudeProvider.astream\` yields the stop event with captured \`tokens_input\` / \`tokens_output\`.
- \`app/chat/orchestrator.py\` — \`_run_stream_loop\` now accumulates per-round token counts from each \`stop\` event into \`stream_state\` (multi-round tool-use turns emit one stop per round, so we accumulate rather than overwrite).
- The orchestrator's existing falsy guard at \`create_message\` keeps storing NULL for 0 totals so stub-mode and legacy providers don't pollute analytics with fake zeroes.

## Tests

- \`TestAssistantTokensPersistence::test_stop_event_tokens_propagate_to_create_message\` — yields \`stop(tokens_input=1234, tokens_output=567)\` and asserts the assistant \`create_message\` call passes those values through.
- \`TestAssistantTokensPersistence::test_stop_event_without_tokens_persists_none\` — yields \`stop()\` (no token fields) and asserts the assistant call still records NULL (legacy / stub compatibility).

## Verification

- \`uv run ruff check\` clean.
- \`uv run pyright app/llm app/chat/orchestrator.py\` clean.
- \`uv run pytest tests/test_chat_*.py\` — **386 passed, 2 skipped** (382 baseline + 2 new + 2 from earlier #684/#686 work).

## Test plan

- [ ] CI: lint-and-test green
- [ ] Manual on staging: send a chat message, confirm new \`messages\` row has non-NULL \`tokens_input\` and \`tokens_output\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)