### PR TITLE
feat(annotations): extend Phase 4 schema for impact-report rows + encryption (#619 PR-A)

### DIFF
--- a/app/annotations/models.py
+++ b/app/annotations/models.py
@@ -18,12 +18,14 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
 from app.db_utils import coerce_uuid, parse_jsonb
+from app.storage import DecryptionError, decrypt_text
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +51,10 @@ class Annotation:
     resolved_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    # Migration 029 extensions
+    draft_version_id: uuid.UUID | None = None
+    mentions: list[uuid.UUID] = field(default_factory=list)
+    stale: bool = False
 
 
 @dataclass
@@ -60,6 +66,8 @@ class AnnotationReply:
     user_id: uuid.UUID
     content: str
     created_at: datetime
+    # Migration 029 extensions
+    mentions: list[uuid.UUID] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -68,32 +76,95 @@ class AnnotationReply:
 
 _ANNOTATION_COLUMNS = (
     "id, user_id, org_id, target_type, target_id, target_metadata, "
-    "content, resolved, resolved_by, resolved_at, created_at, updated_at"
+    "content, resolved, resolved_by, resolved_at, created_at, updated_at, "
+    "content_encrypted, draft_version_id, mentions, stale"
 )
 
-_REPLY_COLUMNS = "id, annotation_id, user_id, content, created_at"
+_REPLY_COLUMNS = "id, annotation_id, user_id, content, created_at, content_encrypted, mentions"
+
+# Indices into the _ANNOTATION_COLUMNS tuple (zero-based)
+_ANN_IDX_ID = 0
+_ANN_IDX_USER_ID = 1
+_ANN_IDX_ORG_ID = 2
+_ANN_IDX_TARGET_TYPE = 3
+_ANN_IDX_TARGET_ID = 4
+_ANN_IDX_TARGET_METADATA = 5
+_ANN_IDX_CONTENT = 6
+_ANN_IDX_RESOLVED = 7
+_ANN_IDX_RESOLVED_BY = 8
+_ANN_IDX_RESOLVED_AT = 9
+_ANN_IDX_CREATED_AT = 10
+_ANN_IDX_UPDATED_AT = 11
+_ANN_IDX_CONTENT_ENCRYPTED = 12
+_ANN_IDX_DRAFT_VERSION_ID = 13
+_ANN_IDX_MENTIONS = 14
+_ANN_IDX_STALE = 15
+
+# Indices into the _REPLY_COLUMNS tuple (zero-based)
+_REPLY_IDX_ID = 0
+_REPLY_IDX_ANNOTATION_ID = 1
+_REPLY_IDX_USER_ID = 2
+_REPLY_IDX_CONTENT = 3
+_REPLY_IDX_CREATED_AT = 4
+_REPLY_IDX_CONTENT_ENCRYPTED = 5
+_REPLY_IDX_MENTIONS = 6
+
+
+def _decode_encrypted_text(ciphertext: bytes | memoryview | None) -> str | None:
+    """Decrypt a BYTEA column; return ``None`` on NULL or decrypt failure.
+
+    Fallback semantics: the caller uses ``None`` to signal "fall back to
+    the legacy plaintext column". Decrypt failures are logged loudly because
+    they can only mean the key rotated or the ciphertext got corrupted.
+    """
+    if ciphertext is None:
+        return None
+    raw = bytes(ciphertext) if isinstance(ciphertext, memoryview) else ciphertext
+    try:
+        return decrypt_text(raw)
+    except DecryptionError:
+        logger.exception("Failed to decrypt annotation column — falling back to plaintext")
+        return None
 
 
 def _row_to_annotation(row: tuple[Any, ...]) -> Annotation:
-    """Build an ``Annotation`` from a raw cursor row."""
-    (
-        ann_id,
-        user_id,
-        org_id,
-        target_type,
-        target_id,
-        target_metadata_raw,
-        content,
-        resolved,
-        resolved_by,
-        resolved_at,
-        created_at,
-        updated_at,
-    ) = row
+    """Build an ``Annotation`` from a raw cursor row selected with _ANNOTATION_COLUMNS.
+
+    Content is sourced from ``content_encrypted`` when present (migration 029
+    onwards), falling back to the legacy plaintext ``content`` column so that
+    existing rows created before the encryption rollout continue to decode.
+    """
+    ann_id = row[_ANN_IDX_ID]
+    user_id = row[_ANN_IDX_USER_ID]
+    org_id = row[_ANN_IDX_ORG_ID]
+    target_type = row[_ANN_IDX_TARGET_TYPE]
+    target_id = row[_ANN_IDX_TARGET_ID]
+    target_metadata_raw = row[_ANN_IDX_TARGET_METADATA]
+    content_plain = row[_ANN_IDX_CONTENT]
+    resolved = row[_ANN_IDX_RESOLVED]
+    resolved_by = row[_ANN_IDX_RESOLVED_BY]
+    resolved_at = row[_ANN_IDX_RESOLVED_AT]
+    created_at = row[_ANN_IDX_CREATED_AT]
+    updated_at = row[_ANN_IDX_UPDATED_AT]
+    content_encrypted = (
+        row[_ANN_IDX_CONTENT_ENCRYPTED] if len(row) > _ANN_IDX_CONTENT_ENCRYPTED else None
+    )
+    draft_version_id_raw = (
+        row[_ANN_IDX_DRAFT_VERSION_ID] if len(row) > _ANN_IDX_DRAFT_VERSION_ID else None
+    )
+    mentions_raw = row[_ANN_IDX_MENTIONS] if len(row) > _ANN_IDX_MENTIONS else []
+    stale = row[_ANN_IDX_STALE] if len(row) > _ANN_IDX_STALE else False
+
+    # Prefer decrypted content; fall back to plaintext for legacy rows.
+    content = _decode_encrypted_text(content_encrypted) or content_plain or ""
 
     target_metadata = parse_jsonb(target_metadata_raw)
     if target_metadata is not None and not isinstance(target_metadata, dict):
         target_metadata = None
+
+    mentions: list[uuid.UUID] = (
+        [coerce_uuid(m) for m in mentions_raw if m is not None] if mentions_raw else []
+    )
 
     return Annotation(
         id=coerce_uuid(ann_id),
@@ -108,18 +179,33 @@ def _row_to_annotation(row: tuple[Any, ...]) -> Annotation:
         resolved_at=resolved_at,
         created_at=created_at,
         updated_at=updated_at,
+        draft_version_id=coerce_uuid(draft_version_id_raw) if draft_version_id_raw else None,
+        mentions=mentions,
+        stale=bool(stale),
     )
 
 
 def _row_to_reply(row: tuple[Any, ...]) -> AnnotationReply:
-    """Build an ``AnnotationReply`` from a raw cursor row."""
-    (
-        reply_id,
-        annotation_id,
-        user_id,
-        content,
-        created_at,
-    ) = row
+    """Build an ``AnnotationReply`` from a raw cursor row selected with _REPLY_COLUMNS.
+
+    Content is sourced from ``content_encrypted`` when present (migration 029
+    onwards), falling back to the legacy plaintext ``content`` column.
+    """
+    reply_id = row[_REPLY_IDX_ID]
+    annotation_id = row[_REPLY_IDX_ANNOTATION_ID]
+    user_id = row[_REPLY_IDX_USER_ID]
+    content_plain = row[_REPLY_IDX_CONTENT]
+    created_at = row[_REPLY_IDX_CREATED_AT]
+    content_encrypted = (
+        row[_REPLY_IDX_CONTENT_ENCRYPTED] if len(row) > _REPLY_IDX_CONTENT_ENCRYPTED else None
+    )
+    mentions_raw = row[_REPLY_IDX_MENTIONS] if len(row) > _REPLY_IDX_MENTIONS else []
+
+    content = _decode_encrypted_text(content_encrypted) or content_plain or ""
+
+    mentions: list[uuid.UUID] = (
+        [coerce_uuid(m) for m in mentions_raw if m is not None] if mentions_raw else []
+    )
 
     return AnnotationReply(
         id=coerce_uuid(reply_id),
@@ -127,6 +213,7 @@ def _row_to_reply(row: tuple[Any, ...]) -> AnnotationReply:
         user_id=coerce_uuid(user_id),
         content=content,
         created_at=created_at,
+        mentions=mentions,
     )
 
 
@@ -321,3 +408,121 @@ def list_replies(
         )
         return []
     return [_row_to_reply(row) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# §9.4 Impact-report row annotations (read-only; writes in PR-B)
+# ---------------------------------------------------------------------------
+
+# Regex for @mention tokens.  Estonian usernames / display names may contain
+# dots and hyphens; we stop at whitespace and punctuation that cannot be part
+# of an identifier.
+_MENTION_RE = re.compile(r"@([\w.\-]+)")
+
+
+def parse_mentions(
+    conn: Any,
+    content: str,
+    org_id: uuid.UUID | str,
+) -> list[uuid.UUID]:
+    """Extract @token-style mentions and resolve them to user_ids in the same org.
+
+    Security: matches are looked up with ``AND org_id = %s`` so an attacker
+    cannot probe for the existence of users in other organisations.  Out-of-org
+    matches are silently dropped.  Duplicate mentions of the same user are
+    deduplicated in the returned list.
+
+    The lookup checks both ``email`` and ``full_name`` columns so that
+    ``@peeter.pärn`` and ``@Peeter Pärn`` both resolve (space replaced by
+    ``_`` is a common convention in Estonian government systems, but both
+    the raw token and the underscore-replaced form are tried).
+
+    Returns an empty list when *content* contains no ``@`` tokens, or when no
+    tokens resolve to users in the given org.
+    """
+    tokens = _MENTION_RE.findall(content)
+    if not tokens:
+        return []
+
+    seen: set[uuid.UUID] = set()
+    result: list[uuid.UUID] = []
+
+    for token in tokens:
+        # Normalise: treat underscores as spaces so @eesnimi_perenimi works too.
+        name_variant = token.replace("_", " ")
+        try:
+            row = conn.execute(
+                """
+                SELECT id FROM users
+                WHERE org_id = %s
+                  AND (
+                      email = %s
+                      OR email = %s
+                      OR full_name ILIKE %s
+                      OR full_name ILIKE %s
+                  )
+                LIMIT 1
+                """,
+                (
+                    str(org_id),
+                    token,  # exact email match e.g. peeter@min.ee
+                    token.lower(),  # case-insensitive email
+                    token,  # exact full_name
+                    name_variant,  # space-variant full_name
+                ),
+            ).fetchone()
+        except Exception:
+            logger.exception("parse_mentions: DB error resolving token %r", token)
+            continue
+
+        if row is None:
+            continue
+
+        user_id = coerce_uuid(row[0])
+        if user_id not in seen:
+            seen.add(user_id)
+            result.append(user_id)
+
+    return result
+
+
+def list_annotations_for_version_row(
+    conn: Any,
+    draft_version_id: uuid.UUID | str,
+    row_kind: str,
+    row_key: str,
+) -> list[Annotation]:
+    """Fetch all annotations on a specific impact-report row within a draft version.
+
+    Encodes the §9.4 target contract:
+        target_type = 'impact_report_item'
+        target_id   = '{row_kind}:{row_key}'
+    filtered on the ``draft_version_id`` FK column added in migration 029.
+
+    The composite index ``idx_annotations_version_target`` makes this O(log n)
+    even as the annotation table grows.
+
+    Returns an empty list when no annotations exist or on DB error.
+    """
+    target_id = f"{row_kind}:{row_key}"
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT {_ANNOTATION_COLUMNS}
+            FROM annotations
+            WHERE draft_version_id = %s
+              AND target_type = 'impact_report_item'
+              AND target_id = %s
+            ORDER BY created_at DESC
+            """,
+            (str(draft_version_id), target_id),
+        ).fetchall()
+    except Exception:
+        logger.exception(
+            "Failed to list annotations for version=%s row_kind=%s row_key=%s",
+            draft_version_id,
+            row_kind,
+            row_key,
+        )
+        return []
+    return [_row_to_annotation(row) for row in rows]

--- a/migrations/029_annotations_extensions.sql
+++ b/migrations/029_annotations_extensions.sql
@@ -1,0 +1,93 @@
+-- Migration 029: Extend annotations schema for impact-report row annotations
+-- (Phase A of #619 row-annotations rollout).
+--
+-- PURPOSE
+--   Adds the columns the service layer needs for impact-report row annotations
+--   (#619 PR-B writes) and encryption-at-rest (#9.5) without breaking any
+--   existing reader.  Prod has 0 rows in annotations / annotation_replies so
+--   the encryption columns ship directly with no Phase B backfill script.
+--
+-- DESIGN DECISION
+--   We extend the existing ``annotations`` / ``annotation_replies`` tables
+--   from migration 011 rather than creating new annotation_threads /
+--   annotation_messages tables.  The sprint plan §9.4 predated an audit of the
+--   existing Phase 4 schema; new tables would have duplicated functionality.
+--
+-- §9.4 target mapping
+--   target_type = 'impact_report_item'   (already in the CHECK constraint)
+--   target_id   = '{row_kind}:{row_key}' (colon-delimited; existing index covers it)
+--   draft_version_id = FK to draft_versions(id) for per-version isolation
+--
+-- ROLLBACK (manual; requires app on pre-PR-A code):
+--   ALTER TABLE annotations
+--     DROP COLUMN IF EXISTS content_encrypted,
+--     DROP COLUMN IF EXISTS draft_version_id,
+--     DROP COLUMN IF EXISTS mentions,
+--     DROP COLUMN IF EXISTS stale,
+--     ALTER COLUMN content SET NOT NULL;
+--   ALTER TABLE annotation_replies
+--     DROP COLUMN IF EXISTS content_encrypted,
+--     DROP COLUMN IF EXISTS mentions,
+--     ALTER COLUMN content SET NOT NULL;
+--   DROP INDEX IF EXISTS idx_annotations_version_target;
+--   DROP INDEX IF EXISTS idx_annotations_stale;
+--   DELETE FROM schema_migrations WHERE version = '029_annotations_extensions';
+-- No data loss — the content column is preserved throughout.
+--
+-- This migration is fully idempotent via IF NOT EXISTS / conditional ALTER.
+
+-- ---------------------------------------------------------------------------
+-- annotations table extensions
+-- ---------------------------------------------------------------------------
+
+-- §9.5 encryption-at-rest: the legacy plaintext content column stays for one
+-- release cycle so PR-B's read fallback can handle any rollback scenario.
+-- We relax NOT NULL here so new encrypted-only writes do not need to
+-- populate a redundant plaintext copy.
+ALTER TABLE annotations ALTER COLUMN content DROP NOT NULL;
+
+-- New BYTEA column that will hold Fernet-encrypted content in PR-B onwards.
+ALTER TABLE annotations ADD COLUMN IF NOT EXISTS content_encrypted bytea;
+
+-- §9.4 per-version isolation: an annotation may be scoped to a specific
+-- draft_version (impact_report_item case) or remain version-agnostic (other
+-- target_types).  NULLABLE for full back-compatibility.
+ALTER TABLE annotations
+    ADD COLUMN IF NOT EXISTS draft_version_id uuid
+    REFERENCES draft_versions(id) ON DELETE CASCADE;
+
+-- §9.4 @mentions: array of in-org user UUIDs resolved at write time from
+-- @kasutaja-style parsing.  Default empty so existing rows satisfy NOT NULL.
+ALTER TABLE annotations
+    ADD COLUMN IF NOT EXISTS mentions uuid[] NOT NULL DEFAULT '{}';
+
+-- §9.4 stale flag: rows whose (row_kind, row_key) no longer exist after a
+-- re-analyze are marked stale=TRUE rather than deleted.  Default FALSE so
+-- existing rows are not surprised by the new column.
+ALTER TABLE annotations
+    ADD COLUMN IF NOT EXISTS stale boolean NOT NULL DEFAULT false;
+
+-- Hot path: load all impact-report annotations for a given draft version
+-- (the primary query in list_annotations_for_version_row).
+CREATE INDEX IF NOT EXISTS idx_annotations_version_target
+    ON annotations(draft_version_id, target_type, target_id)
+    WHERE draft_version_id IS NOT NULL;
+
+-- Partial index for the "show stale only" UI section (§9.4).
+-- Keys on draft_version_id because annotations has no direct draft_id column.
+CREATE INDEX IF NOT EXISTS idx_annotations_stale
+    ON annotations(draft_version_id) WHERE stale = true;
+
+-- ---------------------------------------------------------------------------
+-- annotation_replies table extensions
+-- ---------------------------------------------------------------------------
+-- Replies are message-level: no version scope, no stale flag (those are
+-- thread-level concerns on the parent annotation).  Only encryption + mentions.
+
+ALTER TABLE annotation_replies ALTER COLUMN content DROP NOT NULL;
+
+ALTER TABLE annotation_replies
+    ADD COLUMN IF NOT EXISTS content_encrypted bytea;
+
+ALTER TABLE annotation_replies
+    ADD COLUMN IF NOT EXISTS mentions uuid[] NOT NULL DEFAULT '{}';

--- a/migrations/031_annotations_extensions.sql
+++ b/migrations/031_annotations_extensions.sql
@@ -31,7 +31,7 @@
 --     ALTER COLUMN content SET NOT NULL;
 --   DROP INDEX IF EXISTS idx_annotations_version_target;
 --   DROP INDEX IF EXISTS idx_annotations_stale;
---   DELETE FROM schema_migrations WHERE version = '029_annotations_extensions';
+--   DELETE FROM schema_migrations WHERE version = '031_annotations_extensions';
 -- No data loss — the content column is preserved throughout.
 --
 -- This migration is fully idempotent via IF NOT EXISTS / conditional ALTER.

--- a/tests/test_annotations_models.py
+++ b/tests/test_annotations_models.py
@@ -28,7 +28,9 @@ from app.annotations.models import (
     delete_annotation,
     get_annotation,
     list_annotations_for_target,
+    list_annotations_for_version_row,
     list_replies,
+    parse_mentions,
     resolve_annotation,
 )
 
@@ -51,12 +53,16 @@ def _make_annotation_row(
     target_type: str = "draft",
     target_id: str = "44444444-4444-4444-4444-444444444444",
     target_metadata: str | None = None,
-    content: str = "See vajab muutmist",
+    content: str | None = "See vajab muutmist",
     resolved: bool = False,
     resolved_by: uuid.UUID | None = None,
     resolved_at: datetime | None = None,
+    content_encrypted: bytes | None = None,
+    draft_version_id: uuid.UUID | None = None,
+    mentions: list[uuid.UUID] | None = None,
+    stale: bool = False,
 ) -> tuple[Any, ...]:
-    """Build a raw cursor row matching _ANNOTATION_COLUMNS order."""
+    """Build a raw cursor row matching _ANNOTATION_COLUMNS order (migration 029)."""
     now = datetime.now(UTC)
     return (
         ann_id or uuid.uuid4(),
@@ -71,6 +77,10 @@ def _make_annotation_row(
         resolved_at,
         now,
         now,
+        content_encrypted,
+        draft_version_id,
+        mentions or [],
+        stale,
     )
 
 
@@ -79,9 +89,11 @@ def _make_reply_row(
     reply_id: uuid.UUID | None = None,
     annotation_id: uuid.UUID = _ANN_ID,
     user_id: uuid.UUID = _USER_ID,
-    content: str = "Noustun, parandame.",
+    content: str | None = "Noustun, parandame.",
+    content_encrypted: bytes | None = None,
+    mentions: list[uuid.UUID] | None = None,
 ) -> tuple[Any, ...]:
-    """Build a raw cursor row matching _REPLY_COLUMNS order."""
+    """Build a raw cursor row matching _REPLY_COLUMNS order (migration 029)."""
     now = datetime.now(UTC)
     return (
         reply_id or uuid.uuid4(),
@@ -89,6 +101,8 @@ def _make_reply_row(
         user_id,
         content,
         now,
+        content_encrypted,
+        mentions or [],
     )
 
 
@@ -383,3 +397,263 @@ class TestAuditLogAnnotationDelete:
         mock_log.assert_called_once()
         detail = mock_log.call_args[0][2]
         assert detail["annotation_id"] == str(_ANN_ID)
+
+
+# ---------------------------------------------------------------------------
+# Migration 029 extensions — TestRowAnnotationExtensions
+# ---------------------------------------------------------------------------
+
+_VERSION_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+_OTHER_USER_ID = uuid.UUID("88888888-8888-8888-8888-888888888888")
+
+
+@pytest.fixture(autouse=False)
+def _fernet_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a fresh Fernet key for encryption tests in this class."""
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("STORAGE_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    import app.storage.encrypted as encrypted_module
+
+    monkeypatch.setattr(encrypted_module, "_fernet", None)
+
+
+class TestRowAnnotationExtensions:
+    """Tests for the migration 029 column extensions on _row_to_annotation
+    and the new read helpers parse_mentions / list_annotations_for_version_row."""
+
+    # ------------------------------------------------------------------
+    # _row_to_annotation: encrypted content
+    # ------------------------------------------------------------------
+
+    def test_row_reads_content_from_encrypted_column(self, _fernet_key):
+        """content_encrypted present and non-NULL → decrypted value is used."""
+        from app.storage import encrypt_text
+
+        plaintext = "See eelnõu § 3 vajab täpsustamist."
+        ciphertext = encrypt_text(plaintext)
+
+        row = _make_annotation_row(
+            content=None,  # plaintext column NULL (new write style)
+            content_encrypted=ciphertext,
+            draft_version_id=_VERSION_ID,
+        )
+
+        from app.annotations.models import _row_to_annotation
+
+        ann = _row_to_annotation(row)
+        assert ann.content == plaintext
+
+    def test_row_falls_back_to_plaintext_when_encrypted_null(self):
+        """Legacy row: content_encrypted is NULL, content has the plaintext."""
+        row = _make_annotation_row(
+            content="Vana rida ilma krüpteerimiseta",
+            content_encrypted=None,
+        )
+
+        from app.annotations.models import _row_to_annotation
+
+        ann = _row_to_annotation(row)
+        assert ann.content == "Vana rida ilma krüpteerimiseta"
+
+    def test_row_reads_draft_version_id(self):
+        """draft_version_id is hydrated from the row."""
+        row = _make_annotation_row(draft_version_id=_VERSION_ID)
+
+        from app.annotations.models import _row_to_annotation
+
+        ann = _row_to_annotation(row)
+        assert ann.draft_version_id == _VERSION_ID
+
+    def test_row_reads_mentions(self):
+        """mentions UUID list is hydrated from the row."""
+        row = _make_annotation_row(mentions=[_USER_ID, _OTHER_USER_ID])
+
+        from app.annotations.models import _row_to_annotation
+
+        ann = _row_to_annotation(row)
+        assert ann.mentions == [_USER_ID, _OTHER_USER_ID]
+
+    def test_row_reads_stale_flag(self):
+        """stale=True is preserved through _row_to_annotation."""
+        row = _make_annotation_row(stale=True)
+
+        from app.annotations.models import _row_to_annotation
+
+        ann = _row_to_annotation(row)
+        assert ann.stale is True
+
+    def test_row_defaults_for_legacy_row(self):
+        """A 12-column legacy row (pre-migration-029) uses safe defaults."""
+        now = datetime.now(UTC)
+        # Replicate what a pre-029 row looks like (12 columns, no new ones)
+        legacy_row = (
+            uuid.uuid4(),  # id
+            _USER_ID,  # user_id
+            _ORG_ID,  # org_id
+            "draft",  # target_type
+            "some-id",  # target_id
+            None,  # target_metadata
+            "Vana sisu",  # content
+            False,  # resolved
+            None,  # resolved_by
+            None,  # resolved_at
+            now,  # created_at
+            now,  # updated_at
+            # no content_encrypted, draft_version_id, mentions, stale columns
+        )
+
+        from app.annotations.models import _row_to_annotation
+
+        ann = _row_to_annotation(legacy_row)
+        assert ann.content == "Vana sisu"
+        assert ann.draft_version_id is None
+        assert ann.mentions == []
+        assert ann.stale is False
+
+    # ------------------------------------------------------------------
+    # _row_to_reply: encrypted content
+    # ------------------------------------------------------------------
+
+    def test_reply_row_reads_content_from_encrypted_column(self, _fernet_key):
+        """Reply: content_encrypted non-NULL → decrypted value used."""
+        from app.storage import encrypt_text
+
+        plaintext = "Vastus krüpteeritud kujul."
+        ciphertext = encrypt_text(plaintext)
+
+        row = _make_reply_row(content=None, content_encrypted=ciphertext)
+
+        from app.annotations.models import _row_to_reply
+
+        reply = _row_to_reply(row)
+        assert reply.content == plaintext
+
+    def test_reply_row_falls_back_to_plaintext(self):
+        """Reply legacy row: content_encrypted NULL → plaintext column used."""
+        row = _make_reply_row(content="Vana vastus", content_encrypted=None)
+
+        from app.annotations.models import _row_to_reply
+
+        reply = _row_to_reply(row)
+        assert reply.content == "Vana vastus"
+
+    def test_reply_row_reads_mentions(self):
+        """Reply mentions list is hydrated correctly."""
+        row = _make_reply_row(mentions=[_USER_ID])
+
+        from app.annotations.models import _row_to_reply
+
+        reply = _row_to_reply(row)
+        assert reply.mentions == [_USER_ID]
+
+    # ------------------------------------------------------------------
+    # parse_mentions
+    # ------------------------------------------------------------------
+
+    def test_parse_mentions_resolves_in_org_user(self):
+        """@token that matches a user in the same org is resolved to their UUID."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        result = parse_mentions(conn, "Vaata @peeter.pärn kommentaare.", _ORG_ID)
+
+        assert result == [_USER_ID]
+        # The query must include org_id to prevent cross-org probing.
+        sql = conn.execute.call_args.args[0]
+        assert "org_id" in sql
+
+    def test_parse_mentions_drops_out_of_org_user(self):
+        """@token that does NOT match any user in the org is silently dropped."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        result = parse_mentions(conn, "Vaata @võõras tulemusi.", _ORG_ID)
+
+        assert result == []
+
+    def test_parse_mentions_deduplicates_same_user(self):
+        """Mentioning the same user twice returns only one UUID."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        result = parse_mentions(conn, "@peeter.pärn ja ka @peeter.pärn uuesti.", _ORG_ID)
+
+        assert result == [_USER_ID]
+
+    def test_parse_mentions_empty_content(self):
+        """Content with no @ tokens returns an empty list without hitting the DB."""
+        conn = MagicMock()
+
+        result = parse_mentions(conn, "Lihtsalt tekst, pole mainimisi.", _ORG_ID)
+
+        assert result == []
+        conn.execute.assert_not_called()
+
+    def test_parse_mentions_db_error_is_swallowed(self):
+        """A DB error on a single token is logged and skipped; others proceed."""
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("DB error")
+
+        # Should not raise — returns empty list gracefully.
+        result = parse_mentions(conn, "@kasutaja kommenteerib.", _ORG_ID)
+        assert result == []
+
+    # ------------------------------------------------------------------
+    # list_annotations_for_version_row
+    # ------------------------------------------------------------------
+
+    def test_list_for_version_row_queries_correct_target(self):
+        """Helper builds target_id as '{row_kind}:{row_key}' and filters by version."""
+        conn = MagicMock()
+        row = _make_annotation_row(
+            target_type="impact_report_item",
+            target_id="conflict:abc123",
+            draft_version_id=_VERSION_ID,
+        )
+        conn.execute.return_value.fetchall.return_value = [row]
+
+        results = list_annotations_for_version_row(conn, _VERSION_ID, "conflict", "abc123")
+
+        assert len(results) == 1
+        assert results[0].target_id == "conflict:abc123"
+
+        sql, params = conn.execute.call_args.args
+        assert "impact_report_item" in sql
+        assert "draft_version_id" in sql
+        # target_id param must be the colon-delimited form
+        assert "conflict:abc123" in params
+
+    def test_list_for_version_row_returns_empty_on_db_error(self):
+        """DB errors are caught and an empty list is returned."""
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("DB error")
+
+        result = list_annotations_for_version_row(conn, _VERSION_ID, "gap", "some-key")
+        assert result == []
+
+    def test_list_for_version_row_empty_result(self):
+        """No matching rows → empty list, no exception."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        result = list_annotations_for_version_row(
+            conn, _VERSION_ID, "entity", "http://example.org/Provision/1"
+        )
+        assert result == []
+
+    # ------------------------------------------------------------------
+    # §4.2-equivalent contract: new API surface is exported
+    # ------------------------------------------------------------------
+
+    def test_new_helpers_are_exported_from_module(self):
+        """Placeholder: asserts that PR-A exposes the helpers PR-B will call.
+
+        The actual write-path contract test (encryption mandatory on create)
+        lands in PR-B.
+        """
+        import app.annotations.models as m
+
+        assert callable(m.parse_mentions)
+        assert callable(m.list_annotations_for_version_row)


### PR DESCRIPTION
## Summary

- Extends the existing Phase 4 `annotations` / `annotation_replies` tables (migration 011) — **does NOT create new `annotation_threads` or `annotation_messages` tables** (those would have duplicated Phase 4 functionality; see design decision below)
- Migration `029_annotations_extensions.sql` adds 4 columns to `annotations` (`content_encrypted`, `draft_version_id`, `mentions`, `stale`), 2 columns to `annotation_replies` (`content_encrypted`, `mentions`), and 2 supporting indexes
- `app/annotations/models.py` extended with new dataclass fields, a `_decode_encrypted_text` helper (mirrors `chat/models.py` pattern), updated `_row_to_annotation` / `_row_to_reply` with encryption fallback logic, and two new read-only helpers: `parse_mentions` and `list_annotations_for_version_row`
- 18 new tests in `TestRowAnnotationExtensions` covering encrypted/plaintext fallback, legacy row compat, mention resolution + dedup + org-scope enforcement, and the `list_annotations_for_version_row` contract

## Design decision — extended, not duplicated

The sprint plan §9.4 was written before an audit of the existing Phase 4 schema. The `annotations` table already has `target_type = 'impact_report_item'` in its CHECK constraint and a `(target_type, target_id)` index. The §9.4 contract maps cleanly onto the existing schema:

- `target_type = 'impact_report_item'`
- `target_id = '{row_kind}:{row_key}'` (colon-delimited composite, covered by the existing index)
- New `draft_version_id` FK for per-version isolation

No new tables created. The sprint plan §9.4 `annotation_threads` / `annotation_messages` proposal is superseded by this mapping.

## Migration details

- 4 new columns on `annotations`: `content_encrypted bytea`, `draft_version_id uuid FK`, `mentions uuid[]`, `stale boolean`
- 2 new columns on `annotation_replies`: `content_encrypted bytea`, `mentions uuid[]`
- 2 new indexes: `idx_annotations_version_target` (hot path for version-row lookups), `idx_annotations_stale` (partial, stale UI section)
- Fully idempotent via `IF NOT EXISTS` / conditional ALTER
- Prod has 0 rows in both tables — no backfill needed

## Scope

- `migrations/029_annotations_extensions.sql` — new
- `app/annotations/models.py` — extended
- `tests/test_annotations_models.py` — extended (25 → 43 tests)
- No changes to `routes.py`, `audit.py`, analyze pipeline, or any write paths

## References

Closes part of #619 (PR-A of 3). Writes in PR-B, stale-flag automation in PR-C.
Sprint plan §9.4 (target mapping), §9.5 (encryption-at-rest).

## Test plan

- [x] `uv run ruff format` — 2 files reformatted, clean
- [x] `uv run ruff check` — all checks passed
- [x] `uv run pyright app/annotations/models.py` — 0 errors, 0 warnings
- [x] `uv run pytest tests/test_annotations_models.py -v` — 43/43 passed
- [x] `uv run pytest tests/ -q` — 2001 passed, 23 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)