### PR TITLE
refactor(docs): routes.py → package + lifecycle extraction (#623 PR-A)

### DIFF
--- a/app/docs/routes/__init__.py
+++ b/app/docs/routes/__init__.py
@@ -36,23 +36,21 @@ from app.auth.users import list_users
 from app.db import get_connection as _connect
 from app.docs._helpers import _not_found_page, _parse_uuid
 from app.docs.audit import (
-    log_draft_delete,
     log_draft_upload,
     log_draft_view,
 )
 from app.docs.draft_model import (
     DEFAULT_SORT,
     Draft,
-    delete_draft,
     fetch_draft,
     list_drafts_for_org_filtered,
     list_eelnous_for_vtk,
     list_vtks_for_org,
-    touch_draft_access,
     touch_draft_access_conn,
     update_draft_parent_vtk,
 )
 from app.docs.graph_builder import write_doc_lineage
+from app.docs.routes._lifecycle import delete_draft_handler, keep_draft_handler
 from app.docs.status import (
     PIPELINE_STAGES,
     STATUS_BY_VALUE,
@@ -64,8 +62,6 @@ from app.docs.status import (
     VALID_STATUSES as _VALID_STATUSES,
 )
 from app.docs.upload import DraftUploadError, handle_upload
-from app.jobs.queue import JobQueue
-from app.rag.retriever import delete_chunks_for_draft
 from app.ui.data.data_table import Column, DataTable
 from app.ui.data.pagination import Pagination
 from app.ui.feedback.empty_state import EmptyState
@@ -2272,193 +2268,6 @@ def draft_actions_fragment(req: Request, draft_id: str):
     # and ``body[-1]`` worked; adding the link-vtk modal trailing items
     # made the negative index unsafe.)
     return body[1]
-
-
-# ---------------------------------------------------------------------------
-# POST /drafts/{draft_id}/delete — delete handler
-# ---------------------------------------------------------------------------
-
-
-def delete_draft_handler(req: Request, draft_id: str):
-    """POST /drafts/{draft_id}/delete — remove the draft + encrypted file.
-
-    Owner-only per NFR §5 matrix (fixed by #568). Any same-org colleague
-    used to be able to delete another user's draft because the handler
-    authorized on ``org_id`` alone. The helper in ``app.auth.policy``
-    enforces the full rule: owner OR system admin.
-    """
-    auth_or_redirect = _require_auth(req)
-    if isinstance(auth_or_redirect, Response):
-        return auth_or_redirect
-    auth = auth_or_redirect
-
-    parsed = _parse_uuid(draft_id)
-    if parsed is None:
-        return _not_found_page(req)
-
-    draft = fetch_draft(parsed)
-    if draft is None:
-        return _not_found_page(req)
-    if not can_delete_draft(auth, draft):
-        # Return 404 rather than 403 so we don't leak existence of the
-        # draft to cross-org or non-owner callers.
-        return _not_found_page(req)
-
-    # #628: single transaction for every DB-side deletion. Previously
-    # the handler opened two separate ``_connect()`` contexts (row +
-    # rag_chunks, then background_jobs cancellation) and sandwiched
-    # two external calls (encrypted file + Jena graph) between them
-    # with no boundary. A failure partway through left the system in
-    # an inconsistent state: row gone but jobs still pending, or jobs
-    # cancelled but encrypted file still on disk. The refactor folds
-    # every DB mutation into ONE transactional block and hands the
-    # slow/flaky external cleanup off to a background ``draft_cleanup``
-    # job that can retry independently.
-    storage_path: str | None = None
-    try:
-        with _connect() as conn:
-            storage_path = delete_draft(conn, parsed)
-            # #576: polymorphic soft reference — clear any rag_chunks rows
-            # tied to this draft inside the same transaction as the row
-            # delete so either both land or neither does. Today no private
-            # draft ingestion exists so this is a no-op, but wiring it now
-            # means future ingestion code can't forget.
-            try:
-                delete_chunks_for_draft(conn, parsed)
-            except Exception:
-                logger.exception("Failed to delete rag_chunks for draft id=%s", parsed)
-            # #454/#478: cancel any pending/claimed/running/retrying
-            # background jobs that still reference this draft. Doing
-            # this in the SAME transaction as the row delete means a
-            # rollback doesn't strand orphaned jobs on the queue.
-            # #478 added ``running`` because a worker that picked up
-            # the job just before deletion would otherwise leave the
-            # row behind and produce a spurious failure.
-            conn.execute(
-                """
-                DELETE FROM background_jobs
-                WHERE payload->>'draft_id' = %s
-                  AND status IN ('pending', 'claimed', 'running', 'retrying')
-                """,
-                (str(parsed),),
-            )
-            conn.commit()
-    except Exception:
-        logger.exception("Failed to delete draft id=%s", parsed)
-        return _not_found_page(req)
-
-    # #628: enqueue an async cleanup job for the external effects that
-    # can fail independently of the user-visible delete. The job
-    # retries on its own schedule; a flaky Jena instance no longer
-    # blocks the user flow or leaves the DB inconsistent. Failure to
-    # enqueue is logged but non-fatal — the DB is already clean and
-    # the operator can always delete the file/graph manually.
-    cleanup_payload = {
-        "draft_id": str(parsed),
-        "storage_path": storage_path,
-        "graph_uri": draft.graph_uri,
-    }
-    try:
-        cleanup_job_id = JobQueue().enqueue("draft_cleanup", cleanup_payload, priority=0)
-        logger.info(
-            "Orphan cleanup job enqueued draft=%s job_id=%s storage_path=%s",
-            parsed,
-            cleanup_job_id,
-            storage_path,
-        )
-    except Exception:
-        logger.exception(
-            "Failed to enqueue draft_cleanup job for draft id=%s — "
-            "external resources may be orphaned",
-            parsed,
-        )
-
-    log_draft_delete(
-        auth.get("id"),
-        parsed,
-        filename=draft.filename,
-    )
-
-    # #598: queue a success toast for the drafts listing page.
-    push_flash(req, "Eelnõu kustutatud.", kind="success")
-
-    # #467: when the browser drives the delete via HTMX (the form has
-    # ``hx_post`` + ``hx_target='body'`` + ``hx_swap='outerHTML'`` — see
-    # ``_draft_detail_body``), returning a plain 303 here makes HTMX
-    # follow the redirect as an AJAX GET, fetch the drafts-list partial
-    # (whose first element is a ``<title>`` tag from ``PageShell``), and
-    # swap that entire partial into ``<body>``. The rendered page ends
-    # up with a ``<title>`` inside the body, which browsers treat as
-    # invalid HTML and render as visible text — corrupting the layout.
-    #
-    # The fix is to detect HTMX requests and return an empty 204 with an
-    # ``HX-Redirect`` header so HTMX performs a **real** browser
-    # navigation to ``/drafts`` instead of swapping. Non-HTMX clients
-    # (JS-disabled users hitting the native form action) still get the
-    # 303 redirect.
-    if req.headers.get("HX-Request") == "true":
-        return Response(
-            status_code=204,
-            headers={"HX-Redirect": "/drafts"},
-        )
-    return RedirectResponse(url="/drafts", status_code=303)
-
-
-# ---------------------------------------------------------------------------
-# POST /drafts/{draft_id}/keep — reset last_accessed_at (#572)
-# ---------------------------------------------------------------------------
-
-
-def keep_draft_handler(req: Request, draft_id: str):
-    """POST /drafts/{draft_id}/keep — reset the 90-day archive clock.
-
-    Owner-only per the same policy as delete — resetting the archive
-    clock is a governance action that re-commits the org to retaining
-    the draft for another 90 days. Same-org reviewers and admins MUST
-    NOT be able to bypass the owner's intent to let a stale draft
-    auto-warn.
-    """
-    auth_or_redirect = _require_auth(req)
-    if isinstance(auth_or_redirect, Response):
-        return auth_or_redirect
-    auth = auth_or_redirect
-
-    parsed = _parse_uuid(draft_id)
-    if parsed is None:
-        return _not_found_page(req)
-
-    draft = fetch_draft(parsed)
-    if draft is None:
-        return _not_found_page(req)
-    if not can_delete_draft(auth, draft):
-        # 404 (not 403) — see delete_draft_handler for the reasoning.
-        return _not_found_page(req)
-
-    try:
-        with _connect() as conn:
-            touch_draft_access(conn, parsed)
-            conn.commit()
-    except Exception:
-        logger.exception("Failed to reset last_accessed_at for draft=%s", parsed)
-        return _not_found_page(req)
-
-    log_action(
-        auth.get("id"),
-        "draft.keep",
-        {"draft_id": str(parsed)},
-    )
-
-    # #598: queue a success toast for the detail page redirect target.
-    push_flash(req, "90-päevane loendur lähtestatud.", kind="success")
-
-    # HTMX-driven submits get an HX-Redirect so the browser performs a
-    # real navigation rather than swapping a partial into <body>.
-    if req.headers.get("HX-Request") == "true":
-        return Response(
-            status_code=204,
-            headers={"HX-Redirect": f"/drafts/{parsed}"},
-        )
-    return RedirectResponse(url=f"/drafts/{parsed}", status_code=303)
 
 
 # ---------------------------------------------------------------------------

--- a/app/docs/routes/_lifecycle.py
+++ b/app/docs/routes/_lifecycle.py
@@ -1,0 +1,229 @@
+"""Lifecycle mutation handlers for /drafts (#623 partial split).
+
+Extracted from ``app/docs/routes/__init__.py`` so each mutation handler
+lives next to its peers and ``__init__.py`` shrinks toward a thin
+registration shim. This is the FIRST extraction of the #623 routes
+split; ``link_vtk_handler``, ``new_draft_page``, ``create_draft_handler``,
+``drafts_list_page``, and ``draft_detail_page`` still live in the
+package's ``__init__.py`` and will move in follow-up PRs.
+
+Routes registered:
+
+    POST /drafts/{draft_id}/delete   — delete_draft_handler
+    POST /drafts/{draft_id}/keep     — keep_draft_handler
+
+Both routes are owner-only per ``app.auth.policy.can_delete_draft``;
+cross-org or non-owner callers receive 404 (never 403) so existence
+is not leaked.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+
+from app.auth.audit import log_action
+from app.auth.helpers import require_auth as _require_auth
+from app.auth.policy import can_delete_draft
+from app.db import get_connection as _connect
+from app.docs._helpers import _not_found_page, _parse_uuid
+from app.docs.audit import log_draft_delete
+from app.docs.draft_model import (
+    delete_draft,
+    fetch_draft,
+    touch_draft_access,
+)
+from app.jobs.queue import JobQueue
+from app.rag.retriever import delete_chunks_for_draft
+from app.ui.feedback.flash import push_flash
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# POST /drafts/{draft_id}/delete
+# ---------------------------------------------------------------------------
+
+
+def delete_draft_handler(req: Request, draft_id: str):
+    """POST /drafts/{draft_id}/delete — remove the draft + encrypted file.
+
+    Owner-only per NFR §5 matrix (fixed by #568). Any same-org colleague
+    used to be able to delete another user's draft because the handler
+    authorized on ``org_id`` alone. The helper in ``app.auth.policy``
+    enforces the full rule: owner OR system admin.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    parsed = _parse_uuid(draft_id)
+    if parsed is None:
+        return _not_found_page(req)
+
+    draft = fetch_draft(parsed)
+    if draft is None:
+        return _not_found_page(req)
+    if not can_delete_draft(auth, draft):
+        # Return 404 rather than 403 so we don't leak existence of the
+        # draft to cross-org or non-owner callers.
+        return _not_found_page(req)
+
+    # #628: single transaction for every DB-side deletion. Previously
+    # the handler opened two separate ``_connect()`` contexts (row +
+    # rag_chunks, then background_jobs cancellation) and sandwiched
+    # two external calls (encrypted file + Jena graph) between them
+    # with no boundary. A failure partway through left the system in
+    # an inconsistent state: row gone but jobs still pending, or jobs
+    # cancelled but encrypted file still on disk. The refactor folds
+    # every DB mutation into ONE transactional block and hands the
+    # slow/flaky external cleanup off to a background ``draft_cleanup``
+    # job that can retry independently.
+    storage_path: str | None = None
+    try:
+        with _connect() as conn:
+            storage_path = delete_draft(conn, parsed)
+            # #576: polymorphic soft reference — clear any rag_chunks rows
+            # tied to this draft inside the same transaction as the row
+            # delete so either both land or neither does. Today no private
+            # draft ingestion exists so this is a no-op, but wiring it now
+            # means future ingestion code can't forget.
+            try:
+                delete_chunks_for_draft(conn, parsed)
+            except Exception:
+                logger.exception("Failed to delete rag_chunks for draft id=%s", parsed)
+            # #454/#478: cancel any pending/claimed/running/retrying
+            # background jobs that still reference this draft. Doing
+            # this in the SAME transaction as the row delete means a
+            # rollback doesn't strand orphaned jobs on the queue.
+            # #478 added ``running`` because a worker that picked up
+            # the job just before deletion would otherwise leave the
+            # row behind and produce a spurious failure.
+            conn.execute(
+                """
+                DELETE FROM background_jobs
+                WHERE payload->>'draft_id' = %s
+                  AND status IN ('pending', 'claimed', 'running', 'retrying')
+                """,
+                (str(parsed),),
+            )
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to delete draft id=%s", parsed)
+        return _not_found_page(req)
+
+    # #628: enqueue an async cleanup job for the external effects that
+    # can fail independently of the user-visible delete. The job
+    # retries on its own schedule; a flaky Jena instance no longer
+    # blocks the user flow or leaves the DB inconsistent. Failure to
+    # enqueue is logged but non-fatal — the DB is already clean and
+    # the operator can always delete the file/graph manually.
+    cleanup_payload = {
+        "draft_id": str(parsed),
+        "storage_path": storage_path,
+        "graph_uri": draft.graph_uri,
+    }
+    try:
+        cleanup_job_id = JobQueue().enqueue("draft_cleanup", cleanup_payload, priority=0)
+        logger.info(
+            "Orphan cleanup job enqueued draft=%s job_id=%s storage_path=%s",
+            parsed,
+            cleanup_job_id,
+            storage_path,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to enqueue draft_cleanup job for draft id=%s — "
+            "external resources may be orphaned",
+            parsed,
+        )
+
+    log_draft_delete(
+        auth.get("id"),
+        parsed,
+        filename=draft.filename,
+    )
+
+    # #598: queue a success toast for the drafts listing page.
+    push_flash(req, "Eelnõu kustutatud.", kind="success")
+
+    # #467: when the browser drives the delete via HTMX (the form has
+    # ``hx_post`` + ``hx_target='body'`` + ``hx_swap='outerHTML'`` — see
+    # ``_draft_detail_body``), returning a plain 303 here makes HTMX
+    # follow the redirect as an AJAX GET, fetch the drafts-list partial
+    # (whose first element is a ``<title>`` tag from ``PageShell``), and
+    # swap that entire partial into ``<body>``. The rendered page ends
+    # up with a ``<title>`` inside the body, which browsers treat as
+    # invalid HTML and render as visible text — corrupting the layout.
+    #
+    # The fix is to detect HTMX requests and return an empty 204 with an
+    # ``HX-Redirect`` header so HTMX performs a **real** browser
+    # navigation to ``/drafts`` instead of swapping. Non-HTMX clients
+    # (JS-disabled users hitting the native form action) still get the
+    # 303 redirect.
+    if req.headers.get("HX-Request") == "true":
+        return Response(
+            status_code=204,
+            headers={"HX-Redirect": "/drafts"},
+        )
+    return RedirectResponse(url="/drafts", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# POST /drafts/{draft_id}/keep — reset last_accessed_at (#572)
+# ---------------------------------------------------------------------------
+
+
+def keep_draft_handler(req: Request, draft_id: str):
+    """POST /drafts/{draft_id}/keep — reset the 90-day archive clock.
+
+    Owner-only per the same policy as delete — resetting the archive
+    clock is a governance action that re-commits the org to retaining
+    the draft for another 90 days. Same-org reviewers and admins MUST
+    NOT be able to bypass the owner's intent to let a stale draft
+    auto-warn.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    parsed = _parse_uuid(draft_id)
+    if parsed is None:
+        return _not_found_page(req)
+
+    draft = fetch_draft(parsed)
+    if draft is None:
+        return _not_found_page(req)
+    if not can_delete_draft(auth, draft):
+        # 404 (not 403) — see delete_draft_handler for the reasoning.
+        return _not_found_page(req)
+
+    try:
+        with _connect() as conn:
+            touch_draft_access(conn, parsed)
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to reset last_accessed_at for draft=%s", parsed)
+        return _not_found_page(req)
+
+    log_action(
+        auth.get("id"),
+        "draft.keep",
+        {"draft_id": str(parsed)},
+    )
+
+    # #598: queue a success toast for the detail page redirect target.
+    push_flash(req, "90-päevane loendur lähtestatud.", kind="success")
+
+    # HTMX-driven submits get an HX-Redirect so the browser performs a
+    # real navigation rather than swapping a partial into <body>.
+    if req.headers.get("HX-Request") == "true":
+        return Response(
+            status_code=204,
+            headers={"HX-Redirect": f"/drafts/{parsed}"},
+        )
+    return RedirectResponse(url=f"/drafts/{parsed}", status_code=303)

--- a/tests/test_archive_warning.py
+++ b/tests/test_archive_warning.py
@@ -293,10 +293,10 @@ class TestTouchDraftAccess:
 
 
 class TestKeepDraftRoute:
-    @patch("app.docs.routes.log_action")
-    @patch("app.docs.routes.touch_draft_access")
-    @patch("app.docs.routes._connect")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.log_action")
+    @patch("app.docs.routes._lifecycle.touch_draft_access")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_owner_can_keep_resets_clock(
         self,
@@ -326,8 +326,8 @@ class TestKeepDraftRoute:
         action = mock_log.call_args.args[1]
         assert action == "draft.keep"
 
-    @patch("app.docs.routes.touch_draft_access")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.touch_draft_access")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_non_owner_same_org_is_rejected(
         self,
@@ -350,8 +350,8 @@ class TestKeepDraftRoute:
         assert "Eelnõu ei leitud" in resp.text
         mock_touch.assert_not_called()
 
-    @patch("app.docs.routes.touch_draft_access")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.touch_draft_access")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_cross_org_user_is_rejected(
         self,

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -982,11 +982,11 @@ class TestDraftStatusFragment:
 
 
 class TestDeleteDraftHandler:
-    @patch("app.docs.routes.JobQueue")
-    @patch("app.docs.routes.log_draft_delete")
-    @patch("app.docs.routes.delete_draft")
-    @patch("app.docs.routes._connect")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.delete_draft")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_delete_removes_draft_and_enqueues_cleanup(
         self,
@@ -1051,7 +1051,7 @@ class TestDeleteDraftHandler:
         assert payload["storage_path"] == "/tmp/ciphertext.enc"
         assert payload["graph_uri"] == draft.graph_uri
 
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_delete_other_org_draft_returns_not_found(
         self,
@@ -1067,7 +1067,7 @@ class TestDeleteDraftHandler:
         assert resp.status_code == 200
         assert "Eelnõu ei leitud" in resp.text
 
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_delete_same_org_non_owner_returns_not_found(
         self,
@@ -1087,11 +1087,11 @@ class TestDeleteDraftHandler:
         assert resp.status_code == 200
         assert "Eelnõu ei leitud" in resp.text
 
-    @patch("app.docs.routes.JobQueue")
-    @patch("app.docs.routes.log_draft_delete")
-    @patch("app.docs.routes.delete_draft")
-    @patch("app.docs.routes._connect")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.delete_draft")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_delete_system_admin_cross_org_succeeds(
         self,
@@ -1129,11 +1129,11 @@ class TestDeleteDraftHandler:
         assert resp.headers["location"] == "/drafts"
         mock_delete.assert_called_once()
 
-    @patch("app.docs.routes.JobQueue")
-    @patch("app.docs.routes.log_draft_delete")
-    @patch("app.docs.routes.delete_draft")
-    @patch("app.docs.routes._connect")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.delete_draft")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_delete_draft_htmx_returns_hx_redirect(
         self,
@@ -1271,11 +1271,11 @@ class TestUploadPrecheck:
 class TestFlashMessages:
     @patch("app.docs.routes.list_users")
     @patch("app.docs.routes.list_drafts_for_org_filtered")
-    @patch("app.docs.routes.JobQueue")
-    @patch("app.docs.routes.log_draft_delete")
-    @patch("app.docs.routes.delete_draft")
-    @patch("app.docs.routes._connect")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.delete_draft")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_delete_flash_toast_appears_on_listing(
         self,
@@ -1362,10 +1362,10 @@ class TestFlashMessages:
         assert "Eelnõu üles laaditud, analüüs algas." in detail.text
         assert "toast-success" in detail.text
 
-    @patch("app.docs.routes.touch_draft_access")
-    @patch("app.docs.routes._connect")
+    @patch("app.docs.routes._lifecycle.touch_draft_access")
+    @patch("app.docs.routes._lifecycle._connect")
     @patch("app.docs.routes.log_draft_view")
-    @patch("app.docs.routes.fetch_draft")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
     def test_keep_flashes_toast_on_detail(
         self,

--- a/tests/test_docs_routes_registered.py
+++ b/tests/test_docs_routes_registered.py
@@ -1,0 +1,53 @@
+"""URL-surface assertion for the /drafts routes (#623 routes split).
+
+Pinned BEFORE the routes.py → routes/ package refactor so each move
+step can be verified by re-running this test. If a route accidentally
+gets dropped during the move, the test fails immediately and points
+at the missing path.
+
+The full set covers both ``app/docs/routes.py`` (refactored by #623
+into the routes/ package) and ``app/docs/report_routes.py`` (OUT of
+scope for this PR — included here so we'd notice if a stray edit
+disturbed it). The expected set was captured from
+``app.main.app.routes`` introspection on the pre-refactor commit.
+"""
+
+from __future__ import annotations
+
+
+def test_draft_route_surface_is_stable() -> None:
+    from app.main import app
+
+    paths: set[tuple[str, tuple[str, ...]]] = set()
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if path is None or not path.startswith("/drafts"):
+            continue
+        methods_raw = getattr(route, "methods", None) or ()
+        paths.add((path, tuple(sorted(methods_raw))))
+
+    expected: set[tuple[str, tuple[str, ...]]] = {
+        # routes.py — refactored by #623
+        ("/drafts", ("GET", "HEAD")),
+        ("/drafts", ("POST",)),
+        ("/drafts/new", ("GET", "HEAD")),
+        ("/drafts/{draft_id}", ("GET", "HEAD")),
+        ("/drafts/{draft_id}/status", ("GET", "HEAD")),
+        ("/drafts/{draft_id}/actions", ("GET", "HEAD")),
+        ("/drafts/{draft_id}/keep", ("POST",)),
+        ("/drafts/{draft_id}/delete", ("POST",)),
+        ("/drafts/{draft_id}/link-vtk", ("POST",)),
+        ("/drafts/{draft_id}/retry", ("POST",)),
+        # report_routes.py — out of scope for #623, included as a tripwire
+        ("/drafts/{draft_id}/report", ("GET", "HEAD")),
+        ("/drafts/{draft_id}/report/reanalyze", ("POST",)),
+        ("/drafts/{draft_id}/report/section/{section}", ("GET", "HEAD")),
+        ("/drafts/{draft_id}/export", ("POST",)),
+        ("/drafts/{draft_id}/export-status/{job_id}", ("GET", "HEAD")),
+        ("/drafts/{draft_id}/export/{job_id}/download", ("GET", "HEAD")),
+    }
+
+    missing = expected - paths
+    extra = paths - expected
+    assert not missing, f"routes dropped during refactor: {sorted(missing)}"
+    assert not extra, f"unexpected routes appeared: {sorted(extra)}"


### PR DESCRIPTION
PARTIAL #623 — first of an expected 5-PR split.

## What this PR ships

1. `git mv app/docs/routes.py app/docs/routes/__init__.py` — convert the module to a package without changing any public import path. Git tracks the rename so blame is preserved.
2. Extract `app/docs/routes/_lifecycle.py` with two handlers:
   - `delete_draft_handler` (POST /drafts/{id}/delete)
   - `keep_draft_handler` (POST /drafts/{id}/keep)
3. New `tests/test_docs_routes_registered.py` URL-surface assertion that pins all 16 `/drafts*` paths so any future move detects a dropped route immediately.
4. Update existing tests' patch paths to `app.docs.routes._lifecycle.X` for the delete/keep classes (patch where the symbol is USED, not where it's defined).

## What's NOT in this PR (deferred to follow-up issues)

- `_upload.py` extraction (~490 lines)
- `_list.py` extraction (~600 lines)
- `_detail.py` extraction (~615 lines)
- `_lifecycle.py` is missing `link_vtk_handler` because it depends on `_validate_parent_vtk_fk` (upload) and `_draft_metadata_block` (detail). Moving them all together is the next PR.
- `_shared.py` extraction for cross-cutting helpers.

After all splits land, `__init__.py` becomes a registration shim and no submodule exceeds the DoD's 400-line cap. This PR shrinks `__init__.py` from 2611 → 2425 lines — modest but a real start.

## Why partial

The originally-dispatched agent stalled at the 10-minute watchdog twice on the full-file refactor. Splitting into incremental PRs makes each step reviewable + testable (URL surface assertion catches any dropped route per move) and dodges the agent watchdog when we re-dispatch the remaining splits.

## Test plan

- [x] `uv run pytest` — 2002 passed, 23 skipped (no regressions; +1 new URL-surface test)
- [x] `uv run ruff check + format` — clean
- [x] `uv run pyright app/docs/routes/` — 0 errors
- [ ] Smoke after deploy: list `/drafts`, open one, delete a test draft, keep a test draft

Refs #623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)