### PR TITLE
feat(ui): extract LinkButton primitive (#632)

### DIFF
--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -40,6 +40,7 @@ from app.ui.layout import PageShell
 from app.ui.primitives.annotation_button import AnnotationButton
 from app.ui.primitives.badge import Badge, BadgeVariant
 from app.ui.primitives.button import Button
+from app.ui.primitives.link_button import LinkButton
 from app.ui.surfaces.alert import Alert
 from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.surfaces.info_box import InfoBox
@@ -682,10 +683,10 @@ def draft_report_page(req: Request, draft_id: str):
                 cls="back-link",
             ),
             Div(
-                A(  # noqa: F405
+                LinkButton(
                     "Ava uurijas →",
                     href=f"/explorer?draft={draft.id}",
-                    cls="btn btn-secondary btn-md",
+                    variant="secondary",
                     title="Visualiseeri eelnõu ja mõjutatud sätted graafil.",
                 ),
                 # #614: one-line helper below the button so reviewers
@@ -1080,10 +1081,10 @@ def export_status_fragment(req: Request, draft_id: str, job_id: str):
             )
         return Div(
             Span("Eksport valmis. ", cls="export-status-text"),  # noqa: F405
-            A(  # noqa: F405
+            LinkButton(
                 "Laadi alla .docx",
                 href=f"/drafts/{parsed_draft}/export/{parsed_job_id}/download",
-                cls="btn btn-primary btn-sm",
+                size="sm",
             ),
             id="export-status",
             cls="export-status export-status-success",

--- a/app/docs/routes.py
+++ b/app/docs/routes.py
@@ -64,6 +64,7 @@ from app.ui.layout import PageShell
 from app.ui.primitives.annotation_button import AnnotationButton
 from app.ui.primitives.badge import Badge, BadgeVariant
 from app.ui.primitives.button import Button
+from app.ui.primitives.link_button import LinkButton
 from app.ui.surfaces.alert import Alert
 from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.surfaces.info_box import InfoBox
@@ -610,10 +611,11 @@ def _draft_list_columns() -> list[Column]:
         return _status_badge(row["status_raw"])
 
     def _actions_cell(row: dict[str, Any]):
-        return A(  # noqa: F405
+        return LinkButton(
             "Vaata",
             href=f"/drafts/{row['id']}",
-            cls="btn btn-secondary btn-sm",
+            variant="secondary",
+            size="sm",
         )
 
     def _doc_type_cell(row: dict[str, Any]):
@@ -995,10 +997,10 @@ def _drafts_table_section(
                     "kõiki organisatsiooni eelnõusid."
                 ),
                 icon="🔍",
-                action=A(  # noqa: F405
+                action=LinkButton(
                     "Lähtesta filtrid",
                     href="/drafts",
-                    cls="btn btn-secondary btn-md",
+                    variant="secondary",
                 ),
             )
         else:
@@ -1010,10 +1012,9 @@ def _drafts_table_section(
                     "viiteid, konflikte ja EL-i vastavust."
                 ),
                 icon="📄",
-                action=A(  # noqa: F405
+                action=LinkButton(
                     "Laadi üles uus eelnõu",
                     href="/drafts/new",
-                    cls="btn btn-primary btn-md",
                 ),
             )
         return Div(body, id="drafts-table-wrapper")  # noqa: F405
@@ -1151,10 +1152,9 @@ def drafts_list_page(req: Request):
     )
     header_children.append(
         Div(
-            A(
+            LinkButton(
                 "Laadi üles uus eelnõu",
                 href="/drafts/new",
-                cls="btn btn-primary btn-md",
             ),
             cls="page-actions",
         )
@@ -1434,7 +1434,7 @@ def _upload_form(
                 variant="primary",
                 id="upload-submit",
             ),
-            A("Tühista", href="/drafts", cls="btn btn-ghost btn-md"),  # noqa: F405
+            LinkButton("Tühista", href="/drafts", variant="ghost"),
             # #599: spinner shown while the upload request is in
             # flight. HTMX toggles ``.htmx-request`` on the indicator
             # element referenced by ``hx-indicator`` so the form never
@@ -1974,10 +1974,9 @@ def _draft_detail_body(
     # "Vaata mõjuaruannet" link when the draft has reached ``ready``.
     if draft.status == "ready":
         actions.append(
-            A(  # noqa: F405
+            LinkButton(
                 "Vaata mõjuaruannet",
                 href=f"/drafts/{draft.id}/report",
-                cls="btn btn-primary btn-md",
             )
         )
 

--- a/app/ui/primitives/__init__.py
+++ b/app/ui/primitives/__init__.py
@@ -4,6 +4,7 @@ from app.ui.primitives.annotation_button import AnnotationButton
 from app.ui.primitives.badge import Badge, StatusBadge
 from app.ui.primitives.button import Button, IconButton
 from app.ui.primitives.input import Checkbox, Input, Radio, Select, Textarea
+from app.ui.primitives.link_button import LinkButton
 
 __all__ = [
     "AnnotationButton",
@@ -12,6 +13,7 @@ __all__ = [
     "Checkbox",
     "IconButton",
     "Input",
+    "LinkButton",
     "Radio",
     "Select",
     "StatusBadge",

--- a/app/ui/primitives/link_button.py
+++ b/app/ui/primitives/link_button.py
@@ -1,0 +1,45 @@
+"""LinkButton primitive — anchor styled like a Button (#632).
+
+A real ``<a>`` element with the same ``btn btn-{variant} btn-{size}`` class
+contract as ``Button``. Use this when the action navigates to a URL; use
+``Button`` when the action submits a form or fires HTMX.
+
+Follows the design system spec §4.2 (component API conventions):
+    - Content as positional ``*children``
+    - Style variants via ``variant`` / ``size`` literals
+    - Custom classes appended via ``cls``
+    - Arbitrary HTMX / ARIA attributes passed through via ``**kwargs``
+"""
+
+from fasthtml.common import *  # noqa: F403
+
+from app.ui.primitives.button import ButtonSize, ButtonVariant, _button_icon_size
+from app.ui.primitives.icon import Icon
+
+
+def LinkButton(
+    *children,
+    href: str,
+    variant: ButtonVariant = "primary",
+    size: ButtonSize = "md",
+    icon: str | None = None,
+    cls: str = "",
+    **kwargs,
+):
+    """Anchor styled with the Button class contract."""
+    classes = f"btn btn-{variant} btn-{size}"
+    if cls:
+        classes = f"{classes} {cls}"
+
+    inner: list = []
+    if icon:
+        inner.append(Icon(icon, size=_button_icon_size(size)))
+    inner.extend(children)
+
+    return ft_hx(  # noqa: F405
+        "a",
+        *inner,
+        href=href,
+        cls=classes,
+        **kwargs,
+    )

--- a/docs/superpowers/specs/2026-04-09-design-system.md
+++ b/docs/superpowers/specs/2026-04-09-design-system.md
@@ -243,6 +243,7 @@ def Button(
 |-----------|---------|----------|
 | `Button` | Actions | primary, secondary, ghost, danger |
 | `IconButton` | Icon-only button (e.g., close) | same + sizes |
+| `LinkButton` | Anchor styled as a button (use when action navigates) | same + sizes |
 | `Input` | Single-line text input | text, email, password, number, search, url |
 | `Textarea` | Multi-line text | — |
 | `Select` | Dropdown | single, searchable |

--- a/tests/test_ui_link_button.py
+++ b/tests/test_ui_link_button.py
@@ -1,0 +1,64 @@
+"""Smoke tests for the LinkButton primitive (#632)."""
+
+from typing import cast, get_args
+
+import pytest
+from fasthtml.common import to_xml
+
+from app.ui.primitives.button import ButtonSize, ButtonVariant
+from app.ui.primitives.link_button import LinkButton
+
+_VARIANTS: tuple[ButtonVariant, ...] = cast(tuple[ButtonVariant, ...], get_args(ButtonVariant))
+_SIZES: tuple[ButtonSize, ...] = cast(tuple[ButtonSize, ...], get_args(ButtonSize))
+
+
+@pytest.mark.parametrize("variant", _VARIANTS)
+def test_link_button_variants_render(variant: ButtonVariant):
+    html = to_xml(LinkButton("Vaata", href="/x", variant=variant))
+    assert f"btn-{variant}" in html
+    assert "Vaata" in html
+    assert "<a " in html
+    assert 'href="/x"' in html
+
+
+@pytest.mark.parametrize("size", _SIZES)
+def test_link_button_sizes_render(size: ButtonSize):
+    html = to_xml(LinkButton("Ava", href="/x", size=size))
+    assert f"btn-{size}" in html
+
+
+def test_link_button_default_is_primary_md():
+    html = to_xml(LinkButton("Ava", href="/x"))
+    assert "btn-primary" in html
+    assert "btn-md" in html
+
+
+def test_link_button_custom_cls_is_appended():
+    html = to_xml(LinkButton("Hi", href="/x", cls="page-action"))
+    assert "btn-primary" in html
+    assert "page-action" in html
+
+
+def test_link_button_kwargs_pass_through():
+    html = to_xml(
+        LinkButton(
+            "Ava uurijas",
+            href="/explorer?draft=1",
+            title="Visualiseeri eelnõu",
+            hx_boost="true",
+        )
+    )
+    assert 'title="Visualiseeri eelnõu"' in html
+    assert 'hx-boost="true"' in html
+
+
+def test_link_button_with_icon_renders_svg():
+    html = to_xml(LinkButton("Lisa", href="/new", icon="plus"))
+    assert "<svg" in html
+    assert "/static/icons/sprite.svg#plus" in html
+    assert "icon icon-md" in html
+
+
+def test_link_button_sm_icon_uses_sm_size():
+    html = to_xml(LinkButton("Lisa", href="/new", icon="plus", size="sm"))
+    assert "icon icon-sm" in html


### PR DESCRIPTION
Closes #632.

## Summary
- New `LinkButton(href=..., variant=..., size=..., icon=...)` primitive in `app/ui/primitives/link_button.py` — anchor styled with the same `btn btn-{variant} btn-{size}` class contract owned by `Button`.
- Replaces 8 hardcoded `A(..., cls="btn btn-...")` sites in `app/docs/routes.py` and `app/docs/report_routes.py`.
- Exported from the `app.ui.primitives` package.
- Smoke tests parametrised over every variant and size + icon variants.
- Design system catalog (`docs/superpowers/specs/2026-04-09-design-system.md`) lists `LinkButton` alongside `Button` / `IconButton`.

## Why
Hardcoding `cls="btn btn-..."` on bare `<a>` tags duplicated the internal class contract owned by `Button`. Any future rename of the `btn-*` classes would have silently rotted the link buttons. Per #597 polish sweep.

## Definition of Done
- [x] No raw `A(..., cls="btn ...")` in `app/docs/`
- [x] `LinkButton` documented in design system spec
- [x] `ruff format` + `ruff check` green
- [x] `pyright` green (0 errors)
- [x] `pytest` green (599 passed, 2 skipped — full suite)

## Test plan
- [x] `uv run pytest tests/test_ui_link_button.py tests/test_ui_button.py` — 30 passed
- [x] `uv run pytest -k "docs or draft or report"` — 599 passed
- [ ] Smoke check `/drafts`, `/drafts/new`, `/drafts/<id>`, `/drafts/<id>/report` in staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)