### PR TITLE
feat(docs): export progress indicator (#610)

### DIFF
--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -54,6 +54,7 @@ def analyze_impact(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Run the impact analysis pipeline for one draft.
 

--- a/app/docs/cleanup_handler.py
+++ b/app/docs/cleanup_handler.py
@@ -44,6 +44,7 @@ def draft_cleanup(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Delete the encrypted file + Jena named graph for a removed draft.
 

--- a/app/docs/docx_export.py
+++ b/app/docs/docx_export.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,40 @@ from app.docs.labels import TYPE_LABELS_ET as _TYPE_LABELS_ET
 from app.ui.time import format_tallinn
 
 logger = logging.getLogger(__name__)
+
+
+# Progress callback signature: ``(current, total)``. ``current`` and
+# ``total`` are 1-based work-unit counters; the export progress WS pushes
+# them straight to the browser as ``{"current": N, "total": M}``. Called
+# from inside ``build_impact_report_docx`` after each major section so
+# the UI can render a real ``<progress>`` bar instead of an indeterminate
+# spinner (#610). ``None`` disables progress reporting entirely (used by
+# the existing test suite + any caller that doesn't need WS push).
+ProgressCallback = Callable[[int, int], None]
+
+
+# How often to publish progress mid-table. Larger tables report after
+# every Nth row in addition to the per-section checkpoints; smaller
+# tables (< _PROGRESS_BATCH rows) just emit once on entry + once on
+# exit via the section-level checkpoints. Tunable here so the WS push
+# rate stays reasonable even for outlier 200-row reports (~10 frames
+# per second worst case).
+_PROGRESS_BATCH = 10
+
+
+def _safe_publish(callback: ProgressCallback | None, current: int, total: int) -> None:
+    """Invoke *callback* swallowing any exception.
+
+    The progress channel is best-effort UX glue; a stuck DB write or a
+    flaky Postgres pool must never abort the .docx render. The handler
+    layer logs the failure already, so we don't re-log here.
+    """
+    if callback is None:
+        return
+    try:
+        callback(current, total)
+    except Exception:
+        logger.debug("docx_export: progress callback failed", exc_info=True)
 
 
 # Column order used by ``app.docs.export_handler.export_report`` when
@@ -187,14 +222,27 @@ def _add_summary(doc: Any, report_row: tuple) -> None:
     doc.add_paragraph(f"Tuvastatud lünkade arv: {gaps}")
 
 
-def _add_affected_entities(doc: Any, findings: dict[str, Any]) -> None:
-    """Write the "Mõjutatud üksused" table."""
+def _add_affected_entities(
+    doc: Any,
+    findings: dict[str, Any],
+    *,
+    progress_callback: ProgressCallback | None = None,
+    progress_base: int = 0,
+    progress_total: int = 0,
+) -> int:
+    """Write the "Mõjutatud üksused" table.
+
+    Returns the number of work units consumed (1 for the heading +
+    1 per ``_PROGRESS_BATCH`` rows). The caller passes ``progress_base``
+    (= work units already done) and ``progress_total`` (= grand total)
+    so per-row publishes carry the right numerator.
+    """
     doc.add_heading("Mõjutatud üksused", level=1)
 
     rows: list[dict[str, Any]] = list(findings.get("affected_entities") or [])
     if not rows:
         doc.add_paragraph("Mõjutatud üksuseid ei tuvastatud.")
-        return
+        return 1
 
     table = doc.add_table(rows=1, cols=3)
     table.style = "Light Grid Accent 1"
@@ -202,21 +250,39 @@ def _add_affected_entities(doc: Any, findings: dict[str, Any]) -> None:
     header[0].text = "Tüüp"
     header[1].text = "Nimetus"
     header[2].text = "URI"
-    for row in rows:
+    for index, row in enumerate(rows):
         cells = table.add_row().cells
         cells[0].text = _short_type(str(row.get("type", "")))
         cells[1].text = str(row.get("label", "") or "—")
         cells[2].text = str(row.get("uri", "") or "—")
+        # Mid-table checkpoint: every Nth row OR the last row. Avoids
+        # firing for tiny tables where the section-level publish above
+        # already covers the work.
+        if (index + 1) % _PROGRESS_BATCH == 0:
+            _safe_publish(
+                progress_callback,
+                progress_base + 1 + ((index + 1) // _PROGRESS_BATCH),
+                progress_total,
+            )
+    extra_units = len(rows) // _PROGRESS_BATCH
+    return 1 + extra_units
 
 
-def _add_conflicts(doc: Any, findings: dict[str, Any]) -> None:
-    """Write the "Konfliktid" table."""
+def _add_conflicts(
+    doc: Any,
+    findings: dict[str, Any],
+    *,
+    progress_callback: ProgressCallback | None = None,
+    progress_base: int = 0,
+    progress_total: int = 0,
+) -> int:
+    """Write the "Konfliktid" table. See ``_add_affected_entities`` for the progress contract."""
     doc.add_heading("Konfliktid", level=1)
 
     rows: list[dict[str, Any]] = list(findings.get("conflicts") or [])
     if not rows:
         doc.add_paragraph("Konflikte ei tuvastatud.")
-        return
+        return 1
 
     table = doc.add_table(rows=1, cols=3)
     table.style = "Light Grid Accent 1"
@@ -224,23 +290,41 @@ def _add_conflicts(doc: Any, findings: dict[str, Any]) -> None:
     header[0].text = "Eelnõu viide"
     header[1].text = "Konflikti üksus"
     header[2].text = "Põhjus"
-    for row in rows:
+    for index, row in enumerate(rows):
         cells = table.add_row().cells
         cells[0].text = str(row.get("draft_ref", "") or "—")
         cells[1].text = str(
             row.get("conflicting_label") or row.get("conflicting_entity", "") or "—"
         )
         cells[2].text = str(row.get("reason", "") or "—")
+        if (index + 1) % _PROGRESS_BATCH == 0:
+            _safe_publish(
+                progress_callback,
+                progress_base + 1 + ((index + 1) // _PROGRESS_BATCH),
+                progress_total,
+            )
+    extra_units = len(rows) // _PROGRESS_BATCH
+    return 1 + extra_units
 
 
-def _add_eu_compliance(doc: Any, findings: dict[str, Any]) -> None:
-    """Write the "EL-i õigusaktide vastavus" table."""
+def _add_eu_compliance(
+    doc: Any,
+    findings: dict[str, Any],
+    *,
+    progress_callback: ProgressCallback | None = None,
+    progress_base: int = 0,
+    progress_total: int = 0,
+) -> int:
+    """Write the "EL-i õigusaktide vastavus" table.
+
+    See ``_add_affected_entities`` for the progress contract.
+    """
     doc.add_heading("EL-i õigusaktide vastavus", level=1)
 
     rows: list[dict[str, Any]] = list(findings.get("eu_compliance") or [])
     if not rows:
         doc.add_paragraph("EL-i õigusaktide seoseid ei tuvastatud.")
-        return
+        return 1
 
     table = doc.add_table(rows=1, cols=3)
     table.style = "Light Grid Accent 1"
@@ -248,21 +332,36 @@ def _add_eu_compliance(doc: Any, findings: dict[str, Any]) -> None:
     header[0].text = "EL õigusakt"
     header[1].text = "Eesti säte"
     header[2].text = "Staatus"
-    for row in rows:
+    for index, row in enumerate(rows):
         cells = table.add_row().cells
         cells[0].text = str(row.get("eu_label") or row.get("eu_act", "") or "—")
         cells[1].text = str(row.get("provision_label") or row.get("estonian_provision", "") or "—")
         cells[2].text = str(row.get("transposition_status", "") or "—")
+        if (index + 1) % _PROGRESS_BATCH == 0:
+            _safe_publish(
+                progress_callback,
+                progress_base + 1 + ((index + 1) // _PROGRESS_BATCH),
+                progress_total,
+            )
+    extra_units = len(rows) // _PROGRESS_BATCH
+    return 1 + extra_units
 
 
-def _add_gaps(doc: Any, findings: dict[str, Any]) -> None:
-    """Write the "Lüngad" table."""
+def _add_gaps(
+    doc: Any,
+    findings: dict[str, Any],
+    *,
+    progress_callback: ProgressCallback | None = None,
+    progress_base: int = 0,
+    progress_total: int = 0,
+) -> int:
+    """Write the "Lüngad" table. See ``_add_affected_entities`` for the progress contract."""
     doc.add_heading("Lüngad", level=1)
 
     rows: list[dict[str, Any]] = list(findings.get("gaps") or [])
     if not rows:
         doc.add_paragraph("Lünki ei tuvastatud.")
-        return
+        return 1
 
     table = doc.add_table(rows=1, cols=3)
     table.style = "Light Grid Accent 1"
@@ -270,13 +369,21 @@ def _add_gaps(doc: Any, findings: dict[str, Any]) -> None:
     header[0].text = "Teemaklaster"
     header[1].text = "Sätete kaetus"
     header[2].text = "Kirjeldus"
-    for row in rows:
+    for index, row in enumerate(rows):
         cells = table.add_row().cells
         cells[0].text = str(row.get("topic_cluster_label") or row.get("topic_cluster", "") or "—")
         cells[
             1
         ].text = f"{row.get('referenced_provisions', '0')} / {row.get('total_provisions', '0')}"
         cells[2].text = str(row.get("description", "") or "—")
+        if (index + 1) % _PROGRESS_BATCH == 0:
+            _safe_publish(
+                progress_callback,
+                progress_base + 1 + ((index + 1) // _PROGRESS_BATCH),
+                progress_total,
+            )
+    extra_units = len(rows) // _PROGRESS_BATCH
+    return 1 + extra_units
 
 
 def _add_footer_page_numbers(doc: Any) -> None:
@@ -342,7 +449,32 @@ def _add_footer_page_numbers(doc: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def build_impact_report_docx(draft: Draft, report_row: tuple) -> Path:
+def _compute_progress_total(report_data: dict[str, Any]) -> int:
+    """Total work units for one ``build_impact_report_docx`` call.
+
+    The fixed cost is 4 sections (cover + summary + footer + save).
+    Each of the four detail tables contributes 1 unit for the heading
+    + 1 unit per ``_PROGRESS_BATCH`` rows. We compute it up front so
+    the ``<progress>`` bar's ``max`` attribute is right from the first
+    push (browsers can render an indeterminate bar if ``value > max``,
+    which looks broken).
+    """
+    fixed = 4  # cover, summary, footer, save
+    sections = ("affected_entities", "conflicts", "eu_compliance", "gaps")
+    table_units = 0
+    for key in sections:
+        rows = report_data.get(key) or []
+        # 1 unit for the section heading + 1 unit per N rows.
+        table_units += 1 + (len(rows) // _PROGRESS_BATCH)
+    return fixed + table_units
+
+
+def build_impact_report_docx(
+    draft: Draft,
+    report_row: tuple,
+    *,
+    progress_callback: ProgressCallback | None = None,
+) -> Path:
     """Render the impact report as an Estonian-styled ``.docx`` file.
 
     Writes to ``<EXPORT_DIR>/<draft_id>-<report_id>.docx`` using
@@ -353,6 +485,11 @@ def build_impact_report_docx(draft: Draft, report_row: tuple) -> Path:
         draft: The owning draft dataclass (used for title + created_at).
         report_row: Raw tuple fetched in the order declared by
             :data:`_REPORT_COLUMN_INDEX`.
+        progress_callback: Optional ``(current, total)`` reporter
+            invoked after each major section + every
+            ``_PROGRESS_BATCH`` table rows. ``None`` (default) disables
+            progress reporting entirely so existing callers and tests
+            keep their original behaviour.
 
     Returns:
         Absolute :class:`pathlib.Path` to the generated file.
@@ -364,23 +501,71 @@ def build_impact_report_docx(draft: Draft, report_row: tuple) -> Path:
     out_path = export_dir / f"{draft.id}-{report_id}.docx"
 
     report_data = _parse_report_data(report_row[_REPORT_COLUMN_INDEX["report_data"]])
+    total = _compute_progress_total(report_data)
 
     doc = Document()
 
     _add_cover(doc, draft, report_row)
+    done = 1
+    _safe_publish(progress_callback, done, total)
+
     _add_summary(doc, report_row)
-    _add_affected_entities(doc, report_data)
+    done += 1
+    _safe_publish(progress_callback, done, total)
+
+    consumed = _add_affected_entities(
+        doc,
+        report_data,
+        progress_callback=progress_callback,
+        progress_base=done,
+        progress_total=total,
+    )
+    done += consumed
+    _safe_publish(progress_callback, done, total)
     # Section break keeps the detail tables from bleeding into the cover
     # on single-page reports. WD_SECTION.NEW_PAGE is a page break; if the
     # tables are short the blank space is acceptable for a legal export.
     doc.add_section(WD_SECTION.CONTINUOUS)
-    _add_conflicts(doc, report_data)
-    _add_eu_compliance(doc, report_data)
-    _add_gaps(doc, report_data)
+
+    consumed = _add_conflicts(
+        doc,
+        report_data,
+        progress_callback=progress_callback,
+        progress_base=done,
+        progress_total=total,
+    )
+    done += consumed
+    _safe_publish(progress_callback, done, total)
+
+    consumed = _add_eu_compliance(
+        doc,
+        report_data,
+        progress_callback=progress_callback,
+        progress_base=done,
+        progress_total=total,
+    )
+    done += consumed
+    _safe_publish(progress_callback, done, total)
+
+    consumed = _add_gaps(
+        doc,
+        report_data,
+        progress_callback=progress_callback,
+        progress_base=done,
+        progress_total=total,
+    )
+    done += consumed
+    _safe_publish(progress_callback, done, total)
 
     _add_footer_page_numbers(doc)
+    done += 1
+    _safe_publish(progress_callback, done, total)
 
     doc.save(str(out_path))
+    # Final tick — guarantees the WS sees current == total even when
+    # rounding from per-N-row publishes leaves a small gap.
+    _safe_publish(progress_callback, total, total)
+
     logger.info(
         "docx_export: wrote impact report docx draft=%s report=%s path=%s",
         draft.id,

--- a/app/docs/export_handler.py
+++ b/app/docs/export_handler.py
@@ -11,13 +11,30 @@ exporting is a read-only user action and the draft row stays in
 ``ready``. A failure flips the *job* to ``failed`` (with the usual
 retry-with-backoff semantics) so the user sees the error on the
 export-status polling fragment, but the source draft remains intact.
+
+Progress reporting (#610)
+-------------------------
+
+For long .docx renders the handler publishes a ``{"current": N, "total": M}``
+payload to ``background_jobs.progress`` after each major report section
+plus every ``_PROGRESS_BATCH`` table rows. The export-progress WebSocket
+endpoint (``app/docs/ws_export_progress.py``) reads from this column and
+pushes updates to the browser so the UI shows a real ``<progress>`` bar
+instead of the indeterminate "Eksport käimas..." spinner.
+
+The publish path is best-effort: a failed UPDATE is logged at DEBUG and
+swallowed, so the .docx build always finishes regardless of progress
+channel health.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Any
 from uuid import UUID
+
+from psycopg.types.json import Jsonb
 
 from app.db import get_connection
 from app.docs.docx_export import build_impact_report_docx
@@ -35,11 +52,42 @@ _REPORT_SELECT_COLUMNS = (
 )
 
 
+def _publish_progress(job_id: int, *, current: int, total: int) -> None:
+    """Write the latest ``{current, total}`` payload to ``background_jobs.progress``.
+
+    A short-lived connection per call keeps the .docx render from
+    holding a transaction open for the entire export — workers run
+    concurrently and one stuck transaction would block the queue's
+    ``FOR UPDATE SKIP LOCKED`` claims.
+
+    Best-effort: a failed UPDATE is logged at DEBUG and swallowed so a
+    stuck progress channel never aborts the .docx build. The export
+    polling fallback in ``app/docs/report_routes.py`` still drives the
+    UI to the success/failure terminal state regardless of the WS push.
+    """
+    payload = {"current": current, "total": total}
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                "UPDATE background_jobs SET progress = %s WHERE id = %s",
+                (Jsonb(payload), job_id),
+            )
+            conn.commit()
+    except Exception:
+        logger.debug(
+            "export_report: progress UPDATE failed job=%s payload=%s",
+            job_id,
+            payload,
+            exc_info=True,
+        )
+
+
 def export_report(
     payload: dict[str, Any],
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Render the impact report for *payload['draft_id']* as a ``.docx``.
 
@@ -51,6 +99,13 @@ def export_report(
             any domain row state on failure so we don't actually branch
             on it, but other handlers do.
         max_attempts: Total retry budget for this job.
+        job_id: ``background_jobs.id`` for this invocation. When
+            present we hand a progress callback to the docx builder so
+            the export-progress WebSocket can push real progress to the
+            browser (#610). When ``None`` (e.g. older worker, direct
+            call from a test) the callback is omitted and the build
+            runs without progress reporting — same behaviour as before
+            the migration.
 
     Returns:
         ``{"draft_id": ..., "report_id": ..., "docx_path": ...}``
@@ -81,7 +136,12 @@ def export_report(
     except (TypeError, ValueError) as exc:
         raise ValueError(f"export_report: invalid report_id {raw_report_id!r}") from exc
 
-    logger.info("export_report: starting for draft=%s report=%s", draft_id, report_id)
+    logger.info(
+        "export_report: starting for draft=%s report=%s job=%s",
+        draft_id,
+        report_id,
+        job_id,
+    )
 
     with get_connection() as conn:
         draft = get_draft(conn, draft_id)
@@ -100,7 +160,23 @@ def export_report(
             f"Report {report_id} does not belong to draft {draft_id}; refusing to export"
         )
 
-    docx_path = build_impact_report_docx(draft, report_row)
+    # Build the per-call progress callback. We bind ``job_id`` via a
+    # closure so ``build_impact_report_docx`` doesn't need to know
+    # anything about the queue schema. ``None`` skips progress entirely.
+    progress_callback: Callable[[int, int], None] | None = None
+    if job_id is not None:
+        captured_job_id = job_id
+
+        def _publish(current: int, total: int) -> None:
+            _publish_progress(captured_job_id, current=current, total=total)
+
+        progress_callback = _publish
+
+    docx_path = build_impact_report_docx(
+        draft,
+        report_row,
+        progress_callback=progress_callback,
+    )
     logger.info(
         "export_report: wrote docx draft=%s report=%s path=%s",
         draft_id,

--- a/app/docs/extract_handler.py
+++ b/app/docs/extract_handler.py
@@ -46,6 +46,7 @@ def extract_entities(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Real ``extract_entities`` handler.
 

--- a/app/docs/parse_handler.py
+++ b/app/docs/parse_handler.py
@@ -63,6 +63,7 @@ def parse_draft(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Parse an uploaded draft's file via Apache Tika.
 

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -726,6 +726,11 @@ def draft_report_page(req: Request, draft_id: str):
         _eu_compliance_section(findings, draft_id=str(draft.id)),
         _gaps_section(findings, draft_id=str(draft.id)),
         _export_section(draft),
+        # #610: progressive enhancement — opens a WebSocket subscription
+        # to /ws/drafts/export-progress when the spinner fragment lands
+        # in the DOM. Falls back silently to the existing HTMX polling
+        # if the WS connection fails.
+        Script(src="/static/js/export-progress.js", defer=True),  # noqa: F405
         title=f"Mõjuaruanne — {draft.title}",
         user=auth,
         theme=theme,
@@ -940,11 +945,49 @@ def _export_status_spinner(
     job_id: int,
     job_created: datetime | None = None,
 ) -> Any:
-    """Return the spinner-with-poll fragment used while a job is in flight."""
+    """Return the progress-bar-with-poll fragment used while a job is in flight.
+
+    The fragment contains:
+    - A live ``<progress>`` element (the WS push updates ``value`` /
+      ``max``; without WS data it falls back to the indeterminate
+      style via ``data-indeterminate``).
+    - A numeric label ("42%" once the WS reports progress; falls back
+      to "Eksport käimas..." until the first push lands).
+    - A ``data-export-progress-ws`` marker that the static JS shim
+      (``app/static/js/export-progress.js``) finds on DOMContentLoaded
+      / htmx:afterSwap and uses to open the WebSocket subscription.
+    - The existing ``hx-get`` / ``hx-trigger`` polling attributes so
+      the fragment continues to swap itself every N seconds even when
+      the WebSocket is unavailable (the graceful-degradation contract
+      the polling pre-#610 provided is preserved verbatim).
+    """
     interval = _export_poll_interval_seconds(job_created)
     return Div(
-        Span(cls="btn-spinner", aria_hidden="true"),  # noqa: F405
-        Span(" Eksport käimas... (jälgi allpool olevast logist)"),  # noqa: F405
+        # Marker container the JS shim binds to. Holds the progress
+        # bar + label so a single querySelector finds both children.
+        Div(
+            Progress(  # noqa: F405
+                # No initial ``value`` → renders as indeterminate until
+                # the WS pushes the first ``{current, total}`` payload.
+                cls="export-progress-bar",
+                aria_label="Ekspordi edenemine",
+                data_indeterminate="1",
+            ),
+            Span(  # noqa: F405
+                "Eksport käimas...",
+                cls="export-progress-label",
+            ),
+            data_export_progress_ws="1",
+            data_job_id=str(job_id),
+            data_draft_id=str(draft_id),
+            cls="export-progress-wrapper",
+        ),
+        # Visually-hidden status text for assistive tech (the bar
+        # itself is decorative once the label carries the percentage).
+        Span(  # noqa: F405
+            " (jälgi allpool olevast logist)",
+            cls="muted-text export-status-hint",
+        ),
         id="export-status",
         cls="export-status export-status-pending",
         hx_get=f"/drafts/{draft_id}/export-status/{job_id}",

--- a/app/docs/ws_export_progress.py
+++ b/app/docs/ws_export_progress.py
@@ -1,0 +1,465 @@
+"""WebSocket endpoint for live export job progress (#610).
+
+Same FastHTML ``app.ws()`` pattern as :mod:`app.docs.websocket` (draft
+status, post-#694 review). Handshake auth comes from the JWT
+access-token cookie with refresh fallback. Path is
+``/ws/drafts/export-progress``; clients send a single
+``{"type": "subscribe", "draft_id": "<uuid>", "job_id": <int>}``
+message after the ``connected`` event to start receiving progress
+events for that export job.
+
+Subscription model
+------------------
+
+One connection, one job. The export-status fragment renders a small
+client script that opens this WS, sends the subscribe message for the
+in-flight job, and updates the ``<progress>`` element + numeric label
+on every ``{"type": "progress", "current": N, "total": M}`` push. The
+WS closes itself once the job reaches a terminal status
+(``success`` / ``failed``).
+
+Cross-org safety
+----------------
+
+Before subscribing the handler runs the same authorisation check used
+by the HTTP export-status fragment (:func:`app.auth.policy.can_view_draft`)
+plus a defensive check that the requested ``job_id`` belongs to the
+``draft_id`` in the payload. A user from another org hitting this
+endpoint with a leaked job id receives a single ``error`` frame and
+the socket closes — they never get to read another org's progress.
+
+Polling instead of LISTEN/NOTIFY
+--------------------------------
+
+The progress column is updated by the worker thread (synchronous,
+inside ``app/docs/export_handler.py::_publish_progress``). Rather than
+wire a Postgres ``LISTEN`` channel for one column on one job, this
+handler polls ``background_jobs`` every ``_POLL_INTERVAL_SECONDS`` and
+pushes the current ``{current, total}`` if it changed since the last
+push. The worst-case observable lag is ``_POLL_INTERVAL_SECONDS``
+which is well under the polling fallback's 2-10s tick. If we ever need
+sub-second pushes we can swap the poll loop for a Postgres LISTEN on a
+``progress_published`` channel without changing the WS frame format.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from http.cookies import SimpleCookie
+from typing import Any
+
+from app.auth.jwt_provider import JWTAuthProvider
+from app.auth.policy import can_view_draft
+from app.db import get_connection
+from app.docs.draft_model import fetch_draft
+
+logger = logging.getLogger(__name__)
+
+
+# Heartbeat — same shape as the chat module's per-handler heartbeat
+# (post-review fix to #684). Keeps NAT idle timeouts from dropping the
+# socket during long .docx renders (large reports can spend a minute
+# rendering tables without a status change).
+_WS_HEARTBEAT_INTERVAL_SECONDS = 25.0
+_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS = 5.0
+
+# Poll cadence for the worker-side progress column. Fast enough to feel
+# live in the browser without hammering Postgres; the column itself is
+# tiny (a JSONB blob with two ints) so the SELECT cost is negligible.
+_POLL_INTERVAL_SECONDS = 0.5
+
+# Total budget on the watcher loop. The polling layer in the HTTP
+# fragment caps its own retries at 300s (see ``_EXPORT_POLLING_TIMEOUT_SECONDS``
+# in ``app/docs/report_routes.py``); we mirror that here so a
+# permanently-stuck worker can't keep a WebSocket alive forever.
+_WS_MAX_LIFETIME_SECONDS = 360.0
+
+# Background-job statuses that mean the export is done (success or
+# permanent failure). Reaching one of these closes the WS cleanly.
+_TERMINAL_STATUSES = frozenset({"success", "failed"})
+
+
+def _start_heartbeat(send: Any) -> asyncio.Task[None]:
+    """Spawn a periodic ``{"type": "ping"}`` task for the lifetime of
+    the WS handler invocation. Self-terminates on first send error."""
+
+    async def _beat() -> None:
+        while True:
+            try:
+                await asyncio.sleep(_WS_HEARTBEAT_INTERVAL_SECONDS)
+                await asyncio.wait_for(
+                    send(json.dumps({"type": "ping"})),
+                    timeout=_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug(
+                    "export-progress WS heartbeat send failed; terminating",
+                    exc_info=True,
+                )
+                return
+
+    return asyncio.create_task(_beat())
+
+
+def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) -> str | None:
+    """Parse a single named cookie out of raw ASGI ``Cookie`` headers."""
+    for hdr_name, hdr_value in headers:
+        if hdr_name.lower() == b"cookie":
+            cookie: SimpleCookie = SimpleCookie()
+            cookie.load(hdr_value.decode("latin-1"))
+            morsel = cookie.get(name)
+            if morsel is not None:
+                return morsel.value
+    return None
+
+
+async def _ws_close(send: Any, code: int, reason: str) -> None:
+    """Best-effort WS close. Mirrors the chat module's helper.
+
+    The ASGI ``websocket.close`` envelope is the canonical close path;
+    if the runtime prefers a different shape we fall back to sending a
+    JSON error event before exiting.
+    """
+    try:
+        await send({"type": "websocket.close", "code": code, "reason": reason})
+    except Exception:
+        try:
+            await send(json.dumps({"type": "error", "message": reason, "code": code}))
+        except Exception:
+            logger.debug("export-progress WS close fallback failed", exc_info=True)
+
+
+def _read_job_progress(job_id: int) -> tuple[str | None, dict[str, Any] | None]:
+    """Return ``(status, progress)`` for *job_id*, or ``(None, None)`` on miss.
+
+    Sync DB call — the WS handler offloads it via
+    :func:`asyncio.to_thread` so the event loop is never blocked. The
+    return signature explicitly carries the status so the caller can
+    detect terminal jobs and close the socket without an extra round
+    trip to ``JobQueue.get``.
+    """
+    try:
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT status, progress, payload FROM background_jobs WHERE id = %s",
+                (job_id,),
+            ).fetchone()
+    except Exception:
+        logger.debug("export-progress WS: DB read failed for job=%s", job_id, exc_info=True)
+        return None, None
+    if row is None:
+        return None, None
+    status, raw_progress, _payload = row
+    progress: dict[str, Any] | None
+    if raw_progress is None:
+        progress = None
+    elif isinstance(raw_progress, dict):
+        progress = raw_progress
+    elif isinstance(raw_progress, (bytes, bytearray)):
+        try:
+            progress = json.loads(raw_progress.decode())
+        except (TypeError, ValueError, UnicodeDecodeError):
+            logger.debug("export-progress WS: unparseable bytes job=%s", job_id)
+            progress = None
+    elif isinstance(raw_progress, str):
+        try:
+            progress = json.loads(raw_progress)
+        except (TypeError, ValueError):
+            logger.debug("export-progress WS: unparseable string job=%s", job_id)
+            progress = None
+    else:
+        logger.debug(
+            "export-progress WS: unexpected type for progress job=%s type=%s",
+            job_id,
+            type(raw_progress).__name__,
+        )
+        progress = None
+    return status, progress
+
+
+def _validate_job_belongs_to_draft(job_id: int, draft_id: uuid.UUID) -> bool:
+    """Return ``True`` iff *job_id* is an ``export_report`` job for *draft_id*.
+
+    Defensive cross-org guard: even after the draft-level auth check
+    has passed, a leaked job id from another org must not let the
+    caller pull progress for a job that isn't theirs.
+    """
+    try:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT 1 FROM background_jobs
+                WHERE id = %s
+                  AND job_type = 'export_report'
+                  AND payload->>'draft_id' = %s
+                """,
+                (job_id, str(draft_id)),
+            ).fetchone()
+    except Exception:
+        logger.debug(
+            "export-progress WS: ownership check failed job=%s draft=%s",
+            job_id,
+            draft_id,
+            exc_info=True,
+        )
+        return False
+    return row is not None
+
+
+async def ws_export_progress(
+    msg: str,
+    send: Any,
+    scope: dict[str, Any] | None = None,
+) -> None:
+    """Handle one client message on ``/ws/drafts/export-progress``.
+
+    Expected envelope::
+
+        {"type": "subscribe", "draft_id": "<uuid>", "job_id": <int>}
+
+    On a valid subscribe the handler:
+
+    1. Authorises the caller against the draft via
+       :func:`can_view_draft` (drops the connection on miss).
+    2. Confirms the requested ``job_id`` actually belongs to that draft
+       via :func:`_validate_job_belongs_to_draft`.
+    3. Pushes the current ``progress`` payload as a one-shot
+       ``initial`` event so the client doesn't have to wait for the
+       first per-N-row publish.
+    4. Polls ``background_jobs.progress`` every
+       ``_POLL_INTERVAL_SECONDS``; pushes a ``{"type": "progress",
+       "current": N, "total": M}`` event whenever the value changed
+       since the last push.
+    5. Closes the socket when the job reaches a terminal status
+       (``success`` / ``failed``) or when ``_WS_MAX_LIFETIME_SECONDS``
+       elapses (defence-in-depth against a stuck worker).
+    """
+    try:
+        data = json.loads(msg)
+    except (json.JSONDecodeError, TypeError):
+        await send(json.dumps({"type": "error", "message": "Vigane JSON."}))
+        return
+
+    if not isinstance(data, dict):
+        await send(json.dumps({"type": "error", "message": "Vigane sõnum."}))
+        return
+
+    if data.get("type") != "subscribe":
+        # Forward-compat: ignore unknown message types silently.
+        return
+
+    raw_draft_id = data.get("draft_id")
+    if not raw_draft_id:
+        await send(json.dumps({"type": "error", "message": "Puudub draft_id."}))
+        return
+
+    try:
+        draft_id = uuid.UUID(str(raw_draft_id))
+    except (ValueError, TypeError):
+        await send(json.dumps({"type": "error", "message": "Vigane draft_id."}))
+        return
+
+    raw_job_id = data.get("job_id")
+    if raw_job_id is None:
+        await send(json.dumps({"type": "error", "message": "Puudub job_id."}))
+        return
+
+    try:
+        job_id = int(raw_job_id)
+    except (TypeError, ValueError):
+        await send(json.dumps({"type": "error", "message": "Vigane job_id."}))
+        return
+
+    auth = (scope or {}).get("auth") or {}
+    if not auth.get("id"):
+        await send(json.dumps({"type": "error", "message": "Autentimine nõutav."}))
+        return
+
+    # Authorisation: same gate as the HTTP export-status fragment. We
+    # drop on a denial without leaking whether the draft exists.
+    draft = await asyncio.to_thread(fetch_draft, draft_id)
+    if draft is None or not can_view_draft(auth, draft):
+        await send(json.dumps({"type": "error", "message": "Eelnõu ei leitud."}))
+        return
+
+    # Cross-org defence: even after the draft check, the job id has to
+    # belong to this draft. A leaked job id from another export must
+    # not return progress.
+    job_owns_draft = await asyncio.to_thread(_validate_job_belongs_to_draft, job_id, draft_id)
+    if not job_owns_draft:
+        await send(json.dumps({"type": "error", "message": "Eksporditööd ei leitud."}))
+        return
+
+    # Emit the initial state immediately so the client paints the bar
+    # without waiting for the first poll tick.
+    status, progress = await asyncio.to_thread(_read_job_progress, job_id)
+    last_pushed: tuple[Any, Any] | None = None
+    initial_payload: dict[str, Any] = {
+        "type": "initial",
+        "job_id": job_id,
+        "draft_id": str(draft_id),
+        "status": status,
+    }
+    if progress is not None:
+        initial_payload["current"] = progress.get("current")
+        initial_payload["total"] = progress.get("total")
+        last_pushed = (progress.get("current"), progress.get("total"))
+    await send(json.dumps(initial_payload, default=str))
+
+    # Already terminal? Close immediately.
+    if status in _TERMINAL_STATUSES:
+        await _ws_close(send, 1000, "terminal-status")
+        return
+
+    # Poll loop. Each iteration is offloaded via ``asyncio.to_thread``
+    # so the event loop stays responsive to other connections.
+    elapsed = 0.0
+    while elapsed < _WS_MAX_LIFETIME_SECONDS:
+        try:
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            # The wrapper is tearing us down (client disconnect).
+            raise
+        elapsed += _POLL_INTERVAL_SECONDS
+
+        try:
+            status, progress = await asyncio.to_thread(_read_job_progress, job_id)
+        except Exception:
+            logger.debug("export-progress WS: poll iteration failed", exc_info=True)
+            continue
+
+        # Push only when the (current,total) tuple changes. Avoids
+        # spamming idle frames while a long table is rendering.
+        if progress is not None:
+            current = progress.get("current")
+            total = progress.get("total")
+            if last_pushed != (current, total):
+                try:
+                    await send(
+                        json.dumps(
+                            {
+                                "type": "progress",
+                                "job_id": job_id,
+                                "current": current,
+                                "total": total,
+                            },
+                            default=str,
+                        )
+                    )
+                    last_pushed = (current, total)
+                except Exception:
+                    logger.debug(
+                        "export-progress WS: progress send failed; closing",
+                        exc_info=True,
+                    )
+                    return
+
+        if status in _TERMINAL_STATUSES:
+            # Send a final terminal event so the client can render the
+            # success/error UI without an extra HTTP round trip.
+            try:
+                await send(
+                    json.dumps(
+                        {
+                            "type": "terminal",
+                            "job_id": job_id,
+                            "status": status,
+                        },
+                        default=str,
+                    )
+                )
+            except Exception:
+                logger.debug(
+                    "export-progress WS: terminal send failed",
+                    exc_info=True,
+                )
+            await _ws_close(send, 1000, "terminal-status")
+            return
+
+    # Lifetime budget exhausted. Tell the client politely; the HTTP
+    # polling fallback will surface the "Vajab tähelepanu" warning.
+    try:
+        await send(
+            json.dumps(
+                {
+                    "type": "timeout",
+                    "job_id": job_id,
+                    "message": "Eksport venib, jätkake HTTP-päringutega.",
+                }
+            )
+        )
+    except Exception:
+        logger.debug("export-progress WS: timeout send failed", exc_info=True)
+    await _ws_close(send, 1000, "lifetime-exceeded")
+
+
+def register_export_progress_ws_routes(app: Any) -> None:
+    """Mount the export-progress WS at ``/ws/drafts/export-progress``.
+
+    Mirrors :func:`app.docs.websocket.register_draft_ws_routes`: a
+    cookie-based JWT auth wrapper is installed per invocation, then
+    the message body is delegated to :func:`ws_export_progress`. The
+    heartbeat scope is also per invocation (post-#684 pattern).
+    """
+    _jwt_provider: list[JWTAuthProvider | None] = [None]
+
+    def _get_jwt_provider() -> JWTAuthProvider | None:
+        if _jwt_provider[0] is None:
+            try:
+                _jwt_provider[0] = JWTAuthProvider()
+            except Exception:
+                logger.error(
+                    "export-progress WS: failed to construct JWTAuthProvider",
+                    exc_info=True,
+                )
+                return None
+        return _jwt_provider[0]
+
+    async def _ws_handler(msg: str, send: Any, scope: dict[str, Any] | None = None) -> None:
+        auth_scope: dict[str, Any] = {}
+
+        if scope is not None:
+            raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+            access_token = _extract_cookie_from_headers(raw_headers, "access_token")
+            refresh_token = _extract_cookie_from_headers(raw_headers, "refresh_token")
+
+            if access_token or refresh_token:
+                provider = _get_jwt_provider()
+                if provider is None:
+                    await _ws_close(send, 1011, "auth provider unavailable")
+                    return
+
+                user: dict[str, Any] | None = None
+                if access_token:
+                    verified = provider.get_current_user(access_token)
+                    if verified is not None:
+                        user = dict(verified)
+
+                if user is None and refresh_token:
+                    # Same silent-refresh shape as the chat WS (#637).
+                    from app.auth.middleware import verify_refresh_token_user
+
+                    refreshed_user = verify_refresh_token_user(refresh_token, provider=provider)
+                    if refreshed_user is not None:
+                        user = refreshed_user
+
+                if user is not None:
+                    auth_scope["auth"] = user
+
+        # Heartbeat scoped to this handler invocation (post-#684 pattern).
+        heartbeat = _start_heartbeat(send)
+        try:
+            await ws_export_progress(msg, send, auth_scope if auth_scope else None)
+        finally:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    app.ws("/ws/drafts/export-progress")(_ws_handler)

--- a/app/drafter/handlers.py
+++ b/app/drafter/handlers.py
@@ -4,10 +4,13 @@ Each handler follows the Phase 2 convention established by
 :mod:`app.docs.analyze_handler`:
 
     - Registered via ``@register_handler(job_type)``
-    - Accepts ``(payload, *, attempt, max_attempts)``
+    - Accepts ``(payload, *, attempt, max_attempts, job_id=None)``
     - Returns a summary dict persisted in ``background_jobs.result``
     - Raises on failure; only marks domain state as ``abandoned`` on the
       final attempt (#448 retry-gating pattern)
+    - ``job_id`` is accepted for handler-contract compatibility (#610);
+      drafter handlers don't currently publish progress, so the value
+      is ignored.
 
 The handlers are imported as a side-effect in ``app.drafter.__init__.py``
 so they are registered before the worker claims any drafter job.
@@ -298,6 +301,7 @@ def drafter_clarify(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Generate clarifying questions for a drafting session.
 
@@ -388,6 +392,7 @@ def drafter_research(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Run deep SPARQL queries based on intent + clarifications."""
     session_id = UUID(str(payload["session_id"]))
@@ -445,6 +450,7 @@ def drafter_structure(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Generate a proposed law structure via LLM or use VTK fixed structure."""
     session_id = UUID(str(payload["session_id"]))
@@ -564,6 +570,7 @@ def drafter_draft(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Draft legal text for every section in the proposed structure."""
     session_id = UUID(str(payload["session_id"]))
@@ -677,6 +684,7 @@ def drafter_regenerate_clause(
     *,
     attempt: int = 1,
     max_attempts: int = 3,
+    job_id: int | None = None,
 ) -> dict[str, Any]:
     """Regenerate a single clause via LLM and update the session."""
     session_id = UUID(str(payload["session_id"]))

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -9,11 +9,18 @@ safe because ``JobQueue.claim_next`` uses ``FOR UPDATE SKIP LOCKED``.
 
 Handler contract:
     - Handlers are plain synchronous functions with the signature
-      ``(payload: dict, *, attempt: int = 1, max_attempts: int = 3) -> dict | None``.
+      ``(payload: dict, *, attempt: int = 1, max_attempts: int = 3,
+      job_id: int | None = None) -> dict | None``.
       The keyword-only ``attempt``/``max_attempts`` arguments let
       handlers distinguish "first failure, will retry" from "final
       failure, give up" so they can hold off on flipping domain rows
-      to ``failed`` until the retry budget is exhausted (#448).
+      to ``failed`` until the retry budget is exhausted (#448). The
+      ``job_id`` kwarg is the row id for this invocation; long-running
+      handlers use it to publish progress to ``background_jobs.progress``
+      (see ``app/docs/export_handler.py`` for the export progress
+      indicator wired up in #610). Handlers that don't need it are free
+      to capture it via ``**_kwargs`` or ignore it; the worker passes it
+      unconditionally because the caller-cost is one int per dispatch.
     - The returned dict is persisted in ``background_jobs.result``.
     - Handlers MUST raise to signal failure; raising triggers the
       queue's exponential backoff retry logic automatically.
@@ -159,6 +166,7 @@ class JobWorker:
                 job.payload,
                 attempt=attempt_number,
                 max_attempts=job.max_attempts,
+                job_id=job.id,
             )
         except Exception as exc:  # noqa: BLE001 — handler errors flip job to failed
             tb = traceback.format_exc()

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from app.chat.websocket import register_chat_ws_routes
 from app.docs.report_routes import register_report_routes
 from app.docs.routes import register_draft_routes
 from app.docs.websocket import register_draft_ws_routes
+from app.docs.ws_export_progress import register_export_progress_ws_routes
 from app.drafter.routes import register_drafter_routes
 from app.explorer.pages import explorer_page, register_explorer_pages
 from app.explorer.routes import register_explorer_routes
@@ -247,6 +248,7 @@ register_report_routes(rt)
 register_chat_routes(rt)
 register_chat_ws_routes(app)
 register_draft_ws_routes(app)
+register_export_progress_ws_routes(app)
 register_annotation_routes(rt)
 register_notification_routes(rt)
 

--- a/app/static/css/ui.css
+++ b/app/static/css/ui.css
@@ -1759,6 +1759,73 @@
   align-items: center;
   gap: var(--space-2);
   color: var(--color-text-muted);
+  flex-wrap: wrap;
+}
+
+/* #610 — export progress bar (replaces the indeterminate spinner so
+   the user sees real completion feedback). The marker wrapper holds
+   the <progress> + numeric label; the JS shim binds to it on
+   DOMContentLoaded / htmx:afterSwap. */
+.export-progress-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1 1 auto;
+  min-width: 12rem;
+}
+
+.export-progress-bar {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 0.6rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-surface-strong, var(--color-surface));
+  overflow: hidden;
+}
+
+/* Determinate (we have a numeric value/max) */
+.export-progress-bar::-webkit-progress-bar {
+  background-color: var(--color-surface-strong, var(--color-surface));
+  border-radius: var(--radius-sm);
+}
+
+.export-progress-bar::-webkit-progress-value {
+  background-color: var(--color-primary, currentColor);
+  border-radius: var(--radius-sm);
+  transition: width 200ms ease-out;
+}
+
+.export-progress-bar::-moz-progress-bar {
+  background-color: var(--color-primary, currentColor);
+  border-radius: var(--radius-sm);
+}
+
+/* Indeterminate fallback — pulses while the WS hasn't pushed any
+   numeric value yet (or when no WS connection ever opened). */
+.export-progress-bar[data-indeterminate] {
+  background-image: linear-gradient(
+    90deg,
+    var(--color-surface-strong, var(--color-surface)) 0%,
+    var(--color-primary, currentColor) 50%,
+    var(--color-surface-strong, var(--color-surface)) 100%
+  );
+  background-size: 200% 100%;
+  animation: export-progress-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes export-progress-pulse {
+  0% { background-position: 100% 0%; }
+  100% { background-position: -100% 0%; }
+}
+
+.export-progress-label {
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  min-width: 4ch;
+  text-align: right;
 }
 
 /* ===========================================================================

--- a/app/static/js/export-progress.js
+++ b/app/static/js/export-progress.js
@@ -1,0 +1,167 @@
+/* Export progress — WebSocket push listener (#610).
+ *
+ * Augments the existing 2-10s HTMX polling on the export-status
+ * fragment with a WebSocket push so progress updates land within
+ * 500ms of the worker writing them. The WS is purely an enhancement:
+ * if the connection drops or fails to open at all, the existing
+ * hx-trigger="every Ns" attribute on .export-status keeps polling
+ * and drives the UI to the success/failure terminal state exactly
+ * as before. We deliberately do NOT remove those attributes — the
+ * polling fallback is the graceful-degradation path the issue's
+ * Definition of Done requires.
+ *
+ * Marker contract: the export-status fragment renders a marker
+ * <div data-export-progress-ws data-job-id="..." data-draft-id="...">
+ * with a child <progress> + label that the script updates on every
+ * push event. The script self-initialises on DOMContentLoaded and
+ * also on every htmx:afterSwap so it picks up the marker the moment
+ * the export form returns the spinner fragment via HTMX.
+ *
+ * The WS closes itself once the job reaches a terminal status
+ * (success / failed) so the connection doesn't linger forever after
+ * the .docx is ready.
+ */
+(function () {
+  'use strict';
+
+  // Tracks markers we've already wired up so re-running init() after
+  // an HTMX swap doesn't open a second WebSocket for the same job.
+  var ATTACHED_FLAG = 'data-export-progress-attached';
+
+  function start(marker) {
+    if (typeof WebSocket === 'undefined') return;
+    if (marker.hasAttribute(ATTACHED_FLAG)) return;
+
+    var jobId = marker.getAttribute('data-job-id');
+    var draftId = marker.getAttribute('data-draft-id');
+    if (!jobId || !draftId) return;
+
+    marker.setAttribute(ATTACHED_FLAG, '1');
+
+    var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    var url = proto + '//' + window.location.host + '/ws/drafts/export-progress';
+    var ws;
+    try {
+      ws = new WebSocket(url);
+    } catch (e) {
+      // Browser blocked the connection (CSP, mixed content, etc.).
+      // Existing 2-10s polling keeps the page functional.
+      return;
+    }
+
+    ws.addEventListener('open', function () {
+      try {
+        ws.send(JSON.stringify({
+          type: 'subscribe',
+          draft_id: draftId,
+          job_id: parseInt(jobId, 10)
+        }));
+      } catch (e) {
+        // Send failure is fine — polling keeps driving the UI.
+      }
+    });
+
+    ws.addEventListener('message', function (event) {
+      var data;
+      try {
+        data = JSON.parse(event.data);
+      } catch (e) {
+        return; // ignore malformed frames
+      }
+      if (!data || typeof data !== 'object') return;
+
+      if (data.type === 'ping') return;
+
+      if (data.type === 'initial' || data.type === 'progress') {
+        applyProgress(marker, data.current, data.total);
+        return;
+      }
+
+      if (data.type === 'terminal') {
+        // The HTTP polling tick will catch the success/failed state
+        // within at most _EXPORT_POLLING_TIMEOUT_SECONDS / 2 seconds
+        // and replace the spinner with the download button or alert.
+        // We just close the socket here.
+        try { ws.close(1000, 'terminal-status'); } catch (e) { /* noop */ }
+        return;
+      }
+
+      if (data.type === 'timeout') {
+        // The HTTP polling fallback will surface the "Vajab tähelepanu"
+        // warning via the existing 300s budget. Nothing to do here.
+        try { ws.close(1000, 'timeout'); } catch (e) { /* noop */ }
+        return;
+      }
+
+      if (data.type === 'error') {
+        if (window.console && console.warn) {
+          console.warn('export-progress WS error:', data.message);
+        }
+        try { ws.close(1000, 'error'); } catch (e) { /* noop */ }
+        return;
+      }
+    });
+
+    ws.addEventListener('close', function () {
+      // No reconnect: the existing HTMX polling on the fragment
+      // continues to drive updates. Adding reconnect logic here would
+      // be redundant and could compete with the polling tick. If the
+      // user navigates away and back, this script re-runs from the
+      // new page-load init and re-opens the WS.
+      marker.removeAttribute(ATTACHED_FLAG);
+    });
+
+    ws.addEventListener('error', function () {
+      // Same rationale as 'close'.
+    });
+  }
+
+  function applyProgress(marker, current, total) {
+    var progressEl = marker.querySelector('progress.export-progress-bar');
+    var labelEl = marker.querySelector('.export-progress-label');
+    var hasNumeric = (typeof current === 'number' && typeof total === 'number' && total > 0);
+
+    if (progressEl) {
+      if (hasNumeric) {
+        progressEl.max = total;
+        progressEl.value = current;
+        progressEl.removeAttribute('data-indeterminate');
+      } else {
+        // Indeterminate: drop the value so the bar pulses instead.
+        progressEl.removeAttribute('value');
+        progressEl.setAttribute('data-indeterminate', '1');
+      }
+    }
+
+    if (labelEl) {
+      if (hasNumeric) {
+        var pct = Math.min(100, Math.round((current / total) * 100));
+        labelEl.textContent = pct + '%';
+      }
+      // If we have no numeric data, leave the existing fallback text
+      // ("Eksport käimas...") in place.
+    }
+  }
+
+  function init(root) {
+    var scope = root || document;
+    var markers = scope.querySelectorAll('[data-export-progress-ws][data-job-id]');
+    for (var i = 0; i < markers.length; i++) {
+      start(markers[i]);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { init(); });
+  } else {
+    init();
+  }
+
+  // HTMX swaps in the export-status fragment after the user clicks
+  // "Laadi alla .docx", so we re-scan the swapped subtree to pick up
+  // the marker.
+  document.addEventListener('htmx:afterSwap', function (evt) {
+    var target = evt && evt.target ? evt.target : null;
+    init(target);
+  });
+})();

--- a/migrations/027_background_jobs_progress.sql
+++ b/migrations/027_background_jobs_progress.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- Migration 027: background_jobs.progress JSONB — export progress indicator (#610)
+-- =============================================================================
+--
+-- Sprint 1 Day 3 of the Eelnõud sprint plan. The .docx export job
+-- (handler in ``app/docs/export_handler.py``) currently has no in-flight
+-- progress channel: the UI shows an indeterminate "Eksport käimas..."
+-- spinner that polls ``GET /drafts/{id}/export-status/{job}`` every
+-- 2-10 seconds. For larger reports (50+ affected entities, dozens of
+-- conflicts) this leaves the user staring at a blank spinner for a
+-- minute or more with no signal that anything is happening.
+--
+-- This migration adds an optional ``progress`` JSONB column to
+-- ``background_jobs``. The export handler writes a small payload like
+-- ``{"current": 5, "total": 12}`` every few rendered sections; a new
+-- WebSocket endpoint (``/ws/drafts/export-progress``) reads from this
+-- column and pushes updates to the browser so the spinner can be
+-- replaced with a real ``<progress>`` bar showing actual completion.
+--
+-- The column is intentionally generic (a JSONB blob, not a fixed
+-- ``current/total`` int pair) so future job handlers can publish their
+-- own progress shape — e.g. analyze_impact could emit
+-- ``{"phase": "extracting", "items": 30, "total": 100}`` without
+-- another schema migration.
+--
+-- Idempotent: ``ADD COLUMN IF NOT EXISTS``. Safe to apply on prod with
+-- live workers running because the existing handlers don't read or
+-- write the column at all — the absence of a value is the same as the
+-- pre-migration state.
+-- =============================================================================
+
+ALTER TABLE background_jobs
+    ADD COLUMN IF NOT EXISTS progress JSONB;
+
+COMMENT ON COLUMN background_jobs.progress IS
+    'Optional handler-defined progress payload, e.g. {"current": N, "total": M}. '
+    'Written by long-running handlers (export_report — see app/docs/export_handler.py) '
+    'and read by the /ws/drafts/export-progress WebSocket so the UI can render a '
+    'real progress bar instead of an indeterminate spinner. See migration 027 '
+    'and issue #610.';

--- a/tests/test_export_progress.py
+++ b/tests/test_export_progress.py
@@ -1,0 +1,684 @@
+"""Unit tests for the export progress indicator (#610).
+
+Covers four layers:
+
+1. ``app.docs.export_handler._publish_progress`` writes the right
+   JSONB payload to ``background_jobs.progress`` and tolerates DB
+   errors gracefully (best-effort contract).
+2. ``app.docs.docx_export.build_impact_report_docx`` invokes the
+   optional progress callback the expected number of times for a
+   given report shape, and tolerates a misbehaving callback.
+3. ``app.docs.ws_export_progress.ws_export_progress`` validates
+   subscribe envelopes, enforces auth + cross-org guards, and pushes
+   ``{"current": N, "total": M}`` frames to the client when the
+   underlying ``background_jobs.progress`` column changes.
+4. The HTTP polling fragment in ``app.docs.report_routes`` continues
+   to emit ``hx-get`` / ``hx-trigger`` attributes so the
+   graceful-degradation path keeps working when the WebSocket is
+   unavailable (the issue's DoD).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.docs import ws_export_progress as ws_module
+from app.docs.docx_export import _PROGRESS_BATCH, build_impact_report_docx
+from app.docs.draft_model import Draft
+from app.docs.export_handler import _publish_progress
+
+_DRAFT_ID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_REPORT_ID = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _ConnectCM:
+    """Context-manager wrapper for the ``get_connection`` mock — same
+    shape as the helper in ``tests/test_docs_export_handler.py``."""
+
+    def __init__(self, conn: MagicMock):
+        self.conn = conn
+
+    def __enter__(self) -> MagicMock:
+        return self.conn
+
+    def __exit__(self, *_: Any) -> bool:
+        return False
+
+
+def _make_draft() -> Draft:
+    now = datetime.now(UTC)
+    return Draft(
+        id=_DRAFT_ID,
+        user_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        org_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        title="Test eelnõu",
+        filename="eelnou.docx",
+        content_type=("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        file_size=2048,
+        storage_path="/tmp/cipher.enc",
+        graph_uri=f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}",
+        status="ready",
+        parsed_text_encrypted=None,
+        entity_count=2,
+        error_message=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_report_row(report_data: dict[str, Any] | None = None) -> tuple:
+    """Build a tuple matching ``_REPORT_COLUMN_INDEX`` ordering."""
+    return (
+        _REPORT_ID,
+        _DRAFT_ID,
+        2,
+        1,
+        0,
+        42,
+        report_data
+        or {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+        },
+        "2026-04-09T12:00:00+00:00@1061123",
+        datetime(2026, 4, 9, 12, 0, tzinfo=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. _publish_progress
+# ---------------------------------------------------------------------------
+
+
+class TestPublishProgress:
+    def test_writes_jsonb_payload_to_background_jobs(self):
+        """The handler must UPDATE background_jobs.progress with the
+        ``{current, total}`` payload bound through psycopg's Jsonb so
+        the JSONB column receives a typed value, not a stringified one."""
+        conn = MagicMock()
+        conn.execute = MagicMock()
+        conn.commit = MagicMock()
+
+        with patch("app.docs.export_handler.get_connection") as mock_conn:
+            mock_conn.return_value = _ConnectCM(conn)
+            _publish_progress(42, current=3, total=10)
+
+        conn.execute.assert_called_once()
+        conn.commit.assert_called_once()
+
+        sql, params = conn.execute.call_args.args
+        assert "UPDATE background_jobs" in sql
+        assert "SET progress" in sql
+        assert "WHERE id" in sql
+
+        progress_param, job_id_param = params
+        assert job_id_param == 42
+        # Jsonb wraps the dict — check both .obj and the dict path so we
+        # don't couple to psycopg internals.
+        unwrapped = getattr(progress_param, "obj", progress_param)
+        assert unwrapped == {"current": 3, "total": 10}
+
+    def test_db_failure_is_swallowed(self):
+        """A DB error must NOT propagate — the .docx render is the
+        source of truth and the progress channel is best-effort UX."""
+
+        def boom(*_: Any, **__: Any):
+            raise RuntimeError("connection lost")
+
+        with patch("app.docs.export_handler.get_connection", side_effect=boom):
+            # Must not raise; the export render would abort otherwise.
+            _publish_progress(1, current=1, total=1)
+
+
+# ---------------------------------------------------------------------------
+# 2. build_impact_report_docx — progress callback wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDocxProgressCallback:
+    def test_callback_invoked_for_empty_report(self):
+        """Empty findings still yields multiple section-level publishes
+        + a final ``(total, total)`` pin so the WS sees current==total
+        when the .docx is done."""
+        draft = _make_draft()
+        report_row = _make_report_row()
+        calls: list[tuple[int, int]] = []
+
+        def cb(current: int, total: int) -> None:
+            calls.append((current, total))
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            doc = MagicMock()
+            mock_doc_cls.return_value = doc
+            doc.sections = []  # _add_footer_page_numbers loop is no-op
+            build_impact_report_docx(draft, report_row, progress_callback=cb)
+
+        assert calls, "progress callback was never invoked"
+        assert calls[0][0] == 1
+        assert calls[-1][0] == calls[-1][1]
+
+        totals = {total for _, total in calls}
+        assert len(totals) == 1, f"total drifted across calls: {totals}"
+
+        currents = [c for c, _ in calls]
+        for prev, nxt in zip(currents, currents[1:], strict=False):
+            assert prev <= nxt, f"current went backwards: {prev} -> {nxt}"
+
+    def test_callback_fires_mid_table_for_large_section(self):
+        """A table with > _PROGRESS_BATCH rows must publish progress
+        mid-table so the user sees the bar move during a large
+        affected-entities render rather than jumping section-by-section."""
+        draft = _make_draft()
+        big_rows = [
+            {"uri": f"u-{i}", "label": f"L {i}", "type": "x"}
+            for i in range(_PROGRESS_BATCH * 2 + 5)
+        ]
+        report_row = _make_report_row(
+            {
+                "affected_entities": big_rows,
+                "conflicts": [],
+                "eu_compliance": [],
+                "gaps": [],
+            }
+        )
+        calls: list[tuple[int, int]] = []
+
+        def cb(current: int, total: int) -> None:
+            calls.append((current, total))
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            doc = MagicMock()
+            mock_doc_cls.return_value = doc
+            doc.sections = []
+            build_impact_report_docx(draft, report_row, progress_callback=cb)
+
+        # Empty-report baseline = 8 publishes (cover, summary, 4 section
+        # headings, footer, save + final pin). 25 rows / 10 = 2 mid-table
+        # extras → at least 2 more publishes.
+        assert len(calls) > 8, f"expected >8 publishes for big table, got {len(calls)}: {calls}"
+
+    def test_callback_failure_does_not_abort_render(self):
+        """A misbehaving callback (e.g. DB hiccup mid-render) must not
+        abort the .docx build — every publish goes through ``_safe_publish``."""
+        draft = _make_draft()
+        report_row = _make_report_row()
+
+        def cb(_current: int, _total: int) -> None:
+            raise RuntimeError("DB temporarily unavailable")
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            doc = MagicMock()
+            mock_doc_cls.return_value = doc
+            doc.sections = []
+            # Must not raise.
+            build_impact_report_docx(draft, report_row, progress_callback=cb)
+
+    def test_no_callback_keeps_existing_behaviour(self):
+        """Passing ``progress_callback=None`` (the default for older
+        callers + every test that pre-dates #610) must work unchanged."""
+        draft = _make_draft()
+        report_row = _make_report_row()
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            doc = MagicMock()
+            mock_doc_cls.return_value = doc
+            doc.sections = []
+            # Must not raise; must still call doc.save once.
+            build_impact_report_docx(draft, report_row)
+        doc.save.assert_called_once()
+
+
+def test_progress_batch_is_a_positive_int():
+    assert isinstance(_PROGRESS_BATCH, int)
+    assert _PROGRESS_BATCH > 0
+
+
+# ---------------------------------------------------------------------------
+# 3. WebSocket handler — message validation + auth
+# ---------------------------------------------------------------------------
+
+
+def _drain_messages(received: list[str]) -> list[str]:
+    """Extract the human-readable ``message`` strings from a list of
+    raw WS frames (skipping non-error frames). Helper to keep the test
+    bodies short."""
+    out: list[str] = []
+    for r in received:
+        try:
+            payload = json.loads(r)
+        except (TypeError, ValueError):
+            continue
+        msg = payload.get("message")
+        if isinstance(msg, str):
+            out.append(msg)
+    return out
+
+
+class TestWebSocketValidation:
+    def test_invalid_json_yields_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress("not-json{", send, scope={})
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Vigane JSON" in r for r in received)
+
+    def test_non_dict_yields_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress('["nope"]', send, scope={})
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Vigane sõnum" in m for m in _drain_messages(received))
+
+    def test_unknown_type_silently_ignored(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress(
+                json.dumps({"type": "unsubscribe", "draft_id": str(uuid.uuid4())}),
+                send,
+                scope={},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert received == []
+
+    def test_subscribe_without_draft_id(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress(
+                json.dumps({"type": "subscribe", "job_id": 1}),
+                send,
+                scope={"auth": {"id": "u1"}},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("draft_id" in m for m in _drain_messages(received))
+
+    def test_subscribe_with_invalid_draft_id(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress(
+                json.dumps({"type": "subscribe", "draft_id": "not-a-uuid", "job_id": 1}),
+                send,
+                scope={"auth": {"id": "u1"}},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Vigane draft_id" in m for m in _drain_messages(received))
+
+    def test_subscribe_without_job_id(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress(
+                json.dumps({"type": "subscribe", "draft_id": str(uuid.uuid4())}),
+                send,
+                scope={"auth": {"id": "u1"}},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("job_id" in m for m in _drain_messages(received))
+
+    def test_subscribe_with_invalid_job_id(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress(
+                json.dumps(
+                    {
+                        "type": "subscribe",
+                        "draft_id": str(uuid.uuid4()),
+                        "job_id": "not-an-int",
+                    }
+                ),
+                send,
+                scope={"auth": {"id": "u1"}},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Vigane job_id" in m for m in _drain_messages(received))
+
+    def test_unauthenticated_subscribe_yields_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            await ws_module.ws_export_progress(
+                json.dumps({"type": "subscribe", "draft_id": str(uuid.uuid4()), "job_id": 1}),
+                send,
+                scope={},
+            )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Autentimine" in m for m in _drain_messages(received))
+
+
+def _make_draft_obj(*, org_id: str = "org-1") -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        status="ready",
+        error_message=None,
+    )
+
+
+class TestWebSocketAuthGuards:
+    def test_subscribe_to_missing_draft_yields_404_style_error(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            with patch("app.docs.ws_export_progress.fetch_draft", return_value=None):
+                await ws_module.ws_export_progress(
+                    json.dumps(
+                        {
+                            "type": "subscribe",
+                            "draft_id": str(uuid.uuid4()),
+                            "job_id": 1,
+                        }
+                    ),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Eelnõu ei leitud" in m for m in _drain_messages(received))
+
+    def test_cross_org_subscribe_yields_404_style_not_403(self):
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            draft = _make_draft_obj(org_id="other-org")
+            with (
+                patch("app.docs.ws_export_progress.fetch_draft", return_value=draft),
+                patch("app.docs.ws_export_progress.can_view_draft", return_value=False),
+            ):
+                await ws_module.ws_export_progress(
+                    json.dumps(
+                        {
+                            "type": "subscribe",
+                            "draft_id": str(draft.id),
+                            "job_id": 1,
+                        }
+                    ),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        msgs = _drain_messages(received)
+        assert any("Eelnõu ei leitud" in m for m in msgs)
+        assert not any("403" in m for m in msgs)
+
+    def test_job_not_owned_by_draft_yields_error(self):
+        """A leaked job_id from another draft must be rejected even
+        after the draft-level auth check passes."""
+
+        async def _run() -> list[str]:
+            received: list[str] = []
+
+            async def send(p: str) -> None:
+                received.append(p)
+
+            draft = _make_draft_obj(org_id="org-1")
+            with (
+                patch("app.docs.ws_export_progress.fetch_draft", return_value=draft),
+                patch("app.docs.ws_export_progress.can_view_draft", return_value=True),
+                patch(
+                    "app.docs.ws_export_progress._validate_job_belongs_to_draft",
+                    return_value=False,
+                ),
+            ):
+                await ws_module.ws_export_progress(
+                    json.dumps(
+                        {
+                            "type": "subscribe",
+                            "draft_id": str(draft.id),
+                            "job_id": 9999,
+                        }
+                    ),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        assert any("Eksporditööd" in m for m in _drain_messages(received))
+
+
+class TestWebSocketProgressPush:
+    def test_initial_event_carries_current_total_when_progress_present(self):
+        """A successful subscribe must immediately push the current
+        ``progress`` JSONB payload as an ``initial`` event so the bar
+        paints before the first poll tick. Job in success state closes
+        the socket immediately after."""
+        draft = _make_draft_obj()
+
+        async def _run() -> list[str]:
+            received: list[Any] = []
+
+            async def send(p: Any) -> None:
+                received.append(p)
+
+            with (
+                patch("app.docs.ws_export_progress.fetch_draft", return_value=draft),
+                patch("app.docs.ws_export_progress.can_view_draft", return_value=True),
+                patch(
+                    "app.docs.ws_export_progress._validate_job_belongs_to_draft",
+                    return_value=True,
+                ),
+                patch(
+                    "app.docs.ws_export_progress._read_job_progress",
+                    return_value=("success", {"current": 8, "total": 12}),
+                ),
+            ):
+                await ws_module.ws_export_progress(
+                    json.dumps(
+                        {
+                            "type": "subscribe",
+                            "draft_id": str(draft.id),
+                            "job_id": 7,
+                        }
+                    ),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        # Filter out the ASGI close envelope (a dict, not a JSON string).
+        json_frames = [json.loads(r) for r in received if isinstance(r, str) and r.startswith("{")]
+        first = next(e for e in json_frames if e.get("type") == "initial")
+        assert first["current"] == 8
+        assert first["total"] == 12
+        assert first["status"] == "success"
+
+    def test_progress_change_pushes_progress_event(self):
+        """When the polled ``progress`` value changes, the handler
+        must push a ``progress`` frame to the client and a final
+        ``terminal`` frame when the job hits success."""
+        draft = _make_draft_obj()
+        reads = [
+            ("running", {"current": 3, "total": 10}),
+            ("running", {"current": 6, "total": 10}),
+            ("success", {"current": 10, "total": 10}),
+        ]
+        read_idx = {"i": 0}
+
+        def fake_read(_job_id: int):
+            i = min(read_idx["i"], len(reads) - 1)
+            read_idx["i"] += 1
+            return reads[i]
+
+        async def _run() -> list[Any]:
+            received: list[Any] = []
+
+            async def send(p: Any) -> None:
+                received.append(p)
+
+            with (
+                patch("app.docs.ws_export_progress._POLL_INTERVAL_SECONDS", 0.01),
+                patch("app.docs.ws_export_progress._WS_MAX_LIFETIME_SECONDS", 1.0),
+                patch("app.docs.ws_export_progress.fetch_draft", return_value=draft),
+                patch("app.docs.ws_export_progress.can_view_draft", return_value=True),
+                patch(
+                    "app.docs.ws_export_progress._validate_job_belongs_to_draft",
+                    return_value=True,
+                ),
+                patch(
+                    "app.docs.ws_export_progress._read_job_progress",
+                    side_effect=fake_read,
+                ),
+            ):
+                await ws_module.ws_export_progress(
+                    json.dumps(
+                        {
+                            "type": "subscribe",
+                            "draft_id": str(draft.id),
+                            "job_id": 11,
+                        }
+                    ),
+                    send,
+                    scope={"auth": {"id": "u1", "org_id": "org-1"}},
+                )
+            return received
+
+        received = asyncio.run(_run())
+        json_frames = [json.loads(r) for r in received if isinstance(r, str) and r.startswith("{")]
+        types = [e.get("type") for e in json_frames]
+        assert "initial" in types
+        assert "progress" in types
+        assert "terminal" in types
+
+        progress_events = [e for e in json_frames if e.get("type") == "progress"]
+        assert any(e.get("current") == 6 and e.get("total") == 10 for e in progress_events)
+
+
+# ---------------------------------------------------------------------------
+# 4. Polling fallback still works
+# ---------------------------------------------------------------------------
+
+
+class TestPollingFallbackPreserved:
+    def _render(self, ft_obj: Any) -> str:
+        """Render an FT object to its raw HTML string via FastHTML's
+        ``to_xml`` helper (the canonical way to materialise FT trees in
+        tests — see ``tests/test_ui_layout.py``)."""
+        from fasthtml.common import to_xml
+
+        return to_xml(ft_obj)
+
+    def test_export_status_spinner_keeps_htmx_polling_attributes(self):
+        """The graceful-degradation contract: the spinner fragment
+        must keep its ``hx-get`` / ``hx-trigger`` / ``hx-swap`` so the
+        UI still drives to the success/failed terminal state when the
+        WebSocket is unavailable. This is the issue's DoD."""
+        from app.docs.report_routes import _export_status_spinner
+
+        draft_id = uuid.uuid4()
+        spinner = _export_status_spinner(draft_id, job_id=42, job_created=None)
+        rendered = self._render(spinner)
+
+        assert f"/drafts/{draft_id}/export-status/42" in rendered
+        assert "every" in rendered  # hx-trigger="every Ns"
+        assert "outerHTML" in rendered  # hx-swap
+
+    def test_export_status_spinner_includes_progress_marker(self):
+        """The spinner fragment must expose the
+        ``data-export-progress-ws`` marker the JS shim looks for, plus
+        the ``<progress>`` element + label so the WS push has somewhere
+        to write the bar value."""
+        from app.docs.report_routes import _export_status_spinner
+
+        draft_id = uuid.uuid4()
+        spinner = _export_status_spinner(draft_id, job_id=42, job_created=None)
+        rendered = self._render(spinner)
+
+        assert "data-export-progress-ws" in rendered
+        assert "data-job-id" in rendered
+        assert "data-draft-id" in rendered
+        assert "<progress" in rendered
+        assert "export-progress-label" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Smoke: WS route registration
+# ---------------------------------------------------------------------------
+
+
+class TestRouteRegistration:
+    def test_register_mounts_export_progress_path(self):
+        """``register_export_progress_ws_routes`` must register a
+        handler on ``/ws/drafts/export-progress`` so the FastHTML app
+        can route incoming connections to it."""
+        recorded: list[str] = []
+
+        class _StubApp:
+            def ws(self, path: str, *_args: Any, **_kwargs: Any):
+                recorded.append(path)
+
+                def _decorator(handler: Any) -> Any:
+                    return handler
+
+                return _decorator
+
+        ws_module.register_export_progress_ws_routes(_StubApp())
+        assert recorded == ["/ws/drafts/export-progress"]


### PR DESCRIPTION
## Summary

Sprint 1 Day 3 of the Eelnõud sprint plan (`docs/superpowers/specs/2026-05-02-eelnoud-sprint-plan.md` §5 Day 3). Closes #610.

Replaces the indeterminate "Eksport käimas..." spinner on the impact report page with a real `<progress>` bar driven by a WebSocket push from the worker thread. Builds on the §3 Day 1 status SSOT (#625) and the post-#694 WebSocket pattern.

### Worker side

- **Migration 027** adds an optional `background_jobs.progress JSONB` column. Idempotent (`ADD COLUMN IF NOT EXISTS`); safe to apply with live workers because no existing handler reads or writes it.
- `app/docs/export_handler.py::_publish_progress` writes `{current, total}` payloads via `psycopg.types.json.Jsonb`. Best-effort: a DB hiccup is logged at DEBUG and swallowed so a stuck progress channel never aborts the .docx render.
- `app/docs/docx_export.py::build_impact_report_docx` accepts an optional `progress_callback`. Fires after each major report section + every `_PROGRESS_BATCH` (10) table rows so the `<progress>` bar moves smoothly even when the affected-entities table has 200+ rows.
- `app/jobs/worker.py` now passes `job_id` as a kwarg to handlers; existing handlers (parse, extract, analyze, cleanup, drafter ×5) accept it as `job_id: int | None = None` for handler-contract compatibility.

### Browser side

- `app/docs/ws_export_progress.py` mounts `/ws/drafts/export-progress` using the same FastHTML `app.ws()` + JWT-cookie auth + per-handler heartbeat shape as `app/docs/websocket.py` (the post-#694 draft-status WS).
- The handler validates the `{type: subscribe, draft_id, job_id}` envelope, runs the same `can_view_draft` gate as the HTTP fragment, plus a defensive cross-check that the requested `job_id` belongs to the draft (so a leaked id from another org cannot leak progress).
- Polls `background_jobs.progress` every 0.5s (offloaded via `asyncio.to_thread` so the event loop stays responsive); pushes a `{type: progress, current, total}` frame whenever the value changes; closes cleanly on terminal status (success/failed) or after a 360s lifetime budget.
- The export-status spinner fragment now renders `<progress>` + numeric label inside a `data-export-progress-ws` marker. The static JS shim (`app/static/js/export-progress.js`) binds to it on `DOMContentLoaded` / `htmx:afterSwap` and updates `progress.value` + label text on every push.
- **Existing HTMX polling preserved**: `hx-get` / `hx-trigger` / `hx-swap` attributes stay on the fragment so the page degrades to 2-10s polling exactly as before whenever the WebSocket is unavailable. The polling fragment also drives the success/failed terminal swap (download button, error alert, 300s "Vajab tähelepanu" stale warning) — none of that path changed.

### Tests

`tests/test_export_progress.py` covers all four layers (23 new tests):

1. **`_publish_progress`** writes the right Jsonb payload to `background_jobs.progress` and tolerates DB errors gracefully (best-effort contract).
2. **`build_impact_report_docx`** invokes the optional callback with monotonically-non-decreasing `current` values, fires mid-table for large sections, and finishes with `current == total`. A misbehaving callback never aborts the render.
3. **`ws_export_progress`** validates subscribe envelopes, enforces JWT auth + cross-org guards (404-style errors only — never 403 leaks), and pushes `{current, total}` frames when the polled column changes.
4. **Polling fallback** the spinner fragment still emits the `hx-get` / `hx-trigger` polling attributes (the issue's DoD).

## Verification

- `uv run ruff format app/docs/export_handler.py app/docs/docx_export.py app/docs/ws_export_progress.py app/docs/report_routes.py app/jobs/worker.py app/docs/parse_handler.py app/docs/extract_handler.py app/docs/analyze_handler.py app/docs/cleanup_handler.py app/drafter/handlers.py app/main.py tests/test_export_progress.py` — 12 files left unchanged
- `uv run ruff check ...` — All checks passed
- `uv run pyright ...` — 0 errors, 0 warnings
- `uv run pytest tests/` — **1949 passed, 22 skipped** (1926 baseline + 23 new)

## Test plan

- [ ] Apply migration 027 against staging Postgres (CI dry-run job catches any syntax error)
- [ ] Upload + analyze a large draft on staging (~50 affected entities, 20+ conflicts) and confirm the export bar moves smoothly from 0% → 100% in real time
- [ ] Disable WebSocket in DevTools (Network tab → block `/ws/drafts/export-progress`) and confirm the existing 2-10s polling still drives the spinner → download button transition
- [ ] Open the export from a second tab while the first is still in flight; verify the dedupe path (#627) reuses the same job_id and both tabs see the same progress

## Deviations from the plan

- **WS path**: spec says `/ws/export-progress/{job_id}` (path param). Implemented `/ws/drafts/export-progress` (static path) + `{type: subscribe, draft_id, job_id}` message instead, matching the codebase's established WS pattern (chat/explorer/draft-status all use static paths + subscribe messages — see the `project_ws_pattern.md` memory note from the post-#684 review). FastHTML/Starlette do support WS path params, but introducing them for one endpoint while every other WS in the project uses the subscribe pattern would be inconsistent.
- **Module name**: spec says `ws_export.py`; named it `ws_export_progress.py` for clarity since `app/docs/` already has `export_handler.py`, `docx_export.py`, and `_export_*` helpers — `ws_export.py` would be ambiguous about whether it's the WS for the export job or the WS that exports something.

Sprint plan: `docs/superpowers/specs/2026-05-02-eelnoud-sprint-plan.md`
Day 1 baseline: 5eda5b8 (#625, status SSOT)
Day 2 (#623, routes split): in flight on a separate branch, no file conflicts here.
Day 4 (#613, PDF export): will reuse the same `build_impact_report_docx` shape — just adds a `format` param + LibreOffice subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)