### PR TITLE
fix(docs): draft status single source of truth (#625)

### DIFF
--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -37,7 +37,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from app.db import get_connection
-from app.docs.draft_model import fetch_draft, get_draft
+from app.docs.draft_model import fetch_draft, get_draft, update_draft_status
 from app.docs.entity_extractor import ExtractedRef
 from app.docs.error_mapping import map_failure_to_user_message
 from app.docs.graph_builder import build_draft_graph, write_doc_lineage
@@ -150,18 +150,13 @@ def analyze_impact(
                     ontology_version,
                 ),
             )
-            conn.execute(
-                """
-                update drafts
-                set status = 'ready',
-                    error_message = null,
-                    error_debug = null,
-                    updated_at = now(),
-                    processing_completed_at = now()
-                where id = %s
-                """,
-                (str(draft_id),),
-            )
+            # #625 §4.2: route through the SSOT helper. The helper
+            # clears ``error_message`` / ``error_debug`` to NULL and
+            # stamps ``processing_completed_at = now()`` for terminal
+            # transitions (#670). Lives in the SAME transaction as the
+            # ``impact_reports`` insert above so observers never see a
+            # ``status='ready'`` row without its report.
+            update_draft_status(conn, draft_id, "ready")
             conn.commit()
 
         # #608: push the terminal status to subscribed WS clients first
@@ -310,17 +305,12 @@ def _mark_draft_failed(draft_id: UUID, exc: BaseException) -> None:
     user_msg, debug_detail = map_failure_to_user_message(exc, stage="analyze")
     try:
         with get_connection() as conn:
-            conn.execute(
-                """
-                update drafts
-                set status = 'failed',
-                    error_message = %s,
-                    error_debug = %s,
-                    updated_at = now(),
-                    processing_completed_at = now()
-                where id = %s
-                """,
-                (user_msg[:500], debug_detail, str(draft_id)),
+            update_draft_status(
+                conn,
+                draft_id,
+                "failed",
+                user_msg[:500],
+                error_debug=debug_detail,
             )
             conn.commit()
     except Exception:  # noqa: BLE001

--- a/app/docs/draft_model.py
+++ b/app/docs/draft_model.py
@@ -28,17 +28,19 @@ from typing import Any, Literal, LiteralString
 from app.db import get_connection as _connect
 from app.db_utils import coerce_uuid
 
-logger = logging.getLogger(__name__)
-
-
-VALID_STATUSES = (
-    "uploaded",
-    "parsing",
-    "extracting",
-    "analyzing",
-    "ready",
-    "failed",
+# Re-exported for backwards compatibility -- callers historically imported
+# ``VALID_STATUSES`` and ``update_draft_status`` from this module. The
+# canonical home is ``app.docs.status`` (#625, §4.2 SSOT). The ``noqa``
+# tags keep the re-export visible to ruff without a synthetic ``__all__``
+# (this module is import-by-name not star-imported, so an ``__all__``
+# entry would be cosmetic).
+from app.docs.status import (
+    STATUS_BY_VALUE,  # noqa: F401  -- re-exported
+    VALID_STATUSES,
+    update_draft_status,  # noqa: F401  -- re-exported
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -201,43 +203,10 @@ def create_draft(
     return _row_to_draft(row)
 
 
-_TERMINAL_STATUSES = frozenset({"ready", "failed"})
-
-
-def update_draft_status(
-    conn: Any,
-    draft_id: uuid.UUID | str,
-    status: str,
-    error_message: str | None = None,
-) -> bool:
-    """Transition a draft into a new ``status`` (and optional error message).
-
-    Returns ``True`` when a row was updated. Unlike the read helpers this
-    one takes an explicit connection so the worker can batch the update
-    with other state transitions in a single transaction.
-
-    #670: terminal transitions (``ready``, ``failed``) also stamp
-    ``processing_completed_at = now()``; non-terminal transitions clear
-    it back to NULL so a retry (``failed`` → ``uploaded``) starts with
-    a clean completion clock. Most handlers use raw SQL rather than this
-    helper, but they apply the same rule directly.
-    """
-    if status not in VALID_STATUSES:
-        raise ValueError(f"Invalid draft status: {status!r}")
-
-    completion_clause = "now()" if status in _TERMINAL_STATUSES else "null"
-    result = conn.execute(
-        f"""
-        update drafts
-        set status = %s,
-            error_message = %s,
-            updated_at = now(),
-            processing_completed_at = {completion_clause}
-        where id = %s
-        """,
-        (status, error_message, str(draft_id)),
-    )
-    return (result.rowcount or 0) > 0
+# ``update_draft_status`` lives in ``app.docs.status`` -- imported and
+# re-exported above so existing callers keep working unchanged. The
+# helper, the terminal-status set, and the validation tuple all moved
+# to ``app.docs.status`` as part of the §4.2 SSOT cutover (#625).
 
 
 def update_draft_parent_vtk(

--- a/app/docs/extract_handler.py
+++ b/app/docs/extract_handler.py
@@ -150,17 +150,17 @@ def extract_entities(
                         json.dumps(r.extracted.location),
                     ),
                 )
-            conn.execute(
-                """
-                update drafts
-                set entity_count = %s,
-                    status = 'analyzing',
-                    error_message = null,
-                    error_debug = null,
-                    updated_at = now()
-                where id = %s
-                """,
-                (len(resolved), str(draft_id)),
+            # #625 §4.2: route through the SSOT helper so the status
+            # flip and the entity_count write land in the SAME UPDATE
+            # (preserving the #626 atomicity guarantee). The helper
+            # clears ``error_message`` / ``error_debug`` to NULL on
+            # this transition so stale failure info from a prior
+            # attempt cannot leak forward.
+            update_draft_status(
+                conn,
+                draft_id,
+                "analyzing",
+                extras={"entity_count": len(resolved)},
             )
             conn.commit()
 
@@ -187,17 +187,12 @@ def extract_entities(
             user_msg, debug_detail = map_failure_to_user_message(exc, stage="extract")
             try:
                 with get_connection() as conn:
-                    conn.execute(
-                        """
-                        update drafts
-                        set status = 'failed',
-                            error_message = %s,
-                            error_debug = %s,
-                            updated_at = now(),
-                            processing_completed_at = now()
-                        where id = %s
-                        """,
-                        (user_msg[:500], debug_detail, str(draft_id)),
+                    update_draft_status(
+                        conn,
+                        draft_id,
+                        "failed",
+                        user_msg[:500],
+                        error_debug=debug_detail,
                     )
                     conn.commit()
             except Exception:  # noqa: BLE001

--- a/app/docs/parse_handler.py
+++ b/app/docs/parse_handler.py
@@ -128,26 +128,23 @@ def parse_draft(
             raise ValueError("Tika returned empty text — file may be corrupt or an image-only PDF")
 
         # Step 6: encrypt parsed text and persist alongside status flip.
-        # Use a direct UPDATE because ``update_draft_status`` doesn't
-        # know about the parsed_text_encrypted column; the two need to
-        # land in the same row update so observers never see an
-        # inconsistent (parsed_text_encrypted NULL, status=extracting)
-        # snapshot. encrypt_text raises RuntimeError if the key is unset
-        # in prod — that propagates to the except block below and flips
-        # the draft to failed on the final attempt.
+        # Routed through ``update_draft_status(extras=...)`` so the
+        # ``parsed_text_encrypted`` column lands in the SAME UPDATE as
+        # the status flip -- observers never see a mismatched
+        # ``status='extracting'`` row with NULL parsed_text. The helper
+        # also clears ``error_message`` / ``error_debug`` to NULL on
+        # this transition so stale failure info from a prior attempt
+        # cannot leak forward (#625 §4.2 SSOT). encrypt_text raises
+        # RuntimeError if the key is unset in prod; the exception
+        # propagates to the except block below and flips the draft to
+        # failed on the final attempt.
         encrypted = encrypt_text(parsed_text)
         with get_connection() as conn:
-            conn.execute(
-                """
-                update drafts
-                set parsed_text_encrypted = %s,
-                    status = 'extracting',
-                    error_message = null,
-                    error_debug = null,
-                    updated_at = now()
-                where id = %s
-                """,
-                (encrypted, str(draft_id)),
+            update_draft_status(
+                conn,
+                draft_id,
+                "extracting",
+                extras={"parsed_text_encrypted": encrypted},
             )
             conn.commit()
 
@@ -230,17 +227,12 @@ def _mark_draft_failed(draft_id: UUID, exc: BaseException) -> None:
     user_msg, debug_detail = map_failure_to_user_message(exc, stage="parse")
     try:
         with get_connection() as conn:
-            conn.execute(
-                """
-                update drafts
-                set status = 'failed',
-                    error_message = %s,
-                    error_debug = %s,
-                    updated_at = now(),
-                    processing_completed_at = now()
-                where id = %s
-                """,
-                (user_msg[:500], debug_detail, str(draft_id)),
+            update_draft_status(
+                conn,
+                draft_id,
+                "failed",
+                user_msg[:500],
+                error_debug=debug_detail,
             )
             conn.commit()
     except Exception:  # noqa: BLE001 — best-effort cleanup

--- a/app/docs/retry_handler.py
+++ b/app/docs/retry_handler.py
@@ -45,6 +45,7 @@ from app.auth.policy import can_edit_draft
 from app.db import get_connection as _connect
 from app.docs._helpers import _not_found_page, _parse_uuid
 from app.docs.draft_model import fetch_draft
+from app.docs.status import update_draft_status
 from app.jobs.queue import JobQueue
 
 logger = logging.getLogger(__name__)
@@ -70,20 +71,18 @@ def _reset_draft_for_retry(draft_id: str) -> bool:
     audit trail of prior runs stays intact.
     """
     with _connect() as conn:
-        result = conn.execute(
-            """
-            update drafts
-            set status = 'uploaded',
-                error_message = null,
-                error_debug = null,
-                updated_at = now(),
-                processing_completed_at = null
-            where id = %s
-              and status = 'failed'
-            """,
-            (draft_id,),
+        # #625 §4.2: route through the SSOT helper. ``expected_status``
+        # provides the optimistic-concurrency guard so we only flip
+        # ``failed`` -> ``uploaded`` if the row is still in ``failed``
+        # at write time. The helper clears both error columns and
+        # resets ``processing_completed_at`` to NULL because
+        # ``uploaded`` is non-terminal (#670).
+        updated = update_draft_status(
+            conn,
+            draft_id,
+            "uploaded",
+            expected_status="failed",
         )
-        updated = (result.rowcount or 0) > 0
         if updated:
             # Only clean up the queue when we actually flipped the row.
             # If the UPDATE matched zero rows, something else is driving

--- a/app/docs/routes.py
+++ b/app/docs/routes.py
@@ -53,6 +53,16 @@ from app.docs.draft_model import (
     update_draft_parent_vtk,
 )
 from app.docs.graph_builder import write_doc_lineage
+from app.docs.status import (
+    PIPELINE_STAGES,
+    STATUS_BY_VALUE,
+)
+from app.docs.status import (
+    TERMINAL_STATUSES as _TERMINAL_STATUSES,
+)
+from app.docs.status import (
+    VALID_STATUSES as _VALID_STATUSES,
+)
 from app.docs.upload import DraftUploadError, handle_upload
 from app.jobs.queue import JobQueue
 from app.rag.retriever import delete_chunks_for_draft
@@ -79,20 +89,11 @@ logger = logging.getLogger(__name__)
 # Status display helpers
 # ---------------------------------------------------------------------------
 
-# Public pipeline stages in order. "failed" is a terminal branch rendered
+# Pipeline stages in order. "failed" is a terminal branch rendered
 # separately so the tracker reads left-to-right during normal operation.
-_STATUS_STAGES: tuple[tuple[str, str], ...] = (
-    ("uploaded", "Üles laaditud"),
-    ("parsing", "Töötlemine"),
-    ("extracting", "Olemite eraldamine"),
-    ("analyzing", "Mõjude analüüs"),
-    ("ready", "Valmis"),
-)
-
-_STATUS_LABELS: dict[str, str] = dict(_STATUS_STAGES)
-_STATUS_LABELS["failed"] = "Ebaõnnestus"
-
-_TERMINAL_STATUSES: frozenset[str] = frozenset({"ready", "failed"})
+# Sourced from :data:`app.docs.status.PIPELINE_STAGES` (#625 §4.2 SSOT)
+# so a new status only needs to be added in ``status.py``.
+_STATUS_STAGES: tuple[tuple[str, str], ...] = tuple((s.value, s.label_et) for s in PIPELINE_STAGES)
 
 _PAGE_SIZE = 25
 
@@ -118,36 +119,26 @@ def _is_draft_stale(draft: Draft) -> bool:
     return elapsed > _STALE_THRESHOLD_DAYS * 24 * 60 * 60
 
 
-_STATUS_KEY_MAP: dict[str, str] = {
-    "uploaded": "pending",
-    "parsing": "running",
-    "extracting": "running",
-    "analyzing": "running",
-    "ready": "ok",
-    "failed": "failed",
-}
-
-_STATUS_VARIANT_MAP: dict[str, BadgeVariant] = {
-    "uploaded": "default",
-    "parsing": "primary",
-    "extracting": "primary",
-    "analyzing": "primary",
-    "ready": "success",
-    "failed": "danger",
-}
-
-
 def _status_badge(status: str):
     """Return a Badge for a draft status.
 
     We use plain ``Badge`` instead of ``StatusBadge`` because the latter
     ships its own English-ish label set and our domain statuses
     (uploaded/parsing/extracting/analyzing) need Estonian copy.
+
+    Lookup goes through :data:`app.docs.status.STATUS_BY_VALUE` so the
+    label, variant, and CSS key all stay synchronised with the SSOT
+    (#625 §4.2). Unknown statuses fall back to a neutral pill so a
+    legacy row from before a label was added cannot crash the page.
     """
-    key = _STATUS_KEY_MAP.get(status, "pending")
-    variant: BadgeVariant = _STATUS_VARIANT_MAP.get(status, "default")
-    label = _STATUS_LABELS.get(status, status)
-    return Badge(label, variant=variant, cls=f"draft-status draft-status-{key}")
+    spec = STATUS_BY_VALUE.get(status)
+    if spec is None:
+        return Badge(status, variant="default", cls="draft-status draft-status-pending")
+    return Badge(
+        spec.label_et,
+        variant=spec.badge_variant,
+        cls=f"draft-status draft-status-{spec.css_key}",
+    )
 
 
 def _format_timestamp(value: Any) -> str:
@@ -655,16 +646,10 @@ _DOC_TYPE_CHOICES: tuple[tuple[str, str], ...] = (
 )
 _DOC_TYPE_VALUES: frozenset[str] = frozenset(v for v, _ in _DOC_TYPE_CHOICES)
 
-# Status checkbox group — same six values used by the pipeline.
-# Reusing _STATUS_LABELS keeps the Estonian copy in one place.
-_STATUS_VALUES: tuple[str, ...] = (
-    "uploaded",
-    "parsing",
-    "extracting",
-    "analyzing",
-    "ready",
-    "failed",
-)
+# Status checkbox group -- same six values used by the pipeline.
+# Sourced from :data:`app.docs.status.VALID_STATUSES` (#625 §4.2 SSOT)
+# so the filter bar picks up new statuses automatically.
+_STATUS_VALUES: tuple[str, ...] = _VALID_STATUSES
 
 # Sort dropdown options (label, value).
 _SORT_CHOICES: tuple[tuple[str, str], ...] = (
@@ -867,10 +852,11 @@ def _filter_bar(*, filters: dict, uploaders: list[dict]):
         }
         if value in selected_statuses:
             attrs["checked"] = True
+        spec = STATUS_BY_VALUE.get(value)
         status_inputs.append(
             Label(  # noqa: F405
                 Input(**attrs),  # noqa: F405
-                Span(_STATUS_LABELS.get(value, value)),  # noqa: F405
+                Span(spec.label_et if spec else value),  # noqa: F405
                 cls="checkbox-label",
                 For=f"filter-status-{value}",
             )

--- a/app/docs/status.py
+++ b/app/docs/status.py
@@ -1,0 +1,303 @@
+"""Single source of truth for ``drafts.status`` (#625).
+
+Before this module existed, draft status semantics were scattered across
+seven sites:
+
+    * ``app/docs/draft_model.VALID_STATUSES`` — the validation tuple.
+    * ``app/docs/routes._STATUS_STAGES`` — pipeline order + Estonian copy.
+    * ``app/docs/routes._STATUS_LABELS`` — value → Estonian label.
+    * ``app/docs/routes._STATUS_VARIANT_MAP`` — value → ``BadgeVariant``.
+    * ``app/docs/routes._STATUS_KEY_MAP`` — value → semantic CSS key.
+    * Six raw ``UPDATE drafts SET status = '<literal>' ...`` writes
+      across ``parse_handler`` / ``extract_handler`` / ``analyze_handler``
+      / ``retry_handler`` / ``draft_model.update_draft_status``.
+
+The duplication made it impossible to add a new status without grepping
+the codebase, and the raw SQL writes meant a typo in any one site
+silently fell through Postgres' ``CHECK`` constraint at runtime instead
+of pyright at compile time.
+
+This module collapses all of that into one tuple of ``DraftStatus``
+records plus a typed :func:`update_draft_status` helper. Every read of
+"the Estonian label", "the badge variant", "is this terminal", or
+"what's the next stage in the happy path" goes through
+:data:`STATUS_BY_VALUE`. Every write goes through
+:func:`update_draft_status` so an unknown value raises ``ValueError``
+in the application layer instead of waiting for the DB to reject it.
+
+§4.2 status semantics decision (locked):
+    Per the Eelnõud sprint plan §4.2, ``drafts.status`` is the canonical
+    write path for now. The version-aware cutover (writing to
+    ``draft_versions.status``) lands in #618 PR-B alongside the read
+    cutover. This module deliberately writes ONLY to ``drafts`` so the
+    sequencing is explicit and a bisect can pin the cutover point.
+
+Cost-of-change rationale:
+    The fixed signature ``update_draft_status(conn, draft_id, status,
+    *, error_message=..., error_debug=..., extras=...)`` covers every
+    current call site without forcing the helper to re-implement the
+    half-dozen ad-hoc UPDATE shapes the handlers had grown. ``extras``
+    keeps the rare two-column atomic writes (``parsed_text_encrypted``
+    in the parse handler, ``entity_count`` in the extract handler) in
+    a single UPDATE so we don't break the #626 atomicity guarantee.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from app.ui.primitives.badge import BadgeVariant
+
+
+@dataclass(frozen=True)
+class DraftStatus:
+    """One row in the status SSOT.
+
+    Attributes:
+        value: The string written to ``drafts.status``. Matches the
+            Postgres ``CHECK (status in (...))`` constraint in
+            migration 005.
+        label_et: The Estonian label rendered in the UI (status badge,
+            stage tracker, filter checkboxes).
+        badge_variant: The ``BadgeVariant`` used by ``app.ui.primitives.badge``
+            so the colour stays in sync with the design system.
+        is_terminal: ``True`` for statuses the pipeline never transitions
+            out of on its own (``ready``, ``failed``). The polling /
+            WebSocket layer uses this to decide when to stop pushing
+            updates and when to freeze the elapsed-time label.
+        successor: The next status in the happy-path pipeline, or
+            ``None`` for terminal stages. ``failed`` returns ``None``
+            because retry is an explicit user action, not part of the
+            normal flow.
+        order: Zero-based position in the stage tracker. ``failed`` uses
+            ``99`` so it sorts after the happy path stages without
+            colliding with them.
+        css_key: Semantic key used by the status badge / tracker CSS so
+            the existing ``draft-status-{key}`` and ``status-{key}``
+            class names continue to work after the cutover.
+    """
+
+    value: str
+    label_et: str
+    badge_variant: BadgeVariant
+    is_terminal: bool
+    successor: str | None
+    order: int
+    css_key: str
+
+
+# The canonical status table. Order matters: the happy path stages
+# read top-to-bottom, with ``failed`` pinned to the bottom as the
+# terminal-failure branch.
+#
+# Estonian labels are copied verbatim from the previous
+# ``app/docs/routes.py`` ``_STATUS_STAGES`` + ``_STATUS_LABELS`` maps
+# (and the filter-bar group) so the visible UI copy is unchanged.
+DRAFT_STATUSES: tuple[DraftStatus, ...] = (
+    DraftStatus(
+        value="uploaded",
+        label_et="Üles laaditud",
+        badge_variant="default",
+        is_terminal=False,
+        successor="parsing",
+        order=0,
+        css_key="pending",
+    ),
+    DraftStatus(
+        value="parsing",
+        label_et="Töötlemine",
+        badge_variant="primary",
+        is_terminal=False,
+        successor="extracting",
+        order=1,
+        css_key="running",
+    ),
+    DraftStatus(
+        value="extracting",
+        label_et="Olemite eraldamine",
+        badge_variant="primary",
+        is_terminal=False,
+        successor="analyzing",
+        order=2,
+        css_key="running",
+    ),
+    DraftStatus(
+        value="analyzing",
+        label_et="Mõjude analüüs",
+        badge_variant="primary",
+        is_terminal=False,
+        successor="ready",
+        order=3,
+        css_key="running",
+    ),
+    DraftStatus(
+        value="ready",
+        label_et="Valmis",
+        badge_variant="success",
+        is_terminal=True,
+        successor=None,
+        order=4,
+        css_key="ok",
+    ),
+    DraftStatus(
+        value="failed",
+        label_et="Ebaõnnestus",
+        badge_variant="danger",
+        is_terminal=True,
+        successor=None,
+        order=99,
+        css_key="failed",
+    ),
+)
+
+
+# O(1) lookup by status value. Built once at import time.
+STATUS_BY_VALUE: dict[str, DraftStatus] = {s.value: s for s in DRAFT_STATUSES}
+
+# Tuple of valid status values for backwards-compatibility with the old
+# ``app.docs.draft_model.VALID_STATUSES`` import path. New callers should
+# prefer ``STATUS_BY_VALUE`` (membership check is identical, and a hit
+# returns the full ``DraftStatus`` record with no extra lookup).
+VALID_STATUSES: tuple[str, ...] = tuple(s.value for s in DRAFT_STATUSES)
+
+# Frozen set of terminal statuses. Used by the pipeline handlers to
+# decide whether to stamp ``processing_completed_at = now()`` or clear
+# it back to NULL (#670 — the frozen completion timestamp).
+TERMINAL_STATUSES: frozenset[str] = frozenset(s.value for s in DRAFT_STATUSES if s.is_terminal)
+
+# Pipeline stage tuple kept in DB-write order. Excludes ``failed`` so
+# the tracker UI renders left-to-right during normal operation; the
+# failure branch is rendered separately by the routes layer.
+PIPELINE_STAGES: tuple[DraftStatus, ...] = tuple(
+    s for s in sorted(DRAFT_STATUSES, key=lambda d: d.order) if s.value != "failed"
+)
+
+
+def update_draft_status(
+    conn: Any,
+    draft_id: Any,
+    status: str,
+    error_message: str | None = None,
+    *,
+    error_debug: str | None = None,
+    extras: Mapping[str, Any] | None = None,
+    expected_status: str | None = None,
+) -> bool:
+    """Typed UPDATE that validates ``status`` against :data:`DRAFT_STATUSES`.
+
+    §4.2 cutover: this writes ONLY to ``drafts``. The version-aware
+    ``draft_versions`` write lands in #618 PR-B alongside the read
+    cutover. The handler must NOT touch ``draft_versions`` here -- a
+    bisect on the version cutover relies on this file containing zero
+    references to the new table.
+
+    Behaviour:
+        * Always writes ``status``, ``updated_at = now()``,
+          ``error_message`` and ``error_debug``. The two error columns
+          default to ``NULL`` so any successful transition (parsing →
+          extracting → analyzing → ready, or the retry reset uploaded)
+          clears stale failure info from a prior attempt. The
+          ``_mark_draft_failed`` paths pass explicit strings to set
+          them. This matches the prior raw-SQL behaviour across all
+          handlers (#625 §4.2).
+        * Always stamps ``processing_completed_at`` -- ``now()`` for
+          terminal statuses (``ready`` / ``failed``), ``NULL`` otherwise.
+          This preserves the #670 frozen-completion-timestamp invariant
+          without each caller having to remember it.
+        * ``extras`` carries any additional column writes that must land
+          in the SAME ``UPDATE`` for atomicity (e.g. ``entity_count``
+          from the extract handler, ``parsed_text_encrypted`` from the
+          parse handler). Keys are interpolated into the SQL so callers
+          MUST only pass safe column names -- the only call sites in
+          this package pass ``parsed_text_encrypted`` and
+          ``entity_count``.
+        * ``expected_status`` adds an ``AND status = %s`` predicate to
+          the WHERE clause for optimistic-concurrency control (used by
+          the retry path -- only flip ``failed`` -> ``uploaded`` when
+          the draft is still ``failed`` at write time). The expected
+          value is also validated against :data:`STATUS_BY_VALUE`.
+
+    Args:
+        conn: An open psycopg connection. The caller is responsible for
+            ``commit()`` so this update can be batched into a larger
+            transaction (matches the rest of ``draft_model``).
+        draft_id: ``UUID`` or string. Coerced to ``str`` for psycopg.
+        status: New status value. Must be in :data:`STATUS_BY_VALUE`
+            or ``ValueError`` is raised before any SQL runs.
+        error_message: User-facing Estonian message. ``None`` (default)
+            clears the column to NULL; pass a string to set it. Kept
+            positional so the legacy
+            ``update_draft_status(conn, id, "failed", "Boom")`` call
+            shape continues to work.
+        error_debug: Raw technical detail for admin triage (#609).
+            ``None`` (default) clears the column to NULL.
+        extras: Additional ``column_name -> value`` writes that must
+            land in the same UPDATE. ``None`` (default) when not needed.
+        expected_status: Optimistic-concurrency guard. When supplied,
+            the UPDATE only runs if the row is currently in this
+            status; ``rowcount == 0`` means another writer beat us.
+
+    Returns:
+        ``True`` if a row was actually updated, ``False`` if the WHERE
+        clause matched nothing. Mirrors the previous
+        ``draft_model.update_draft_status`` contract.
+
+    Raises:
+        ValueError: ``status`` (or ``expected_status``) is not a known
+            draft status.
+    """
+    if status not in STATUS_BY_VALUE:
+        raise ValueError(f"Unknown draft status: {status!r}")
+    if expected_status is not None and expected_status not in STATUS_BY_VALUE:
+        raise ValueError(f"Unknown expected draft status: {expected_status!r}")
+
+    # Build the SET clause in a deterministic order so test assertions
+    # on the executed SQL string remain stable across runs. Always
+    # writes the same fixed prefix; ``extras`` are appended in sorted
+    # column-name order at the tail.
+    set_parts: list[str] = [
+        "status = %s",
+        "error_message = %s",
+        "error_debug = %s",
+        "updated_at = now()",
+    ]
+    params: list[Any] = [status, error_message, error_debug]
+
+    # #670: terminal transitions stamp the frozen completion timestamp;
+    # non-terminal transitions clear it back to NULL so a retry path
+    # (``failed`` -> ``uploaded``) doesn't carry stale completion time.
+    if status in TERMINAL_STATUSES:
+        set_parts.append("processing_completed_at = now()")
+    else:
+        set_parts.append("processing_completed_at = null")
+
+    # ``extras`` columns are interpolated by name; values are bound as
+    # parameters. Sorted for deterministic SQL output.
+    if extras:
+        for column in sorted(extras):
+            set_parts.append(f"{column} = %s")
+            params.append(extras[column])
+
+    set_clause = ",\n            ".join(set_parts)
+
+    # WHERE clause -- always ``id = %s`` plus an optional optimistic
+    # ``status = %s`` predicate for the retry path.
+    where_parts: list[str] = ["id = %s"]
+    params.append(str(draft_id))
+    if expected_status is not None:
+        where_parts.append("status = %s")
+        params.append(expected_status)
+    where_clause = " and ".join(where_parts)
+
+    # Note: deliberately writing to ``drafts`` only. Do NOT add a write
+    # to ``draft_versions`` here -- that cutover is owned by #618 PR-B
+    # and depends on the read path being version-aware first.
+    sql = f"""
+        update drafts
+        set {set_clause}
+        where {where_clause}
+    """
+    result = conn.execute(sql, tuple(params))
+    return (result.rowcount or 0) > 0

--- a/tests/test_docs_analyze_handler.py
+++ b/tests/test_docs_analyze_handler.py
@@ -167,11 +167,15 @@ class TestAnalyzeImpactHappyPath:
         mock_put.assert_called_once_with(_GRAPH_URI, "# turtle")
 
         # The insert_conn must have received one INSERT into impact_reports
-        # and one UPDATE drafts.
+        # and one UPDATE drafts. Post-#625 the SSOT helper writes
+        # parameterised SQL so we look for the "ready" status in the
+        # bound params, not the SQL string.
         calls = insert_conn.execute.call_args_list
         sql_texts = [c.args[0].lower() for c in calls]
         assert any("insert into impact_reports" in s for s in sql_texts)
-        assert any("update drafts" in s and "ready" in s for s in sql_texts)
+        update_calls = [c for c in calls if "update drafts" in c.args[0].lower()]
+        assert len(update_calls) == 1
+        assert update_calls[0].args[1][0] == "ready"
         insert_conn.commit.assert_called_once()
 
         # Return payload contains the critical summary fields.

--- a/tests/test_docs_extract_handler.py
+++ b/tests/test_docs_extract_handler.py
@@ -92,9 +92,13 @@ class TestHappyPath:
         # 2) status→extracting
         # 3) combined delete + inserts + update
         mock_conns = [MagicMock(), MagicMock(), MagicMock()]
-        # Status update (block 2) must report rowcount > 0 so
-        # update_draft_status returns True.
+        # Status update calls (block 2 ``extracting`` and block 3
+        # ``analyzing``) must report rowcount > 0 so the SSOT helper
+        # returns True. Post-#625 the analyzing transition routes
+        # through ``update_draft_status`` from inside the combined
+        # transaction, so conn[2] also needs a real rowcount.
         mock_conns[1].execute.return_value.rowcount = 1
+        mock_conns[2].execute.return_value.rowcount = 1
 
         extracted = [_ref("KarS § 133"), _ref("TsÜS § 12"), _ref("KarS § 1")]
         resolved = [
@@ -167,7 +171,13 @@ class TestHappyPath:
         ]
         assert len(insert_calls) == 3
 
-        # The UPDATE drafts call must set entity_count=3 and status='analyzing'.
+        # The UPDATE drafts call must set status='analyzing' and
+        # entity_count=3. Post-#625 the SSOT helper writes parameterised
+        # SQL (``status = %s``, not the literal); we assert on the param
+        # order produced by ``app.docs.status.update_draft_status`` --
+        # the prefix is always ``[status, error_message, error_debug]``
+        # followed by sorted-by-column-name extras (``entity_count``)
+        # and finally the WHERE-clause draft id.
         update_calls = [
             call
             for call in combined_exec.call_args_list
@@ -175,9 +185,13 @@ class TestHappyPath:
         ]
         assert len(update_calls) == 1
         update_sql, update_params = update_calls[0].args
-        assert "status = 'analyzing'" in update_sql
-        assert update_params[0] == 3  # entity_count
-        assert update_params[1] == str(draft_id)
+        assert "status = %s" in update_sql
+        assert "entity_count = %s" in update_sql
+        assert update_params[0] == "analyzing"
+        assert update_params[1] is None  # error_message cleared
+        assert update_params[2] is None  # error_debug cleared
+        assert update_params[3] == 3  # entity_count (sole extras key)
+        assert update_params[-1] == str(draft_id)
 
         # Exactly ONE commit for the combined transaction.
         mock_conns[2].commit.assert_called_once()
@@ -200,8 +214,11 @@ class TestHappyPath:
         draft_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
         draft = _make_draft(draft_id=draft_id)
         # 3 connections: get_draft, status→extracting, combined tx.
+        # Both status-mutating connections need rowcount > 0 so the
+        # SSOT helper (#625 §4.2) returns True.
         mock_conns = [MagicMock(), MagicMock(), MagicMock()]
         mock_conns[1].execute.return_value.rowcount = 1
+        mock_conns[2].execute.return_value.rowcount = 1
 
         location = {"chunk": 5, "offset": 1234, "extra": "meta"}
         extracted = [
@@ -266,7 +283,11 @@ class TestHappyPath:
         draft = _make_draft(draft_id=draft_id)
 
         mock_conns = [MagicMock(), MagicMock(), MagicMock()]
+        # Both status-mutating connections need rowcount > 0 so the
+        # SSOT helper (#625 §4.2) returns True. conn[2] now hosts
+        # the analyzing transition alongside the DELETE/INSERT block.
         mock_conns[1].execute.return_value.rowcount = 1
+        mock_conns[2].execute.return_value.rowcount = 1
 
         extracted = [_ref("KarS § 133")]
         resolved = [
@@ -398,20 +419,21 @@ class TestFailurePaths:
             mock_resolve.assert_not_called()
 
         # The third connection's execute should be the failed UPDATE.
+        # Post-#625 the SSOT helper writes parameterised SQL so we
+        # check on the params produced by ``app.docs.status.update_draft_status``:
+        # the first param is the new status ("failed"), the second is
+        # the user-facing Estonian message (#609), the third is the
+        # raw debug detail, and the LAST is the draft id.
         failed_exec = mock_conns[2].execute.call_args_list
-        assert any(
-            "update drafts" in call.args[0].lower() and "status = 'failed'" in call.args[0].lower()
-            for call in failed_exec
-        )
-        # #609: the first param is the user-facing Estonian message,
-        # the second is the raw debug detail.
-        failed_call = next(
-            call for call in failed_exec if "status = 'failed'" in call.args[0].lower()
-        )
-        user_msg, debug_detail, draft_id_param = failed_call.args[1]
+        assert any("update drafts" in call.args[0].lower() for call in failed_exec)
+        failed_call = next(call for call in failed_exec if "update drafts" in call.args[0].lower())
+        params = failed_call.args[1]
+        assert params[0] == "failed"
+        user_msg = params[1]
+        debug_detail = params[2]
         assert isinstance(user_msg, str)
         assert "LLM boom" in debug_detail
-        assert draft_id_param == str(draft_id)
+        assert params[-1] == str(draft_id)
 
     def test_extractor_failure_does_not_mark_failed_when_retry_pending(self):
         """#448: a transient extractor error on attempt 1 must not flip the draft.
@@ -485,11 +507,12 @@ class TestFailurePaths:
                     max_attempts=3,
                 )
 
+        # Post-#625 the SSOT helper writes parameterised SQL so we
+        # assert on the params produced by ``update_draft_status``.
         last_exec = mock_conns[2].execute.call_args_list
-        assert any(
-            "update drafts" in call.args[0].lower() and "status = 'failed'" in call.args[0].lower()
-            for call in last_exec
-        )
+        assert any("update drafts" in call.args[0].lower() for call in last_exec)
+        failed_call = next(call for call in last_exec if "update drafts" in call.args[0].lower())
+        assert failed_call.args[1][0] == "failed"
 
 
 # ---------------------------------------------------------------------------
@@ -653,7 +676,10 @@ class TestCombinedTransaction:
 
         # Dedicated failed-status UPDATE ran on conn index 3 and
         # committed (independent transaction, doesn't touch
-        # draft_entities).
+        # draft_entities). Post-#625 the SSOT helper writes
+        # parameterised SQL so we check the params for "failed".
         failed_exec = mock_conns[3].execute.call_args_list
-        assert any("status = 'failed'" in call.args[0].lower() for call in failed_exec)
+        assert any("update drafts" in call.args[0].lower() for call in failed_exec)
+        failed_call = next(call for call in failed_exec if "update drafts" in call.args[0].lower())
+        assert failed_call.args[1][0] == "failed"
         mock_conns[3].commit.assert_called_once()

--- a/tests/test_docs_integration_e2e.py
+++ b/tests/test_docs_integration_e2e.py
@@ -222,37 +222,34 @@ def _make_conn_factory(state: _State):
             return cursor
 
         if "update drafts" in sql_lower and "status" in sql_lower:
-            # update_draft_status / pipeline status flips. ``params`` for
-            # update_draft_status is (status, error_message, draft_id);
-            # for the parse_handler "set parsed_text_encrypted=..." flow
-            # it's (ciphertext_bytes, draft_id) — extract the new status
-            # from the SQL string instead of guessing the param order.
-            assert state.draft_row is not None
+            # Pipeline status flips. Post-#625 §4.2 every transition
+            # routes through ``app.docs.status.update_draft_status`` so
+            # the SQL is parameterised: the param tuple always starts
+            # with ``[status, error_message, error_debug, ...extras...,
+            # draft_id]``. Extras are sorted by column name so
+            # ``entity_count`` and ``parsed_text_encrypted`` (the only
+            # extras used in this package) land at known positions.
+            assert state.draft_row is not None and params is not None
             row = list(state.draft_row)
-            if "set parsed_text_encrypted" in sql_lower:
-                # Parse handler combined update: parsed_text_encrypted
-                # (Fernet bytes) + status='extracting'.
-                row[10] = params[0] if params else None
-                row[9] = "extracting"
-            elif "status = 'analyzing'" in sql_lower:
-                # extract_entities final UPDATE: entity_count + status.
-                if params is not None:
-                    row[11] = params[0]  # entity_count
-                row[9] = "analyzing"
-            elif "status = 'ready'" in sql_lower:
-                row[9] = "ready"
-            elif "status = 'failed'" in sql_lower:
-                # #609: _mark_draft_failed uses a direct UPDATE with
-                # params (user_msg, debug_detail, draft_id). The
-                # user-facing Estonian text lands in error_message.
-                row[9] = "failed"
-                if params is not None and len(params) >= 1:
-                    row[12] = params[0]  # error_message
-            elif params and len(params) >= 2:
-                # update_draft_status — first param is the new status.
-                row[9] = str(params[0])
-                if len(params) >= 3 and params[1] is not None:
-                    row[12] = params[1]  # error_message
+            new_status = str(params[0])
+            row[9] = new_status
+            error_message = params[1]
+            if error_message is not None:
+                row[12] = error_message
+            else:
+                row[12] = None  # successful transition clears stale error
+            # ``params[2]`` is error_debug (not mirrored on Draft).
+            # ``params[3:-1]`` are extras in sorted column-name order:
+            #   - extracting transition: ``parsed_text_encrypted``
+            #   - analyzing transition:  ``entity_count``
+            if "parsed_text_encrypted = %s" in sql_lower:
+                # Find the parsed_text_encrypted slot. Sorted alpha
+                # order with no other extras puts it at index 3.
+                row[10] = params[3]
+            if "entity_count = %s" in sql_lower:
+                # Sorted alpha order with no other extras puts entity_count
+                # at index 3.
+                row[11] = params[3]
             cursor.rowcount = 1
             state.draft_row = tuple(row)
             return cursor

--- a/tests/test_docs_parse_handler.py
+++ b/tests/test_docs_parse_handler.py
@@ -148,43 +148,38 @@ class _Patches:
 # ---------------------------------------------------------------------------
 
 
-def _failed_update_params(conns: list[_FakeConn]) -> tuple | None:
-    """Return the params of the first ``update drafts set status='failed'`` call.
+def _failed_update_params(conns: list[_FakeConn], update_draft_status_mock) -> tuple | None:
+    """Return ``(user_msg, debug_detail, draft_id)`` for the first
+    ``failed`` transition recorded on the ``update_draft_status`` mock.
 
-    ``_mark_draft_failed`` runs a direct SQL UPDATE so tests have to
-    introspect the connection's ``execute.call_args_list`` rather than
-    the ``update_draft_status`` mock.
+    Post-#625 the entire status SSOT lives in ``app.docs.status`` and
+    every transition (including ``_mark_draft_failed``) routes through
+    the helper -- so we look at the mock directly rather than scanning
+    raw SQL strings. The legacy positional-args tuple shape is preserved
+    so the per-test assertions don't have to change.
     """
-    for conn in conns:
-        for call in conn.execute.call_args_list:
-            sql = call.args[0].lower()
-            if "update drafts" in sql and "status = 'failed'" in sql:
-                return call.args[1]
+    del conns  # No longer used; raw SQL is gone post-cutover.
+    for call in update_draft_status_mock.call_args_list:
+        if len(call.args) < 3 or call.args[2] != "failed":
+            continue
+        # Positional call: (conn, draft_id, "failed", user_msg)
+        # Keyword call:   (conn, draft_id, "failed") + error_debug=...
+        user_msg = call.args[3] if len(call.args) > 3 else call.kwargs.get("error_message")
+        debug_detail = call.kwargs.get("error_debug")
+        return (user_msg, debug_detail, str(call.args[1]))
     return None
 
 
 def _statuses_written(conns: list[_FakeConn], update_draft_status_mock) -> list[str]:
     """Return every draft status written by the handler under test.
 
-    Covers both:
-      - ``update_draft_status(conn, id, <status>)`` (``parsing``
-        transition is routed through the draft_model helper)
-      - the direct SQL UPDATEs for the ``extracting`` and ``failed``
-        transitions.
+    Post-#625 every transition routes through ``update_draft_status``
+    (the SSOT helper at ``app.docs.status``), so we just collect the
+    third positional arg from the mock's call log. ``conns`` is still
+    accepted to keep the public test-helper signature stable.
     """
-    statuses = [c.args[2] for c in update_draft_status_mock.call_args_list]
-    for conn in conns:
-        for call in conn.execute.call_args_list:
-            sql = call.args[0].lower()
-            if "update drafts" not in sql:
-                continue
-            if "status = 'failed'" in sql:
-                statuses.append("failed")
-            elif "status = 'extracting'" in sql:
-                statuses.append("extracting")
-            elif "status = 'ready'" in sql:
-                statuses.append("ready")
-    return statuses
+    del conns  # No longer used; raw SQL is gone post-cutover.
+    return [c.args[2] for c in update_draft_status_mock.call_args_list if len(c.args) >= 3]
 
 
 # ---------------------------------------------------------------------------
@@ -209,29 +204,30 @@ class TestParseDraftHappyPath:
             "application/pdf",
         )
 
-        # 2. update_draft_status was called once with "parsing"
-        #    (the second transition, to "extracting", goes via direct
-        #    conn.execute because it needs to write parsed_text too).
+        # 2. update_draft_status was called twice: once for "parsing"
+        #    (mid-pipeline) and once for "extracting" (post-Tika). Both
+        #    transitions go through the §4.2 SSOT helper post-#625;
+        #    the second call carries the Fernet ciphertext via
+        #    ``extras={"parsed_text_encrypted": ...}``.
         status_calls = [c.args[2] for c in p.m_update_draft_status.call_args_list]
-        # No "failed" should appear on the happy path.
         assert "parsing" in status_calls
+        assert "extracting" in status_calls
+        # No "failed" should appear on the happy path.
         assert "failed" not in status_calls
 
-        # 3. The parsed_text_encrypted + status='extracting' UPDATE must
-        #    have run on one of the connections; the first param must be
-        #    bytes (Fernet ciphertext), not a plain string.
-        updated_ids = []
-        for conn in p.conns:
-            for call in conn.execute.call_args_list:
-                sql = call.args[0]
-                if "parsed_text_encrypted" in sql and "extracting" in sql:
-                    params = call.args[1]
-                    assert isinstance(params[0], bytes), (
-                        "parsed_text_encrypted must be bytes (Fernet ciphertext), "
-                        f"got {type(params[0])}"
-                    )
-                    updated_ids.append(params[1])
-        assert str(draft.id) in updated_ids
+        # 3. The "extracting" call must carry parsed_text_encrypted in
+        #    extras AND the value must be bytes (Fernet ciphertext), not
+        #    a plain string. This is the atomicity guarantee that lets
+        #    observers never see ``status='extracting'`` with NULL
+        #    parsed_text in the same row.
+        extracting_calls = [
+            c for c in p.m_update_draft_status.call_args_list if c.args[2] == "extracting"
+        ]
+        assert len(extracting_calls) == 1
+        extras = extracting_calls[0].kwargs.get("extras") or {}
+        assert "parsed_text_encrypted" in extras
+        assert isinstance(extras["parsed_text_encrypted"], bytes)
+        assert str(extracting_calls[0].args[1]) == str(draft.id)
 
         # 4. extract_entities was enqueued with the draft id.
         p.m_queue.enqueue.assert_called_once()
@@ -245,7 +241,14 @@ class TestParseDraftHappyPath:
         assert result["text_length"] == len("extracted legal text" * 10)
 
     def test_happy_path_strips_old_error_message(self):
-        """On success, the parsed_text UPDATE must also clear error_message."""
+        """On success the SSOT helper must clear error_message + error_debug.
+
+        Post-#625 every status transition goes through
+        ``update_draft_status`` -- the helper writes ``error_message``
+        and ``error_debug`` to NULL on every call where the kwargs are
+        not supplied (default ``None``), so a clean transition implicitly
+        purges stale failure info from a prior attempt.
+        """
         draft = _make_draft()
 
         with _Patches() as p:
@@ -255,15 +258,18 @@ class TestParseDraftHappyPath:
 
             parse_draft({"draft_id": str(draft.id)})
 
-            # At least one execute call must null out error_message.
-            found = False
-            for conn in p.conns:
-                for call in conn.execute.call_args_list:
-                    sql = call.args[0]
-                    if "error_message = null" in sql:
-                        found = True
-                        break
-            assert found, "Successful parse must clear error_message"
+        # The "extracting" transition must carry no explicit
+        # error_message / error_debug (so the helper writes NULL).
+        extracting_calls = [
+            c for c in p.m_update_draft_status.call_args_list if c.args[2] == "extracting"
+        ]
+        assert len(extracting_calls) == 1
+        call = extracting_calls[0]
+        # Either explicitly None (kwarg) or absent (positional shape).
+        assert call.kwargs.get("error_message") is None
+        assert call.kwargs.get("error_debug") is None
+        if len(call.args) > 3:
+            assert call.args[3] is None  # positional error_message slot
 
 
 # ---------------------------------------------------------------------------
@@ -324,7 +330,7 @@ class TestEmptyTikaResult:
 
         # #609: the stored error_message must be the mapped Estonian
         # string, and error_debug must carry the raw ValueError text.
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None, "expected an UPDATE ... status='failed' call"
         user_msg, debug_detail, _draft_id = params
         # "empty text" is not a currently mapped failure mode, so it
@@ -389,7 +395,7 @@ class TestTikaFailure:
         assert "failed" in statuses
         # #609: raw exception text goes to error_debug, user-facing
         # Estonian string goes to error_message.
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         user_msg, debug_detail, _ = params
         assert "connect refused" in debug_detail
@@ -440,7 +446,7 @@ class TestTikaFailure:
                     max_attempts=3,
                 )
 
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         user_msg, _debug, _ = params
         assert len(user_msg) <= 500
@@ -472,7 +478,7 @@ class TestStorageFailures:
         assert "failed" in statuses
         # #609: FileNotFoundError maps to the "laadige uuesti üles"
         # Estonian message so the user knows the next action.
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         user_msg, _debug, _ = params
         assert user_msg == MSG_FILE_MISSING
@@ -495,7 +501,7 @@ class TestStorageFailures:
 
         statuses = _statuses_written(p.conns, p.m_update_draft_status)
         assert "failed" in statuses
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         _user_msg, debug_detail, _ = params
         # Raw error text must be preserved in error_debug for admins.
@@ -526,7 +532,7 @@ class TestUnexpectedException:
         statuses = _statuses_written(p.conns, p.m_update_draft_status)
         assert "failed" in statuses
         # #609: unknown -> generic Estonian fallback + raw debug text.
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         user_msg, debug_detail, _ = params
         assert user_msg == MSG_UNKNOWN
@@ -567,7 +573,7 @@ class TestUnexpectedException:
                     max_attempts=3,
                 )
 
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         user_msg, debug_detail, _ = params
         assert user_msg == MSG_TIKA_CAPACITY
@@ -591,7 +597,7 @@ class TestUnexpectedException:
                     max_attempts=3,
                 )
 
-        params = _failed_update_params(p.conns)
+        params = _failed_update_params(p.conns, p.m_update_draft_status)
         assert params is not None
         user_msg, _debug, _ = params
         assert user_msg == MSG_ENCRYPTED_PDF

--- a/tests/test_docs_status.py
+++ b/tests/test_docs_status.py
@@ -1,0 +1,335 @@
+"""Tests for the draft-status SSOT module (#625).
+
+Two layers of guarantees are pinned here:
+
+1. ``DRAFT_STATUSES`` is a closed, well-formed table -- every row has
+   a non-empty Estonian label, a valid badge variant, and a successor
+   pointer that either is ``None`` or names another known status. A
+   regression that adds a typo'd successor or omits a label will fail
+   here long before the UI breaks at runtime.
+
+2. ``update_draft_status`` is the exclusive write path. The validation,
+   error-clearing, terminal-stamp, and -- the §4.2 contract --
+   "writes ONLY to ``drafts``" invariants are all asserted directly so
+   the version cutover in #618 PR-B is an explicit, bisectable change.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import get_args
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.docs.status import (
+    DRAFT_STATUSES,
+    PIPELINE_STAGES,
+    STATUS_BY_VALUE,
+    TERMINAL_STATUSES,
+    VALID_STATUSES,
+    DraftStatus,
+    update_draft_status,
+)
+from app.ui.primitives.badge import BadgeVariant
+
+_DRAFT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+# ---------------------------------------------------------------------------
+# Table well-formedness
+# ---------------------------------------------------------------------------
+
+
+_BADGE_VARIANTS: frozenset[str] = frozenset(get_args(BadgeVariant))
+
+
+@pytest.mark.parametrize("spec", DRAFT_STATUSES, ids=[s.value for s in DRAFT_STATUSES])
+class TestDraftStatusTable:
+    """Each row in :data:`DRAFT_STATUSES` must be well-formed."""
+
+    def test_value_is_nonempty_string(self, spec: DraftStatus):
+        assert isinstance(spec.value, str) and spec.value, (
+            "DraftStatus.value must be a non-empty string"
+        )
+
+    def test_label_et_is_nonempty_string(self, spec: DraftStatus):
+        assert isinstance(spec.label_et, str) and spec.label_et.strip(), (
+            f"DraftStatus({spec.value!r}).label_et must be a non-empty Estonian string"
+        )
+
+    def test_badge_variant_is_valid(self, spec: DraftStatus):
+        assert spec.badge_variant in _BADGE_VARIANTS, (
+            f"DraftStatus({spec.value!r}).badge_variant={spec.badge_variant!r} "
+            f"is not a known BadgeVariant ({sorted(_BADGE_VARIANTS)})"
+        )
+
+    def test_successor_is_known_status_or_none(self, spec: DraftStatus):
+        if spec.successor is None:
+            return
+        assert spec.successor in STATUS_BY_VALUE, (
+            f"DraftStatus({spec.value!r}).successor={spec.successor!r} "
+            "is not a known DraftStatus value"
+        )
+
+    def test_terminal_status_has_no_successor(self, spec: DraftStatus):
+        if spec.is_terminal:
+            assert spec.successor is None, (
+                f"DraftStatus({spec.value!r}) is terminal but has successor {spec.successor!r}"
+            )
+
+    def test_css_key_is_nonempty(self, spec: DraftStatus):
+        assert isinstance(spec.css_key, str) and spec.css_key, (
+            f"DraftStatus({spec.value!r}).css_key must be a non-empty string"
+        )
+
+
+class TestStatusTableInvariants:
+    """Cross-row invariants that the per-row parametrise can't catch."""
+
+    def test_values_are_unique(self):
+        values = [s.value for s in DRAFT_STATUSES]
+        assert len(values) == len(set(values)), "DraftStatus.value must be unique"
+
+    def test_orders_are_unique(self):
+        orders = [s.order for s in DRAFT_STATUSES]
+        assert len(orders) == len(set(orders)), "DraftStatus.order must be unique"
+
+    def test_status_by_value_covers_every_row(self):
+        assert set(STATUS_BY_VALUE) == {s.value for s in DRAFT_STATUSES}
+
+    def test_valid_statuses_matches_table(self):
+        assert set(VALID_STATUSES) == {s.value for s in DRAFT_STATUSES}
+
+    def test_terminal_statuses_subset(self):
+        expected = {s.value for s in DRAFT_STATUSES if s.is_terminal}
+        assert TERMINAL_STATUSES == expected
+
+    def test_pipeline_stages_excludes_failed(self):
+        values = {s.value for s in PIPELINE_STAGES}
+        assert "failed" not in values, "failed must not appear in PIPELINE_STAGES"
+        # And contains every non-failed status.
+        expected = {s.value for s in DRAFT_STATUSES if s.value != "failed"}
+        assert values == expected
+
+    def test_pipeline_stages_are_in_order(self):
+        orders = [s.order for s in PIPELINE_STAGES]
+        assert orders == sorted(orders), "PIPELINE_STAGES must be sorted by order"
+
+    def test_happy_path_chain_is_walkable(self):
+        """Walking ``successor`` from ``uploaded`` must end at a terminal."""
+        seen: list[str] = []
+        cursor: str | None = "uploaded"
+        while cursor is not None:
+            assert cursor not in seen, "successor chain has a cycle"
+            seen.append(cursor)
+            cursor = STATUS_BY_VALUE[cursor].successor
+        assert seen[-1] == "ready", (
+            f"Walking successors from 'uploaded' must reach 'ready'; chain was {seen!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# update_draft_status -- validation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDraftStatusValidation:
+    def test_unknown_status_raises_value_error(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Unknown draft status"):
+            update_draft_status(conn, _DRAFT_ID, "bogus")
+        # No SQL must have run -- the validation gate is upfront.
+        conn.execute.assert_not_called()
+
+    def test_unknown_expected_status_raises_value_error(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Unknown expected draft status"):
+            update_draft_status(conn, _DRAFT_ID, "uploaded", expected_status="zzz")
+        conn.execute.assert_not_called()
+
+    @pytest.mark.parametrize("status", VALID_STATUSES)
+    def test_every_valid_status_is_accepted(self, status: str):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+        # Must not raise.
+        update_draft_status(conn, _DRAFT_ID, status)
+        conn.execute.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# update_draft_status -- SQL shape and parameter contract
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDraftStatusSqlShape:
+    """Pin the produced SQL + params so the integration fakes (and the
+    §4.2 cutover invariant) stay accurate.
+    """
+
+    def test_writes_to_drafts_only(self):
+        """§4.2 contract: this helper must NOT touch ``draft_versions``.
+
+        The version-aware write lands in #618 PR-B. Until then, every
+        UPDATE produced by the helper must reference only the legacy
+        ``drafts`` table -- a regression that adds a stray
+        ``draft_versions`` write would defeat the bisect that pins the
+        cutover sequence.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        for status in VALID_STATUSES:
+            conn.reset_mock()
+            update_draft_status(conn, _DRAFT_ID, status)
+            sql = conn.execute.call_args.args[0].lower()
+            assert "draft_versions" not in sql, (
+                f"update_draft_status({status!r}) must not write to draft_versions; "
+                f"§4.2 cutover lives in #618 PR-B. SQL was:\n{sql}"
+            )
+            assert "update drafts" in sql
+
+    def test_default_call_writes_status_and_clears_errors(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(conn, _DRAFT_ID, "parsing")
+
+        sql, params = conn.execute.call_args.args
+        assert "status = %s" in sql
+        assert "error_message = %s" in sql
+        assert "error_debug = %s" in sql
+        assert "updated_at = now()" in sql
+        # status, error_message=None, error_debug=None, draft_id
+        assert params == ("parsing", None, None, str(_DRAFT_ID))
+
+    def test_terminal_transition_stamps_completion_now(self):
+        for terminal in TERMINAL_STATUSES:
+            conn = MagicMock()
+            conn.execute.return_value.rowcount = 1
+            update_draft_status(conn, _DRAFT_ID, terminal)
+            sql = conn.execute.call_args.args[0]
+            assert "processing_completed_at = now()" in sql, (
+                f"Terminal status {terminal!r} must stamp processing_completed_at = now()"
+            )
+
+    def test_non_terminal_transition_clears_completion(self):
+        for spec in DRAFT_STATUSES:
+            if spec.is_terminal:
+                continue
+            conn = MagicMock()
+            conn.execute.return_value.rowcount = 1
+            update_draft_status(conn, _DRAFT_ID, spec.value)
+            sql = conn.execute.call_args.args[0]
+            assert "processing_completed_at = null" in sql, (
+                f"Non-terminal status {spec.value!r} must clear processing_completed_at"
+            )
+
+    def test_error_message_passed_positionally(self):
+        """Legacy positional shape ``(conn, id, status, msg)`` still works."""
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(conn, _DRAFT_ID, "failed", "Boom")
+
+        params = conn.execute.call_args.args[1]
+        assert params[0] == "failed"
+        assert params[1] == "Boom"
+        assert params[2] is None  # error_debug
+
+    def test_error_debug_kwarg_lands_in_third_param_slot(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(
+            conn,
+            _DRAFT_ID,
+            "failed",
+            "User-facing",
+            error_debug="raw stack trace",
+        )
+
+        params = conn.execute.call_args.args[1]
+        assert params == (
+            "failed",
+            "User-facing",
+            "raw stack trace",
+            str(_DRAFT_ID),
+        )
+
+    def test_extras_land_in_sorted_column_order(self):
+        """The ``extras`` columns are interpolated in sorted alphabetic
+        order so the param tuple's layout stays deterministic.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(
+            conn,
+            _DRAFT_ID,
+            "extracting",
+            extras={"parsed_text_encrypted": b"ciphertext"},
+        )
+
+        sql, params = conn.execute.call_args.args
+        assert "parsed_text_encrypted = %s" in sql
+        # status, error_message=None, error_debug=None, parsed_text_encrypted, draft_id
+        assert params == (
+            "extracting",
+            None,
+            None,
+            b"ciphertext",
+            str(_DRAFT_ID),
+        )
+
+    def test_extras_multiple_columns_are_sorted(self):
+        """Two extras must land in alphabetic order regardless of dict
+        insertion order so the integration fakes stay deterministic.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(
+            conn,
+            _DRAFT_ID,
+            "ready",
+            extras={"parsed_text_encrypted": b"x", "entity_count": 3},
+        )
+
+        sql, params = conn.execute.call_args.args
+        # entity_count comes before parsed_text_encrypted alphabetically.
+        ec_idx = sql.find("entity_count = %s")
+        pte_idx = sql.find("parsed_text_encrypted = %s")
+        assert 0 < ec_idx < pte_idx, "extras must be interpolated in sorted alphabetic order"
+        assert params == ("ready", None, None, 3, b"x", str(_DRAFT_ID))
+
+    def test_expected_status_adds_optimistic_where_predicate(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(
+            conn,
+            _DRAFT_ID,
+            "uploaded",
+            expected_status="failed",
+        )
+
+        sql, params = conn.execute.call_args.args
+        assert "where id = %s and status = %s" in sql.lower()
+        # status=uploaded, error_message=None, error_debug=None, id, expected=failed
+        assert params == ("uploaded", None, None, str(_DRAFT_ID), "failed")
+
+    def test_returns_true_when_row_was_updated(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+        assert update_draft_status(conn, _DRAFT_ID, "parsing") is True
+
+    def test_returns_false_when_no_rows_match(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 0
+        assert update_draft_status(conn, _DRAFT_ID, "parsing") is False
+
+    def test_returns_false_when_rowcount_is_none(self):
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = None
+        assert update_draft_status(conn, _DRAFT_ID, "parsing") is False


### PR DESCRIPTION
Closes #625. Eelnõud sprint plan §4.2 Day 1.

## §4.2 contract (locked, Option A)

Per the [§4.2 decision](https://github.com/henrikaavik/Seadusloome/issues/625#issuecomment-4364601922) (per-version status is canonical), this PR writes ONLY to `drafts.status`. The version-aware cutover (writing to `draft_versions.status`) lands in #618 PR-B alongside the read-path cutover. The new test `tests/test_docs_status.py::TestUpdateDraftStatusSqlShape::test_writes_to_drafts_only` pins this so a regression that adds a stray `draft_versions` write breaks loudly.

## What changed

### New SSOT module: `app/docs/status.py`
- `DraftStatus` frozen dataclass: `value`, `label_et`, `badge_variant`, `is_terminal`, `successor`, `order`, `css_key`.
- `DRAFT_STATUSES`, `STATUS_BY_VALUE`, `VALID_STATUSES`, `TERMINAL_STATUSES`, `PIPELINE_STAGES`.
- `update_draft_status(conn, draft_id, status, error_message=None, *, error_debug=None, extras=None, expected_status=None)`:
  - Validates `status` (and `expected_status`) against the table.
  - Auto-stamps `processing_completed_at = now()` for terminal transitions, `NULL` otherwise (preserves #670).
  - Defaults clear `error_message` / `error_debug` to NULL on every successful transition; `_mark_draft_failed` paths pass strings to set them.
  - `extras` keeps `parsed_text_encrypted` (parse handler) and `entity_count` (extract handler) writes in the SAME UPDATE as the status flip — preserving the #626 atomicity guarantee without leaking those columns into the helper API.
  - `expected_status` adds the optimistic-concurrency `AND status = %s` predicate used by the retry path.

### Cutover sites (8 raw `UPDATE drafts SET status = ...` writes → 0)
- `app/docs/parse_handler.py` — extracting (+ parsed_text_encrypted) + failed
- `app/docs/extract_handler.py` — analyzing (+ entity_count) + failed
- `app/docs/analyze_handler.py` — ready + failed
- `app/docs/retry_handler.py` — uploaded (with `expected_status="failed"` guard)
- `app/docs/draft_model.py` — old `update_draft_status` body removed; module re-exports `VALID_STATUSES` and `update_draft_status` from `status.py` for backwards compat (10+ existing import sites unchanged).

### `app/docs/routes.py` label/variant cleanup
Dropped `_STATUS_STAGES` (now derived from `PIPELINE_STAGES`), `_STATUS_LABELS`, `_STATUS_KEY_MAP`, `_STATUS_VARIANT_MAP`, and the local `_TERMINAL_STATUSES` constant. `_status_badge` and the filter-bar status checkboxes now look up `STATUS_BY_VALUE`. Estonian copy verified verbatim against the prior maps.

### Tests
- New `tests/test_docs_status.py` — 64 tests:
  - Parametrised over `DRAFT_STATUSES`: every row has a non-empty Estonian label, a valid `BadgeVariant`, a successor that is None or a known status, terminal-status invariants, non-empty `css_key`.
  - Cross-row invariants: unique values + orders, `STATUS_BY_VALUE`/`VALID_STATUSES`/`TERMINAL_STATUSES` agree with the table, `PIPELINE_STAGES` excludes failed and is order-sorted, walking `successor` from `uploaded` lands on `ready`.
  - `update_draft_status` validation + SQL-shape contract: unknown status raises `ValueError` with no SQL run, every `VALID_STATUSES` value is accepted, terminal stamps `processing_completed_at = now()`, non-terminal clears it, `extras` interpolated in sorted alphabetic order, `expected_status` adds the optimistic WHERE predicate, return value reflects rowcount.
  - **§4.2 contract test**: asserts `update_draft_status` writes ONLY to `drafts` — no reference to `draft_versions` in the executed SQL across every status. This pins the cutover sequence so the version cutover in #618 PR-B is an explicit, bisectable change.
- Updated handler tests (`test_docs_parse_handler.py`, `test_docs_extract_handler.py`, `test_docs_analyze_handler.py`) to introspect the SSOT helper's mock calls instead of scanning raw SQL strings for `status = '<literal>'`.
- Updated `tests/test_docs_integration_e2e.py` fake to read the new status from `params[0]` and decode `extras` from the trailing positional slots.

## Verification

- [x] `grep -rin "UPDATE drafts SET status\|update drafts set status" app/` → only matches a docstring in `app/docs/status.py`
- [x] `uv run ruff format app/docs/status.py app/docs/*_handler.py app/docs/draft_model.py app/docs/routes.py tests/test_docs_status.py` — clean
- [x] `uv run ruff check ...` — all checks passed
- [x] `uv run pyright app/docs/status.py app/docs/draft_model.py app/docs/routes.py app/docs/parse_handler.py app/docs/extract_handler.py app/docs/analyze_handler.py app/docs/retry_handler.py` — 0 errors, 0 warnings
- [x] `uv run pytest tests/` — 1926 passed, 22 skipped (was 1862 + 64 new = 1926)

## Test plan
- [ ] Smoke test on staging: upload a draft, confirm the status tracker labels (`Üles laaditud`, `Töötlemine`, `Olemite eraldamine`, `Mõjude analüüs`, `Valmis`) match before/after
- [ ] Smoke test on staging: trigger a failure and click "Proovi uuesti" — the retry path's `expected_status="failed"` guard must not regress the optimistic-concurrency check
- [ ] Smoke test on staging: confirm the filter-bar status checkboxes still render in Estonian
- [ ] Diff prod logs for any unexpected `Unknown draft status:` `ValueError` entries during the 24h post-deploy window

## Refs
- Eelnõud sprint plan: `docs/superpowers/specs/2026-05-02-eelnoud-sprint-plan.md` (commit `bc7b4d1`)
- §4.2 status semantics decision: https://github.com/henrikaavik/Seadusloome/issues/625#issuecomment-4364601922
- Detailed implementation plan: https://github.com/henrikaavik/Seadusloome/issues/625#issuecomment-4364537416

🤖 Generated with [Claude Code](https://claude.com/claude-code)