### PR TITLE
fix(chat): drop plaintext message columns + lock content_encrypted NOT NULL (#687)

### DIFF
--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -222,40 +222,19 @@ def _delete_messages_after_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Messa
 
 
 def _update_message_content(conn: Any, msg_id: uuid.UUID, new_content: str) -> None:
-    """Update a user message's content.
+    """Update a user message's content (encrypted column only).
 
-    Writes to ``content_encrypted`` when :func:`app.storage.encrypt_text`
-    is available (production) and falls back to the plaintext column
-    otherwise (dev environments without an encryption key). The read
-    path in :func:`_row_to_message` prefers the encrypted column, so the
-    dual-write keeps decryption working after edits.
-
-    Production safety: in ``APP_ENV=production`` (where
-    :func:`app.config.is_stub_allowed` returns ``False``) an encryption
-    failure re-raises instead of silently writing plaintext. Drafts are
-    politically sensitive — a plaintext fallback in prod would leak the
-    very data the encryption-at-rest policy exists to protect. In dev /
-    test the plaintext fallback keeps the app runnable without a key.
+    The plaintext ``content`` column was dropped by migration 026, so
+    every edit writes ciphertext to ``content_encrypted``. If
+    :func:`app.storage.encrypt_text` raises (e.g. dev environment with
+    no key configured) we re-raise instead of silently dropping the
+    edit — there is no plaintext column left to fall back to.
     """
-    from app.config import is_stub_allowed
+    from app.storage import encrypt_text
 
-    try:
-        from app.storage import encrypt_text
-
-        ciphertext = encrypt_text(new_content or "")
-    except Exception:
-        if not is_stub_allowed():
-            logger.exception("encrypt_text failed in production — refusing plaintext fallback")
-            raise
-        logger.exception("encrypt_text failed — writing plaintext content (dev fallback)")
-        conn.execute(
-            "UPDATE messages SET content = %s, content_encrypted = NULL WHERE id = %s",
-            (new_content, str(msg_id)),
-        )
-        return
-
+    ciphertext = encrypt_text(new_content or "")
     conn.execute(
-        "UPDATE messages SET content = NULL, content_encrypted = %s WHERE id = %s",
+        "UPDATE messages SET content_encrypted = %s WHERE id = %s",
         (ciphertext, str(msg_id)),
     )
 

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from app.db_utils import coerce_uuid, parse_jsonb
+from app.db_utils import coerce_uuid
 from app.storage import DecryptionError, decrypt_text, encrypt_text
 
 logger = logging.getLogger(__name__)
@@ -115,26 +115,26 @@ def _is_missing_v017_column_error(exc: BaseException) -> bool:
     )
 
 
-# NOTE (#570): SELECT returns both the plaintext and the ``*_encrypted``
-# columns. ``_row_to_message`` prefers the encrypted column when set and
-# falls back to the plaintext column for rows that predate the backfill
-# (migration 014 adds the columns, scripts/migrate_chat_encryption.py
-# populates them, a later migration drops the plaintext columns).
+# NOTE (#687, supersedes #570): the legacy plaintext columns
+# (``content``, ``tool_input``, ``tool_output``, ``rag_context``) were
+# dropped by migration 026. ``content_encrypted`` is the sole source of
+# truth and is NOT NULL at the DB level. The ``_row_to_message`` reader
+# raises if it ever sees a NULL ciphertext so a future regression cannot
+# silently serve "no content".
 _MESSAGE_COLUMNS = (
-    "id, conversation_id, role, content, tool_name, tool_input, "
-    "tool_output, rag_context, tokens_input, tokens_output, model, created_at, "
+    "id, conversation_id, role, tool_name, "
+    "tokens_input, tokens_output, model, created_at, "
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
     "rag_context_encrypted, is_pinned, is_truncated"
 )
 
 # Legacy SELECT list used when migration 017 has not yet applied (the
-# ``is_pinned`` / ``is_truncated`` columns are absent). Without this
-# fallback, loading any conversation raises ``UndefinedColumn`` and the
-# conversation view silently renders the empty state — users then see
-# the example-prompt cards instead of their history. See #596 follow-up.
+# ``is_pinned`` / ``is_truncated`` columns are absent). Kept for the
+# narrow rollout window where the new image hits a stale schema cache;
+# post-026 the plaintext columns are also gone here.
 _MESSAGE_COLUMNS_PRE017 = (
-    "id, conversation_id, role, content, tool_name, tool_input, "
-    "tool_output, rag_context, tokens_input, tokens_output, model, created_at, "
+    "id, conversation_id, role, tool_name, "
+    "tokens_input, tokens_output, model, created_at, "
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
     "rag_context_encrypted"
 )
@@ -213,52 +213,45 @@ def _row_to_conversation(row: tuple[Any, ...]) -> Conversation:
 def _row_to_message(row: tuple[Any, ...]) -> Message:
     """Build a ``Message`` from a raw cursor row.
 
-    Column order matches :data:`_MESSAGE_COLUMNS`. Encrypted columns take
-    precedence over their plaintext counterparts; the plaintext fallback
-    only matters for rows written before the #570 rollout (see migration
-    014 and ``scripts/migrate_chat_encryption.py``).
+    Column order matches :data:`_MESSAGE_COLUMNS`. The plaintext columns
+    were dropped by migration 026; ``content_encrypted`` is the sole
+    source of truth and is NOT NULL at the DB layer. We re-assert the
+    invariant here so a regression that re-introduces a NULL write
+    surfaces as a hard error instead of an empty message body.
     """
     msg_id = row[0]
     conversation_id = row[1]
     role = row[2]
-    content_plain = row[3]
-    tool_name = row[4]
-    tool_input_raw = row[5]
-    tool_output_raw = row[6]
-    rag_context_raw = row[7]
-    tokens_input = row[8]
-    tokens_output = row[9]
-    model = row[10]
-    created_at = row[11]
-    content_encrypted = row[12]
-    tool_input_encrypted = row[13]
-    tool_output_encrypted = row[14]
-    rag_context_encrypted = row[15]
-    # Migration 017 — pin / truncated flags. Defensive indexing so pre-017
-    # test fixtures that build 16-tuple rows continue to work.
-    is_pinned = bool(row[16]) if len(row) > 16 and row[16] is not None else False
-    is_truncated = bool(row[17]) if len(row) > 17 and row[17] is not None else False
+    tool_name = row[3]
+    tokens_input = row[4]
+    tokens_output = row[5]
+    model = row[6]
+    created_at = row[7]
+    content_encrypted = row[8]
+    tool_input_encrypted = row[9]
+    tool_output_encrypted = row[10]
+    rag_context_encrypted = row[11]
+    # Migration 017 — pin / truncated flags. Defensive indexing so the
+    # pre-017 SELECT fallback (12-tuple rows) still loads cleanly.
+    is_pinned = bool(row[12]) if len(row) > 12 and row[12] is not None else False
+    is_truncated = bool(row[13]) if len(row) > 13 and row[13] is not None else False
 
-    # Content: prefer encrypted blob, fall back to plaintext TEXT column.
-    decrypted_content = _decode_encrypted_text(content_encrypted)
-    content = decrypted_content if decrypted_content is not None else (content_plain or "")
+    if content_encrypted is None:
+        raise ValueError(
+            f"messages.id={msg_id}: content_encrypted IS NULL — "
+            "encryption-at-rest invariant violated (see migration 026)"
+        )
+    content = _decode_encrypted_text(content_encrypted) or ""
 
-    # tool_input: prefer encrypted JSON blob; fall back to plaintext JSONB.
     tool_input = _decode_encrypted_json(tool_input_encrypted)
-    if tool_input is None:
-        tool_input = parse_jsonb(tool_input_raw)
     if tool_input is not None and not isinstance(tool_input, dict):
         tool_input = None
 
     tool_output = _decode_encrypted_json(tool_output_encrypted)
-    if tool_output is None:
-        tool_output = parse_jsonb(tool_output_raw)
     if tool_output is not None and not isinstance(tool_output, dict):
         tool_output = None
 
     rag_context = _decode_encrypted_json(rag_context_encrypted)
-    if rag_context is None:
-        rag_context = parse_jsonb(rag_context_raw)
     if rag_context is not None and not isinstance(rag_context, list):
         rag_context = None
 
@@ -558,10 +551,11 @@ def create_message(
     if role not in VALID_ROLES:
         raise ValueError(f"Invalid message role: {role!r}")
 
-    # #570: write payload columns to their ``*_encrypted`` BYTEA siblings via
-    # Fernet. The legacy plaintext columns stay NULL on new INSERTs — Phase C
-    # migration will drop them entirely. Encrypting here (instead of at the
-    # DB layer via pgcrypto) keeps the key inside the app process and lets
+    # #687 (supersedes #570): payload columns are written exclusively to
+    # the ``*_encrypted`` BYTEA siblings via Fernet. The legacy plaintext
+    # columns were dropped by migration 026; ``content_encrypted`` is
+    # NOT NULL at the DB level. Encrypting here (rather than at the DB
+    # layer via pgcrypto) keeps the key inside the app process and lets
     # us reuse the same Fernet primitive as drafts.parsed_text_encrypted.
     content_ciphertext = encrypt_text(content) if content else encrypt_text("")
     tool_input_ciphertext = (
@@ -583,12 +577,10 @@ def create_message(
     row = conn.execute(
         f"""
         INSERT INTO messages
-            (conversation_id, role, content, tool_name, tool_input,
-             tool_output, rag_context, tokens_input, tokens_output, model,
+            (conversation_id, role, tool_name, tokens_input, tokens_output, model,
              content_encrypted, tool_input_encrypted, tool_output_encrypted,
              rag_context_encrypted)
-        VALUES (%s, %s, NULL, %s, NULL::jsonb, NULL::jsonb, NULL::jsonb, %s, %s, %s,
-                %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING {_MESSAGE_COLUMNS}
         """,
         (
@@ -827,20 +819,18 @@ def fork_conversation(
     # ``create_conversation`` does not set ``title_is_custom``; migration
     # 017 defaults it to FALSE so we do not need an extra UPDATE.
 
-    # Copy messages byte-for-byte — include the encrypted BYTEA columns
-    # directly. ``created_at`` is preserved so the fork reads in the same
-    # order as the source up to the boundary.
+    # Copy messages byte-for-byte — only the encrypted BYTEA columns
+    # carry payload after migration 026. ``created_at`` is preserved so
+    # the fork reads in the same order as the source up to the boundary.
     conn.execute(
         """
         INSERT INTO messages (
-            conversation_id, role, content, tool_name, tool_input,
-            tool_output, rag_context, tokens_input, tokens_output, model,
+            conversation_id, role, tool_name, tokens_input, tokens_output, model,
             content_encrypted, tool_input_encrypted, tool_output_encrypted,
             rag_context_encrypted, is_pinned, is_truncated, created_at
         )
         SELECT
-            %s, role, content, tool_name, tool_input,
-            tool_output, rag_context, tokens_input, tokens_output, model,
+            %s, role, tool_name, tokens_input, tokens_output, model,
             content_encrypted, tool_input_encrypted, tool_output_encrypted,
             rag_context_encrypted, is_pinned, is_truncated, created_at
         FROM messages

--- a/migrations/026_drop_chat_plaintext_columns.sql
+++ b/migrations/026_drop_chat_plaintext_columns.sql
@@ -1,0 +1,39 @@
+-- =============================================================================
+-- Migration 026: drop plaintext chat columns + lock content_encrypted NOT NULL
+-- =============================================================================
+--
+-- Phase C of the chat-encryption rollout (#687, follow-up to #570 / migration
+-- 014). Migration 014 added ``*_encrypted`` BYTEA columns alongside the
+-- legacy plaintext columns; ``scripts/migrate_chat_encryption.py`` (Phase B)
+-- backfilled them. The Step 1 pre-flight on prod (issue comment, 2026-05-02)
+-- confirmed zero rows have ``content_encrypted IS NULL`` — the messages
+-- table is in fact empty in prod, so this migration is risk-free.
+--
+-- Safety net: a defensive PL/pgSQL block re-runs the pre-flight inline.
+-- If any row violates the invariant the migration aborts before the
+-- destructive DROPs run, so a botched deploy cannot lose data.
+-- =============================================================================
+
+DO $$
+DECLARE
+  pending BIGINT;
+BEGIN
+  SELECT COUNT(*) INTO pending FROM messages WHERE content_encrypted IS NULL;
+  IF pending > 0 THEN
+    RAISE EXCEPTION
+      'Refusing to drop plaintext columns: % messages still have content_encrypted IS NULL — '
+      're-run scripts/migrate_chat_encryption.py before applying this migration',
+      pending;
+  END IF;
+END $$;
+
+ALTER TABLE messages
+  DROP COLUMN content,
+  DROP COLUMN tool_input,
+  DROP COLUMN tool_output,
+  DROP COLUMN rag_context;
+
+-- The encrypted column is now the sole source of truth for message content.
+-- Locking it NOT NULL guarantees future writes cannot regress to a
+-- "no-payload" state without an explicit migration to relax the constraint.
+ALTER TABLE messages ALTER COLUMN content_encrypted SET NOT NULL;

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -900,37 +900,34 @@ class TestAuditKeys:
 
 
 # ---------------------------------------------------------------------------
-# P2.5: _update_message_content fail-safe in production.
+# P2.5: _update_message_content requires encryption (post-migration-026).
 # ---------------------------------------------------------------------------
 
 
-class TestUpdateMessageContentFailSafe:
-    def test_dev_falls_back_to_plaintext_on_encryption_failure(self, provider_patch, monkeypatch):
-        """In dev (``APP_ENV != production``) encrypt errors write plaintext."""
+class TestUpdateMessageContentRequiresEncryption:
+    """Migration 026 dropped the plaintext ``content`` column, so there is
+    no fallback. Every edit must encrypt; an encryption failure raises in
+    every environment (#687)."""
+
+    def test_writes_only_encrypted_column(self, provider_patch, monkeypatch):
         from app.chat.handlers import _update_message_content
 
         monkeypatch.setenv("APP_ENV", "development")
 
         conn = MagicMock()
-
-        def boom(_text: str) -> bytes:
-            raise RuntimeError("no key")
-
-        # Patch the import site used inside _update_message_content.
-        with patch("app.storage.encrypt_text", side_effect=boom):
+        with patch("app.storage.encrypt_text", return_value=b"ciphertext"):
             _update_message_content(conn, _MSG_ID, "uus sisu")
 
-        # Plaintext-path UPDATE landed.
         sql, params = conn.execute.call_args.args
-        assert "content = %s" in sql
-        assert "content_encrypted = NULL" in sql
-        assert params == ("uus sisu", str(_MSG_ID))
+        assert "content_encrypted = %s" in sql
+        # The plaintext column is gone — the SQL must not mention it.
+        assert "content = " not in sql
+        assert params == (b"ciphertext", str(_MSG_ID))
 
-    def test_prod_reraises_on_encryption_failure(self, provider_patch, monkeypatch):
-        """In production encrypt errors must NOT fall back to plaintext."""
+    def test_raises_on_encryption_failure(self, provider_patch, monkeypatch):
         from app.chat.handlers import _update_message_content
 
-        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("APP_ENV", "development")
 
         conn = MagicMock()
 
@@ -941,7 +938,6 @@ class TestUpdateMessageContentFailSafe:
             with pytest.raises(RuntimeError, match="no key"):
                 _update_message_content(conn, _MSG_ID, "tundlik sisu")
 
-        # No UPDATE was executed — the write never touched the DB.
         conn.execute.assert_not_called()
 
 

--- a/tests/test_chat_models.py
+++ b/tests/test_chat_models.py
@@ -88,9 +88,6 @@ def _make_message_row(
     role: str = "user",
     content: str = "Mis on tsiviilseadustik?",
     tool_name: str | None = None,
-    tool_input: str | None = None,
-    tool_output: str | None = None,
-    rag_context: str | None = None,
     tokens_input: int | None = None,
     tokens_output: int | None = None,
     model: str | None = None,
@@ -99,21 +96,23 @@ def _make_message_row(
     tool_output_encrypted: bytes | None = None,
     rag_context_encrypted: bytes | None = None,
 ) -> tuple[Any, ...]:
-    """Build a raw cursor row matching _MESSAGE_COLUMNS order.
+    """Build a raw cursor row matching :data:`_MESSAGE_COLUMNS` order.
 
-    #570 adds four encrypted BYTEA columns. The plaintext defaults above
-    exercise the fallback path used for pre-backfill rows.
+    Migration 026 dropped the plaintext payload columns; rows now carry
+    only the ``*_encrypted`` BYTEA columns. ``content_encrypted``
+    defaults to a real Fernet ciphertext of ``content`` so positive-path
+    tests need not pre-encrypt the fixture.
     """
+    from app.storage import encrypt_text
+
     now = datetime.now(UTC)
+    if content_encrypted is None:
+        content_encrypted = encrypt_text(content or "")
     return (
         msg_id or uuid.uuid4(),
         conversation_id or uuid.uuid4(),
         role,
-        content,
         tool_name,
-        tool_input,
-        tool_output,
-        rag_context,
         tokens_input,
         tokens_output,
         model,
@@ -319,14 +318,16 @@ class TestCreateMessage:
         conn.execute.assert_called_once()
 
     def test_create_tool_message(self):
+        from app.storage import encrypt_text
+
         conn = MagicMock()
         conv_id = uuid.uuid4()
         row = _make_message_row(
             conversation_id=conv_id,
             role="tool",
             tool_name="query_ontology",
-            tool_input='{"query": "SELECT ..."}',
-            tool_output='{"results": []}',
+            tool_input_encrypted=encrypt_text('{"query": "SELECT ..."}'),
+            tool_output_encrypted=encrypt_text('{"results": []}'),
         )
         conn.execute.return_value.fetchone.return_value = row
 

--- a/tests/test_chat_models_encryption.py
+++ b/tests/test_chat_models_encryption.py
@@ -43,9 +43,9 @@ _CONV_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
 def _echo_row(conn_mock: MagicMock) -> list[Any]:
     """Capture the INSERT params and build a matching row for ``fetchone``.
 
-    The chat INSERT binds 10 positional params; columns 6..9 are the four
-    encrypted BYTEA values. We map those back into a cursor row that has
-    the full 16-column shape ``_MESSAGE_COLUMNS`` expects.
+    Migration 026 dropped the plaintext payload columns; the INSERT now
+    binds 10 positional params and ``_MESSAGE_COLUMNS`` is 14 wide
+    (no ``content``/``tool_input``/``tool_output``/``rag_context``).
     """
     params = conn_mock.execute.call_args.args[1]
     (
@@ -65,11 +65,7 @@ def _echo_row(conn_mock: MagicMock) -> list[Any]:
         uuid.uuid4(),
         _CONV_ID,
         role,
-        None,  # content (plaintext) — new writes NULL it
         tool_name,
-        None,  # tool_input plaintext
-        None,  # tool_output plaintext
-        None,  # rag_context plaintext
         tokens_input,
         tokens_output,
         model,
@@ -194,63 +190,38 @@ class TestNullJsonColumns:
         assert result.rag_context is None
 
 
-class TestPlaintextFallback:
-    """Rows that pre-date the #570 backfill still decode correctly."""
+class TestEncryptionInvariant:
+    """Migration 026 dropped the plaintext fallback. ``_row_to_message``
+    must refuse a row whose ``content_encrypted`` is NULL so a future
+    regression cannot silently serve empty message bodies (#687)."""
 
-    def test_row_with_plaintext_only_is_readable(self):
+    def test_null_content_encrypted_raises(self):
+        from app.chat.models import _row_to_message
+
         now = datetime.now(UTC)
         row = (
             uuid.uuid4(),
             _CONV_ID,
             "user",
-            "pre-backfill plaintext",  # content (plaintext)
             None,  # tool_name
-            None,  # tool_input plaintext
-            None,  # tool_output plaintext
-            None,  # rag_context plaintext
-            None,
-            None,
-            None,
+            None,  # tokens_input
+            None,  # tokens_output
+            None,  # model
             now,
-            None,  # content_encrypted — NULL, triggers fallback
+            None,  # content_encrypted — NULL is the regression
             None,
             None,
             None,
+            False,
+            False,
         )
 
-        msg = _row_to_message(row)
-        assert msg.content == "pre-backfill plaintext"
-        assert msg.tool_input is None
+        with pytest.raises(ValueError, match="content_encrypted IS NULL"):
+            _row_to_message(row)
 
-    def test_row_with_plaintext_jsonb_only_is_readable(self):
-        now = datetime.now(UTC)
-        row = (
-            uuid.uuid4(),
-            _CONV_ID,
-            "tool",
-            "legacy tool message",
-            "query_ontology",
-            {"query": "SELECT"},  # tool_input plaintext JSONB (parsed dict)
-            {"results": []},
-            [{"chunk_id": "x"}],
-            None,
-            None,
-            None,
-            now,
-            None,
-            None,
-            None,
-            None,
-        )
-
-        msg = _row_to_message(row)
-        assert msg.content == "legacy tool message"
-        assert msg.tool_input == {"query": "SELECT"}
-        assert msg.tool_output == {"results": []}
-        assert msg.rag_context == [{"chunk_id": "x"}]
-
-    def test_encrypted_column_takes_precedence_over_plaintext(self):
-        """If both columns are populated, the encrypted one wins."""
+    def test_encrypted_only_row_decodes_cleanly(self):
+        """Positive control: a row with only encrypted columns reads back
+        as the original plaintext, no plaintext column required."""
         from app.storage import encrypt_text
 
         now = datetime.now(UTC)
@@ -258,10 +229,6 @@ class TestPlaintextFallback:
             uuid.uuid4(),
             _CONV_ID,
             "user",
-            "stale plaintext",  # should be ignored
-            None,
-            None,
-            None,
             None,
             None,
             None,
@@ -271,9 +238,13 @@ class TestPlaintextFallback:
             None,
             None,
             None,
+            False,
+            False,
         )
+
         msg = _row_to_message(row)
         assert msg.content == "authoritative ciphertext"
+        assert msg.tool_input is None
 
 
 class TestSecurityInspection:

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -66,6 +66,33 @@ def _make_conversation(
     )
 
 
+def _make_message_row(
+    *,
+    role: str = "user",
+    content: str = "x",
+) -> tuple[Any, ...]:
+    """Build a 14-tuple matching ``app.chat.models._MESSAGE_COLUMNS`` order
+    (post-migration-026: no plaintext payload columns)."""
+    from app.storage import encrypt_text
+
+    return (
+        uuid.uuid4(),
+        _CONV_ID,
+        role,
+        None,  # tool_name
+        None,  # tokens_input
+        None,  # tokens_output
+        None,  # model
+        datetime.now(UTC),
+        encrypt_text(content),
+        None,  # tool_input_encrypted
+        None,  # tool_output_encrypted
+        None,  # rag_context_encrypted
+        False,  # is_pinned
+        False,  # is_truncated
+    )
+
+
 def _make_message(
     role: str = "user",
     content: str = "Tere",
@@ -264,7 +291,7 @@ class TestOrchestratorHappyPath:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
 
         call_counter = {"n": 0}
         base_conv_row = (
@@ -281,24 +308,7 @@ class TestOrchestratorHappyPath:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -368,7 +378,7 @@ class TestOrchestratorToolUse:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
 
         call_counter = {"n": 0}
         base_conv_row = (
@@ -385,24 +395,7 @@ class TestOrchestratorToolUse:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "Tere",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row(content="Tere")
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -453,7 +446,7 @@ class TestOrchestratorMaxToolRounds:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
 
         call_counter = {"n": 0}
         base_conv_row = (
@@ -470,24 +463,7 @@ class TestOrchestratorMaxToolRounds:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -541,7 +517,7 @@ class TestOrchestratorDraftContext:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation(context_draft_id=_DRAFT_ID)
-        now = datetime.now(UTC)
+        datetime.now(UTC)
 
         call_counter = {"n": 0}
         base_conv_row = (
@@ -558,24 +534,7 @@ class TestOrchestratorDraftContext:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -611,7 +570,7 @@ class TestOrchestratorLLMError:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
         call_counter = {"n": 0}
         base_conv_row = (
             conv.id,
@@ -627,24 +586,7 @@ class TestOrchestratorLLMError:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -672,7 +614,7 @@ class TestOrchestratorPersistence:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
 
         call_counter = {"n": 0}
         base_conv_row = (
@@ -689,24 +631,7 @@ class TestOrchestratorPersistence:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -1189,7 +1114,7 @@ class TestOrchestratorPartialPersistence:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
         call_counter = {"n": 0}
         base_conv_row = (
             conv.id,
@@ -1205,24 +1130,7 @@ class TestOrchestratorPartialPersistence:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -1263,7 +1171,7 @@ class TestOrchestratorPartialPersistence:
         mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
         call_counter = {"n": 0}
         base_conv_row = (
             conv.id,
@@ -1279,24 +1187,7 @@ class TestOrchestratorPartialPersistence:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,  # content_encrypted (#570)
-                None,  # tool_input_encrypted
-                None,  # tool_output_encrypted
-                None,  # rag_context_encrypted
-            )
+            return _make_message_row()
 
         conn.execute.return_value.fetchone = side_effect_fetchone
         conn.execute.return_value.fetchall.return_value = []
@@ -1362,7 +1253,7 @@ def _setup_orchestrator_conn(mock_get_conn: Any, *, context_draft_id: Any = None
     mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
     conv = _make_conversation()
-    now = datetime.now(UTC)
+    datetime.now(UTC)
 
     call_counter = {"n": 0}
     base_conv_row = (
@@ -1379,24 +1270,7 @@ def _setup_orchestrator_conn(mock_get_conn: Any, *, context_draft_id: Any = None
         call_counter["n"] += 1
         if call_counter["n"] == 1:
             return base_conv_row
-        return (
-            uuid.uuid4(),
-            _CONV_ID,
-            "user",
-            "x",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            now,
-            None,
-            None,
-            None,
-            None,
-        )
+        return _make_message_row()
 
     conn.execute.return_value.fetchone = side_effect_fetchone
     conn.execute.return_value.fetchall.return_value = []
@@ -1945,7 +1819,7 @@ class TestCostBudgetAdvisoryLock:
         also run ``INSERT INTO messages``.
         """
         conv = _make_conversation()
-        now = datetime.now(UTC)
+        datetime.now(UTC)
 
         # Shared counter so subsequent calls return message rows.
         call_counter = {"n": 0}
@@ -1963,24 +1837,7 @@ class TestCostBudgetAdvisoryLock:
             call_counter["n"] += 1
             if call_counter["n"] == 1:
                 return base_conv_row
-            return (
-                uuid.uuid4(),
-                _CONV_ID,
-                "user",
-                "x",
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                now,
-                None,
-                None,
-                None,
-                None,
-            )
+            return _make_message_row()
 
         # We'll hand out a stream of conns — the orchestrator opens a fresh
         # connection per ``with get_connection()`` block. Capture per-conn

--- a/tests/test_chat_rag_integration.py
+++ b/tests/test_chat_rag_integration.py
@@ -37,6 +37,33 @@ def _auth() -> dict[str, Any]:
     return {"id": _USER_ID, "org_id": _ORG_ID}
 
 
+def _make_message_row(
+    *,
+    role: str = "user",
+    content: str = "x",
+) -> tuple[Any, ...]:
+    """Build a 14-tuple matching ``app.chat.models._MESSAGE_COLUMNS`` order
+    (post-migration-026: no plaintext payload columns)."""
+    from app.storage import encrypt_text
+
+    return (
+        uuid.uuid4(),
+        _CONV_ID,
+        role,
+        None,  # tool_name
+        None,  # tokens_input
+        None,  # tokens_output
+        None,  # model
+        datetime.now(UTC),
+        encrypt_text(content),
+        None,  # tool_input_encrypted
+        None,  # tool_output_encrypted
+        None,  # rag_context_encrypted
+        False,  # is_pinned
+        False,  # is_truncated
+    )
+
+
 def _make_conversation(
     *,
     conv_id: uuid.UUID = _CONV_ID,
@@ -141,7 +168,7 @@ def _setup_mock_conn(mock_get_conn: MagicMock) -> MagicMock:
     mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
 
     conv = _make_conversation()
-    now = datetime.now(UTC)
+    datetime.now(UTC)
 
     call_counter = {"n": 0}
     base_conv_row = (
@@ -158,24 +185,7 @@ def _setup_mock_conn(mock_get_conn: MagicMock) -> MagicMock:
         call_counter["n"] += 1
         if call_counter["n"] == 1:
             return base_conv_row
-        return (
-            uuid.uuid4(),
-            _CONV_ID,
-            "user",
-            "x",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            now,
-            None,  # content_encrypted (#570)
-            None,  # tool_input_encrypted
-            None,  # tool_output_encrypted
-            None,  # rag_context_encrypted
-        )
+        return _make_message_row()
 
     conn.execute.return_value.fetchone = side_effect_fetchone
     conn.execute.return_value.fetchall.return_value = []


### PR DESCRIPTION
Closes #687. Phase C of the chat-encryption rollout (#570 → #687).

## Pre-flight
Step 1 ran on prod 2026-05-02 (issue comment): zero rows have `content_encrypted IS NULL` — the `messages` table is in fact empty in prod, so this migration is risk-free in our environment.

## Migration 026
Drops the plaintext payload columns (`content`, `tool_input`, `tool_output`, `rag_context`) from `messages` and locks `content_encrypted` NOT NULL. A defensive PL/pgSQL block re-runs the pre-flight inline so a botched deploy aborts before the destructive `DROP COLUMN`s execute.

## Code
- `app/chat/models.py`
  - `_MESSAGE_COLUMNS` / `_MESSAGE_COLUMNS_PRE017` no longer reference the plaintext payload columns.
  - `_row_to_message` raises `ValueError` if `content_encrypted IS NULL` so a future regression cannot silently serve empty message bodies.
  - `create_message` and `fork_conversation` write only the `*_encrypted` columns.
  - Removed the now-unused `parse_jsonb` import.
- `app/chat/handlers.py::_update_message_content` no longer falls back to plaintext on encryption failure — every environment must encrypt or raise; there is no plaintext column left to write to.

## Tests
- Replaced `TestPlaintextFallback` with `TestEncryptionInvariant` — asserts `_row_to_message` raises on `content_encrypted IS NULL` and that an encrypted-only row decodes cleanly.
- Replaced `TestUpdateMessageContentFailSafe` with `TestUpdateMessageContentRequiresEncryption` — both dev and prod raise on encryption failure; the SQL writes only the encrypted column.
- Updated `_make_message_row` fixture in `test_chat_models.py` to the new 14-column shape.
- Added a `_make_message_row()` helper in `test_chat_orchestrator.py` and `test_chat_rag_integration.py` and replaced ten hand-built 16-tuple `fetchone` mocks with calls to it.

## Definition of Done
- [x] Pre-flight verification SQL run against prod, returns all zeroes (in this case, no rows at all)
- [x] Migration 026 drops the plaintext columns + sets `content_encrypted NOT NULL` with a defensive runtime check
- [x] `app/chat/models.py` no longer references plaintext columns
- [x] `app/chat/handlers.py` no longer has the plaintext fallback in `_update_message_content`
- [x] Tests adapted; `TestEncryptionInvariant` regression added for the read-path NULL guard
- [x] Skipped Step 2 (7-day defensive logging soak) — not load-bearing because prod has zero rows; documented in #687 comment

## Test plan
- [x] `uv run ruff check` + `uv run ruff format` — green on touched files
- [x] `uv run pyright app/chat/models.py app/chat/handlers.py` — 0 errors
- [x] `uv run pytest` — 1850 passed, 22 skipped
- [ ] Confirm migration 026 applies cleanly during the Coolify deploy (auto-runs via `docker/entrypoint.sh`)
- [ ] Smoke test the chat UI on staging after deploy: send a message, reload conversation, edit a message, fork a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)