### PR TITLE
feat(docs): PDF export via headless LibreOffice (#613)

### DIFF
--- a/app/docs/docx_export.py
+++ b/app/docs/docx_export.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -573,3 +575,62 @@ def build_impact_report_docx(
         out_path,
     )
     return out_path
+
+
+_SOFFICE_TIMEOUT_SECONDS = 60
+
+
+def convert_docx_to_pdf(docx_path: Path) -> Path:
+    """Convert an existing .docx into a sibling .pdf via headless LibreOffice (#613).
+
+    The .docx remains the single source of truth for content; PDF is a
+    pure visual rendering of the same file. This guarantees the two
+    formats can never diverge.
+
+    LibreOffice writes the PDF to ``--outdir`` with the same stem as
+    the input file. Returns the absolute path to the generated PDF.
+
+    ``HOME=/tmp`` is set in the subprocess env to silence the benign
+    ``dconf-CRITICAL`` warning that fires when the container's HOME
+    (e.g. ``/nonexistent``) is not writable. The warning does not
+    affect headless conversion but pollutes logs.
+
+    Raises:
+        FileNotFoundError: ``soffice`` not on PATH (dev environments
+            without LibreOffice installed). Callers must surface a
+            clear error rather than retry — installing LibreOffice is
+            an operator action, not a transient failure.
+        subprocess.TimeoutExpired: conversion exceeded
+            :data:`_SOFFICE_TIMEOUT_SECONDS`.
+        subprocess.CalledProcessError: ``soffice`` exited non-zero;
+            the captured stderr is included in the exception's output.
+    """
+    soffice = shutil.which("soffice")
+    if soffice is None:
+        raise FileNotFoundError("soffice not on PATH; LibreOffice is required for PDF export")
+    out_dir = docx_path.parent
+    env = {**os.environ, "HOME": "/tmp"}
+    subprocess.run(
+        [
+            soffice,
+            "--headless",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            str(out_dir),
+            str(docx_path),
+        ],
+        env=env,
+        check=True,
+        timeout=_SOFFICE_TIMEOUT_SECONDS,
+        capture_output=True,
+    )
+    pdf_path = out_dir / (docx_path.stem + ".pdf")
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"LibreOffice did not produce expected PDF at {pdf_path}")
+    logger.info(
+        "docx_export: converted to pdf docx=%s pdf=%s",
+        docx_path,
+        pdf_path,
+    )
+    return pdf_path

--- a/app/docs/export_handler.py
+++ b/app/docs/export_handler.py
@@ -5,6 +5,16 @@ handler loads the draft + the latest ``impact_reports`` row, calls the
 .docx builder in :mod:`app.docs.docx_export`, and returns the absolute
 path to the generated file in its result dict.
 
+The optional ``format`` payload key (#613) selects the output. For
+``"docx"`` (the default, also the implicit value for legacy jobs
+written before #613) the handler returns ``{"docx_path": ...}``. For
+``"pdf"`` the handler still builds the .docx (so PDF and .docx content
+can never diverge) and then shells out to LibreOffice headless via
+:func:`app.docs.docx_export.convert_docx_to_pdf` to convert it; the
+result dict gains a ``pdf_path`` and the ``format`` echo. The download
+handler in :mod:`app.docs.report_routes` picks the right artefact +
+MIME from the job payload.
+
 Unlike the other Phase 2 handlers (``parse_draft``, ``extract_entities``,
 ``analyze_impact``) this one never transitions ``drafts.status`` —
 exporting is a read-only user action and the draft row stays in
@@ -37,9 +47,11 @@ from uuid import UUID
 from psycopg.types.json import Jsonb
 
 from app.db import get_connection
-from app.docs.docx_export import build_impact_report_docx
+from app.docs.docx_export import build_impact_report_docx, convert_docx_to_pdf
 from app.docs.draft_model import get_draft
 from app.jobs.worker import register_handler
+
+_VALID_FORMATS = ("docx", "pdf")
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +139,12 @@ def export_report(
     if not raw_report_id:
         raise ValueError("export_report payload missing required 'report_id'")
 
+    fmt = str(payload.get("format") or "docx")
+    if fmt not in _VALID_FORMATS:
+        raise ValueError(
+            f"export_report: unsupported format {fmt!r}; expected one of {_VALID_FORMATS}"
+        )
+
     try:
         draft_id = UUID(str(raw_draft_id))
     except (TypeError, ValueError) as exc:
@@ -137,9 +155,10 @@ def export_report(
         raise ValueError(f"export_report: invalid report_id {raw_report_id!r}") from exc
 
     logger.info(
-        "export_report: starting for draft=%s report=%s job=%s",
+        "export_report: starting for draft=%s report=%s format=%s job=%s",
         draft_id,
         report_id,
+        fmt,
         job_id,
     )
 
@@ -184,11 +203,32 @@ def export_report(
         docx_path,
     )
 
-    return {
+    result: dict[str, Any] = {
         "draft_id": str(draft_id),
         "report_id": str(report_id),
+        "format": fmt,
         "docx_path": str(docx_path),
     }
+
+    if fmt == "pdf":
+        # The .docx is the source of truth for content; PDF is a pure
+        # visual rendering of the same file via headless LibreOffice.
+        # Conversion typically takes 2-3 s on the prod VPS for a typical
+        # 5-section report (verified during the §4.3 base-image probe).
+        # The progress channel is left at its terminal "1.0" tick from
+        # the docx render — adding a "converting…" sub-stage would mean
+        # invalidating the WS protocol and re-shaping the JS shim, which
+        # is more change than the user experience justifies.
+        pdf_path = convert_docx_to_pdf(docx_path)
+        result["pdf_path"] = str(pdf_path)
+        logger.info(
+            "export_report: wrote pdf draft=%s report=%s path=%s",
+            draft_id,
+            report_id,
+            pdf_path,
+        )
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -39,7 +39,7 @@ from app.ui.forms.app_form import AppForm
 from app.ui.layout import PageShell
 from app.ui.primitives.annotation_button import AnnotationButton
 from app.ui.primitives.badge import Badge, BadgeVariant
-from app.ui.primitives.button import Button
+from app.ui.primitives.button import Button, ButtonVariant
 from app.ui.primitives.link_button import LinkButton
 from app.ui.surfaces.alert import Alert
 from app.ui.surfaces.card import Card, CardBody, CardHeader
@@ -51,6 +51,8 @@ logger = logging.getLogger(__name__)
 
 
 _DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_PDF_MIME = "application/pdf"
+_VALID_EXPORT_FORMATS = ("docx", "pdf")
 
 # Cap how many rows we render inline. The full findings JSON is still
 # embedded in the impact_reports row and the .docx export contains
@@ -564,36 +566,56 @@ def _gaps_section(findings: dict[str, Any], draft_id: str = "") -> Any:
     )
 
 
+def _export_form(draft: Draft, *, fmt: str, label: str, variant: ButtonVariant) -> Any:
+    """Render one export-trigger form for a single output format (#613).
+
+    Both the .docx and .pdf forms POST to the same endpoint; the only
+    difference is the hidden ``format`` field. Both target the shared
+    ``#export-status`` div so the user can switch formats by clicking
+    the other button (the dedupe guard in
+    :func:`_find_active_export_job` keys on draft + report + format so
+    a .pdf request does not collide with an in-flight .docx job)."""
+    return AppForm(
+        Hidden(name="format", value=fmt),  # noqa: F405
+        Button(
+            label,
+            type="submit",
+            variant=variant,
+        ),
+        Span(  # noqa: F405
+            "",
+            cls=f"btn-spinner export-spinner export-spinner-{fmt}",
+            aria_hidden="true",
+        ),
+        method="post",
+        action=f"/drafts/{draft.id}/export",
+        hx_post=f"/drafts/{draft.id}/export",
+        hx_swap="innerHTML",
+        hx_target="#export-status",
+        hx_indicator=f".export-spinner-{fmt}",
+        cls=f"export-form export-form-{fmt}",
+    )
+
+
 def _export_section(draft: Draft) -> Any:
-    """Build the export action card with HTMX-driven status placeholder."""
+    """Build the export action card with HTMX-driven status placeholder.
+
+    Two buttons (#613): .docx (primary, default) and .pdf (secondary).
+    They share the ``#export-status`` div so progress + download UI
+    flips between the two as the user picks one or the other. Dedupe
+    of in-flight jobs is keyed on draft+report+format so the two
+    formats do not collide."""
     return Card(
         CardHeader(H3("Eksport", cls="card-title")),  # noqa: F405
         CardBody(
             P(  # noqa: F405
-                "Laadi alla terviklik mõjuaruanne .docx vormingus.",
+                "Laadi alla terviklik mõjuaruanne kas .docx või .pdf vormingus.",
                 cls="muted-text",
             ),
-            AppForm(
-                Button(
-                    "Laadi alla .docx",
-                    type="submit",
-                    variant="primary",
-                ),
-                # #599: spinner beside the submit so the form does not
-                # appear frozen while the export is generated. HTMX
-                # toggles ``.htmx-request`` on the indicator element.
-                Span(  # noqa: F405
-                    "",
-                    cls="btn-spinner export-spinner",
-                    aria_hidden="true",
-                ),
-                method="post",
-                action=f"/drafts/{draft.id}/export",
-                hx_post=f"/drafts/{draft.id}/export",
-                hx_swap="innerHTML",
-                hx_target="#export-status",
-                hx_indicator=".export-spinner",
-                cls="export-form",
+            Div(  # noqa: F405
+                _export_form(draft, fmt="docx", label="Laadi alla .docx", variant="primary"),
+                _export_form(draft, fmt="pdf", label="Laadi alla .pdf", variant="secondary"),
+                cls="export-actions",
             ),
             Div(id="export-status", cls="export-status"),
         ),
@@ -888,12 +910,19 @@ def report_section_fragment(req: Request, draft_id: str, section: str):
 # ---------------------------------------------------------------------------
 
 
-def _find_active_export_job(draft_id: uuid.UUID, report_id: str) -> int | None:
-    """Return an in-flight export_report job id for *draft_id* if one exists.
+def _find_active_export_job(draft_id: uuid.UUID, report_id: str, fmt: str) -> int | None:
+    """Return an in-flight export_report job id for *draft_id* + *fmt* if one exists.
 
     "In-flight" = status IN (pending, claimed, running, retrying). The
     caller uses this to dedupe #627: a repeated click should reuse the
-    job already running rather than queueing a second .docx render.
+    job already running rather than queueing a second render.
+
+    The dedupe key includes ``format`` (#613) so a click on .pdf does
+    not collide with an in-flight .docx render — they are separate
+    artefacts and a user may legitimately want both. Legacy jobs
+    written before #613 had no ``format`` key in the payload; we treat
+    them as "docx" via ``COALESCE(payload->>'format', 'docx')``.
+
     Returns ``None`` if nothing is in flight, or on any DB error (the
     fallback is to just enqueue a fresh job so we never block the user
     on a broken lookup).
@@ -907,16 +936,18 @@ def _find_active_export_job(draft_id: uuid.UUID, report_id: str) -> int | None:
                   AND status IN ('pending', 'claimed', 'running', 'retrying')
                   AND payload->>'draft_id' = %s
                   AND payload->>'report_id' = %s
+                  AND COALESCE(payload->>'format', 'docx') = %s
                 ORDER BY id DESC
                 LIMIT 1
                 """,
-                (str(draft_id), str(report_id)),
+                (str(draft_id), str(report_id), fmt),
             ).fetchone()
     except Exception:
         logger.exception(
-            "_find_active_export_job failed for draft=%s report=%s",
+            "_find_active_export_job failed for draft=%s report=%s format=%s",
             draft_id,
             report_id,
+            fmt,
         )
         return None
     return int(row[0]) if row else None
@@ -996,8 +1027,13 @@ def _export_status_spinner(
     )
 
 
-def export_draft_report_handler(req: Request, draft_id: str):
-    """POST /drafts/{draft_id}/export — enqueue an export_report job."""
+async def export_draft_report_handler(req: Request, draft_id: str):
+    """POST /drafts/{draft_id}/export — enqueue an export_report job.
+
+    Accepts an optional form/query field ``format=docx|pdf`` (#613).
+    Defaults to ``docx`` when missing or unrecognised so older clients
+    keep working unchanged.
+    """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
         return auth_or_redirect
@@ -1015,19 +1051,31 @@ def export_draft_report_handler(req: Request, draft_id: str):
     if report_row is None:
         return _not_found_page(req)
 
+    # Read ``format`` from form (HTMX hidden input) with query-string
+    # fallback (browser-native form submit). Anything outside the
+    # allow-list silently degrades to ``docx`` so a malformed request
+    # never errors out — the worst case is the user gets a .docx when
+    # they wanted a .pdf, which they can retry.
+    fmt = "docx"
+    try:
+        form = await req.form()
+        raw_fmt = form.get("format") or req.query_params.get("format")
+    except Exception:
+        raw_fmt = req.query_params.get("format")
+    if isinstance(raw_fmt, str) and raw_fmt.lower() in _VALID_EXPORT_FORMATS:
+        fmt = raw_fmt.lower()
+
     report_id = str(report_row[0])
-    # #627: dedupe. If an export job for this draft+report is already
-    # pending/claimed/running, reuse its id instead of enqueueing a new
-    # one. Without this guard a reviewer could spam-click the button
-    # (or the HTMX request could double-fire on flaky networks) and
-    # queue up a pile of redundant .docx renders.
-    existing_job_id = _find_active_export_job(parsed, report_id)
+    # #627: dedupe per (draft, report, format). A click on .pdf must
+    # not collide with an in-flight .docx and vice-versa.
+    existing_job_id = _find_active_export_job(parsed, report_id, fmt)
     if existing_job_id is not None:
         logger.info(
-            "Reusing existing export_report job %s for draft=%s report=%s",
+            "Reusing existing export_report job %s for draft=%s report=%s format=%s",
             existing_job_id,
             parsed,
             report_id,
+            fmt,
         )
         # #572: still counts as access.
         touch_draft_access_conn(parsed)
@@ -1036,7 +1084,11 @@ def export_draft_report_handler(req: Request, draft_id: str):
     try:
         job_id = JobQueue().enqueue(
             "export_report",
-            {"draft_id": str(parsed), "report_id": report_id},
+            {
+                "draft_id": str(parsed),
+                "report_id": report_id,
+                "format": fmt,
+            },
             priority=10,
         )
     except Exception:
@@ -1057,6 +1109,7 @@ def export_draft_report_handler(req: Request, draft_id: str):
             "draft_id": str(parsed),
             "report_id": report_id,
             "job_id": job_id,
+            "format": fmt,
         },
     )
     # #572: export counts as access; reset the archive clock.
@@ -1230,12 +1283,27 @@ def download_export_handler(req: Request, draft_id: str, job_id: str):
     if str(payload.get("draft_id")) != str(parsed_draft):
         return _not_found_page(req)
 
+    # #613: pick the artefact + MIME based on the job's stored format.
+    # Legacy jobs without a format key are treated as docx so any
+    # in-flight pre-#613 download links keep working.
+    fmt = str(payload.get("format") or "docx").lower()
+    if fmt not in _VALID_EXPORT_FORMATS:
+        fmt = "docx"
+
     result = job.result or {}
-    docx_path = result.get("docx_path")
-    if not docx_path or not Path(str(docx_path)).exists():
+    if fmt == "pdf":
+        artefact_path = result.get("pdf_path")
+        media_type = _PDF_MIME
+        suffix = "pdf"
+    else:
+        artefact_path = result.get("docx_path")
+        media_type = _DOCX_MIME
+        suffix = "docx"
+
+    if not artefact_path or not Path(str(artefact_path)).exists():
         return _not_found_page(req)
 
-    filename = f"impact_report_{_slugify(draft.title)}.docx"
+    filename = f"impact_report_{_slugify(draft.title)}.{suffix}"
     log_action(
         auth.get("id"),
         "draft.report.export.download",
@@ -1243,14 +1311,15 @@ def download_export_handler(req: Request, draft_id: str, job_id: str):
             "draft_id": str(parsed_draft),
             "job_id": parsed_job_id,
             "filename": filename,
+            "format": fmt,
         },
     )
     # #572: download counts as access; reset the archive clock.
     touch_draft_access_conn(parsed_draft)
 
     return FileResponse(
-        path=str(docx_path),
-        media_type=_DOCX_MIME,
+        path=str(artefact_path),
+        media_type=media_type,
         filename=filename,
     )
 

--- a/tests/test_docs_export_handler.py
+++ b/tests/test_docs_export_handler.py
@@ -104,9 +104,13 @@ class TestExportReportHappyPath:
         assert call.args[0] is draft
         assert call.args[1] == report_row
 
+        # #613: handler now echoes the chosen format in the result so the
+        # download route can pick the right artefact + MIME. Default is
+        # "docx" when the payload has no ``format`` key.
         assert result == {
             "draft_id": str(_DRAFT_ID),
             "report_id": str(_REPORT_ID),
+            "format": "docx",
             "docx_path": str(fake_path),
         }
 

--- a/tests/test_docs_report_routes.py
+++ b/tests/test_docs_report_routes.py
@@ -321,10 +321,16 @@ class TestExportDraftReportHandler:
         assert "Eksport käimas" in resp.text
         assert f"/drafts/{_DRAFT_ID}/export-status/99" in resp.text
         # Job was enqueued with the right type and payload.
+        # #613: payload now carries an explicit format (defaults to "docx"
+        # when the client doesn't post one).
         queue_instance.enqueue.assert_called_once()
         args, kwargs = queue_instance.enqueue.call_args
         assert args[0] == "export_report"
-        assert args[1] == {"draft_id": str(_DRAFT_ID), "report_id": str(_REPORT_ID)}
+        assert args[1] == {
+            "draft_id": str(_DRAFT_ID),
+            "report_id": str(_REPORT_ID),
+            "format": "docx",
+        }
         assert kwargs.get("priority") == 10
 
     @patch("app.docs.report_routes.JobQueue")

--- a/tests/test_export_pdf.py
+++ b/tests/test_export_pdf.py
@@ -1,0 +1,249 @@
+"""Tests for PDF export (#613).
+
+Three layers covered:
+    1. ``convert_docx_to_pdf`` — LibreOffice subprocess shape, env, error paths
+    2. ``export_report`` handler — `format=pdf` triggers conversion + persists `pdf_path`
+    3. Download route — picks the PDF artefact + ``application/pdf`` MIME
+
+The integration test at the end actually shells out to ``soffice`` if it
+is on PATH; it is automatically skipped on dev boxes / CI runners that
+don't have LibreOffice installed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from app.docs.docx_export import _SOFFICE_TIMEOUT_SECONDS, convert_docx_to_pdf
+from app.docs.export_handler import export_report
+
+_DRAFT_ID = UUID("44444444-4444-4444-4444-444444444444")
+_REPORT_ID = UUID("55555555-5555-5555-5555-555555555555")
+
+
+# ---------------------------------------------------------------------------
+# convert_docx_to_pdf
+# ---------------------------------------------------------------------------
+
+
+class TestConvertDocxToPdf:
+    def test_invokes_soffice_with_correct_args(self, tmp_path: Path) -> None:
+        docx_path = tmp_path / "report.docx"
+        docx_path.write_bytes(b"PK\x03\x04 fake docx")  # noqa: S102 — test stub
+
+        # Simulate soffice creating the PDF
+        def _fake_run(cmd: Any, **kwargs: Any) -> Any:
+            (tmp_path / "report.pdf").write_bytes(b"%PDF-1.4 fake")
+            return MagicMock(returncode=0)
+
+        with (
+            patch("app.docs.docx_export.shutil.which", return_value="/usr/bin/soffice"),
+            patch("app.docs.docx_export.subprocess.run", side_effect=_fake_run) as mock_run,
+        ):
+            pdf_path = convert_docx_to_pdf(docx_path)
+
+        assert pdf_path == tmp_path / "report.pdf"
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        assert args[0] == [
+            "/usr/bin/soffice",
+            "--headless",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            str(tmp_path),
+            str(docx_path),
+        ]
+        assert kwargs["check"] is True
+        assert kwargs["timeout"] == _SOFFICE_TIMEOUT_SECONDS
+        assert kwargs["capture_output"] is True
+        # HOME=/tmp silences the dconf warning seen during §4.3 verification
+        assert kwargs["env"]["HOME"] == "/tmp"
+
+    def test_raises_when_soffice_missing(self, tmp_path: Path) -> None:
+        docx_path = tmp_path / "report.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+        with patch("app.docs.docx_export.shutil.which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="soffice not on PATH"):
+                convert_docx_to_pdf(docx_path)
+
+    def test_raises_when_pdf_not_produced(self, tmp_path: Path) -> None:
+        """soffice exits 0 but doesn't write the expected file → hard error."""
+        docx_path = tmp_path / "report.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+        with (
+            patch("app.docs.docx_export.shutil.which", return_value="/usr/bin/soffice"),
+            patch(
+                "app.docs.docx_export.subprocess.run",
+                return_value=MagicMock(returncode=0),
+            ),
+        ):
+            with pytest.raises(FileNotFoundError, match="did not produce expected PDF"):
+                convert_docx_to_pdf(docx_path)
+
+    def test_subprocess_timeout_propagates(self, tmp_path: Path) -> None:
+        docx_path = tmp_path / "report.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+        with (
+            patch("app.docs.docx_export.shutil.which", return_value="/usr/bin/soffice"),
+            patch(
+                "app.docs.docx_export.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="soffice", timeout=60),
+            ),
+        ):
+            with pytest.raises(subprocess.TimeoutExpired):
+                convert_docx_to_pdf(docx_path)
+
+    def test_subprocess_nonzero_propagates(self, tmp_path: Path) -> None:
+        docx_path = tmp_path / "report.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+        with (
+            patch("app.docs.docx_export.shutil.which", return_value="/usr/bin/soffice"),
+            patch(
+                "app.docs.docx_export.subprocess.run",
+                side_effect=subprocess.CalledProcessError(
+                    returncode=1, cmd="soffice", stderr=b"GPG key expired"
+                ),
+            ),
+        ):
+            with pytest.raises(subprocess.CalledProcessError):
+                convert_docx_to_pdf(docx_path)
+
+
+# ---------------------------------------------------------------------------
+# export_report handler
+# ---------------------------------------------------------------------------
+
+
+def _stub_draft() -> Any:
+    draft = MagicMock()
+    draft.id = _DRAFT_ID
+    return draft
+
+
+def _stub_report_row() -> tuple:
+    # (id, draft_id, ...) — only the first two are checked by the handler.
+    return (str(_REPORT_ID), str(_DRAFT_ID), 0, 0, 0, 0, {}, "v1", None)
+
+
+class TestExportReportFormat:
+    def test_default_format_is_docx_no_subprocess(self, tmp_path: Path) -> None:
+        docx_path = tmp_path / "out.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+
+        with (
+            patch("app.docs.export_handler.get_connection") as mock_conn_cm,
+            patch("app.docs.export_handler.get_draft", return_value=_stub_draft()),
+            patch(
+                "app.docs.export_handler.build_impact_report_docx",
+                return_value=docx_path,
+            ),
+            patch("app.docs.export_handler.convert_docx_to_pdf") as mock_convert,
+        ):
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = _stub_report_row()
+            mock_conn_cm.return_value.__enter__.return_value = mock_conn
+
+            result = export_report({"draft_id": str(_DRAFT_ID), "report_id": str(_REPORT_ID)})
+
+        assert result["format"] == "docx"
+        assert result["docx_path"] == str(docx_path)
+        assert "pdf_path" not in result
+        # PDF conversion never invoked on the docx path.
+        mock_convert.assert_not_called()
+
+    def test_pdf_format_invokes_conversion_and_persists_path(self, tmp_path: Path) -> None:
+        docx_path = tmp_path / "out.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+        pdf_path = tmp_path / "out.pdf"
+
+        with (
+            patch("app.docs.export_handler.get_connection") as mock_conn_cm,
+            patch("app.docs.export_handler.get_draft", return_value=_stub_draft()),
+            patch(
+                "app.docs.export_handler.build_impact_report_docx",
+                return_value=docx_path,
+            ),
+            patch(
+                "app.docs.export_handler.convert_docx_to_pdf",
+                return_value=pdf_path,
+            ) as mock_convert,
+        ):
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = _stub_report_row()
+            mock_conn_cm.return_value.__enter__.return_value = mock_conn
+
+            result = export_report(
+                {
+                    "draft_id": str(_DRAFT_ID),
+                    "report_id": str(_REPORT_ID),
+                    "format": "pdf",
+                }
+            )
+
+        assert result["format"] == "pdf"
+        assert result["docx_path"] == str(docx_path)
+        assert result["pdf_path"] == str(pdf_path)
+        mock_convert.assert_called_once_with(docx_path)
+
+    def test_unknown_format_rejected_with_value_error(self) -> None:
+        with pytest.raises(ValueError, match="unsupported format"):
+            export_report(
+                {
+                    "draft_id": str(_DRAFT_ID),
+                    "report_id": str(_REPORT_ID),
+                    "format": "xlsx",
+                }
+            )
+
+    def test_legacy_payload_without_format_treated_as_docx(self, tmp_path: Path) -> None:
+        """Pre-#613 jobs in the queue have no `format` key — must still work."""
+        docx_path = tmp_path / "out.docx"
+        docx_path.write_bytes(b"PK\x03\x04")
+        with (
+            patch("app.docs.export_handler.get_connection") as mock_conn_cm,
+            patch("app.docs.export_handler.get_draft", return_value=_stub_draft()),
+            patch(
+                "app.docs.export_handler.build_impact_report_docx",
+                return_value=docx_path,
+            ),
+            patch("app.docs.export_handler.convert_docx_to_pdf") as mock_convert,
+        ):
+            mock_conn = MagicMock()
+            mock_conn.execute.return_value.fetchone.return_value = _stub_report_row()
+            mock_conn_cm.return_value.__enter__.return_value = mock_conn
+            result = export_report({"draft_id": str(_DRAFT_ID), "report_id": str(_REPORT_ID)})
+        assert result["format"] == "docx"
+        mock_convert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke (real soffice — skipped unless LibreOffice is available)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    shutil.which("soffice") is None,
+    reason="LibreOffice (soffice) not available; install for full smoke",
+)
+def test_real_soffice_produces_valid_pdf(tmp_path: Path) -> None:
+    """End-to-end: build a tiny .docx and shell out to the real soffice."""
+    from docx import Document
+
+    doc = Document()
+    doc.add_heading("Test", level=0)
+    doc.add_paragraph("Hello PDF.")
+    docx_path = tmp_path / "tiny.docx"
+    doc.save(str(docx_path))
+
+    pdf_path = convert_docx_to_pdf(docx_path)
+
+    assert pdf_path.exists()
+    assert pdf_path.read_bytes().startswith(b"%PDF-")


### PR DESCRIPTION
Closes #613.

Sprint 1 Day 4 of the [Eelnõud sprint plan](https://github.com/henrikaavik/Seadusloome/blob/main/docs/superpowers/specs/2026-05-02-eelnoud-sprint-plan.md). Adds a `.pdf` download button alongside `.docx` on the impact report page. PDF is rendered by shelling out to `soffice --headless --convert-to pdf` against the same `.docx` the existing builder produces, so the two formats can never diverge in content.

LibreOffice was shipped to the prod image earlier in the sprint via PR #697 (§4.3 deploy-risk isolation). `soffice` 25.2.3.2 verified working in the running container.

## Summary
- New `convert_docx_to_pdf` helper in `app/docs/docx_export.py` — subprocess + 60s timeout + `HOME=/tmp` to silence the dconf warning observed in §4.3
- `export_report` accepts a `format` payload key (`docx` default, `pdf` opt-in); legacy jobs without it stay docx-only
- Two side-by-side forms in `_export_section` — one per format; dedupe in `_find_active_export_job` keys on `(draft, report, format)` so a .pdf request never collides with an in-flight .docx job
- Download handler picks the right artefact + MIME from the job's stored format
- 9 new tests in `tests/test_export_pdf.py` covering subprocess shape, every error path, handler dispatch, and an integration smoke gated on `soffice` availability

## Test plan
- [x] `uv run ruff format` + `uv run ruff check` — green
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest` — 1958 passed, 23 skipped
- [ ] Smoke after deploy: `/drafts/<id>/report` shows two buttons; .pdf download serves a valid PDF

## Why manual implementation
The originally-dispatched code-implementer agent stalled at the 10-minute watchdog (after Day 2 #623 also stalled). Took over manually rather than re-dispatching to keep the sprint on schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)