### PR TITLE
feat(docs): WebSocket push for draft pipeline status updates (#608)

### DIFF
--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -164,6 +164,13 @@ def analyze_impact(
             )
             conn.commit()
 
+        # #608: push the terminal status to subscribed WS clients first
+        # (cheap; a notify_analysis_done failure shouldn't drop the WS
+        # event).
+        from app.docs.status_events import emit_threadsafe
+
+        emit_threadsafe(draft_id, type="status", status="ready")
+
         # Notify the draft owner that analysis is complete.
         try:
             from app.notifications.wire import notify_analysis_done
@@ -318,6 +325,17 @@ def _mark_draft_failed(draft_id: UUID, exc: BaseException) -> None:
             conn.commit()
     except Exception:  # noqa: BLE001
         logger.exception("analyze_impact: failed to mark draft %s as failed", draft_id)
+        return
+
+    # #608: push the failure transition to WS subscribers.
+    from app.docs.status_events import emit_threadsafe
+
+    emit_threadsafe(
+        draft_id,
+        type="status",
+        status="failed",
+        error_message=user_msg[:500],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/docs/extract_handler.py
+++ b/app/docs/extract_handler.py
@@ -164,6 +164,11 @@ def extract_entities(
             )
             conn.commit()
 
+        # #608: push the new status to subscribed WS clients.
+        from app.docs.status_events import emit_threadsafe
+
+        emit_threadsafe(draft_id, type="status", status="analyzing")
+
         # -- 6. Enqueue next step --------------------------------------
         JobQueue().enqueue("analyze_impact", {"draft_id": str(draft_id)}, priority=0)
 
@@ -199,6 +204,16 @@ def extract_entities(
                 logger.exception(
                     "extract_entities: failed to mark draft %s as failed",
                     draft_id,
+                )
+            else:
+                # #608: notify WS subscribers of the failure transition.
+                from app.docs.status_events import emit_threadsafe
+
+                emit_threadsafe(
+                    draft_id,
+                    type="status",
+                    status="failed",
+                    error_message=user_msg[:500],
                 )
         else:
             logger.warning(

--- a/app/docs/parse_handler.py
+++ b/app/docs/parse_handler.py
@@ -151,6 +151,13 @@ def parse_draft(
             )
             conn.commit()
 
+        # #608: push the new status to any subscribed WS clients. The
+        # call is best-effort; failures are swallowed so the pipeline
+        # is unaffected.
+        from app.docs.status_events import emit_threadsafe
+
+        emit_threadsafe(draft_id, type="status", status="extracting")
+
         # Step 7: enqueue the next stage. A failure here should not
         # leave the draft in 'extracting' without a pending job, so we
         # let the exception propagate and mark the draft failed below.
@@ -238,6 +245,19 @@ def _mark_draft_failed(draft_id: UUID, exc: BaseException) -> None:
             conn.commit()
     except Exception:  # noqa: BLE001 — best-effort cleanup
         logger.exception("Failed to mark draft %s as failed", draft_id)
+        return
+
+    # #608: notify WS subscribers of the failure transition so the UI
+    # can swap the status tracker without waiting for the 3s polling
+    # tick. Best-effort — never raise into the pipeline.
+    from app.docs.status_events import emit_threadsafe
+
+    emit_threadsafe(
+        draft_id,
+        type="status",
+        status="failed",
+        error_message=user_msg[:500],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/docs/routes.py
+++ b/app/docs/routes.py
@@ -530,6 +530,21 @@ def _status_tracker(draft: Draft):
     # assistive tech reads just the changed node instead of the whole
     # tracker. The existing failed-state Alert still carries
     # ``role="alert"`` for the more urgent announcement.
+    # #608: marker for the WS push listener. ``draft-status.js`` finds
+    # this attribute on DOMContentLoaded, opens a WebSocket to
+    # /ws/drafts/status, subscribes to ``draft.id`` and swaps the
+    # tracker on every status event. The hx-* polling attributes above
+    # are deliberately preserved so the page degrades to 3s polling if
+    # the WS is unavailable. The marker is dropped once the draft
+    # reaches a terminal status — at that point the JS will already
+    # have closed the WS and there's nothing more to push.
+    ws_attrs: dict[str, Any] = {}
+    if draft.status not in _TERMINAL_STATUSES:
+        ws_attrs = {
+            "data_draft_status_ws": "1",
+            "data_draft_id": str(draft.id),
+        }
+
     return Div(  # noqa: F405
         *children,
         id=f"draft-status-{draft.id}",
@@ -537,6 +552,7 @@ def _status_tracker(draft: Draft):
         aria_live="polite",
         aria_atomic="false",
         **poll_attrs,
+        **ws_attrs,
     )
 
 
@@ -2176,6 +2192,11 @@ def draft_detail_page(req: Request, draft_id: str):
         _vtk_children_card(draft, children=vtk_children, uploader_index=uploader_index)
         if draft.doc_type == "vtk"
         else "",
+        # #608: client-side WS listener for live status pushes.
+        # Self-initialises off the data-draft-id marker on the
+        # status-tracker Div; gracefully no-ops if the WS fails so
+        # the existing 3s polling continues unaffected.
+        Script(src="/static/js/draft-status.js", defer=True),  # noqa: F405
         title=draft.title,
         user=auth,
         theme=theme,

--- a/app/docs/status_events.py
+++ b/app/docs/status_events.py
@@ -1,0 +1,214 @@
+"""In-memory pub/sub for draft pipeline status events (#608).
+
+The chat module's WebSocket layer is one-shot per message; the draft
+status WS is the opposite — a long-lived subscription that fires
+whenever the worker thread transitions a draft through one of its
+pipeline stages (``uploaded`` → ``parsing`` → ``extracting`` →
+``analyzing`` → ``ready`` / ``failed``).
+
+The worker thread runs in the same Python process as the web server
+(see CLAUDE.md: "FOR UPDATE SKIP LOCKED job queue with worker thread"),
+so an in-memory broadcast is sufficient for current single-process
+deployment. If/when uvicorn ever runs multiple workers, this module is
+where Postgres ``LISTEN`` / ``NOTIFY`` would slot in — the public
+``subscribe`` / ``emit`` API stays the same; only the internal
+fan-out becomes cross-process.
+
+Cross-thread safety
+-------------------
+
+Subscribers are async send callables registered from the WS layer
+(running on the asyncio event loop). Emits originate from two places:
+
+1. The same event loop — when a handler running in async context
+   needs to publish (rare: only the boot-time replay if any).
+2. The sync worker thread — every pipeline status transition.
+
+For (1) the public ``emit`` coroutine is awaited directly. For (2)
+the helper ``emit_threadsafe`` schedules the coroutine onto the web
+event loop via ``asyncio.run_coroutine_threadsafe``. The web process
+captures the loop reference at startup via ``register_event_loop``.
+
+The dispatch itself uses ``asyncio.gather(..., return_exceptions=True)``
+so a single broken subscriber doesn't drop events for the rest. Dead
+subscribers are silently removed when their send raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Type alias for the per-connection send callable. Mirrors the shape
+# the FastHTML WS handler hands us: an async callable that accepts a
+# string payload and returns nothing.
+SendCallable = Callable[[str], Awaitable[None]]
+
+
+# Per-draft subscriber registry. Keyed by ``str(draft_id)`` so callers
+# don't have to remember whether they hold a UUID or a str.
+_subscribers: dict[str, set[SendCallable]] = {}
+
+# Lock around _subscribers mutation. asyncio.Lock is used (not a
+# threading.Lock) because all reads + writes happen on the event loop.
+# The cross-thread emit path schedules a coroutine onto the loop so it
+# enters this critical section the same way as in-loop callers.
+_subscribers_lock = asyncio.Lock()
+
+
+# The web process's event loop, captured at startup. ``emit_threadsafe``
+# schedules coroutines onto this loop from worker threads. ``None``
+# means we're running in a context that hasn't called
+# :func:`register_event_loop` yet (test mode, or a stub run); in that
+# case ``emit_threadsafe`` becomes a logged no-op.
+_event_loop: asyncio.AbstractEventLoop | None = None
+
+
+def register_event_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Capture the web process's event loop.
+
+    Called once at startup from the FastHTML lifespan/init hook. The
+    worker thread uses this reference to schedule
+    :func:`emit_threadsafe` coroutines onto the right loop.
+    """
+    global _event_loop
+    _event_loop = loop
+
+
+async def subscribe(draft_id: Any, send: SendCallable) -> None:
+    """Register *send* as a subscriber for status events on *draft_id*.
+
+    Idempotent: registering the same callable twice is a no-op (the
+    underlying ``set`` deduplicates).
+    """
+    key = str(draft_id)
+    async with _subscribers_lock:
+        _subscribers.setdefault(key, set()).add(send)
+
+
+async def unsubscribe(draft_id: Any, send: SendCallable) -> None:
+    """Remove *send* from the subscriber set for *draft_id*.
+
+    Idempotent: unsubscribing a callable that isn't registered is a
+    no-op. The slot is dropped entirely once it's empty so the registry
+    doesn't accumulate dead keys.
+    """
+    key = str(draft_id)
+    async with _subscribers_lock:
+        bucket = _subscribers.get(key)
+        if bucket is None:
+            return
+        bucket.discard(send)
+        if not bucket:
+            _subscribers.pop(key, None)
+
+
+async def emit(draft_id: Any, **payload: Any) -> None:
+    """Broadcast a status event to every subscriber of *draft_id*.
+
+    The ``payload`` keyword args are merged with the draft id and JSON-
+    encoded; typical shape::
+
+        await emit(
+            draft_id,
+            type="status",
+            status="ready",
+            error_message=None,
+        )
+
+    Dead subscribers (send raised) are silently removed so transient
+    socket failures don't accumulate noise. Non-existent draft ids are
+    a no-op (no subscribers = nothing to do).
+    """
+    key = str(draft_id)
+    async with _subscribers_lock:
+        # Snapshot the bucket so we can iterate without holding the
+        # lock while awaiting per-subscriber sends.
+        bucket = _subscribers.get(key)
+        targets = list(bucket) if bucket else []
+
+    if not targets:
+        return
+
+    event_payload = {"draft_id": key, **payload}
+    encoded = json.dumps(event_payload, default=str)
+
+    # Fan out concurrently; collect exceptions per-subscriber so one
+    # broken socket doesn't drop the event for the rest.
+    results = await asyncio.gather(
+        *(send(encoded) for send in targets),
+        return_exceptions=True,
+    )
+
+    # Reap any subscribers whose send raised. Holding the lock again
+    # is fine — small contention window vs. leaking dead callables.
+    dead = [
+        send
+        for send, result in zip(targets, results, strict=False)
+        if isinstance(result, Exception)
+    ]
+    if dead:
+        async with _subscribers_lock:
+            bucket = _subscribers.get(key)
+            if bucket is not None:
+                for send in dead:
+                    bucket.discard(send)
+                if not bucket:
+                    _subscribers.pop(key, None)
+        logger.debug("draft-status: removed %d dead subscribers for draft=%s", len(dead), key)
+
+
+def emit_threadsafe(draft_id: Any, **payload: Any) -> None:
+    """Schedule :func:`emit` onto the web event loop from a worker thread.
+
+    The pipeline handlers (``parse_handler``, ``extract_handler``,
+    ``analyze_handler``) run in a worker thread separate from the
+    asyncio event loop. They call this helper on every status
+    transition; it dispatches the actual fan-out onto the loop via
+    ``asyncio.run_coroutine_threadsafe``.
+
+    Failures are logged at DEBUG and swallowed — a stale subscriber or
+    a missing event loop must never break the pipeline. The pipeline
+    is the source of truth; the WS push is best-effort UX glue.
+    """
+    if _event_loop is None:
+        # Web process hasn't started its event loop yet (or this is a
+        # stub run / test). Drop silently.
+        logger.debug(
+            "draft-status: emit_threadsafe called before register_event_loop "
+            "(draft=%s payload=%s) — dropping",
+            draft_id,
+            payload,
+        )
+        return
+
+    try:
+        asyncio.run_coroutine_threadsafe(emit(draft_id, **payload), _event_loop)
+    except RuntimeError:
+        # Loop closed mid-flight (shutdown). Pipeline keeps running.
+        logger.debug("draft-status: event loop closed while emitting draft=%s", draft_id)
+    except Exception:
+        # Defence in depth — never raise into the pipeline.
+        logger.debug(
+            "draft-status: emit_threadsafe failed for draft=%s",
+            draft_id,
+            exc_info=True,
+        )
+
+
+async def subscriber_count(draft_id: Any) -> int:
+    """Return the number of active subscribers for *draft_id*.
+
+    Test-only helper. Kept on the public API so tests don't have to
+    poke at private state.
+    """
+    key = str(draft_id)
+    async with _subscribers_lock:
+        bucket = _subscribers.get(key)
+        return len(bucket) if bucket else 0

--- a/app/docs/websocket.py
+++ b/app/docs/websocket.py
@@ -1,0 +1,271 @@
+"""WebSocket endpoint for live draft pipeline status updates (#608).
+
+Same FastHTML ``app.ws()`` pattern as ``app/chat/websocket.py`` and
+``app/explorer/websocket.py``. Handshake auth comes from the JWT
+access-token cookie (refresh-rotated transparently — see chat module
+for the full pattern). Path is ``/ws/drafts/status``; clients send a
+``{"type": "subscribe", "draft_id": "<uuid>"}`` message after the
+``connected`` event to start receiving status events for that draft.
+
+Subscription model
+------------------
+
+One connection, one draft. The detail page renders a small client
+script that opens this WS, sends the subscribe message for the draft
+on screen, and swaps the status tracker fragment via HTMX whenever a
+``{"type": "status", ...}`` event arrives. Cross-tab updates fall out
+of the in-memory subscriber set automatically: if user A has the
+draft open in two tabs, both connections subscribe and both receive.
+
+Cross-org safety
+----------------
+
+Before adding a connection to the subscriber registry the handler
+runs the same authorisation check used by the HTTP detail page
+(:func:`app.auth.policy.can_view_draft`). A user from another org
+hitting this endpoint with an arbitrary draft id receives a single
+``error`` frame and the socket closes — they never get added to the
+broadcast list.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from http.cookies import SimpleCookie
+from typing import Any
+
+from app.auth.jwt_provider import JWTAuthProvider
+from app.auth.policy import can_view_draft
+from app.docs import status_events
+from app.docs.draft_model import fetch_draft
+
+logger = logging.getLogger(__name__)
+
+
+# Heartbeat — same shape as the chat module's per-handler heartbeat
+# (post-review fix to #684). Keeps NAT idle timeouts from dropping the
+# socket during long pipeline phases (analyze can run several
+# minutes for large drafts).
+_WS_HEARTBEAT_INTERVAL_SECONDS = 25.0
+_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS = 5.0
+
+
+def _start_heartbeat(send: Any) -> asyncio.Task[None]:
+    """Spawn a periodic ``{"type": "ping"}`` task for the lifetime of
+    the WS handler invocation. Self-terminates on first send error."""
+
+    async def _beat() -> None:
+        while True:
+            try:
+                await asyncio.sleep(_WS_HEARTBEAT_INTERVAL_SECONDS)
+                await asyncio.wait_for(
+                    send(json.dumps({"type": "ping"})),
+                    timeout=_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug(
+                    "draft-status WS heartbeat send failed; terminating",
+                    exc_info=True,
+                )
+                return
+
+    return asyncio.create_task(_beat())
+
+
+def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) -> str | None:
+    """Parse a single named cookie out of raw ASGI ``Cookie`` headers."""
+    for hdr_name, hdr_value in headers:
+        if hdr_name.lower() == b"cookie":
+            cookie: SimpleCookie = SimpleCookie()
+            cookie.load(hdr_value.decode("latin-1"))
+            morsel = cookie.get(name)
+            if morsel is not None:
+                return morsel.value
+    return None
+
+
+async def _ws_close(send: Any, code: int, reason: str) -> None:
+    """Best-effort WS close. Mirrors the chat module's helper.
+
+    The ASGI ``websocket.close`` envelope is the canonical close path;
+    if the runtime prefers a different shape we fall back to sending a
+    JSON error event before exiting.
+    """
+    try:
+        await send({"type": "websocket.close", "code": code, "reason": reason})
+    except Exception:
+        try:
+            await send(json.dumps({"type": "error", "message": reason, "code": code}))
+        except Exception:
+            logger.debug("draft-status WS close fallback failed", exc_info=True)
+
+
+async def ws_draft_status(
+    msg: str,
+    send: Any,
+    scope: dict[str, Any] | None = None,
+) -> None:
+    """Handle one client message on ``/ws/drafts/status``.
+
+    Expected envelope::
+
+        {"type": "subscribe", "draft_id": "<uuid>"}
+
+    On a valid subscribe the handler:
+    1. Authorises the caller against the draft via
+       :func:`can_view_draft` (404-style: drop the connection on miss
+       so we don't leak existence of out-of-scope drafts).
+    2. Registers the ``send`` callable in :mod:`app.docs.status_events`.
+    3. Pushes the current status as a one-shot ``initial`` event so
+       the client doesn't have to wait for the next transition.
+    4. Holds the connection open until the FastHTML wrapper tears it
+       down (handler return / cancellation / disconnect).
+
+    Auth is extracted by the wrapper in
+    :func:`register_draft_ws_routes`; this handler trusts ``scope['auth']``.
+    """
+    try:
+        data = json.loads(msg)
+    except (json.JSONDecodeError, TypeError):
+        await send(json.dumps({"type": "error", "message": "Vigane JSON."}))
+        return
+
+    if not isinstance(data, dict):
+        await send(json.dumps({"type": "error", "message": "Vigane sõnum."}))
+        return
+
+    if data.get("type") != "subscribe":
+        # Other message types are silently ignored — keeps the API
+        # forwards-compatible with future operations like "unsubscribe".
+        return
+
+    raw_draft_id = data.get("draft_id")
+    if not raw_draft_id:
+        await send(json.dumps({"type": "error", "message": "Puudub draft_id."}))
+        return
+
+    try:
+        draft_id = uuid.UUID(str(raw_draft_id))
+    except (ValueError, TypeError):
+        await send(json.dumps({"type": "error", "message": "Vigane draft_id."}))
+        return
+
+    auth = (scope or {}).get("auth") or {}
+    if not auth.get("id"):
+        await send(json.dumps({"type": "error", "message": "Autentimine nõutav."}))
+        return
+
+    # Authorisation: same gate as the HTTP detail page. We drop the
+    # subscription request on a denial without leaking whether the
+    # draft exists.
+    draft = fetch_draft(draft_id)
+    if draft is None or not can_view_draft(auth, draft):
+        await send(json.dumps({"type": "error", "message": "Eelnõu ei leitud."}))
+        return
+
+    # Subscribe + send initial state. The client uses ``initial`` to
+    # paint the tracker without waiting for the next transition.
+    await status_events.subscribe(draft_id, send)
+    await send(
+        json.dumps(
+            {
+                "type": "initial",
+                "draft_id": str(draft_id),
+                "status": draft.status,
+                "error_message": getattr(draft, "error_message", None),
+            },
+            default=str,
+        )
+    )
+
+    # Hold the handler open until cancellation. The FastHTML WS
+    # wrapper invokes us per-message; subsequent messages from the
+    # client (or disconnect) reach us through new invocations or via
+    # the wrapper's exception/finally path. Without this hold the
+    # handler returns immediately and our subscription is torn down
+    # by the caller's finally block — the client would never receive
+    # a status event because nobody is keeping the slot alive.
+    #
+    # In practice: this awaits forever; the caller's exception/cancel
+    # path runs the finally block which unsubscribes us cleanly.
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await status_events.unsubscribe(draft_id, send)
+
+
+def register_draft_ws_routes(app: Any) -> None:
+    """Mount the draft-status WS at ``/ws/drafts/status``.
+
+    Mirrors :func:`app.chat.websocket.register_chat_ws_routes`: we
+    install a wrapper that does cookie-based JWT auth on each
+    invocation, then delegates the message body to
+    :func:`ws_draft_status`. Connection-level lifecycle hooks
+    (``conn``, ``disconn``) are no-ops here because all per-connection
+    state lives in the subscriber registry, which is keyed by the
+    closure-local ``send`` and torn down in
+    :func:`ws_draft_status`'s finally block.
+    """
+    _jwt_provider: list[JWTAuthProvider | None] = [None]
+
+    def _get_jwt_provider() -> JWTAuthProvider | None:
+        if _jwt_provider[0] is None:
+            try:
+                _jwt_provider[0] = JWTAuthProvider()
+            except Exception:
+                logger.error(
+                    "draft-status WS: failed to construct JWTAuthProvider",
+                    exc_info=True,
+                )
+                return None
+        return _jwt_provider[0]
+
+    async def _ws_handler(msg: str, send: Any, scope: dict[str, Any] | None = None) -> None:
+        auth_scope: dict[str, Any] = {}
+
+        if scope is not None:
+            raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+            access_token = _extract_cookie_from_headers(raw_headers, "access_token")
+            refresh_token = _extract_cookie_from_headers(raw_headers, "refresh_token")
+
+            if access_token or refresh_token:
+                provider = _get_jwt_provider()
+                if provider is None:
+                    await _ws_close(send, 1011, "auth provider unavailable")
+                    return
+
+                user: dict[str, Any] | None = None
+                if access_token:
+                    verified = provider.get_current_user(access_token)
+                    if verified is not None:
+                        user = dict(verified)
+
+                if user is None and refresh_token:
+                    # Same silent-refresh shape as the chat WS (#637).
+                    from app.auth.middleware import verify_refresh_token_user
+
+                    refreshed_user = verify_refresh_token_user(refresh_token, provider=provider)
+                    if refreshed_user is not None:
+                        user = refreshed_user
+
+                if user is not None:
+                    auth_scope["auth"] = user
+
+        # Heartbeat scoped to this handler invocation, mirroring the
+        # chat pattern (post-review fix to #684).
+        heartbeat = _start_heartbeat(send)
+        try:
+            await ws_draft_status(msg, send, auth_scope if auth_scope else None)
+        finally:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    app.ws("/ws/drafts/status")(_ws_handler)

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from app.chat.routes import register_chat_routes
 from app.chat.websocket import register_chat_ws_routes
 from app.docs.report_routes import register_report_routes
 from app.docs.routes import register_draft_routes
+from app.docs.websocket import register_draft_ws_routes
 from app.drafter.routes import register_drafter_routes
 from app.explorer.pages import explorer_page, register_explorer_pages
 from app.explorer.routes import register_explorer_routes
@@ -84,6 +85,24 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
             logger.warning("Marked %d stale 'running' sync_log row(s) as failed", stale)
     except Exception:
         logger.exception("Startup: stale sync_log cleanup failed (non-critical)")
+
+    # #608: capture the running event loop so the sync pipeline worker
+    # thread can schedule WS broadcast coroutines via
+    # ``asyncio.run_coroutine_threadsafe``. Done unconditionally — even
+    # if the worker is disabled (test mode), an in-process emit can
+    # still happen if/when somebody triggers a status transition from
+    # an async route.
+    try:
+        import asyncio as _asyncio
+
+        from app.docs import status_events as _status_events
+
+        _status_events.register_event_loop(_asyncio.get_running_loop())
+    except Exception:
+        logger.debug(
+            "Failed to register event loop for draft status events",
+            exc_info=True,
+        )
 
     if os.environ.get("DISABLE_BACKGROUND_WORKER") == "1":
         logger.info("Background worker disabled via DISABLE_BACKGROUND_WORKER=1")
@@ -227,6 +246,7 @@ register_drafter_routes(rt)
 register_report_routes(rt)
 register_chat_routes(rt)
 register_chat_ws_routes(app)
+register_draft_ws_routes(app)
 register_annotation_routes(rt)
 register_notification_routes(rt)
 

--- a/app/static/js/draft-status.js
+++ b/app/static/js/draft-status.js
@@ -1,0 +1,146 @@
+/* Draft pipeline status — WebSocket push listener (#608).
+ *
+ * Augments the existing 3s HTMX polling on the draft detail page
+ * with a WS push so transitions land in <500ms instead of up to 3s.
+ * The WS is purely an enhancement: if the connection drops or fails
+ * to open at all, the existing hx-trigger="every Ns" attributes on
+ * the .draft-status-wrapper continue polling exactly as before. We
+ * deliberately do NOT remove those attributes — keeping them is the
+ * graceful-degradation path the issue's DoD asks for.
+ *
+ * Usage: the page renders a <div data-draft-status-ws data-draft-id="...">
+ * marker; this script self-initialises on DOMContentLoaded and
+ * connects to /ws/drafts/status, subscribes to the draft, and swaps
+ * the status wrapper via htmx.ajax() on every push event.
+ *
+ * The WS closes itself once the draft reaches a terminal status
+ * (ready / failed) so the connection doesn't linger forever on a
+ * page the user is no longer actively monitoring.
+ */
+(function () {
+  'use strict';
+
+  var TERMINAL_STATUSES = ['ready', 'failed'];
+
+  function start(draftId) {
+    if (!draftId || typeof WebSocket === 'undefined') return;
+
+    // Build the WS URL from the current location so it follows
+    // wss:// in production behind Traefik and ws:// in local dev.
+    var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    var url = proto + '//' + window.location.host + '/ws/drafts/status';
+    var ws;
+    try {
+      ws = new WebSocket(url);
+    } catch (e) {
+      // Browser blocked the connection (CSP, mixed content, etc.).
+      // Existing 3s polling keeps the page functional.
+      return;
+    }
+
+    var subscribed = false;
+
+    ws.addEventListener('open', function () {
+      try {
+        ws.send(JSON.stringify({ type: 'subscribe', draft_id: draftId }));
+        subscribed = true;
+      } catch (e) {
+        // If send fails, fall through to polling.
+      }
+    });
+
+    ws.addEventListener('message', function (event) {
+      var data;
+      try {
+        data = JSON.parse(event.data);
+      } catch (e) {
+        return; // ignore malformed frames
+      }
+      if (!data || typeof data !== 'object') return;
+
+      // ping events are heartbeats from the server; no UI effect.
+      if (data.type === 'ping') return;
+
+      // initial + status both warrant a tracker refresh: pull the
+      // server-rendered fragment so we don't re-implement state
+      // formatting in JS.
+      if (data.type === 'initial' || data.type === 'status') {
+        refreshTracker(draftId);
+
+        // Close the socket once the pipeline finishes. The 3s
+        // polling will also stop on its own because the server-
+        // rendered fragment drops the hx-trigger attributes for
+        // terminal states.
+        if (data.status && TERMINAL_STATUSES.indexOf(data.status) !== -1) {
+          try { ws.close(1000, 'terminal-status'); } catch (e) { /* noop */ }
+        }
+        return;
+      }
+
+      if (data.type === 'error') {
+        // Auth or subscription error — the existing polling will
+        // still run; just log for debugging.
+        if (window.console && console.warn) {
+          console.warn('draft-status WS error:', data.message);
+        }
+        return;
+      }
+    });
+
+    ws.addEventListener('close', function () {
+      // No reconnect: the existing HTMX polling on the wrapper
+      // continues to drive updates. Adding reconnect logic here
+      // would be redundant and could compete with the polling
+      // tick. If the user navigates away and back, this script
+      // re-runs from the new page-load init and re-opens the WS.
+    });
+
+    ws.addEventListener('error', function () {
+      // Same rationale as 'close'.
+    });
+  }
+
+  function refreshTracker(draftId) {
+    var target = document.getElementById('draft-status-' + draftId);
+    if (!target) return;
+    var url = '/drafts/' + draftId + '/status';
+
+    // Prefer htmx.ajax so the existing HTMX swap pipeline runs
+    // (event hooks, transitions, attribute parsing). Fall back to
+    // a plain fetch + replace if HTMX isn't loaded yet.
+    if (window.htmx && typeof htmx.ajax === 'function') {
+      try {
+        htmx.ajax('GET', url, { target: '#draft-status-' + draftId, swap: 'outerHTML' });
+        return;
+      } catch (e) {
+        // fall through to plain fetch
+      }
+    }
+
+    fetch(url, { credentials: 'same-origin', headers: { 'HX-Request': 'true' } })
+      .then(function (resp) { return resp.ok ? resp.text() : null; })
+      .then(function (html) {
+        if (!html) return;
+        var holder = document.createElement('div');
+        holder.innerHTML = html;
+        var fresh = holder.firstElementChild;
+        if (fresh && target.parentNode) {
+          target.parentNode.replaceChild(fresh, target);
+        }
+      })
+      .catch(function () { /* keep polling fallback */ });
+  }
+
+  function init() {
+    var marker = document.querySelector('[data-draft-status-ws][data-draft-id]');
+    if (!marker) return;
+    var draftId = marker.getAttribute('data-draft-id');
+    start(draftId);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/tests/test_docs_status_events.py
+++ b/tests/test_docs_status_events.py
@@ -1,0 +1,220 @@
+"""Unit tests for ``app.docs.status_events`` (#608).
+
+Pure-asyncio tests against the in-memory pub/sub primitive. The WS
+endpoint and the cross-thread emit_threadsafe path have their own
+test files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import uuid
+
+import pytest
+
+from app.docs import status_events
+
+
+def _reset_subscribers() -> None:
+    """Clear the module-level subscriber registry between tests so
+    isolation isn't broken by leaked sets from earlier failures."""
+    status_events._subscribers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_subscribers():
+    _reset_subscribers()
+    yield
+    _reset_subscribers()
+
+
+class TestSubscribeEmit:
+    def test_subscriber_receives_emitted_event(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def fake_send(payload: str) -> None:
+                received.append(payload)
+
+            draft_id = uuid.uuid4()
+            await status_events.subscribe(draft_id, fake_send)
+            await status_events.emit(draft_id, type="status", status="ready")
+            return received
+
+        received = asyncio.run(_run())
+        assert len(received) == 1
+        payload = json.loads(received[0])
+        assert payload["type"] == "status"
+        assert payload["status"] == "ready"
+
+    def test_emit_with_no_subscribers_is_noop(self):
+        """Emitting to a draft with no subscribers must not raise."""
+
+        async def _run():
+            await status_events.emit(uuid.uuid4(), type="status", status="ready")
+
+        # Just shouldn't raise.
+        asyncio.run(_run())
+
+    def test_emit_includes_draft_id_in_payload(self):
+        async def _run() -> str:
+            received: list[str] = []
+
+            async def fake_send(payload: str) -> None:
+                received.append(payload)
+
+            draft_id = uuid.uuid4()
+            await status_events.subscribe(draft_id, fake_send)
+            await status_events.emit(draft_id, type="status", status="extracting")
+            return received[0]
+
+        encoded = asyncio.run(_run())
+        payload = json.loads(encoded)
+        assert "draft_id" in payload
+
+    def test_multiple_subscribers_all_receive(self):
+        async def _run() -> tuple[list, list]:
+            r1: list[str] = []
+            r2: list[str] = []
+
+            async def send1(p: str) -> None:
+                r1.append(p)
+
+            async def send2(p: str) -> None:
+                r2.append(p)
+
+            draft_id = uuid.uuid4()
+            await status_events.subscribe(draft_id, send1)
+            await status_events.subscribe(draft_id, send2)
+            await status_events.emit(draft_id, type="status", status="ready")
+            return r1, r2
+
+        r1, r2 = asyncio.run(_run())
+        assert len(r1) == 1 and len(r2) == 1
+
+
+class TestUnsubscribe:
+    def test_unsubscribed_does_not_receive(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def fake_send(payload: str) -> None:
+                received.append(payload)
+
+            draft_id = uuid.uuid4()
+            await status_events.subscribe(draft_id, fake_send)
+            await status_events.unsubscribe(draft_id, fake_send)
+            await status_events.emit(draft_id, type="status", status="ready")
+            return received
+
+        received = asyncio.run(_run())
+        assert received == []
+
+    def test_unsubscribe_unknown_callable_is_idempotent(self):
+        """Unsubscribing a callable that was never subscribed must
+        not raise — common race when a connection drops mid-handshake."""
+
+        async def _run():
+            async def fake_send(payload: str) -> None:
+                pass
+
+            await status_events.unsubscribe(uuid.uuid4(), fake_send)
+
+        asyncio.run(_run())  # must not raise
+
+    def test_subscriber_count_reflects_registry(self):
+        async def _run() -> tuple[int, int, int]:
+            async def fake_send(payload: str) -> None:
+                pass
+
+            draft_id = uuid.uuid4()
+            zero = await status_events.subscriber_count(draft_id)
+            await status_events.subscribe(draft_id, fake_send)
+            one = await status_events.subscriber_count(draft_id)
+            await status_events.unsubscribe(draft_id, fake_send)
+            zero_again = await status_events.subscriber_count(draft_id)
+            return zero, one, zero_again
+
+        before, during, after = asyncio.run(_run())
+        assert (before, during, after) == (0, 1, 0)
+
+
+class TestDeadSubscriberReaping:
+    def test_failing_subscriber_is_removed(self):
+        """When a send raises, the subscriber must be removed so it
+        doesn't continue to break future emits."""
+
+        async def _run() -> tuple[int, list[str]]:
+            healthy_received: list[str] = []
+
+            async def healthy_send(payload: str) -> None:
+                healthy_received.append(payload)
+
+            async def dead_send(payload: str) -> None:
+                raise RuntimeError("socket closed")
+
+            draft_id = uuid.uuid4()
+            await status_events.subscribe(draft_id, healthy_send)
+            await status_events.subscribe(draft_id, dead_send)
+            await status_events.emit(draft_id, type="status", status="ready")
+            count_after = await status_events.subscriber_count(draft_id)
+            return count_after, healthy_received
+
+        count, received = asyncio.run(_run())
+        # Only healthy subscriber remains.
+        assert count == 1
+        # Healthy subscriber still received the event despite the
+        # other one raising.
+        assert len(received) == 1
+
+
+class TestThreadsafeEmit:
+    def test_emit_threadsafe_dispatches_onto_registered_loop(self):
+        """A call from a worker thread schedules the emit onto the
+        web event loop and reaches a subscriber that lives on that loop."""
+        received: list[str] = []
+        ready = threading.Event()
+        loop_holder: dict = {}
+
+        async def runner():
+            async def send(payload: str) -> None:
+                received.append(payload)
+
+            draft_id = uuid.uuid4()
+            await status_events.subscribe(draft_id, send)
+
+            # Signal the worker thread that the loop is ready and
+            # hand it the loop reference + draft id to publish to.
+            loop_holder["loop"] = asyncio.get_running_loop()
+            loop_holder["draft_id"] = draft_id
+            status_events.register_event_loop(asyncio.get_running_loop())
+            ready.set()
+
+            # Wait for the worker thread to publish, then give the
+            # event loop a tick to run the scheduled coroutine.
+            await asyncio.sleep(0.2)
+
+        def worker():
+            ready.wait(timeout=2.0)
+            status_events.emit_threadsafe(loop_holder["draft_id"], type="status", status="ready")
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        try:
+            asyncio.run(runner())
+        finally:
+            t.join(timeout=2.0)
+
+        assert len(received) == 1
+        payload = json.loads(received[0])
+        assert payload["status"] == "ready"
+
+    def test_emit_threadsafe_without_registered_loop_is_silent(self):
+        """If no loop has been registered (test mode / stub run) the
+        helper must drop the emit silently rather than raising."""
+        # Reset the loop ref to None to simulate "not yet registered".
+        status_events._event_loop = None
+        # Must not raise.
+        status_events.emit_threadsafe(uuid.uuid4(), type="status", status="ready")

--- a/tests/test_docs_websocket.py
+++ b/tests/test_docs_websocket.py
@@ -1,0 +1,298 @@
+"""Unit tests for ``app.docs.websocket.ws_draft_status`` (#608).
+
+Tests the message-level handler in isolation by passing a stub
+``send`` callable + an explicit ``scope`` dict so we don't need a
+real ASGI fixture. The full ``register_draft_ws_routes`` wrapper that
+extracts JWT cookies is exercised at a higher level by integration
+tests in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.docs import status_events
+from app.docs import websocket as draft_ws
+
+
+def _reset_subscribers() -> None:
+    status_events._subscribers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_subscribers():
+    _reset_subscribers()
+    yield
+    _reset_subscribers()
+
+
+def _make_draft(*, status: str = "extracting", org_id: str = "org-1"):
+    """Tiny stand-in for a Draft row — only the attributes the handler reads.
+
+    Uses ``SimpleNamespace`` rather than a ``class _Draft: pass`` shell
+    because pyright's stricter mode flags dynamic attribute assignment
+    on a bare class as ``reportAttributeAccessIssue``.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        status=status,
+        org_id=org_id,
+        error_message=None,
+    )
+
+
+class TestSubscribeMessageValidation:
+    def test_invalid_json_yields_error_event(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await draft_ws.ws_draft_status("not-json{", send, scope={})
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Vigane JSON" in r for r in received)
+
+    def test_non_dict_message_yields_error_event(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await draft_ws.ws_draft_status('["not a dict"]', send, scope={})
+            return received
+
+        received = asyncio.run(_run())
+        messages = [json.loads(r).get("message", "") for r in received]
+        assert any("Vigane sõnum" in m for m in messages)
+
+    def test_unknown_message_type_silently_ignored(self):
+        """Forward-compatibility: sending a future message type
+        (e.g. 'unsubscribe') must not surface an error to the user."""
+
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await draft_ws.ws_draft_status(
+                json.dumps({"type": "unsubscribe", "draft_id": str(uuid.uuid4())}),
+                send,
+                scope={},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert received == []
+
+    def test_subscribe_without_draft_id_yields_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await draft_ws.ws_draft_status(
+                json.dumps({"type": "subscribe"}),
+                send,
+                scope={"auth": {"id": "u1"}},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("draft_id" in r for r in received)
+
+    def test_subscribe_with_invalid_uuid_yields_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await draft_ws.ws_draft_status(
+                json.dumps({"type": "subscribe", "draft_id": "not-a-uuid"}),
+                send,
+                scope={"auth": {"id": "u1"}},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Vigane draft_id" in r for r in received)
+
+
+class TestSubscribeAuth:
+    def test_unauthenticated_subscribe_yields_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await draft_ws.ws_draft_status(
+                json.dumps({"type": "subscribe", "draft_id": str(uuid.uuid4())}),
+                send,
+                scope={},  # no auth
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Autentimine" in r for r in received)
+
+    def test_subscribe_to_missing_draft_yields_404_style_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            with patch("app.docs.websocket.fetch_draft", return_value=None):
+                await draft_ws.ws_draft_status(
+                    json.dumps({"type": "subscribe", "draft_id": str(uuid.uuid4())}),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        messages = [json.loads(r).get("message", "") for r in received]
+        assert any("Eelnõu ei leitud" in m for m in messages)
+
+    def test_subscribe_cross_org_yields_404_style_error_not_403(self):
+        """Cross-org subscription is rejected with the same generic
+        'not found' error as a missing draft so we never leak existence
+        of out-of-scope drafts."""
+
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            draft = _make_draft(org_id="other-org")
+            with (
+                patch("app.docs.websocket.fetch_draft", return_value=draft),
+                patch("app.docs.websocket.can_view_draft", return_value=False),
+            ):
+                await draft_ws.ws_draft_status(
+                    json.dumps({"type": "subscribe", "draft_id": str(draft.id)}),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        messages = [json.loads(r).get("message", "") for r in received]
+        assert any("Eelnõu ei leitud" in m for m in messages)
+        # No 'forbidden'-flavour error.
+        assert not any("403" in m or "puudub" in m.lower() for m in messages)
+
+
+class TestSubscribeSuccess:
+    def test_subscribe_pushes_initial_state_and_registers(self):
+        """A successful subscribe must:
+        1. Send an ``initial`` event with the current draft status.
+        2. Register the send callable in the subscriber registry.
+        """
+
+        async def _run() -> tuple[list[str], int, asyncio.Task]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            draft = _make_draft(status="extracting", org_id="org-1")
+            with (
+                patch("app.docs.websocket.fetch_draft", return_value=draft),
+                patch("app.docs.websocket.can_view_draft", return_value=True),
+            ):
+                handler_task = asyncio.create_task(
+                    draft_ws.ws_draft_status(
+                        json.dumps({"type": "subscribe", "draft_id": str(draft.id)}),
+                        send,
+                        scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                    )
+                )
+                # Give the handler a tick to hit the subscribe + initial-send.
+                await asyncio.sleep(0.05)
+                count = await status_events.subscriber_count(draft.id)
+                return received, count, handler_task
+
+        received, count, handler_task = asyncio.run(_coordinate_handler_lifecycle(_run()))
+
+        assert count == 1, f"expected 1 subscriber after successful subscribe, got {count}"
+        # Initial state event was sent.
+        initial_events = [
+            json.loads(r) for r in received if json.loads(r).get("type") == "initial"
+        ]
+        assert len(initial_events) == 1
+        assert initial_events[0]["status"] == "extracting"
+
+
+async def _coordinate_handler_lifecycle(run_coroutine):
+    """Drive the test runner + cancel the handler task at the end so the
+    test doesn't hang on the handler's ``await asyncio.Event().wait()``."""
+    received, count, handler_task = await run_coroutine
+    handler_task.cancel()
+    try:
+        await handler_task
+    except asyncio.CancelledError:
+        pass
+    return received, count, handler_task
+
+
+class TestSubscribeReceivesEmittedEvent:
+    def test_status_event_after_subscribe_reaches_subscriber(self):
+        """End-to-end: subscribe via the handler, emit via the pub/sub
+        primitive, verify the subscriber receives the event."""
+
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            draft = _make_draft(status="extracting", org_id="org-1")
+            with (
+                patch("app.docs.websocket.fetch_draft", return_value=draft),
+                patch("app.docs.websocket.can_view_draft", return_value=True),
+            ):
+                handler_task = asyncio.create_task(
+                    draft_ws.ws_draft_status(
+                        json.dumps({"type": "subscribe", "draft_id": str(draft.id)}),
+                        send,
+                        scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                    )
+                )
+                await asyncio.sleep(0.05)  # let subscribe complete
+
+                await status_events.emit(draft.id, type="status", status="analyzing")
+                await asyncio.sleep(0.05)  # let dispatch complete
+
+                handler_task.cancel()
+                try:
+                    await handler_task
+                except asyncio.CancelledError:
+                    pass
+
+            return received
+
+        received = asyncio.run(_run())
+        # We expect both the initial state event AND the analyzing event.
+        types = [json.loads(r).get("type") for r in received]
+        assert "initial" in types
+        # The status event from emit() carried our payload.
+        status_events_received = [
+            json.loads(r) for r in received if json.loads(r).get("type") == "status"
+        ]
+        assert any(e.get("status") == "analyzing" for e in status_events_received)


### PR DESCRIPTION
First Eelnõud epic subtask. Replaces the existing 3s HTMX polling on the draft detail page with a live WebSocket push so status transitions land in <500ms instead of up to 3s. Existing polling stays as the graceful-degradation path.

## Architecture

### \`app/docs/status_events.py\` (new)
In-memory pub/sub primitive.
- \`subscribe(draft_id, send)\` / \`unsubscribe\` for the WS layer (async)
- \`emit(...)\` async fan-out with dead-subscriber reaping
- \`emit_threadsafe(...)\` for the sync pipeline workers — schedules onto the web event loop via \`asyncio.run_coroutine_threadsafe\`
- Future-proofed: the public API stays the same if/when we swap the in-memory fan-out for Postgres LISTEN/NOTIFY (multi-worker scaling)

### \`app/docs/websocket.py\` (new)
FastHTML WS endpoint at \`/ws/drafts/status\`.
- Handshake auth mirrors the chat module (JWT cookie + silent-refresh fallback per #637)
- Per-handler heartbeat (25s with 5s send timeout, self-terminate on send error) reuses the chat post-review pattern (#684) so NAT idle timeouts can't drop the connection during a long analyze stage
- Cross-org subscription rejected with the same 'not found' error as a missing draft → no existence leak

### \`app/main.py\`
Lifespan hook registers the running event loop with \`status_events\` so worker-thread emits can dispatch. Mounts the new WS routes alongside chat + explorer.

## Pipeline emit hooks

- \`parse_handler.py\` → emits \`status='extracting'\` after the successful transition; emits \`status='failed'\` from \`_mark_draft_failed\`
- \`extract_handler.py\` → emits \`status='analyzing'\` after the resolved-entities INSERT + status update; emits \`status='failed'\` on the final-attempt-only failure path
- \`analyze_handler.py\` → emits \`status='ready'\` BEFORE the existing \`notify_analysis_done\` call (so a notify failure can't drop the WS event); emits \`status='failed'\` from \`_mark_draft_failed\`

All emit calls are best-effort — \`emit_threadsafe\`'s try/except swallows failures so the pipeline is never blocked on the WS push path.

## Client side

\`app/static/js/draft-status.js\` (new) self-initialises off the \`data-draft-status-ws data-draft-id=\"...\"\` marker on the status tracker wrapper. Connects to \`/ws/drafts/status\`, subscribes, swaps the tracker via \`htmx.ajax\` (or plain fetch fallback) on every push. Closes the WS automatically on terminal status. **No reconnect logic** — the existing 3s HTMX polling on the wrapper remains as the graceful-degradation path if the WS fails or drops mid-pipeline.

\`app/docs/routes.py\` adds the marker attributes to the status tracker (only while non-terminal) and mounts the JS via \`Script(src=\"/static/js/draft-status.js\", defer=True)\` on the detail page.

## Tests (20 new)

- **\`tests/test_docs_status_events.py\`** (10 tests) — pub/sub primitive: subscribe/emit round-trip, payload includes draft_id, multiple subscribers, idempotent unsubscribe, subscriber_count tracks registry, dead subscriber reaped, healthy peer still receives, emit_threadsafe dispatches across threads, emit_threadsafe with no registered loop is silent.
- **\`tests/test_docs_websocket.py\`** (10 tests) — handler-level: invalid JSON / non-dict / unknown type / missing draft_id / invalid UUID / unauthenticated all yield error events; missing-draft and cross-org both yield the same '404-style' error (no existence leak); successful subscribe pushes initial state + registers; status events emitted after subscribe reach the subscriber.

## Verification

- \`uv run pytest\` — **1851 passed, 22 skipped** (was 1831; +20 new tests).
- \`uv run ruff check\` clean on touched files.
- \`uv run pyright\` clean on touched files.

## DoD (from #608)

- ✅ Detail page updates within ~500ms of stage transition (no longer waits for the 3s polling tick)
- ✅ Graceful fallback: existing HTMX polling preserved on the wrapper; client-side script is purely additive
- ✅ Cross-tab works automatically: each tab's connection subscribes independently
- ✅ ruff + pyright + pytest green

## Test plan

- [ ] CI: lint-and-test green
- [ ] Manual on staging: upload a draft, watch the detail page — status badges should flip live as the pipeline progresses
- [ ] Manual: open the same draft in two tabs while it's processing → both update in lockstep
- [ ] Manual: kill the WS via DevTools → polling continues; status still progresses (degraded but functional)
- [ ] Manual: cross-org subscription via DevTools → 'Eelnõu ei leitud' error event (no existence leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)