### PR TITLE
Phase 1: post-review remediation — 5 critical bugs from this session's PRs

### DIFF
--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -360,6 +360,8 @@ def _persist_partial_assistant(
     *,
     is_truncated: bool,
     error_suffix: str | None = None,
+    tokens_input: int | None = None,
+    tokens_output: int | None = None,
 ) -> uuid.UUID | None:
     """Persist a partial / truncated assistant message.
 
@@ -367,6 +369,13 @@ def _persist_partial_assistant(
     missing (migration 017 not yet applied) we fall back to a plain
     insert + WARNING. Returns the new message id on success or ``None``
     if persistence itself fails.
+
+    ``tokens_input`` / ``tokens_output`` capture the per-turn token
+    counts accumulated up to the point of cancellation/timeout (post-
+    review fix to #688). Without them every cancelled or timed-out turn
+    persisted the partial assistant row with NULL tokens despite the
+    LLM having produced billable output that ``_log_cost`` already
+    recorded in the ``llm_usage`` table.
     """
     if not full_content and not error_suffix:
         return None
@@ -384,6 +393,8 @@ def _persist_partial_assistant(
                 text,
                 model=model,
                 rag_context=rag_context_json,
+                tokens_input=tokens_input if tokens_input else None,
+                tokens_output=tokens_output if tokens_output else None,
             )
             if is_truncated:
                 try:
@@ -991,15 +1002,27 @@ class ChatOrchestrator:
                                 },
                             )
                         elif event.type == "stop":
-                            # #662: capture per-turn token counts so the
-                            # assistant message row records them. The
-                            # provider tallies these from message_start /
-                            # message_delta usage events; this is the
-                            # final hand-off to persistence.
+                            # #662 / post-review fix: capture per-round
+                            # token counts and OVERWRITE rather than
+                            # accumulate. Anthropic's
+                            # ``message_start.input_tokens`` reports the
+                            # FULL prompt for that round, which on a
+                            # multi-round tool-use turn includes the
+                            # original prompt PLUS every prior assistant
+                            # message PLUS every tool_result block.
+                            # Accumulating across N rounds would sum the
+                            # prompt-prefix N times.
+                            #
+                            # The persisted message-row tokens reflect
+                            # the FINAL round (the assistant content
+                            # actually shown to the user). Per-round
+                            # API-call costs are separately recorded one
+                            # row per call in ``llm_usage`` by
+                            # ``_log_cost`` inside the provider.
                             if event.tokens_input is not None:
-                                stream_state["tokens_in"] += event.tokens_input
+                                stream_state["tokens_in"] = event.tokens_input
                             if event.tokens_output is not None:
-                                stream_state["tokens_out"] += event.tokens_output
+                                stream_state["tokens_out"] = event.tokens_output
                             # Continue — the post-loop logic decides
                             # whether we're truly done (no pending tools).
 
@@ -1101,6 +1124,9 @@ class ChatOrchestrator:
             if stream_state["full_content"]:
                 # #660: psycopg is sync; offload the partial-persist so a
                 # cancellation handler doesn't block the event loop.
+                # Post-review fix to #688: forward the per-turn token
+                # counts captured so far so the assistant message row
+                # records billable tokens even on the deadline path.
                 await asyncio.to_thread(
                     _persist_partial_assistant,
                     conversation_id,
@@ -1109,6 +1135,8 @@ class ChatOrchestrator:
                     rag_context_json,
                     is_truncated=True,
                     error_suffix=" [Viga: serveri vastus võttis liiga kaua aega]",
+                    tokens_input=stream_state["tokens_in"],
+                    tokens_output=stream_state["tokens_out"],
                 )
             try:
                 await _safe_send(
@@ -1138,6 +1166,8 @@ class ChatOrchestrator:
                     getattr(self.llm, "_model", None),
                     rag_context_json,
                     is_truncated=True,
+                    tokens_input=stream_state["tokens_in"],
+                    tokens_output=stream_state["tokens_out"],
                 )
             )
             # #661: shield the stopped-event send from a second cancel so
@@ -1172,6 +1202,8 @@ class ChatOrchestrator:
                 getattr(self.llm, "_model", None),
                 rag_context_json,
                 is_truncated=True,
+                tokens_input=stream_state["tokens_in"],
+                tokens_output=stream_state["tokens_out"],
             )
             return
         except Exception:
@@ -1188,6 +1220,8 @@ class ChatOrchestrator:
                     rag_context_json,
                     is_truncated=True,
                     error_suffix=" [Viga: vastus katkestati]",
+                    tokens_input=stream_state["tokens_in"],
+                    tokens_output=stream_state["tokens_out"],
                 )
             try:
                 await _safe_send(

--- a/app/chat/websocket.py
+++ b/app/chat/websocket.py
@@ -36,58 +36,70 @@ logger = logging.getLogger(__name__)
 
 _MAX_MESSAGE_LENGTH = 10_000
 
-# #658 — server-side WS heartbeat. Emit a tiny ping every N seconds for
-# the lifetime of the connection so NAT idle timeouts / proxy idle-cuts
-# can't silently kill the socket during long RAG / LLM rounds.
+# #658 — server-side WS heartbeat. Emit a tiny ping every N seconds
+# during message handling so NAT idle timeouts / proxy idle-cuts can't
+# silently kill the socket during long RAG / LLM rounds.
 _WS_HEARTBEAT_INTERVAL_SECONDS = 25.0
 
-# #658 — per-connection heartbeat task registry. Keyed by id(send) so
-# we can cancel the heartbeat when the WS disconnects. ``id(send)`` is
-# stable for the lifetime of one connection (same pattern as the
-# existing ``_per_send_tasks`` registry below).
-_heartbeat_tasks: dict[int, asyncio.Task[None]] = {}
+# Bound the heartbeat ``send()`` call so a hung TCP send buffer (the
+# exact scenario the heartbeat is meant to detect) can't itself hang
+# the heartbeat task forever. Post-review fix to #684.
+_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS = 5.0
 
 
 def _start_heartbeat(send: Any) -> asyncio.Task[None]:
     """Spawn a background task that emits ``{"type": "ping"}`` every
     ``_WS_HEARTBEAT_INTERVAL_SECONDS``.
 
-    Returns the task so the caller can cancel it on disconnect. Send
-    errors are logged at DEBUG and swallowed — the task keeps ticking
-    so a transient send failure doesn't take down the heartbeat.
+    Returns the task so the caller can cancel it when message handling
+    completes. Self-terminates on the first send failure (post-review
+    fix to #684): once the socket is dead, every subsequent ``send``
+    will fail forever, so the loop is pointless. Each ``send`` is also
+    bounded by ``_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS`` so a hung TCP
+    buffer cannot hang the heartbeat indefinitely.
+
+    Lifetime is scoped to a single ``_ws_handler`` invocation
+    (per-message-handling) rather than to the whole WS connection.
+    NAT/proxy idle-cuts are only a concern *during* a long server-side
+    operation; an idle connection sends nothing in either direction and
+    is functionally unaffected by an absent heartbeat.
     """
 
     async def _beat() -> None:
         while True:
             try:
                 await asyncio.sleep(_WS_HEARTBEAT_INTERVAL_SECONDS)
-                await send(json.dumps({"type": "ping"}))
+                await asyncio.wait_for(
+                    send(json.dumps({"type": "ping"})),
+                    timeout=_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS,
+                )
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.debug("WS heartbeat send failed (continuing)", exc_info=True)
+                # Self-terminate: the socket is dead or the buffer is
+                # hung. Continuing the loop would just re-fail every
+                # 25s and accumulate noisy DEBUG logs forever.
+                logger.debug("WS heartbeat send failed; terminating", exc_info=True)
+                return
 
     task = asyncio.create_task(_beat())
     return task
 
 
 async def on_connect(send: Any) -> None:
-    """Called when a WebSocket client connects to /ws/chat."""
+    """Called when a WebSocket client connects to /ws/chat.
+
+    The heartbeat is now spawned inside ``_ws_handler`` per message
+    handling (see ``register_chat_ws_routes`` below) so this hook just
+    emits the initial ``connected`` event.
+    """
     logger.info("Chat WS client connected")
     await send(json.dumps({"type": "connected"}))
-    _heartbeat_tasks[id(send)] = _start_heartbeat(send)
 
 
 async def on_disconnect(send: Any) -> None:
     """Called when a WebSocket client disconnects."""
     logger.info("Chat WS client disconnected")
-    task = _heartbeat_tasks.pop(id(send), None)
-    if task is not None:
-        task.cancel()
-        try:
-            await task
-        except (asyncio.CancelledError, Exception):
-            pass
 
 
 async def ws_chat(
@@ -399,6 +411,17 @@ def register_chat_ws_routes(app: Any) -> None:
 
         key = id(send)
         tasks = _per_send_tasks.setdefault(key, {})
+        # Post-review fix to #684: spawn the heartbeat here (where
+        # ``send`` is the closure-local that ``_per_send_tasks`` keys
+        # off) rather than in the FastHTML ``conn``/``disconn`` hooks.
+        # Those hooks are separate ASGI invocations and may receive
+        # different ``send`` objects (each constructed as
+        # ``partial(_send_ws, conn)`` per call), so a registry keyed by
+        # ``id(send)`` cannot reliably pair register-with-cancel across
+        # them. Scoping the heartbeat to one ``_ws_handler`` invocation
+        # is also functionally sufficient: NAT idle timeouts only
+        # matter while a long server-side operation is in flight.
+        heartbeat = _start_heartbeat(send)
         try:
             await ws_chat(
                 msg,
@@ -414,6 +437,14 @@ def register_chat_ws_routes(app: Any) -> None:
             _cancel_all_and_drop(key)
             raise
         finally:
+            # Always cancel the heartbeat when message handling ends —
+            # success, exception, or graceful return — so we never leak
+            # background tasks beyond the request lifetime.
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except (asyncio.CancelledError, Exception):
+                pass
             # Drop the registry slot once no tasks are running. If a task
             # is still in-flight (normal mid-stream case) we leave it —
             # its own ``_run`` finally-block pops the conversation key

--- a/app/docs/_helpers.py
+++ b/app/docs/_helpers.py
@@ -30,11 +30,19 @@ from app.ui.theme import get_theme_from_request
 class ResolvedDraft(NamedTuple):
     """Result of a successful :func:`resolve_draft` call.
 
-    A real subclass (not a bare ``tuple[Draft, dict]``) so call sites can
-    discriminate via ``isinstance(result, ResolvedDraft)`` — important
-    because FastHTML FT elements (e.g. the 404 page returned on
-    auth/load/authz failure) are themselves plain tuples and would
-    otherwise match a tuple-based discriminator.
+    A typed ``NamedTuple`` (rather than a bare ``tuple[Draft, dict]``) so
+    call sites can discriminate the success branch from the failure
+    branch via ``isinstance(result, ResolvedDraft)``. The failure branch
+    returns an opaque response object (Starlette ``Response`` for auth
+    redirects, FastHTML FT element for the 404 page) and the typed
+    discriminator stays unambiguous regardless of what the failure side
+    returns. Future-proofs against fastcore versions where FT may
+    inherit from ``tuple``, and against ad-hoc ``(error, code)`` tuples
+    returned by any upstream helper.
+
+    Supports both attribute access (``resolved.draft``) and tuple
+    unpacking (``draft, auth = resolved``) — see the test in
+    ``tests/test_docs_helpers.py`` that locks in this dual API.
     """
 
     draft: Draft
@@ -92,8 +100,10 @@ def resolve_draft(
     appropriate response object — either a Starlette ``Response`` (auth
     redirect) or a FastHTML FT element from :func:`_not_found_page`.
 
-    Discriminate via ``isinstance(result, ResolvedDraft)`` (NOT plain
-    ``tuple`` — FT elements are tuples too)::
+    Discriminate via ``isinstance(result, ResolvedDraft)`` rather than
+    ``isinstance(result, tuple)`` — see :class:`ResolvedDraft` for the
+    rationale (typed discriminator that does not depend on whether the
+    failure-branch return type happens to subclass ``tuple``)::
 
         resolved = resolve_draft(req, draft_id)
         if not isinstance(resolved, ResolvedDraft):

--- a/app/llm/claude.py
+++ b/app/llm/claude.py
@@ -508,24 +508,28 @@ class ClaudeProvider(LLMProvider):
                         if usage:
                             tokens_input = getattr(usage, "input_tokens", 0)
 
-        self._log_cost(
-            feature=feature,
-            tokens_input=tokens_input,
-            tokens_output=tokens_output,
-            user_id=user_id,
-            org_id=org_id,
-        )
-
-        # #662: emit the per-turn token counts on the terminal stop
-        # event so the orchestrator can persist them on the assistant
-        # message row. The cost-tracker call above writes a separate
-        # llm_usage row; the message-level counts here are what the
-        # chat history shows in the UI ("input: 1234, output: 567").
-        yield StreamEvent(
-            type="stop",
-            tokens_input=tokens_input,
-            tokens_output=tokens_output,
-        )
+        # #662 / post-review fix: yield the stop event FIRST so the
+        # orchestrator can read the per-turn tokens off it and persist
+        # them on the assistant message row, then log_cost in a finally
+        # block so the llm_usage row is recorded even if the consumer
+        # cancels the generator immediately after receiving the stop
+        # frame. Previously cost was logged before the yield, so a
+        # cancel between the two left llm_usage incremented but the
+        # message row had NULL tokens — analytics drift across cancel.
+        try:
+            yield StreamEvent(
+                type="stop",
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
+            )
+        finally:
+            self._log_cost(
+                feature=feature,
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
+                user_id=user_id,
+                org_id=org_id,
+            )
 
 
 _default_provider: ClaudeProvider | None = None

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -872,6 +872,265 @@ class TestAssistantTokensPersistence:
         assert assistant_call.kwargs.get("tokens_input") is None
         assert assistant_call.kwargs.get("tokens_output") is None
 
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.execute_tool")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_multi_round_tool_use_persists_last_round_tokens(
+        self, mock_get_conn, mock_execute_tool, mock_create_msg
+    ):
+        """Anthropic's message_start.input_tokens reports the FULL
+        prompt for each tool-use round (including all prior turns and
+        tool_result blocks). If the orchestrator accumulated across
+        rounds the persisted total would sum the prompt-prefix N times.
+        Contract: persist the LAST round's tokens — the count that
+        corresponds to the assistant content actually shown.
+
+        Per-round costs are separately tallied one row per API call in
+        the ``llm_usage`` table by ``_log_cost`` inside the provider.
+        """
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        now = datetime.now(UTC)
+        call_counter = {"n": 0}
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+
+        def side_effect_fetchone():
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return base_conv_row
+            return (
+                uuid.uuid4(),
+                _CONV_ID,
+                "user",
+                "x",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                now,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        conn.execute.return_value.fetchone = side_effect_fetchone
+        conn.execute.return_value.fetchall.return_value = []
+        mock_create_msg.return_value = MagicMock(id=_MSG_ID)
+        mock_execute_tool.return_value = {"results": []}
+
+        # Two-round tool use: round 1 yields a tool_use + stop with
+        # 100/50 tokens; round 2 yields content + stop with 180/120 tokens
+        # (the round-2 prompt includes round-1's history, so 180 > 100
+        # is realistic for what Anthropic reports).
+        events_seq = [
+            [
+                StreamEvent(
+                    type="tool_use",
+                    tool_name="get_provision_details",
+                    tool_input={"provision_uri": "estleg:ks_113"},
+                    tool_use_id="toolu_round1",
+                ),
+                StreamEvent(type="stop", tokens_input=100, tokens_output=50),
+            ],
+            [
+                StreamEvent(type="content", delta="Lõplik vastus."),
+                StreamEvent(type="stop", tokens_input=180, tokens_output=120),
+            ],
+        ]
+        llm = FakeLLM(events_seq)
+        collector = _Collector()
+        orchestrator = ChatOrchestrator(llm, FakeSparql())
+        asyncio.run(orchestrator.handle_message(_CONV_ID, "Test", _auth(), collector))
+
+        assistant_calls = [
+            c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
+        ]
+        assert assistant_calls, "expected an assistant create_message call"
+        assistant_call = assistant_calls[-1]
+        # Last-round-wins: 180 (not 100+180=280) and 120 (not 50+120=170).
+        assert assistant_call.kwargs.get("tokens_input") == 180, (
+            f"expected last round's tokens_input=180, got "
+            f"{assistant_call.kwargs.get('tokens_input')}"
+        )
+        assert assistant_call.kwargs.get("tokens_output") == 120, (
+            f"expected last round's tokens_output=120, got "
+            f"{assistant_call.kwargs.get('tokens_output')}"
+        )
+
+
+class TestPartialPersistTokensCapture:
+    """Post-review fix to #688: every cancel/timeout path must forward the
+    accumulated tokens to ``_persist_partial_assistant`` so the partial
+    assistant row records billable usage instead of NULL."""
+
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_persist_partial_assistant_forwards_tokens_to_create_message(
+        self, mock_get_conn, mock_create_msg
+    ):
+        """Direct unit test on the helper: when called with non-zero
+        ``tokens_input`` / ``tokens_output``, ``create_message`` receives
+        the same values."""
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+        mock_create_msg.return_value = MagicMock(id=_MSG_ID)
+
+        result = _persist_partial_assistant(
+            _CONV_ID,
+            "partial content",
+            "fake-model",
+            None,
+            is_truncated=True,
+            tokens_input=234,
+            tokens_output=67,
+        )
+
+        assert result == _MSG_ID
+        mock_create_msg.assert_called_once()
+        kwargs = mock_create_msg.call_args.kwargs
+        assert kwargs.get("tokens_input") == 234
+        assert kwargs.get("tokens_output") == 67
+
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_persist_partial_assistant_passes_none_for_zero_tokens(
+        self, mock_get_conn, mock_create_msg
+    ):
+        """Falsy-check semantics: ``tokens_input=0`` is forwarded as
+        ``None`` so stub-mode and pre-stream-cancel scenarios don't
+        pollute analytics with fake zeroes."""
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+        mock_create_msg.return_value = MagicMock(id=_MSG_ID)
+
+        _persist_partial_assistant(
+            _CONV_ID,
+            "partial",
+            None,
+            None,
+            is_truncated=True,
+            tokens_input=0,
+            tokens_output=0,
+        )
+
+        kwargs = mock_create_msg.call_args.kwargs
+        assert kwargs.get("tokens_input") is None
+        assert kwargs.get("tokens_output") is None
+
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_cancel_path_persists_tokens_captured_so_far(self, mock_get_conn, mock_create_msg):
+        """End-to-end: CancelledError mid-stream-loop must call
+        ``_persist_partial_assistant`` with the tokens from whatever
+        stop events fired before the cancel arrived."""
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        now = datetime.now(UTC)
+        call_counter = {"n": 0}
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+
+        def side_effect_fetchone():
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return base_conv_row
+            return (
+                uuid.uuid4(),
+                _CONV_ID,
+                "user",
+                "x",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                now,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        conn.execute.return_value.fetchone = side_effect_fetchone
+        conn.execute.return_value.fetchall.return_value = []
+        mock_create_msg.return_value = MagicMock(id=_MSG_ID)
+
+        # LLM emits content + a stop with tokens, then on the FOLLOW-UP
+        # round the orchestrator would loop again; we simulate cancel by
+        # raising CancelledError on the second astream call.
+        class CancellingLLM(FakeLLM):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            async def astream(self, prompt, **kwargs):
+                self._calls += 1
+                if self._calls == 1:
+                    yield StreamEvent(type="content", delta="Esimene osa.")
+                    yield StreamEvent(
+                        type="tool_use",
+                        tool_name="search_provisions",
+                        tool_input={"query": "x"},
+                        tool_use_id="toolu_1",
+                    )
+                    yield StreamEvent(type="stop", tokens_input=300, tokens_output=80)
+                else:
+                    raise asyncio.CancelledError()
+
+        with patch("app.chat.orchestrator.execute_tool", return_value={"results": []}):
+            llm = CancellingLLM()
+            collector = _Collector()
+            orchestrator = ChatOrchestrator(llm, FakeSparql())
+            try:
+                asyncio.run(orchestrator.handle_message(_CONV_ID, "Test", _auth(), collector))
+            except asyncio.CancelledError:
+                pass  # expected — orchestrator re-raises after persist
+
+        # The orchestrator should have persisted a partial assistant row
+        # via the CancelledError handler with the tokens captured from
+        # round 1's stop event.
+        assistant_calls = [
+            c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
+        ]
+        assert assistant_calls, "CancelledError path must persist a partial assistant row"
+        # Last call is the partial-persist (round 1's stop set tokens=300/80).
+        assistant_call = assistant_calls[-1]
+        assert assistant_call.kwargs.get("tokens_input") == 300
+        assert assistant_call.kwargs.get("tokens_output") == 80
+
 
 class TestOrchestratorPartialPersistence:
     """M1: Partial message should be persisted with error suffix on LLM failure."""

--- a/tests/test_chat_websocket_heartbeat.py
+++ b/tests/test_chat_websocket_heartbeat.py
@@ -45,28 +45,67 @@ def test_heartbeat_emits_ping_on_interval(monkeypatch) -> None:
     assert len(pings) >= 2, f"expected at least 2 pings in 180ms, got {len(pings)}: {received}"
 
 
-def test_heartbeat_swallows_send_errors(monkeypatch) -> None:
-    """Heartbeat survives a transient send failure without crashing."""
+def test_heartbeat_self_terminates_on_send_error(monkeypatch) -> None:
+    """Post-review fix to #684: once ``send`` raises, the socket is
+    almost certainly dead and looping forever just spams DEBUG logs and
+    leaks a background task. The heartbeat must self-terminate cleanly
+    on the first send failure."""
     monkeypatch.setattr(ws_mod, "_WS_HEARTBEAT_INTERVAL_SECONDS", 0.02)
 
     calls: list[int] = []
 
-    async def flaky_send(payload: str) -> None:
+    async def always_failing_send(payload: str) -> None:
         calls.append(len(calls))
-        if len(calls) == 2:
-            raise RuntimeError("transient")
+        raise RuntimeError("socket closed")
 
-    async def _run() -> None:
-        task = _start_heartbeat(flaky_send)
-        try:
-            await asyncio.sleep(0.1)
-        finally:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+    async def _run() -> asyncio.Task[None]:
+        task = _start_heartbeat(always_failing_send)
+        # Give the loop enough time to attempt several pings IF it were
+        # going to retry. With the self-terminate contract it should
+        # have exited after the very first failure.
+        await asyncio.sleep(0.1)
+        return task
 
-    asyncio.run(_run())
+    task = asyncio.run(_run())
 
-    assert len(calls) >= 3, "heartbeat must keep ticking after a send error"
+    # The task must have completed on its own (no cancel needed).
+    assert task.done(), "heartbeat must self-terminate after first send error"
+    # Only one send call should have happened — the one that raised.
+    assert len(calls) == 1, (
+        f"expected the heartbeat to abort after the first failure, got {len(calls)} calls"
+    )
+
+
+def test_heartbeat_send_is_bounded_by_timeout(monkeypatch) -> None:
+    """Post-review fix to #684: a hung TCP send buffer must not hang
+    the heartbeat. The send is wrapped in ``asyncio.wait_for`` with a
+    short timeout, after which the heartbeat self-terminates (since the
+    timeout indicates the socket is dead)."""
+    monkeypatch.setattr(ws_mod, "_WS_HEARTBEAT_INTERVAL_SECONDS", 0.02)
+    monkeypatch.setattr(ws_mod, "_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS", 0.05)
+
+    sends_started: list[float] = []
+
+    async def hanging_send(payload: str) -> None:
+        sends_started.append(asyncio.get_event_loop().time())
+        await asyncio.sleep(3600)  # would hang forever without wait_for
+
+    async def _run() -> tuple[asyncio.Task[None], float]:
+        task = _start_heartbeat(hanging_send)
+        # Wait long enough for sleep+send_timeout to fire and the loop
+        # to self-terminate via the TimeoutError path.
+        started = asyncio.get_event_loop().time()
+        await asyncio.sleep(0.2)
+        elapsed = asyncio.get_event_loop().time() - started
+        return task, elapsed
+
+    task, elapsed = asyncio.run(_run())
+
+    # Heartbeat self-terminated via the wait_for timeout path.
+    assert task.done(), "heartbeat must self-terminate when send hangs past the timeout"
+    # Real-time elapsed bounded; the test isn't hung.
+    assert elapsed < 1.0, "test must not hang waiting on the send"
+    # send was attempted at least once — the timeout cancelled it
+    # mid-flight which counts as a send-error for our self-terminate
+    # logic.
+    assert len(sends_started) >= 1


### PR DESCRIPTION
This PR closes the **5 critical findings** from the post-session code review (which audited PRs #683, #684, #685, #686, #688, #689 for cumulative integration bugs).

## Findings addressed

### C1 — Token persistence dropped on every non-success path
**Discovered by:** orchestrator integration review.
\`_persist_partial_assistant\` had no \`tokens_input\`/\`tokens_output\` parameters. All four cancel/timeout call sites (turn deadline, CancelledError, WebSocketSendTimeout, generic Exception) saved NULL tokens despite #688 plumbing them through StreamEvent. The most common cancel case (user clicks Stop mid-response) showed a truncated message with NULL tokens even though the LLM produced billable output.

**Fix:** signature extension + 4 forward-passes + 3 regression tests covering the helper directly, the 0→None falsy semantics, and the end-to-end cancel path.

### C2 — WS heartbeat task leak
**Discovered by:** WS lifecycle review.
\`_heartbeat_tasks\` was keyed by \`id(send)\`, which is unstable across FastHTML's separate-ASGI-invocation \`on_connect\` and \`on_disconnect\` hooks. Every chat connection leaked a heartbeat task that pinged a stale connection every 25s forever, swallowing errors.

**Fix:**
- Move \`_start_heartbeat\` into \`_ws_handler\` (where the \`send\` closure-local IS stable, mirroring \`_per_send_tasks\`); \`finally\` block cancels on every exit path.
- Self-terminate on first send error — a dead socket means continuing the loop is pointless.
- Wrap each \`send\` in \`asyncio.wait_for(5s)\` so a hung TCP buffer can't hang the heartbeat itself (the exact scenario it's meant to detect).
- Test rewritten: \`test_heartbeat_self_terminates_on_send_error\` + \`test_heartbeat_send_is_bounded_by_timeout\`. Original cadence test preserved.

### C3 — \`_log_cost\` ordering loses tokens on consumer cancel
**Discovered by:** LLM provider review.
\`ClaudeProvider.astream\` called \`_log_cost\` BEFORE yielding the stop StreamEvent. A consumer cancel between the two left \`llm_usage\` incremented but the message row had NULL tokens — analytics drift across cancel.

**Fix:** yield stop FIRST, run \`_log_cost\` in a \`finally\` block. Cost-logging now survives consumer cancel; the stop event still reaches the orchestrator first.

### C4 — Multi-round token accumulation double-counted
**Discovered by:** LLM provider review.
Anthropic's \`message_start.input_tokens\` reports the FULL prompt for each tool-use round (including history + prior tool_results). Accumulating with \`+=\` summed the prompt-prefix N times — the persisted message-row total didn't match any single \`llm_usage\` row.

**Fix:** \`+=\` → \`=\` (last-round-wins, matches the assistant content actually shown). Per-round costs remain correctly tallied per row in \`llm_usage\` by the provider's \`_log_cost\`. Comment in the orchestrator now documents the contract.

**New test:** \`test_multi_round_tool_use_persists_last_round_tokens\` — 2-round tool use, asserts the assistant row has round-2 tokens (180/120) not the cumulative sum (280/170).

### C5 — \`resolve_draft\` docstring rationale was factually wrong
**Discovered by:** docs helper review.
Claimed FT elements are tuple subclasses requiring NamedTuple discriminator. Verified at runtime: \`isinstance(ft, tuple) == False\` on current fastcore. The NamedTuple is still the right design (typed, attribute-access, unpack-friendly), but the docstring would mislead future contributors.

**Fix:** rewrote both the class and function docstrings with the accurate rationale (typed discriminator that doesn't depend on whether the failure-branch return value happens to subclass tuple; future-proof against fastcore upgrades + ad-hoc tuple returns from upstream helpers).

## Verification

- \`uv run pytest\` — **1817 passed, 22 skipped** (was 1812; this PR adds 5 new tests).
- \`uv run ruff check\` clean on all touched files.
- \`uv run pyright\` clean on all touched files.

## Files changed

- \`app/chat/orchestrator.py\` — C1 + C4
- \`app/chat/websocket.py\` — C2
- \`app/llm/claude.py\` — C3
- \`app/docs/_helpers.py\` — C5
- \`tests/test_chat_orchestrator.py\` — 4 new tests (C1 + C4)
- \`tests/test_chat_websocket_heartbeat.py\` — rewritten 1 test, added 1 (C2)

## What's NOT in this PR (Phase 2)

The post-review plan also surfaced "Important" findings that ship in Phase 2:
- Estonian diacritic regression (õ vs o)
- \`asyncio.wait_for\` + \`to_thread\` thread leak under load
- Pre-stream global deadline budget
- HX-Refresh + dead HX-Trigger interaction
- \`action: Literal["view", "edit"]\` on \`resolve_draft\`
- \`_load_impact_summary\` ordering (latent regression risk)

These are bundled in the next planned PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)