### PR TITLE
Add resolve_draft helper for the auth/parse/fetch/authz preamble (#624)

### DIFF
--- a/app/docs/_helpers.py
+++ b/app/docs/_helpers.py
@@ -11,13 +11,36 @@ depend on :mod:`app.docs.routes` itself, or the cycle returns.
 from __future__ import annotations
 
 import uuid
+from typing import Any, NamedTuple
 
 from fasthtml.common import H1, A, P  # noqa: F401
 from starlette.requests import Request
+from starlette.responses import Response
 
+from app.auth.helpers import require_auth
+from app.auth.policy import can_edit_draft, can_view_draft
+from app.auth.provider import UserDict
+from app.docs import draft_model as _dm
+from app.docs.draft_model import Draft
 from app.ui.layout import PageShell
 from app.ui.surfaces.alert import Alert
 from app.ui.theme import get_theme_from_request
+
+
+class ResolvedDraft(NamedTuple):
+    """Result of a successful :func:`resolve_draft` call.
+
+    A real subclass (not a bare ``tuple[Draft, dict]``) so call sites can
+    discriminate via ``isinstance(result, ResolvedDraft)`` — important
+    because FastHTML FT elements (e.g. the 404 page returned on
+    auth/load/authz failure) are themselves plain tuples and would
+    otherwise match a tuple-based discriminator.
+    """
+
+    draft: Draft
+    # ``UserDict`` is a TypedDict; widen to ``Any`` so call sites can
+    # also pass a plain ``dict`` (test fixtures, audit-log reconstructions).
+    auth: UserDict | dict[str, Any] | Any
 
 
 def _parse_uuid(raw: str) -> uuid.UUID | None:
@@ -45,3 +68,67 @@ def _not_found_page(req: Request):
         active_nav="/drafts",
         request=req,
     )
+
+
+def resolve_draft(
+    req: Request,
+    draft_id: str,
+    *,
+    action: str = "view",
+) -> ResolvedDraft | Any:
+    """Run the standard auth + parse + load + authorize preamble for a draft route.
+
+    The drafts module has ~15 handlers that all open with the same five
+    steps:
+
+    1. Auth check (redirect to /auth/login on miss).
+    2. Parse the URL ``draft_id`` into a UUID.
+    3. Load the draft from the DB.
+    4. Authorize the caller against the draft (view / edit) — return 404
+       (not 403) so we never leak existence of out-of-scope drafts.
+
+    This helper consolidates that preamble (#624). On success it returns
+    a :class:`ResolvedDraft` named tuple. On any failure it returns the
+    appropriate response object — either a Starlette ``Response`` (auth
+    redirect) or a FastHTML FT element from :func:`_not_found_page`.
+
+    Discriminate via ``isinstance(result, ResolvedDraft)`` (NOT plain
+    ``tuple`` — FT elements are tuples too)::
+
+        resolved = resolve_draft(req, draft_id)
+        if not isinstance(resolved, ResolvedDraft):
+            return resolved
+        draft, auth = resolved.draft, resolved.auth
+
+    Args:
+        req: The Starlette request.
+        draft_id: The URL-path UUID string for the draft.
+        action: ``"view"`` (default) gates on :func:`can_view_draft`;
+            ``"edit"`` gates on :func:`can_edit_draft` for handlers that
+            mutate state.
+
+    Returns:
+        Either a :class:`ResolvedDraft` if authorised, or an opaque
+        response object to return verbatim.
+    """
+    auth_or_redirect = require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    parsed = _parse_uuid(draft_id)
+    if parsed is None:
+        return _not_found_page(req)
+
+    # Look up via the module rather than a direct import so test patches
+    # on ``app.docs.draft_model.fetch_draft`` actually intercept the call.
+    draft = _dm.fetch_draft(parsed)
+    if draft is None:
+        return _not_found_page(req)
+
+    gate = can_edit_draft if action == "edit" else can_view_draft
+    if not gate(auth, draft):
+        # 404 (not 403) so cross-org probing can't enumerate draft ids.
+        return _not_found_page(req)
+
+    return ResolvedDraft(draft=draft, auth=auth)

--- a/tests/test_docs_helpers.py
+++ b/tests/test_docs_helpers.py
@@ -1,0 +1,157 @@
+"""Unit tests for ``app.docs._helpers.resolve_draft`` (#624).
+
+Each branch (auth fail / bad UUID / draft missing / authz fail / success)
+is exercised independently with mocked dependencies. These are pure
+unit tests — no DB, no FastHTML routing, no auth middleware.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from starlette.responses import RedirectResponse
+
+from app.docs._helpers import ResolvedDraft, resolve_draft
+
+
+def _make_request(auth_scope: dict[str, Any] | None = None) -> Any:
+    """Build a minimal request stub that ``require_auth`` and
+    ``_not_found_page`` both accept."""
+    req = MagicMock()
+    req.scope = {"auth": auth_scope}
+    req.headers = {}
+    return req
+
+
+def _make_draft(*, org_id: str = "org-1") -> Any:
+    draft = MagicMock()
+    draft.id = uuid.uuid4()
+    draft.org_id = org_id
+    return draft
+
+
+class TestResolveDraftAuth:
+    def test_returns_redirect_when_unauthenticated(self):
+        """If require_auth returns a Response, resolve_draft passes it
+        through verbatim — never tries to load the draft."""
+        redirect = RedirectResponse(url="/auth/login", status_code=303)
+        req = _make_request(auth_scope=None)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=redirect),
+            patch("app.docs._helpers._dm.fetch_draft") as mock_fetch,
+        ):
+            result = resolve_draft(req, str(uuid.uuid4()))
+
+        assert result is redirect
+        mock_fetch.assert_not_called()
+
+
+class TestResolveDraftParse:
+    def test_returns_404_for_non_uuid_path_param(self):
+        """Bad UUID strings short-circuit to _not_found_page."""
+        auth = {"id": "user-1", "org_id": "org-1", "full_name": "Test User", "role": "drafter"}
+        req = _make_request(auth_scope=auth)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=auth),
+            patch("app.docs._helpers._dm.fetch_draft") as mock_fetch,
+        ):
+            result = resolve_draft(req, "not-a-uuid")
+
+        # Not a ResolvedDraft → caller returns it as a 404 page.
+        assert not isinstance(result, ResolvedDraft)
+        mock_fetch.assert_not_called()
+
+
+class TestResolveDraftLoad:
+    def test_returns_404_when_draft_missing(self):
+        """A valid UUID with no matching draft returns the 404 page."""
+        auth = {"id": "user-1", "org_id": "org-1", "full_name": "Test User", "role": "drafter"}
+        req = _make_request(auth_scope=auth)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=auth),
+            patch("app.docs._helpers._dm.fetch_draft", return_value=None),
+        ):
+            result = resolve_draft(req, str(uuid.uuid4()))
+
+        assert not isinstance(result, ResolvedDraft)
+
+
+class TestResolveDraftAuthz:
+    def test_returns_404_when_view_authz_denies(self):
+        """Cross-org access returns the 404 page (not 403) so we don't
+        leak existence of out-of-scope drafts."""
+        auth = {"id": "user-1", "org_id": "org-1", "full_name": "Test User", "role": "drafter"}
+        draft = _make_draft(org_id="org-2")  # different org
+        req = _make_request(auth_scope=auth)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=auth),
+            patch("app.docs._helpers._dm.fetch_draft", return_value=draft),
+            patch("app.docs._helpers.can_view_draft", return_value=False),
+        ):
+            result = resolve_draft(req, str(draft.id))
+
+        assert not isinstance(result, ResolvedDraft)
+
+    def test_uses_can_edit_for_action_edit(self):
+        """``action='edit'`` switches the gate from can_view to can_edit."""
+        auth = {"id": "user-1", "org_id": "org-1", "full_name": "Test User", "role": "drafter"}
+        draft = _make_draft()
+        req = _make_request(auth_scope=auth)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=auth),
+            patch("app.docs._helpers._dm.fetch_draft", return_value=draft),
+            patch("app.docs._helpers.can_view_draft", return_value=True) as mock_view,
+            patch("app.docs._helpers.can_edit_draft", return_value=True) as mock_edit,
+        ):
+            result = resolve_draft(req, str(draft.id), action="edit")
+
+        assert isinstance(result, ResolvedDraft)
+        mock_edit.assert_called_once_with(auth, draft)
+        mock_view.assert_not_called()
+
+
+class TestResolveDraftSuccess:
+    def test_returns_resolved_draft_on_success(self):
+        """All checks passing returns a ResolvedDraft with both fields."""
+        auth = {"id": "user-1", "org_id": "org-1", "full_name": "Test User", "role": "drafter"}
+        draft = _make_draft()
+        req = _make_request(auth_scope=auth)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=auth),
+            patch("app.docs._helpers._dm.fetch_draft", return_value=draft),
+            patch("app.docs._helpers.can_view_draft", return_value=True),
+        ):
+            result = resolve_draft(req, str(draft.id))
+
+        assert isinstance(result, ResolvedDraft)
+        assert result.draft is draft
+        assert result.auth is auth
+
+    def test_resolved_draft_supports_attribute_and_tuple_unpack(self):
+        """ResolvedDraft is a NamedTuple — both forms must work."""
+        auth = {"id": "user-1", "org_id": "org-1", "full_name": "Test User", "role": "drafter"}
+        draft = _make_draft()
+        req = _make_request(auth_scope=auth)
+
+        with (
+            patch("app.docs._helpers.require_auth", return_value=auth),
+            patch("app.docs._helpers._dm.fetch_draft", return_value=draft),
+            patch("app.docs._helpers.can_view_draft", return_value=True),
+        ):
+            result = resolve_draft(req, str(draft.id))
+
+        assert isinstance(result, ResolvedDraft)
+        # Attribute access
+        assert result.draft is draft
+        # Tuple unpack — important because callers may use either form.
+        unpacked_draft, unpacked_auth = result
+        assert unpacked_draft is draft
+        assert unpacked_auth is auth


### PR DESCRIPTION
## Summary

Closes #624.

The drafts module has ~15 handlers that all open with the same five-step preamble:

1. \`require_auth(req)\` — redirect Response on miss
2. \`_parse_uuid(draft_id)\` — \`_not_found_page\` on bad UUID
3. \`fetch_draft(uuid)\` — \`_not_found_page\` on miss
4. \`can_view_draft\` / \`can_edit_draft\` — \`_not_found_page\` (NOT 403, to prevent cross-org existence enumeration)

This PR consolidates that preamble in a single helper.

## Changes

- \`app/docs/_helpers.py\`: new \`resolve_draft(req, draft_id, *, action='view')\` returning either a \`ResolvedDraft\` (NamedTuple of draft + auth) on success or an opaque response object (Starlette Response or FastHTML FT element) on failure.
- \`ResolvedDraft\` is a NamedTuple class — discriminate with \`isinstance(result, ResolvedDraft)\`. (Critical: FastHTML FT elements are themselves plain tuples, so \`isinstance(..., tuple)\` would match both.)
- \`tests/test_docs_helpers.py\`: 7 unit tests covering each branch (auth fail / bad UUID / draft missing / cross-org authz fail / edit-action gate switch / success / tuple-unpack compatibility).

## Caller pattern

\`\`\`python
def some_draft_handler(req, draft_id):
    resolved = resolve_draft(req, draft_id)
    if not isinstance(resolved, ResolvedDraft):
        return resolved
    draft, auth = resolved.draft, resolved.auth
    ...
\`\`\`

## Migration note for follow-up PRs

Existing handlers keep working unchanged. Future PRs can convert them incrementally — each one will need to update the corresponding test patches from \`@patch('app.docs.routes.fetch_draft')\` to \`@patch('app.docs.draft_model.fetch_draft')\`, because the helper looks the function up via the source module rather than the re-imported name in routes.py. (The existing patch target stops working once the handler routes through the helper.)

## Verification

- \`uv run pytest\` — **1812 passed, 22 skipped**.
- \`uv run ruff check\` clean.
- \`uv run pyright app/docs/_helpers.py\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)