### PR TITLE
infra: add LibreOffice base image (§4.3 deploy-risk isolation)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,14 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl git && \
     rm -rf /var/lib/apt/lists/*
 
+# §4.3 LibreOffice base image (Eelnõud sprint plan 2026-05-02).
+# Installed here so the deploy risk is validated independently before any
+# code that calls `soffice --headless --convert-to pdf` ships (#613 PDF export).
+# Nothing in the app uses LibreOffice yet — this is a pure infrastructure step.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libreoffice-core libreoffice-writer \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv


### PR DESCRIPTION
## Why

Deploy-risk isolation per **Eelnõud sprint plan §4.3** (`docs/superpowers/specs/2026-05-02-eelnoud-sprint-plan.md`).

#613 (PDF export) will call `soffice --headless --convert-to pdf` once it lands. Rather than discover image-size or cold-start surprises when the feature PR ships, this standalone PR validates the deploy independently — before Sprint 1 Day 4.

## What

Adds a single `apt-get` step to the **runtime stage** of `docker/Dockerfile`:

```dockerfile
RUN apt-get update \
    && apt-get install -y --no-install-recommends libreoffice-core libreoffice-writer \
    && rm -rf /var/lib/apt/lists/*
```

Placed after the existing `curl git` install block, before `WORKDIR /app`. No Python code touches LibreOffice — this PR is infrastructure only.

## Acceptance criteria

- [ ] Image build succeeds on CI
- [ ] Container cold start < 30s (measure after deploy to prod)
- [ ] Image size delta < 600 MB (if exceeded, escalate before #613 starts — consider reportlab fallback)
- [ ] Site still serves 200 after deploy (`curl -fsS https://seadusloome.sixtyfour.ee/api/ping`)

## Relation to #613

This is the **prerequisite PR**, not the feature. Do **not** close #613 on merge. Sprint 1 Day 4 pre-flight asserts this PR is merged and deployed before #613 work begins.