### PR TITLE
feat(#618 PR-B): versioning upload + analyze pipeline cutover

### DIFF
--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -51,6 +51,7 @@ from app.docs.similarity import (
     persist_similarities,
     update_uri_index,
 )
+from app.docs.version_model import get_latest_version
 from app.jobs.worker import register_handler
 from app.sync.jena_loader import put_named_graph
 
@@ -141,16 +142,29 @@ def analyze_impact(
         report_data = json.dumps(dataclasses.asdict(findings))
 
         with get_connection() as conn:
+            # #618 PR-B: bind the impact report to the latest
+            # ``draft_versions`` row so per-version diff/timeline (PR-C)
+            # can join against the right report.  The lookup runs
+            # inside the same transaction as the INSERT so a v3
+            # parallel upload mid-analyze cannot retro-attach this
+            # report to the wrong version.  The column is NULLABLE
+            # via migration 032 so a missing v1 row (impossible
+            # post-migration but defended-against) does not block the
+            # insert.
+            latest_version = get_latest_version(conn, draft_id)
+            draft_version_id = str(latest_version.id) if latest_version is not None else None
             conn.execute(
                 """
                 insert into impact_reports
-                    (id, draft_id, affected_count, conflict_count,
-                     gap_count, impact_score, report_data, ontology_version)
-                values (%s, %s, %s, %s, %s, %s, %s, %s)
+                    (id, draft_id, draft_version_id, affected_count,
+                     conflict_count, gap_count, impact_score,
+                     report_data, ontology_version)
+                values (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     str(report_id),
                     str(draft_id),
+                    draft_version_id,
                     findings.affected_count,
                     findings.conflict_count,
                     findings.gap_count,

--- a/app/docs/draft_model.py
+++ b/app/docs/draft_model.py
@@ -302,10 +302,50 @@ def touch_draft_access_conn(draft_id: uuid.UUID | str) -> bool:
 
 
 def get_draft(conn: Any, draft_id: uuid.UUID | str) -> Draft | None:
-    """Return a single draft by id, or ``None``."""
+    """Return a single draft by id, or ``None``.
+
+    §4.2 cutover (#618 PR-B):
+        The SELECT now JOINs ``drafts`` against the latest
+        ``draft_versions`` row so the returned :class:`Draft` reflects
+        the *current* version's pipeline state -- ``status``,
+        ``parsed_text_encrypted``, ``graph_uri``, and ``storage_path``
+        all come from ``draft_versions`` when a row is present.
+
+        ``COALESCE(version.col, drafts.col)`` keeps the legacy
+        ``drafts.*`` columns as a fallback so a draft that somehow
+        ended up without a v1 row still surfaces the old data.  Post
+        migration 030 every draft has at least one version, but the
+        defensive read keeps tests + integration fakes that pre-date
+        the cutover working without modification.
+
+        The ``Draft`` dataclass shape is unchanged so every existing
+        caller continues to read ``draft.status`` / ``draft.graph_uri``
+        / ``draft.parsed_text_encrypted`` against the version-backed
+        values without code change.
+    """
     try:
         row = conn.execute(
-            f"select {_DRAFT_COLUMNS} from drafts where id = %s",
+            """
+            select
+                d.id, d.user_id, d.org_id, d.title, d.filename,
+                d.content_type, d.file_size,
+                coalesce(v.storage_path, d.storage_path),
+                coalesce(v.graph_uri, d.graph_uri),
+                coalesce(v.status, d.status),
+                coalesce(v.parsed_text_encrypted, d.parsed_text_encrypted),
+                d.entity_count, d.error_message,
+                d.created_at, d.updated_at, d.last_accessed_at,
+                d.doc_type, d.parent_vtk_id, d.processing_completed_at
+            from drafts d
+            left join draft_versions v
+                on v.draft_id = d.id
+                and v.version_number = (
+                    select max(version_number)
+                    from draft_versions
+                    where draft_id = d.id
+                )
+            where d.id = %s
+            """,
             (str(draft_id),),
         ).fetchone()
     except Exception:
@@ -579,6 +619,40 @@ def list_vtks_for_org(
             ).fetchall()
     except Exception:
         logger.exception("Failed to list VTKs for org=%s", org_id)
+        return []
+    return [_row_to_draft(row) for row in rows]
+
+
+def list_versionable_drafts_for_org(
+    conn: Any,
+    org_id: uuid.UUID | str,
+) -> list[Draft]:
+    """Return drafts that may serve as the parent of a new version (#618 PR-B).
+
+    Used by the upload form to populate the "Versioon olemasolevast
+    eelnõust" picker.  Only drafts whose latest version is in the
+    terminal ``ready`` status are eligible: a parent that is still
+    parsing/extracting/analyzing has nothing meaningful to compare a
+    new version against, and a ``failed`` parent should be retried via
+    the retry path before getting a fresh version layered on top.
+
+    Org-scoped at the SQL layer so a cross-org draft can never appear
+    in the picker.  Newest-first ordering matches the rest of the
+    listing helpers in this module.
+    """
+    try:
+        rows = conn.execute(
+            f"""
+            select {_DRAFT_COLUMNS}
+            from drafts
+            where org_id = %s
+              and status = 'ready'
+            order by created_at desc
+            """,
+            (str(org_id),),
+        ).fetchall()
+    except Exception:
+        logger.exception("Failed to list versionable drafts for org=%s", org_id)
         return []
     return [_row_to_draft(row) for row in rows]
 

--- a/app/docs/routes/__init__.py
+++ b/app/docs/routes/__init__.py
@@ -45,6 +45,7 @@ from app.docs.draft_model import (
     fetch_draft,
     list_drafts_for_org_filtered,
     list_eelnous_for_vtk,
+    list_versionable_drafts_for_org,
     list_vtks_for_org,
     touch_draft_access_conn,
     update_draft_parent_vtk,
@@ -1325,13 +1326,74 @@ def _vtk_picker(
     )
 
 
+def _version_picker(
+    versionable_drafts: list[Draft],
+    *,
+    selected: str | None = None,
+):
+    """Render the "Versioon olemasolevast eelnõust" picker (#618 PR-B).
+
+    Optional select that lets the uploader create a NEW version of an
+    existing ``ready``-status draft instead of a brand-new draft.  When
+    the picker is left at the default empty option, the upload follows
+    the legacy "new draft" branch.
+
+    Empty list -> the picker still renders but only shows the "Uus
+    eelnõu (pole versioon)" sentinel; this keeps the DOM structure
+    deterministic regardless of how many parents are eligible.
+    """
+    selected_str = str(selected) if selected else ""
+    options: list = [
+        Option(  # noqa: F405
+            "Uus eelnõu (pole versioon)",
+            value="",
+            selected=(selected_str == ""),
+        )
+    ]
+    for existing in versionable_drafts:
+        existing_id = str(existing.id)
+        # Truncate long titles so the dropdown stays readable.  60 chars
+        # matches the brief; the trailing ellipsis is added when truncation
+        # actually fires.
+        title = existing.title or existing.filename or existing_id
+        display_title = title if len(title) <= 60 else f"{title[:60]}…"
+        options.append(
+            Option(  # noqa: F405
+                f"Versioon eelnõust: {display_title}",
+                value=existing_id,
+                selected=(existing_id == selected_str),
+            )
+        )
+    return Div(  # noqa: F405
+        Label(  # noqa: F405
+            "Versioneerimine",
+            fr="field-parent-draft",
+            cls="form-field-label",
+        ),
+        Select(  # noqa: F405
+            *options,
+            name="parent_draft_id",
+            id="field-parent-draft",
+            cls="input input-select",
+        ),
+        Small(  # noqa: F405
+            "Kui valid olemasoleva eelnõu, salvestatakse fail uue versioonina, "
+            "mitte uue eelnõuna.",
+            cls="form-field-help",
+        ),
+        cls="form-field",
+    )
+
+
 def _upload_form(
     *,
     title_value: str = "",
     error: str | None = None,
     vtks: list[Draft] | None = None,
+    versionable_drafts: list[Draft] | None = None,
     doc_type_value: str = "eelnou",
     parent_vtk_id_value: str | None = None,
+    parent_draft_id_value: str | None = None,
 ):
     """Render the multipart upload form.
 
@@ -1343,10 +1405,18 @@ def _upload_form(
     #640: adds a "Dokumendi tüüp" radio group and a "Seotud VTK"
     ``<select>`` populated with the caller's org's VTKs. Validation of
     both fields happens server-side in ``create_draft_handler``.
+
+    #618 PR-B: adds the optional "Versioneerimine" picker so the
+    uploader can create a new version of an existing ``ready`` draft
+    instead of a brand-new draft.  When the picker is empty the form
+    behaves exactly like before; when populated the route handler
+    routes the upload through the new-version branch in
+    :func:`app.docs.upload.handle_upload`.
     """
     error_alert = Alert(error, variant="danger") if error else None
     picker_disabled = doc_type_value == "vtk"
     vtk_list = vtks or []
+    versionable_list = versionable_drafts or []
 
     return Form(  # noqa: F405
         Div(
@@ -1366,7 +1436,7 @@ def _upload_form(
                 cls="input",
             ),
             Small(  # noqa: F405
-                "Kuni 200 tähemärki.",
+                "Kuni 200 tähemärki. Uue versiooni puhul päritakse pealkiri vanemalt eelnõult.",
                 cls="form-field-help",
             ),
             cls="form-field",
@@ -1376,6 +1446,10 @@ def _upload_form(
             vtk_list,
             selected=parent_vtk_id_value,
             disabled=picker_disabled,
+        ),
+        _version_picker(
+            versionable_list,
+            selected=parent_draft_id_value,
         ),
         Div(
             Label(  # noqa: F405
@@ -1464,9 +1538,19 @@ def new_draft_page(req: Request):
     # caller's org's VTKs. Cross-org leaks are impossible because the
     # helper scopes the query to ``auth['org_id']``. The ``org_id``
     # check at the top of the handler guarantees a non-None value here.
+    #
+    # #618 PR-B: also populate the "Versioneerimine" picker with every
+    # ``ready``-status draft in the same org so the uploader can target
+    # an existing draft for a follow-on version.
     org_id_str = str(auth["org_id"])
     vtks = list_vtks_for_org(org_id_str)
-    form, error_alert = _upload_form(vtks=vtks)
+    try:
+        with _connect() as conn:
+            versionable = list_versionable_drafts_for_org(conn, org_id_str)
+    except Exception:
+        logger.exception("Failed to load versionable drafts for org=%s", org_id_str)
+        versionable = []
+    form, error_alert = _upload_form(vtks=vtks, versionable_drafts=versionable)
     card_children: list = []
     if error_alert is not None:
         card_children.append(error_alert)
@@ -1536,6 +1620,14 @@ async def create_draft_handler(req: Request):
     * A VTK upload cannot carry a ``parent_vtk_id`` (DB CHECK mirror).
     * A ``parent_vtk_id`` must exist, belong to the caller's org, and
       have ``doc_type = 'vtk'``.
+
+    #618 PR-B: additionally accepts an optional ``parent_draft_id`` --
+    when supplied the upload becomes a NEW VERSION of the targeted
+    draft (a new ``draft_versions`` row, no new ``drafts`` row).  The
+    full validation (existence, same-org ownership, ``status='ready'``)
+    happens inside :func:`app.docs.upload.handle_upload` and surfaces
+    as a Estonian :class:`DraftUploadError` -- this handler just parses
+    the form value and forwards it.
     """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
@@ -1557,6 +1649,15 @@ async def create_draft_handler(req: Request):
     parent_vtk_str = str(parent_vtk_raw).strip() if parent_vtk_raw else ""
     parent_vtk_uuid = _parse_uuid(parent_vtk_str) if parent_vtk_str else None
 
+    # #618 PR-B: parse the new "Versioneerimine" picker value.  Empty /
+    # missing means "create a new draft, not a version".  A malformed
+    # UUID is rejected up front so we never call ``handle_upload`` with
+    # garbage; same-org / status validation lives downstream because it
+    # needs the connection.
+    parent_draft_raw = form.get("parent_draft_id", "")
+    parent_draft_str = str(parent_draft_raw).strip() if parent_draft_raw else ""
+    parent_draft_uuid = _parse_uuid(parent_draft_str) if parent_draft_str else None
+
     error_message: str | None = None
     status_code = 200
 
@@ -1570,6 +1671,16 @@ async def create_draft_handler(req: Request):
     elif parent_vtk_uuid is not None and doc_type_value == "vtk":
         # A VTK cannot have a parent VTK — same rule as the DB CHECK.
         error_message = "VTK ei saa olla seotud teise VTKga."
+        status_code = 400
+    elif parent_draft_str and parent_draft_uuid is None:
+        # The user submitted something in the version picker but it wasn't
+        # a valid UUID -- reject before we touch the DB.
+        error_message = "Vanem-eelnõu ei ole kättesaadav."
+        status_code = 400
+    elif parent_draft_uuid is not None and doc_type_value == "vtk":
+        # A VTK cannot itself be a follow-on version of another draft --
+        # reading-stage progression is an eelnõu lifecycle concept.
+        error_message = "VTK ei saa olla teise eelnõu versioon."
         status_code = 400
     elif parent_vtk_uuid is not None:
         # FK target must exist, be in the same org, and be a VTK.
@@ -1603,9 +1714,14 @@ async def create_draft_handler(req: Request):
                     upload,  # type: ignore[arg-type]
                     doc_type=doc_type_value,
                     parent_vtk_id=parent_vtk_uuid,
+                    parent_draft_id=parent_draft_uuid,
                 )
             except DraftUploadError as exc:
                 error_message = str(exc)
+                # Keep the legacy 200-with-banner shape so existing
+                # tests (and the HTMX form rerender) continue to behave
+                # the same; only the upfront-validation branches above
+                # set 400.
             else:
                 log_draft_upload(
                     auth.get("id"),
@@ -1615,11 +1731,21 @@ async def create_draft_handler(req: Request):
                     file_size=draft.file_size,
                 )
                 # #598: queue a success toast for the detail page.
-                push_flash(
-                    req,
-                    "Eelnõu üles laaditud, analüüs algas.",
-                    kind="success",
-                )
+                # The Estonian copy differs slightly between the
+                # "new draft" and "new version" branches so users see
+                # the right narrative.
+                if parent_draft_uuid is not None:
+                    push_flash(
+                        req,
+                        "Uus versioon üles laaditud, analüüs algas.",
+                        kind="success",
+                    )
+                else:
+                    push_flash(
+                        req,
+                        "Eelnõu üles laaditud, analüüs algas.",
+                        kind="success",
+                    )
                 return RedirectResponse(url=f"/drafts/{draft.id}", status_code=303)
 
     # At this point we definitely have an error_message.
@@ -1629,13 +1755,23 @@ async def create_draft_handler(req: Request):
     # banner + toast pattern is consistent with the happy-path redirect.
     push_flash(req, error_message, kind="danger")
 
-    vtks = list_vtks_for_org(str(auth["org_id"])) if auth.get("org_id") else []
+    org_id_for_pickers = str(auth["org_id"]) if auth.get("org_id") else None
+    vtks = list_vtks_for_org(org_id_for_pickers) if org_id_for_pickers else []
+    versionable: list[Draft] = []
+    if org_id_for_pickers:
+        try:
+            with _connect() as conn:
+                versionable = list_versionable_drafts_for_org(conn, org_id_for_pickers)
+        except Exception:
+            logger.exception("Failed to load versionable drafts for org=%s", org_id_for_pickers)
     form_el, _ = _upload_form(
         title_value=title_value,
         error=error_message,
         vtks=vtks,
+        versionable_drafts=versionable,
         doc_type_value=doc_type_value if doc_type_value in _VALID_DOC_TYPES else "eelnou",
         parent_vtk_id_value=parent_vtk_str or None,
+        parent_draft_id_value=parent_draft_str or None,
     )
     page = PageShell(
         H1("Uus eelnõu", cls="page-title"),  # noqa: F405

--- a/app/docs/status.py
+++ b/app/docs/status.py
@@ -1,4 +1,4 @@
-"""Single source of truth for ``drafts.status`` (#625).
+"""Single source of truth for draft status (#625, #618 PR-B).
 
 Before this module existed, draft status semantics were scattered across
 seven sites:
@@ -25,12 +25,19 @@ records plus a typed :func:`update_draft_status` helper. Every read of
 :func:`update_draft_status` so an unknown value raises ``ValueError``
 in the application layer instead of waiting for the DB to reject it.
 
-§4.2 status semantics decision (locked):
-    Per the Eelnõud sprint plan §4.2, ``drafts.status`` is the canonical
-    write path for now. The version-aware cutover (writing to
-    ``draft_versions.status``) lands in #618 PR-B alongside the read
-    cutover. This module deliberately writes ONLY to ``drafts`` so the
-    sequencing is explicit and a bisect can pin the cutover point.
+§4.2 cutover sequence (locked):
+
+    1. #625 — ``update_draft_status`` writes ONLY to ``drafts.status``
+       (the previous state of this module).  Done.
+    2. #618 PR-A — ship ``draft_versions`` schema + backfill, but app
+       still reads/writes ``drafts.*``.  Done.
+    3. #618 PR-B (THIS PR) — atomic read+write cutover.  Reads JOIN
+       through ``draft_versions``; writes go to the latest
+       ``draft_versions`` row PLUS a same-transaction defensive mirror
+       to ``drafts.status`` so legacy callers still see the new state
+       and rollback to PR-A is trivial.
+    4. #618 PR-D (future) — drop ``drafts.status`` + the defensive
+       mirror.  Migration 03X.
 
 Cost-of-change rationale:
     The fixed signature ``update_draft_status(conn, draft_id, status,
@@ -174,6 +181,14 @@ PIPELINE_STAGES: tuple[DraftStatus, ...] = tuple(
     s for s in sorted(DRAFT_STATUSES, key=lambda d: d.order) if s.value != "failed"
 )
 
+# Columns that exist on BOTH ``drafts`` and ``draft_versions`` and
+# therefore should be mirrored to the version row when supplied via the
+# ``extras`` parameter to :func:`update_draft_status` (#618 PR-B).
+# ``entity_count`` is intentionally absent: the version row tracks
+# parse/extract output as a side effect of status transitions, not an
+# independent counter.
+_VERSION_MIRRORED_EXTRAS: frozenset[str] = frozenset({"parsed_text_encrypted"})
+
 
 def update_draft_status(
     conn: Any,
@@ -187,11 +202,22 @@ def update_draft_status(
 ) -> bool:
     """Typed UPDATE that validates ``status`` against :data:`DRAFT_STATUSES`.
 
-    §4.2 cutover: this writes ONLY to ``drafts``. The version-aware
-    ``draft_versions`` write lands in #618 PR-B alongside the read
-    cutover. The handler must NOT touch ``draft_versions`` here -- a
-    bisect on the version cutover relies on this file containing zero
-    references to the new table.
+    §4.2 cutover (#618 PR-B):
+        Writes the new ``status`` to BOTH the latest
+        ``draft_versions`` row AND ``drafts.status`` in the same
+        transaction.  The ``drafts.status`` write is a defensive mirror
+        kept for one release cycle so:
+
+        * Legacy readers that have not yet pivoted to the version-aware
+          read path still see the new state.
+        * A rollback to PR-A (drop the ``draft_versions`` write) is a
+          single-line revert with no schema change.
+
+        The version write goes to the latest ``draft_versions`` row
+        for the draft (``ORDER BY version_number DESC LIMIT 1``) so a
+        v3 upload's status updates do not bleed into v2.  PR-D will
+        drop the ``drafts.status`` mirror and the column itself
+        (migration 03X).
 
     Behaviour:
         * Always writes ``status``, ``updated_at = now()``,
@@ -205,14 +231,20 @@ def update_draft_status(
         * Always stamps ``processing_completed_at`` -- ``now()`` for
           terminal statuses (``ready`` / ``failed``), ``NULL`` otherwise.
           This preserves the #670 frozen-completion-timestamp invariant
-          without each caller having to remember it.
+          without each caller having to remember it.  Stamped ONLY on
+          ``drafts`` -- ``draft_versions`` does not have this column
+          (the per-version completion is implicit from the version's
+          own status transitions).
         * ``extras`` carries any additional column writes that must land
           in the SAME ``UPDATE`` for atomicity (e.g. ``entity_count``
           from the extract handler, ``parsed_text_encrypted`` from the
           parse handler). Keys are interpolated into the SQL so callers
           MUST only pass safe column names -- the only call sites in
           this package pass ``parsed_text_encrypted`` and
-          ``entity_count``.
+          ``entity_count``.  Extras are written to BOTH tables when the
+          column exists on both (``parsed_text_encrypted`` lives on
+          both); ``entity_count`` only exists on ``drafts`` so it is
+          written there only.
         * ``expected_status`` adds an ``AND status = %s`` predicate to
           the WHERE clause for optimistic-concurrency control (used by
           the retry path -- only flip ``failed`` -> ``uploaded`` when
@@ -240,9 +272,12 @@ def update_draft_status(
             status; ``rowcount == 0`` means another writer beat us.
 
     Returns:
-        ``True`` if a row was actually updated, ``False`` if the WHERE
-        clause matched nothing. Mirrors the previous
-        ``draft_model.update_draft_status`` contract.
+        ``True`` if a row was actually updated in ``drafts``, ``False``
+        if the WHERE clause matched nothing. The return value tracks
+        the legacy ``drafts`` write because that is the predicate the
+        retry path checks for optimistic-concurrency wins; the version
+        write is always best-effort (a draft pre-PR-A backfill that is
+        somehow missing a v1 row should not block a status update).
 
     Raises:
         ValueError: ``status`` (or ``expected_status``) is not a known
@@ -257,47 +292,82 @@ def update_draft_status(
     # on the executed SQL string remain stable across runs. Always
     # writes the same fixed prefix; ``extras`` are appended in sorted
     # column-name order at the tail.
-    set_parts: list[str] = [
+    drafts_set_parts: list[str] = [
         "status = %s",
         "error_message = %s",
         "error_debug = %s",
         "updated_at = now()",
     ]
-    params: list[Any] = [status, error_message, error_debug]
+    drafts_params: list[Any] = [status, error_message, error_debug]
 
     # #670: terminal transitions stamp the frozen completion timestamp;
     # non-terminal transitions clear it back to NULL so a retry path
     # (``failed`` -> ``uploaded``) doesn't carry stale completion time.
     if status in TERMINAL_STATUSES:
-        set_parts.append("processing_completed_at = now()")
+        drafts_set_parts.append("processing_completed_at = now()")
     else:
-        set_parts.append("processing_completed_at = null")
+        drafts_set_parts.append("processing_completed_at = null")
 
     # ``extras`` columns are interpolated by name; values are bound as
     # parameters. Sorted for deterministic SQL output.
     if extras:
         for column in sorted(extras):
-            set_parts.append(f"{column} = %s")
-            params.append(extras[column])
+            drafts_set_parts.append(f"{column} = %s")
+            drafts_params.append(extras[column])
 
-    set_clause = ",\n            ".join(set_parts)
+    drafts_set_clause = ",\n            ".join(drafts_set_parts)
 
     # WHERE clause -- always ``id = %s`` plus an optional optimistic
     # ``status = %s`` predicate for the retry path.
-    where_parts: list[str] = ["id = %s"]
-    params.append(str(draft_id))
+    drafts_where_parts: list[str] = ["id = %s"]
+    drafts_params.append(str(draft_id))
     if expected_status is not None:
-        where_parts.append("status = %s")
-        params.append(expected_status)
-    where_clause = " and ".join(where_parts)
+        drafts_where_parts.append("status = %s")
+        drafts_params.append(expected_status)
+    drafts_where_clause = " and ".join(drafts_where_parts)
 
-    # Note: deliberately writing to ``drafts`` only. Do NOT add a write
-    # to ``draft_versions`` here -- that cutover is owned by #618 PR-B
-    # and depends on the read path being version-aware first.
-    sql = f"""
-        update drafts
-        set {set_clause}
-        where {where_clause}
+    # ------------------------------------------------------------------
+    # Step 1: write the new status to the LATEST draft_versions row.
+    # ------------------------------------------------------------------
+    # The version write happens FIRST so that if it fails (e.g. a
+    # never-backfilled draft has no v1 row), the legacy ``drafts``
+    # update still runs as a safety net.  Conversely the legacy update
+    # is what determines our return value because the retry path's
+    # optimistic-concurrency check expects to see a 0-rowcount when
+    # another writer already flipped the row.
+    version_set_parts: list[str] = ["status = %s"]
+    version_params: list[Any] = [status]
+    if extras:
+        for column in sorted(extras):
+            if column not in _VERSION_MIRRORED_EXTRAS:
+                continue
+            version_set_parts.append(f"{column} = %s")
+            version_params.append(extras[column])
+    version_set_clause = ", ".join(version_set_parts)
+    version_params.append(str(draft_id))
+
+    version_sql = f"""
+        update draft_versions
+        set {version_set_clause}
+        where id = (
+            select id from draft_versions
+            where draft_id = %s
+            order by version_number desc
+            limit 1
+        )
     """
-    result = conn.execute(sql, tuple(params))
+    conn.execute(version_sql, tuple(version_params))
+
+    # ------------------------------------------------------------------
+    # Step 2: defensive mirror to ``drafts`` (legacy column).  Kept for
+    # one release cycle so PR-A rollback is a one-line revert and
+    # so any reader that has not yet pivoted to the version-aware path
+    # still observes the new status.  PR-D will drop this UPDATE.
+    # ------------------------------------------------------------------
+    drafts_sql = f"""
+        update drafts
+        set {drafts_set_clause}
+        where {drafts_where_clause}
+    """
+    result = conn.execute(drafts_sql, tuple(drafts_params))
     return (result.rowcount or 0) > 0

--- a/app/docs/upload.py
+++ b/app/docs/upload.py
@@ -4,14 +4,28 @@ This module owns the *validation + persistence* half of the document
 upload flow. It is deliberately kept outside ``routes.py`` so the logic
 can be unit-tested without spinning up a FastHTML ``TestClient``.
 
-Flow:
+Flow (new-draft branch):
     1. Validate title, filename, content-type, and size.
     2. Read the upload stream into memory.
     3. Encrypt and persist via ``app.storage.store_file``.
     4. Build a stable ``graph_uri`` for the draft's Jena named graph.
     5. Insert the ``drafts`` row with ``status='uploaded'``.
+    5b. Insert a v1 ``draft_versions`` row in the SAME transaction so
+        the read JOIN in :func:`app.docs.draft_model.get_draft` always
+        finds a backing version (#618 PR-B).
     6. Enqueue a ``parse_draft`` background job.
     7. Return the created ``Draft``.
+
+Flow (new-version branch, #618 PR-B):
+    When ``parent_draft_id`` is supplied, the handler creates a NEW
+    ``draft_versions`` row tied to the EXISTING parent draft instead
+    of a brand-new ``drafts`` row.  The new version inherits the
+    parent's ``owner_id`` / ``org_id`` (cross-org uploads are
+    rejected) and steps the parent's latest ``reading_stage`` one
+    notch forward via :func:`app.docs.version_model.next_reading_stage`.
+    The fresh encrypted file path becomes the version's
+    ``storage_path``; ``graph_uri`` is allocated per §9.5 as
+    ``...drafts/{parent_id}/v{version_number}``.
 
 Any failure after step 3 is caught so the encrypted file can be removed
 before the exception is re-raised — we never want ciphertext lying
@@ -22,11 +36,19 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from typing import Any, Protocol
 
+from app.auth.audit import log_action
 from app.auth.provider import UserDict
 from app.db import get_connection as _connect
-from app.docs.draft_model import Draft, create_draft
+from app.docs.draft_model import Draft, create_draft, get_draft
+from app.docs.version_model import (
+    create_draft_version,
+    get_latest_version,
+    get_next_version_number,
+    next_reading_stage,
+)
 from app.jobs import JobQueue
 from app.storage import delete_file, store_file
 
@@ -171,6 +193,7 @@ async def handle_upload(
     *,
     doc_type: str = "eelnou",
     parent_vtk_id: Any = None,
+    parent_draft_id: Any = None,
     job_queue: JobQueue | None = None,
     conn_factory: Any = None,
 ) -> Draft:
@@ -179,6 +202,10 @@ async def handle_upload(
     Args:
         user: Authenticated caller. Must carry a non-empty ``org_id``.
         title: Draft title supplied by the uploader (1-200 chars).
+            Ignored when ``parent_draft_id`` is set — a new version
+            inherits the parent's title because the legislative text
+            is what changes between readings, not the draft's
+            identity.
         upload: Starlette ``UploadFile`` (or any object matching
             :class:`_UploadLike`) pointing at the multipart stream.
         doc_type: Document classification — ``'eelnou'`` (default) or
@@ -190,6 +217,16 @@ async def handle_upload(
             the same org. The route handler validates FK existence and
             same-org ownership; this function persists whatever is
             passed in.
+        parent_draft_id: Optional foreign-key link to an existing
+            ``drafts`` row.  When supplied, the handler creates a NEW
+            ``draft_versions`` row tied to the parent (#618 PR-B
+            "version" branch) instead of a fresh ``drafts`` row.  The
+            parent must exist, belong to the caller's org, and have
+            ``status='ready'`` (cross-org / mid-pipeline parents are
+            rejected with a Estonian :class:`DraftUploadError`).  The
+            uploader inherits the parent's ``owner_id`` / ``org_id``
+            so a colleague uploading a v2 cannot orphan the version
+            from the original drafter's audit trail.
         job_queue: Optional ``JobQueue`` to enqueue the parse job.
             Defaults to a fresh :class:`app.jobs.JobQueue` instance —
             tests pass a stub to avoid hitting Postgres.
@@ -198,7 +235,11 @@ async def handle_upload(
             patch this to inject a mock.
 
     Returns:
-        The freshly-inserted :class:`Draft`.
+        The freshly-inserted :class:`Draft`.  When the version branch
+        runs, the returned dataclass reflects the PARENT draft id +
+        the new version's ``storage_path`` / ``graph_uri`` / ``status``
+        (because :func:`app.docs.draft_model.get_draft` JOINs through
+        ``draft_versions`` for those fields post-PR-B).
 
     Raises:
         DraftUploadError: Validation failed. Message is Estonian and
@@ -213,7 +254,13 @@ async def handle_upload(
         # handles the runtime case.
         raise DraftUploadError("Ainult organisatsiooni liikmed saavad eelnõusid üles laadida.")
 
-    cleaned_title = _validate_title(title)
+    # Title validation only matters for the new-draft branch — versions
+    # inherit the parent's title.  We still validate filename + bytes
+    # for both branches.
+    if parent_draft_id is None:
+        cleaned_title = _validate_title(title)
+    else:
+        cleaned_title = title.strip() if title else ""
     filename = _validate_filename(upload.filename)
     content_type = _validate_content_type(upload.content_type)
 
@@ -230,30 +277,39 @@ async def handle_upload(
     queue = job_queue or JobQueue()
     try:
         with factory() as conn:
-            draft = create_draft(
-                conn,
-                user_id=user_id,
-                org_id=org_id,
-                title=cleaned_title,
-                filename=filename,
-                content_type=content_type,
-                file_size=file_size,
-                storage_path=stored.storage_path,
-                # graph_uri must embed the freshly-minted draft id, but we
-                # only get the id after the INSERT. Use a stable placeholder
-                # based on the storage_path (which is already unique) then
-                # patch the real URI immediately afterwards.
-                graph_uri=f"{_GRAPH_URI_PREFIX}pending-{stored.storage_path}",
-                doc_type=doc_type,  # type: ignore[arg-type]
-                parent_vtk_id=parent_vtk_id,
-            )
-            final_graph_uri = f"{_GRAPH_URI_PREFIX}{draft.id}"
-            conn.execute(
-                "update drafts set graph_uri = %s where id = %s",
-                (final_graph_uri, str(draft.id)),
-            )
+            if parent_draft_id is not None:
+                draft = _create_new_version(
+                    conn,
+                    parent_draft_id=parent_draft_id,
+                    user=user,
+                    file_size=file_size,
+                    filename=filename,
+                    content_type=content_type,
+                    storage_path=stored.storage_path,
+                )
+            else:
+                draft = _create_new_draft(
+                    conn,
+                    user_id=user_id,
+                    org_id=org_id,
+                    title=cleaned_title,
+                    filename=filename,
+                    content_type=content_type,
+                    file_size=file_size,
+                    storage_path=stored.storage_path,
+                    doc_type=doc_type,
+                    parent_vtk_id=parent_vtk_id,
+                )
             conn.commit()
-        draft.graph_uri = final_graph_uri
+    except DraftUploadError:
+        # User-facing validation failure — clean up the orphan file
+        # before re-raising so the caller can render the error.
+        logger.info(
+            "Draft upload validation failed; cleaning up file path=%s",
+            stored.storage_path,
+        )
+        delete_file(stored.storage_path)
+        raise
     except Exception:
         logger.exception(
             "Draft insert failed after file was stored — cleaning up path=%s",
@@ -275,11 +331,213 @@ async def handle_upload(
         logger.exception("Failed to enqueue parse_draft job for draft_id=%s", draft.id)
 
     logger.info(
-        "Draft uploaded id=%s user=%s org=%s size=%d filename=%s",
+        "Draft uploaded id=%s user=%s org=%s size=%d filename=%s parent_draft=%s",
         draft.id,
         user_id,
         org_id,
         file_size,
         filename,
+        parent_draft_id,
     )
     return draft
+
+
+# ---------------------------------------------------------------------------
+# Branch implementations (new draft vs new version)
+# ---------------------------------------------------------------------------
+
+
+def _create_new_draft(
+    conn: Any,
+    *,
+    user_id: Any,
+    org_id: Any,
+    title: str,
+    filename: str,
+    content_type: str,
+    file_size: int,
+    storage_path: str,
+    doc_type: str,
+    parent_vtk_id: Any,
+) -> Draft:
+    """Insert a brand-new ``drafts`` row + its v1 ``draft_versions`` row.
+
+    Both rows land in the same transaction so a partial commit can
+    never leave a draft without a backing version.  The post-insert
+    ``graph_uri`` patch (which now embeds the freshly-minted draft id)
+    is also part of the same transaction.
+    """
+    draft = create_draft(
+        conn,
+        user_id=user_id,
+        org_id=org_id,
+        title=title,
+        filename=filename,
+        content_type=content_type,
+        file_size=file_size,
+        storage_path=storage_path,
+        # graph_uri must embed the freshly-minted draft id, but we
+        # only get the id after the INSERT. Use a stable placeholder
+        # based on the storage_path (which is already unique) then
+        # patch the real URI immediately afterwards.
+        graph_uri=f"{_GRAPH_URI_PREFIX}pending-{storage_path}",
+        doc_type=doc_type,  # type: ignore[arg-type]
+        parent_vtk_id=parent_vtk_id,
+    )
+    final_graph_uri = f"{_GRAPH_URI_PREFIX}{draft.id}"
+    conn.execute(
+        "update drafts set graph_uri = %s where id = %s",
+        (final_graph_uri, str(draft.id)),
+    )
+    draft.graph_uri = final_graph_uri
+
+    # #618 PR-B: explicit v1 row in the SAME transaction.  Migration
+    # 030's backfill handled every PRE-PR-A draft; new uploads need
+    # an in-code insert because the migration only runs once.
+    create_draft_version(
+        conn,
+        draft_id=draft.id,
+        version_number=1,
+        reading_stage="vtk",
+        storage_path=storage_path,
+        graph_uri=final_graph_uri,
+        status="uploaded",
+        created_by=user_id,
+    )
+    log_action(
+        str(user_id),
+        "draft.version.create",
+        {
+            "draft_id": str(draft.id),
+            "version_number": 1,
+            "reading_stage": "vtk",
+        },
+    )
+    return draft
+
+
+def _create_new_version(
+    conn: Any,
+    *,
+    parent_draft_id: Any,
+    user: UserDict,
+    file_size: int,
+    filename: str,
+    content_type: str,
+    storage_path: str,
+) -> Draft:
+    """Insert a NEW ``draft_versions`` row tied to *parent_draft_id*.
+
+    The parent must exist, belong to the caller's org, and be in the
+    terminal ``ready`` status.  Any other state surfaces as a
+    user-facing :class:`DraftUploadError` so the route handler can
+    re-render the form with a banner.
+
+    The new version inherits the parent's ``owner_id`` (NOT the
+    uploader's id, because the audit trail of ownership stays with
+    the original drafter) and is allocated the next free
+    ``version_number``.  Reading stage steps one notch forward in the
+    legislative pipeline.
+
+    Returns the parent :class:`Draft` (re-fetched through
+    :func:`get_draft` so the JOIN surfaces the new version's
+    ``storage_path`` / ``graph_uri`` / ``status`` to the caller).
+    """
+    if not isinstance(parent_draft_id, uuid.UUID):
+        try:
+            parent_draft_id = uuid.UUID(str(parent_draft_id))
+        except (TypeError, ValueError) as exc:
+            raise DraftUploadError("Vanem-eelnõu ei ole kättesaadav.") from exc
+
+    parent = get_draft(conn, parent_draft_id)
+    if parent is None:
+        # 404-equivalent: the parent does not exist.  We do NOT
+        # disclose existence vs cross-org separately so the same
+        # message covers both branches.
+        raise DraftUploadError("Vanem-eelnõu ei ole kättesaadav.")
+
+    user_org_id = user.get("org_id")
+    if user_org_id is None or str(parent.org_id) != str(user_org_id):
+        # Cross-org parent — same indistinguishable message as above so
+        # we never confirm the existence of another org's draft.
+        raise DraftUploadError("Vanem-eelnõu ei ole kättesaadav.")
+
+    # The parent's status is read through the version-aware JOIN so a
+    # parent whose latest version is mid-pipeline is correctly rejected.
+    if parent.status != "ready":
+        raise DraftUploadError("Uue versiooni saab luua ainult eelnõust, mille analüüs on valmis.")
+
+    # Allocate the next version slot.  The SELECT runs against the open
+    # connection so two concurrent uploads against the same parent will
+    # serialise on the row-level lock the subsequent INSERT takes.
+    next_version = get_next_version_number(conn, parent_draft_id)
+    latest = get_latest_version(conn, parent_draft_id)
+    base_stage = latest.reading_stage if latest is not None else "vtk"
+    next_stage = next_reading_stage(base_stage)
+
+    # §9.5 per-version graph URI scheme.
+    graph_uri = f"{_GRAPH_URI_PREFIX}{parent_draft_id}/v{next_version}"
+
+    create_draft_version(
+        conn,
+        draft_id=parent_draft_id,
+        version_number=next_version,
+        reading_stage=next_stage,
+        storage_path=storage_path,
+        graph_uri=graph_uri,
+        status="uploaded",
+        # Inherit ownership from the parent draft so the audit trail
+        # stays attached to the original drafter.  The acting user is
+        # captured in the audit log_action call below.
+        created_by=parent.user_id,
+    )
+
+    # Touch ``drafts.updated_at`` + flip the legacy status mirror back
+    # to ``uploaded`` so the listing UI reflects the in-flight pipeline
+    # for the new version.  Also bump file metadata so the latest
+    # filename / size matches the new bytes.
+    conn.execute(
+        """
+        update drafts
+        set status = %s,
+            filename = %s,
+            content_type = %s,
+            file_size = %s,
+            storage_path = %s,
+            graph_uri = %s,
+            updated_at = now(),
+            error_message = null,
+            error_debug = null,
+            processing_completed_at = null
+        where id = %s
+        """,
+        (
+            "uploaded",
+            filename,
+            content_type,
+            file_size,
+            storage_path,
+            graph_uri,
+            str(parent_draft_id),
+        ),
+    )
+
+    log_action(
+        str(user["id"]),
+        "draft.version.create",
+        {
+            "draft_id": str(parent_draft_id),
+            "version_number": next_version,
+            "reading_stage": next_stage,
+            "uploader_id": str(user["id"]),
+        },
+    )
+
+    # Re-fetch the parent so the returned Draft reflects the new
+    # version's status / graph_uri / storage_path via the JOIN.
+    refreshed = get_draft(conn, parent_draft_id)
+    if refreshed is None:
+        # Should be impossible given we just wrote both rows, but
+        # defend against it so the caller doesn't get a None back.
+        raise RuntimeError(f"Failed to re-fetch draft {parent_draft_id} after version insert")
+    return refreshed

--- a/app/docs/version_model.py
+++ b/app/docs/version_model.py
@@ -42,6 +42,33 @@ READING_STAGES: tuple[str, ...] = (
     "enacted",
 )
 
+
+def next_reading_stage(current: str) -> str:
+    """Return the next stage in the happy-path legislative pipeline.
+
+    Used by :mod:`app.docs.upload` when creating a new version off an
+    existing draft: the new version inherits the parent draft's latest
+    reading stage one step forward (``vtk`` -> ``reading_1``,
+    ``reading_1`` -> ``reading_2``, ...).
+
+    The terminal stage ``enacted`` has no successor: an attempt to step
+    forward from it returns ``enacted`` itself rather than raising,
+    matching the spec where republishing an enacted law is allowed but
+    does not advance the pipeline.
+
+    Raises:
+        ValueError: ``current`` is not a known :data:`READING_STAGES`
+            value.  Callers should validate user input via
+            :data:`READING_STAGES` before passing it through.
+    """
+    if current not in READING_STAGES:
+        raise ValueError(f"Unknown reading stage: {current!r}")
+    if current == "enacted":
+        return "enacted"
+    idx = READING_STAGES.index(current)
+    return READING_STAGES[idx + 1]
+
+
 # ---------------------------------------------------------------------------
 # Dataclass
 # ---------------------------------------------------------------------------
@@ -181,3 +208,124 @@ def get_latest_version(conn: Any, draft_id: uuid.UUID | str) -> DraftVersion | N
         logger.exception("Failed to fetch latest version for draft=%s", draft_id)
         return None
     return _row_to_version(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Write helpers (#618 PR-B cutover)
+# ---------------------------------------------------------------------------
+
+
+def create_draft_version(
+    conn: Any,
+    *,
+    draft_id: uuid.UUID | str,
+    version_number: int,
+    reading_stage: str,
+    storage_path: str,
+    graph_uri: str,
+    status: str,
+    created_by: uuid.UUID | str,
+    parsed_text_encrypted: bytes | None = None,
+) -> DraftVersion:
+    """Insert a new ``draft_versions`` row and return it.
+
+    Used by :mod:`app.docs.upload` for both the initial v1 row of every
+    new draft AND for follow-on versions uploaded against an existing
+    draft (the v2+ branch).  Takes an explicit connection so the caller
+    can land the insert in the same transaction as the parent
+    :func:`app.docs.draft_model.create_draft` call -- a partial commit
+    must never leave a draft without a v1 row.
+
+    Args:
+        conn: Open psycopg connection.  Caller commits.
+        draft_id: Parent draft.  FK violation will surface as the
+            underlying ``IntegrityError`` so callers know to roll back.
+        version_number: 1-based version index.  Caller is responsible
+            for computing the value (typically
+            ``MAX(version_number) + 1`` for v2+ uploads, ``1`` for new
+            drafts).  Uniqueness is enforced by the DB ``UNIQUE``
+            constraint on ``(draft_id, version_number)``.
+        reading_stage: One of :data:`READING_STAGES`.  Validated
+            client-side so a typo surfaces as ``ValueError`` before SQL
+            runs (the DB ``CHECK`` constraint would catch it too, but
+            the client-side guard gives a friendlier traceback).
+        storage_path: Fernet-encrypted file path produced by
+            :func:`app.storage.store_file`.
+        graph_uri: Per-version Jena named graph URI.  See the §9.5
+            scheme: ``...drafts/{draft_id}/v{version_number}``.
+        status: Initial pipeline status; always ``'uploaded'`` for the
+            normal upload flow.  Validated against
+            :data:`app.docs.status.STATUS_BY_VALUE` so a typo cannot
+            slip past the application layer.
+        created_by: User id of the uploader.  Inherited from the
+            authenticated session.
+        parsed_text_encrypted: Optional Fernet ciphertext.  ``None``
+            until the parse pipeline runs for this version (matches the
+            ``drafts.parsed_text_encrypted`` lifecycle).
+
+    Returns:
+        The freshly-inserted :class:`DraftVersion`.
+
+    Raises:
+        ValueError: ``reading_stage`` or ``status`` is not in the
+            allowed set.  Surfaced before any SQL runs.
+    """
+    # Local import to avoid a circular: status -> draft_model -> version_model
+    # would form a cycle if status was imported at module top.
+    from app.docs.status import STATUS_BY_VALUE
+
+    if reading_stage not in READING_STAGES:
+        raise ValueError(f"Unknown reading stage: {reading_stage!r}")
+    if status not in STATUS_BY_VALUE:
+        raise ValueError(f"Unknown draft status: {status!r}")
+
+    row = conn.execute(
+        f"""
+        INSERT INTO draft_versions (
+            draft_id, version_number, reading_stage,
+            parsed_text_encrypted, storage_path, graph_uri,
+            status, created_by
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING {_VERSION_COLUMNS}
+        """,
+        (
+            str(draft_id),
+            version_number,
+            reading_stage,
+            parsed_text_encrypted,
+            storage_path,
+            graph_uri,
+            status,
+            str(created_by),
+        ),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError("INSERT ... RETURNING draft_versions produced no row")
+    return _row_to_version(row)
+
+
+def get_next_version_number(conn: Any, draft_id: uuid.UUID | str) -> int:
+    """Return ``MAX(version_number) + 1`` for *draft_id*.
+
+    Used by the v2+ upload branch in :mod:`app.docs.upload` to allocate
+    the next version slot under the same lock the caller already holds
+    on the parent draft row.  Returns ``1`` when the parent has no
+    versions yet (cannot happen post migration 030's backfill, but the
+    safe default keeps tests independent).
+
+    Takes an explicit connection so the read can sit inside the same
+    transaction as the subsequent :func:`create_draft_version` call --
+    otherwise two concurrent v2 uploads against the same parent could
+    race on the unique-version-number constraint.
+    """
+    row = conn.execute(
+        """
+        SELECT COALESCE(MAX(version_number), 0)
+        FROM draft_versions
+        WHERE draft_id = %s
+        """,
+        (str(draft_id),),
+    ).fetchone()
+    current = int(row[0]) if row and row[0] is not None else 0
+    return current + 1

--- a/migrations/032_impact_reports_version_fk.sql
+++ b/migrations/032_impact_reports_version_fk.sql
@@ -1,0 +1,62 @@
+-- =============================================================================
+-- Migration 032: Per-version impact reports — draft_version_id FK on impact_reports
+-- =============================================================================
+--
+-- Adds the ``draft_version_id`` column to ``impact_reports`` so each impact
+-- analysis run is bound to a specific :class:`DraftVersion` rather than the
+-- bare ``drafts.id``.  This is the analyze-pipeline half of the §4.2 cutover
+-- shipped in #618 PR-B (the upload + read/write cutover lives in the same PR
+-- but is application code).
+--
+-- Design decisions (sprint plan §6 Days 5-7):
+--   - Column is NULLABLE so the migration is non-blocking against any
+--     in-flight analyze job.  A subsequent backfill UPDATE links every
+--     existing row to v1 of its draft (the only version that exists post
+--     migration 030 backfill).  Future PR-D may flip this to NOT NULL.
+--   - ``ON DELETE CASCADE`` so deleting a draft_version row (e.g. user
+--     hard-deletes a specific reading) propagates to its impact report,
+--     mirroring the existing ``draft_id`` FK behaviour.
+--   - Plain B-tree index on ``draft_version_id`` for the
+--     ``WHERE draft_version_id = $1`` lookup the report routes will issue
+--     once they pivot to per-version queries (#618 PR-C).
+--
+-- Idempotency:
+--   - ``ADD COLUMN IF NOT EXISTS`` and ``CREATE INDEX IF NOT EXISTS`` make
+--     the schema mutations safe to re-run.
+--   - The backfill UPDATE only touches rows where the FK is still NULL so a
+--     partial-failure replay does not double-write.
+--
+-- ROLLBACK procedure (manual; requires app on pre-PR-B code):
+--   ALTER TABLE impact_reports DROP COLUMN IF EXISTS draft_version_id;
+--   DROP INDEX IF EXISTS idx_impact_reports_draft_version;
+--   DELETE FROM schema_migrations WHERE version = '032_impact_reports_version_fk';
+--   Then redeploy previous app image.  No data loss because the source of
+--   truth (drafts + draft_versions) is untouched.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- Schema mutation
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE impact_reports
+    ADD COLUMN IF NOT EXISTS draft_version_id uuid
+    REFERENCES draft_versions(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_impact_reports_draft_version
+    ON impact_reports(draft_version_id);
+
+-- ---------------------------------------------------------------------------
+-- Backfill: link every existing impact_reports row to the latest version of
+-- its parent draft.  Post migration 030 this is always v1 because no caller
+-- has produced a v2 yet, but the LIMIT 1 + ORDER BY DESC stays correct
+-- when re-run after #618 PR-B has actually shipped v2 uploads.
+-- ---------------------------------------------------------------------------
+
+UPDATE impact_reports ir
+SET draft_version_id = (
+    SELECT id FROM draft_versions
+    WHERE draft_id = ir.draft_id
+    ORDER BY version_number DESC
+    LIMIT 1
+)
+WHERE ir.draft_version_id IS NULL;

--- a/tests/test_docs_analyze_handler.py
+++ b/tests/test_docs_analyze_handler.py
@@ -20,9 +20,27 @@ import pytest
 from app.docs.analyze_handler import analyze_impact
 from app.docs.draft_model import Draft
 from app.docs.impact.analyzer import ImpactFindings
+from app.docs.version_model import DraftVersion
 
 _DRAFT_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+_VERSION_ID = uuid.UUID("88888888-8888-8888-8888-888888888888")
 _GRAPH_URI = f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}"
+
+
+def _make_version() -> DraftVersion:
+    """Build a v1 :class:`DraftVersion` for analyze_handler patches."""
+    return DraftVersion(
+        id=_VERSION_ID,
+        draft_id=_DRAFT_ID,
+        version_number=1,
+        reading_stage="vtk",
+        parsed_text_encrypted=None,
+        storage_path="/tmp/cipher.enc",
+        graph_uri=_GRAPH_URI,
+        status="analyzing",
+        created_at=datetime.now(UTC),
+        created_by=uuid.UUID("55555555-5555-5555-5555-555555555555"),
+    )
 
 
 def _make_draft(status: str = "analyzing") -> Draft:
@@ -128,6 +146,7 @@ class TestAnalyzeImpactHappyPath:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch(
                 "app.docs.analyze_handler.build_draft_graph",
                 return_value="# turtle",
@@ -173,9 +192,22 @@ class TestAnalyzeImpactHappyPath:
         calls = insert_conn.execute.call_args_list
         sql_texts = [c.args[0].lower() for c in calls]
         assert any("insert into impact_reports" in s for s in sql_texts)
-        update_calls = [c for c in calls if "update drafts" in c.args[0].lower()]
-        assert len(update_calls) == 1
-        assert update_calls[0].args[1][0] == "ready"
+        # #618 PR-B: the impact_reports INSERT must carry a
+        # ``draft_version_id`` column bound to the latest version.
+        insert_call = next(c for c in calls if "insert into impact_reports" in c.args[0].lower())
+        assert "draft_version_id" in insert_call.args[0]
+        # Param order: report_id, draft_id, draft_version_id, ...
+        assert insert_call.args[1][2] == str(_VERSION_ID)
+        # §4.2 cutover (#618 PR-B): update_draft_status now writes to BOTH
+        # tables, so we expect an UPDATE drafts AND an UPDATE draft_versions.
+        update_drafts_calls = [c for c in calls if "update drafts" in c.args[0].lower()]
+        update_versions_calls = [c for c in calls if "update draft_versions" in c.args[0].lower()]
+        assert len(update_drafts_calls) == 1
+        assert update_versions_calls, (
+            "analyze_handler must write status='ready' to draft_versions via the "
+            "version-aware update_draft_status (§4.2 cutover, #618 PR-B)"
+        )
+        assert update_drafts_calls[0].args[1][0] == "ready"
         insert_conn.commit.assert_called_once()
 
         # Return payload contains the critical summary fields.
@@ -198,6 +230,7 @@ class TestAnalyzeImpactHappyPath:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch(
                 "app.docs.analyze_handler.build_draft_graph",
                 return_value="# ttl",
@@ -254,6 +287,7 @@ class TestAnalyzeImpactHappyPath:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch(
                 "app.docs.analyze_handler.build_draft_graph",
                 return_value="# ttl",
@@ -320,6 +354,7 @@ class TestAnalyzeImpactFailurePaths:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
             patch(
                 "app.docs.analyze_handler.put_named_graph",
@@ -349,6 +384,7 @@ class TestAnalyzeImpactFailurePaths:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
             patch(
                 "app.docs.analyze_handler.put_named_graph",
@@ -385,6 +421,7 @@ class TestAnalyzeImpactFailurePaths:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
             patch(
                 "app.docs.analyze_handler.put_named_graph",
@@ -450,6 +487,7 @@ class TestAnalyzeImpactLineageHook:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
             patch("app.docs.analyze_handler.put_named_graph", return_value=True),
             patch(
@@ -505,6 +543,7 @@ class TestAnalyzeImpactLineageHook:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
             patch("app.docs.analyze_handler.put_named_graph", return_value=True),
             patch(
@@ -559,6 +598,7 @@ class TestAnalyzeImpactLineageHook:
         with (
             patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
             patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
             patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
             patch("app.docs.analyze_handler.put_named_graph", return_value=True),
             patch(

--- a/tests/test_docs_draft_model.py
+++ b/tests/test_docs_draft_model.py
@@ -33,6 +33,7 @@ from app.docs.draft_model import (
     get_draft,
     list_drafts_for_org,
     list_eelnous_for_vtk,
+    list_versionable_drafts_for_org,
     list_vtks_for_org,
     update_draft_parent_vtk,
     update_draft_status,
@@ -519,6 +520,112 @@ class TestListVtksForOrg:
         assert len(vtks) == 1
         assert vtks[0].title == "Maanteeseaduse VTK"
         assert vtks[0].id == _VTK_ID
+
+
+# ---------------------------------------------------------------------------
+# list_versionable_drafts_for_org -- version picker helper (#618 PR-B)
+# ---------------------------------------------------------------------------
+
+
+class TestListVersionableDraftsForOrg:
+    def test_filters_to_org_and_ready_status(self):
+        """The picker only surfaces drafts that are (a) owned by the
+        caller's org and (b) in the terminal ``ready`` status.  In-flight
+        drafts (parsing/extracting/analyzing/failed) are excluded so the
+        uploader cannot version-fork an unstable parent.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [
+            _make_raw_row(
+                draft_id=uuid.uuid4(),
+                status="ready",
+                title="Eelnõu A",
+            ),
+        ]
+        result = list_versionable_drafts_for_org(conn, _ORG_ID)
+
+        assert len(result) == 1
+        assert result[0].title == "Eelnõu A"
+
+        sql, params = conn.execute.call_args.args
+        sql_lower = sql.lower()
+        assert "where org_id = %s" in sql_lower
+        assert "status = 'ready'" in sql_lower
+        assert params == (str(_ORG_ID),)
+
+    def test_returns_empty_when_no_eligible_drafts(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        assert list_versionable_drafts_for_org(conn, _ORG_ID) == []
+
+    def test_db_error_returns_empty_list(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("boom")
+        assert list_versionable_drafts_for_org(conn, _ORG_ID) == []
+
+    def test_orders_newest_first(self):
+        """Picker is ordered ``created_at DESC`` so the most recent
+        ``ready`` draft surfaces at the top of the dropdown.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        list_versionable_drafts_for_org(conn, _ORG_ID)
+        sql = conn.execute.call_args.args[0].lower()
+        assert "order by created_at desc" in sql
+
+
+# ---------------------------------------------------------------------------
+# get_draft -- §4.2 cutover (#618 PR-B): JOIN through draft_versions
+# ---------------------------------------------------------------------------
+
+
+class TestGetDraftJoinCutover:
+    """Post-PR-B ``get_draft`` JOINs through ``draft_versions`` so the
+    returned :class:`Draft` reflects the latest version's pipeline state
+    via ``COALESCE(version.col, drafts.col)``.
+
+    These tests pin the JOIN shape so a future PR-D can drop the legacy
+    fallback safely.
+    """
+
+    def test_select_uses_left_join_on_latest_version(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = _make_raw_row()
+        get_draft(conn, _DRAFT_ID)
+
+        sql = conn.execute.call_args.args[0].lower()
+        assert "from drafts d" in sql
+        assert "left join draft_versions v" in sql
+        assert "select max(version_number)" in sql, (
+            "JOIN must select the LATEST version (MAX(version_number)) so "
+            "v3 status updates surface on get_draft, not v2"
+        )
+
+    def test_coalesces_version_columns_over_drafts_columns(self):
+        """Status / parsed_text_encrypted / graph_uri / storage_path
+        all come from the version row when one exists.  The COALESCE
+        falls back to drafts.* so a draft missing a v1 row (impossible
+        post migration 030 but defended-against) still returns data.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = _make_raw_row()
+        get_draft(conn, _DRAFT_ID)
+
+        sql = conn.execute.call_args.args[0].lower()
+        for col in ("storage_path", "graph_uri", "status", "parsed_text_encrypted"):
+            assert f"coalesce(v.{col}, d.{col})" in sql, (
+                f"get_draft must COALESCE {col} from draft_versions over drafts"
+            )
+
+    def test_returns_none_when_no_row(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        assert get_draft(conn, _DRAFT_ID) is None
+
+    def test_db_error_returns_none(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("conn lost")
+        assert get_draft(conn, _DRAFT_ID) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_docs_extract_handler.py
+++ b/tests/test_docs_extract_handler.py
@@ -152,9 +152,10 @@ class TestHappyPath:
         }
 
         # Combined-transaction connection (index 2) receives:
-        #   1 DELETE + 3 INSERTs + 1 UPDATE = 5 execute calls total.
+        #   1 DELETE + 3 INSERTs + 2 UPDATEs (#618 PR-B: update_draft_status
+        #   writes to BOTH draft_versions and drafts in the same call) = 6.
         combined_exec = mock_conns[2].execute
-        assert combined_exec.call_count == 5
+        assert combined_exec.call_count == 6
 
         delete_calls = [
             call

--- a/tests/test_docs_integration_e2e.py
+++ b/tests/test_docs_integration_e2e.py
@@ -147,6 +147,10 @@ def _make_conn_factory(state: _State):
     def _execute(sql: str, params: tuple | None = None):
         sql_lower = " ".join(sql.split()).lower()
         cursor = MagicMock()
+        # Default rowcount=0 so callers using ``(rowcount or 0) > 0``
+        # get a usable boolean back.  Branches that simulate a real
+        # UPDATE override this to 1.
+        cursor.rowcount = 0
 
         # ----- drafts table -----
         if "insert into drafts" in sql_lower and "returning" in sql_lower:
@@ -208,8 +212,19 @@ def _make_conn_factory(state: _State):
             state.draft_row = tuple(row)
             return cursor
 
-        if "select" in sql_lower and "from drafts" in sql_lower and "where id" in sql_lower:
-            # get_draft / fetch_draft
+        if (
+            "select" in sql_lower
+            and "from drafts" in sql_lower
+            and ("where id" in sql_lower or "where d.id" in sql_lower)
+        ):
+            # get_draft / fetch_draft.  Post #618 PR-B the get_draft SELECT
+            # JOINs through ``draft_versions`` and aliases drafts as ``d``,
+            # so the WHERE predicate is ``where d.id`` rather than the
+            # legacy ``where id``.  Both shapes return the same draft row
+            # because the COALESCE in the new query falls back to the
+            # legacy ``drafts.*`` columns when no version row exists --
+            # which is the case in this in-memory stub since we never
+            # write a v1 row here.
             cursor.fetchone.return_value = state.draft_row
             return cursor
 
@@ -219,6 +234,56 @@ def _make_conn_factory(state: _State):
                 cursor.fetchone.return_value = (1 if state.draft_row else 0,)
             else:
                 cursor.fetchall.return_value = [state.draft_row] if state.draft_row else []
+            return cursor
+
+        if "insert into draft_versions" in sql_lower and "returning" in sql_lower:
+            # #618 PR-B: the upload handler now creates an explicit v1
+            # draft_versions row alongside the drafts INSERT.  Mint a
+            # synthetic version row so create_draft_version's
+            # RETURNING ... fetchone gets a usable tuple.  This stub
+            # doesn't otherwise track version state because
+            # update_draft_status's version write is a no-op below.
+            assert params is not None
+            (
+                v_draft_id,
+                version_number,
+                reading_stage,
+                _parsed_text_encrypted,
+                v_storage_path,
+                v_graph_uri,
+                v_status,
+                v_created_by,
+            ) = params
+            v_id = uuid.uuid4()
+            now = datetime.now(UTC)
+            cursor.fetchone.return_value = (
+                v_id,
+                uuid.UUID(v_draft_id) if isinstance(v_draft_id, str) else v_draft_id,
+                int(version_number),
+                str(reading_stage),
+                None,
+                str(v_storage_path),
+                str(v_graph_uri),
+                str(v_status),
+                now,
+                uuid.UUID(v_created_by) if isinstance(v_created_by, str) else v_created_by,
+            )
+            return cursor
+
+        if "update draft_versions" in sql_lower:
+            # #618 PR-B cutover: update_draft_status now writes to BOTH
+            # draft_versions AND drafts.  This stub doesn't model the
+            # draft_versions rows so the version UPDATE is a no-op --
+            # the legacy ``drafts`` mirror immediately following carries
+            # the actual state mutation that the test asserts on.
+            cursor.rowcount = 1
+            return cursor
+
+        if "select" in sql_lower and "max(version_number)" in sql_lower:
+            # get_next_version_number: handle the COALESCE(MAX, 0) query
+            # used by the v2+ upload branch.  We don't model real version
+            # rows here so always return 0 (caller adds 1).
+            cursor.fetchone.return_value = (0,)
             return cursor
 
         if "update drafts" in sql_lower and "status" in sql_lower:
@@ -284,21 +349,24 @@ def _make_conn_factory(state: _State):
 
         if "from impact_reports" in sql_lower:
             # report routes look up the latest report by draft_id.
+            # Post #618 PR-B the INSERT params layout is:
+            #   (id, draft_id, draft_version_id, affected_count,
+            #    conflict_count, gap_count, impact_score, report_data,
+            #    ontology_version)
+            # The legacy SELECT used by the report routes still
+            # expects the old shape (no draft_version_id), so we skip
+            # index 2 (draft_version_id) when reconstructing the row.
             if state.impact_reports:
                 report = state.impact_reports[-1]
-                # The query returns:
-                #   id, draft_id, affected_count, conflict_count,
-                #   gap_count, impact_score, report_data, ontology_version,
-                #   generated_at
                 cursor.fetchone.return_value = (
-                    report[0],
-                    report[1],
-                    report[2],
-                    report[3],
-                    report[4],
-                    report[5],
-                    report[6],
-                    report[7],
+                    report[0],  # id
+                    report[1],  # draft_id
+                    report[3],  # affected_count (params[2] is draft_version_id)
+                    report[4],  # conflict_count
+                    report[5],  # gap_count
+                    report[6],  # impact_score
+                    report[7],  # report_data
+                    report[8],  # ontology_version
                     datetime.now(UTC),
                 )
             else:
@@ -539,8 +607,10 @@ class TestDocsPipelineE2E:
             # has a valid JSON dict to deserialise — the analyzer wrote
             # the dataclass via dataclasses.asdict, but our state mock
             # stored the raw params tuple.
+            # #618 PR-B: the INSERT params now carry draft_version_id at
+            # index 2, so report_data lives at index 7 (was 6 pre-PR-B).
             report_row = list(state.impact_reports[-1])
-            report_row[6] = json.dumps(
+            report_row[7] = json.dumps(
                 {
                     "affected_entities": [],
                     "conflicts": [],

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -2264,9 +2264,13 @@ class TestResetDraftForRetrySql:
 
         assert _reset_draft_for_retry("44444444-4444-4444-4444-444444444444") is True
 
-        update_call = conn.execute.call_args_list[0]
-        sql = update_call.args[0].lower()
-        assert "update drafts" in sql
+        # #618 PR-B: update_draft_status now writes to BOTH draft_versions
+        # AND drafts in the same call.  The drafts UPDATE owns the
+        # processing_completed_at clear.
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        sql = drafts_call.args[0].lower()
         assert "processing_completed_at = null" in sql
 
 

--- a/tests/test_docs_status.py
+++ b/tests/test_docs_status.py
@@ -154,7 +154,8 @@ class TestUpdateDraftStatusValidation:
         conn.execute.return_value.rowcount = 1
         # Must not raise.
         update_draft_status(conn, _DRAFT_ID, status)
-        conn.execute.assert_called_once()
+        # #618 PR-B: two UPDATEs fire — draft_versions then drafts mirror.
+        assert conn.execute.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -167,14 +168,25 @@ class TestUpdateDraftStatusSqlShape:
     §4.2 cutover invariant) stay accurate.
     """
 
-    def test_writes_to_drafts_only(self):
-        """§4.2 contract: this helper must NOT touch ``draft_versions``.
+    def test_writes_to_both_draft_versions_and_drafts(self):
+        """§4.2 cutover (#618 PR-B): the helper writes to BOTH tables.
 
-        The version-aware write lands in #618 PR-B. Until then, every
-        UPDATE produced by the helper must reference only the legacy
-        ``drafts`` table -- a regression that adds a stray
-        ``draft_versions`` write would defeat the bisect that pins the
-        cutover sequence.
+        Post-PR-B the version-aware status update lands first (so the
+        latest ``draft_versions`` row is the source of truth) and a
+        defensive mirror to ``drafts.status`` keeps legacy readers
+        working for one release cycle.  PR-D will drop the
+        ``drafts.status`` write and the column.
+
+        A regression that drops EITHER write breaks the cutover:
+
+            * Missing the ``draft_versions`` UPDATE means PR-C diff /
+              timeline UI sees a stale per-version status.
+            * Missing the ``drafts`` UPDATE means legacy readers (every
+              listing query that hasn't been pivoted yet) see a stale
+              status column.
+
+        The test asserts both UPDATE statements fire in the SAME
+        ``update_draft_status`` call so the contract is checked end-to-end.
         """
         conn = MagicMock()
         conn.execute.return_value.rowcount = 1
@@ -182,12 +194,16 @@ class TestUpdateDraftStatusSqlShape:
         for status in VALID_STATUSES:
             conn.reset_mock()
             update_draft_status(conn, _DRAFT_ID, status)
-            sql = conn.execute.call_args.args[0].lower()
-            assert "draft_versions" not in sql, (
-                f"update_draft_status({status!r}) must not write to draft_versions; "
-                f"§4.2 cutover lives in #618 PR-B. SQL was:\n{sql}"
+            sql_calls = [c.args[0].lower() for c in conn.execute.call_args_list]
+            joined = "\n".join(sql_calls)
+            assert "draft_versions" in joined, (
+                f"update_draft_status({status!r}) must write to draft_versions; "
+                f"§4.2 cutover (#618 PR-B). SQL was:\n{joined}"
             )
-            assert "update drafts" in sql
+            assert "update drafts" in joined, (
+                f"update_draft_status({status!r}) must defensive-mirror to drafts.status; "
+                f"§4.2 cutover (#618 PR-B). SQL was:\n{joined}"
+            )
 
     def test_default_call_writes_status_and_clears_errors(self):
         conn = MagicMock()
@@ -195,7 +211,12 @@ class TestUpdateDraftStatusSqlShape:
 
         update_draft_status(conn, _DRAFT_ID, "parsing")
 
-        sql, params = conn.execute.call_args.args
+        # Two UPDATEs: first to draft_versions, second to drafts.
+        # The drafts UPDATE owns the error-clearing + completion-stamp logic.
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        sql, params = drafts_call.args
         assert "status = %s" in sql
         assert "error_message = %s" in sql
         assert "error_debug = %s" in sql
@@ -208,7 +229,10 @@ class TestUpdateDraftStatusSqlShape:
             conn = MagicMock()
             conn.execute.return_value.rowcount = 1
             update_draft_status(conn, _DRAFT_ID, terminal)
-            sql = conn.execute.call_args.args[0]
+            drafts_call = next(
+                c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+            )
+            sql = drafts_call.args[0]
             assert "processing_completed_at = now()" in sql, (
                 f"Terminal status {terminal!r} must stamp processing_completed_at = now()"
             )
@@ -220,7 +244,10 @@ class TestUpdateDraftStatusSqlShape:
             conn = MagicMock()
             conn.execute.return_value.rowcount = 1
             update_draft_status(conn, _DRAFT_ID, spec.value)
-            sql = conn.execute.call_args.args[0]
+            drafts_call = next(
+                c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+            )
+            sql = drafts_call.args[0]
             assert "processing_completed_at = null" in sql, (
                 f"Non-terminal status {spec.value!r} must clear processing_completed_at"
             )
@@ -232,7 +259,10 @@ class TestUpdateDraftStatusSqlShape:
 
         update_draft_status(conn, _DRAFT_ID, "failed", "Boom")
 
-        params = conn.execute.call_args.args[1]
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        params = drafts_call.args[1]
         assert params[0] == "failed"
         assert params[1] == "Boom"
         assert params[2] is None  # error_debug
@@ -249,7 +279,10 @@ class TestUpdateDraftStatusSqlShape:
             error_debug="raw stack trace",
         )
 
-        params = conn.execute.call_args.args[1]
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        params = drafts_call.args[1]
         assert params == (
             "failed",
             "User-facing",
@@ -271,7 +304,10 @@ class TestUpdateDraftStatusSqlShape:
             extras={"parsed_text_encrypted": b"ciphertext"},
         )
 
-        sql, params = conn.execute.call_args.args
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        sql, params = drafts_call.args
         assert "parsed_text_encrypted = %s" in sql
         # status, error_message=None, error_debug=None, parsed_text_encrypted, draft_id
         assert params == (
@@ -296,7 +332,10 @@ class TestUpdateDraftStatusSqlShape:
             extras={"parsed_text_encrypted": b"x", "entity_count": 3},
         )
 
-        sql, params = conn.execute.call_args.args
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        sql, params = drafts_call.args
         # entity_count comes before parsed_text_encrypted alphabetically.
         ec_idx = sql.find("entity_count = %s")
         pte_idx = sql.find("parsed_text_encrypted = %s")
@@ -314,7 +353,10 @@ class TestUpdateDraftStatusSqlShape:
             expected_status="failed",
         )
 
-        sql, params = conn.execute.call_args.args
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        sql, params = drafts_call.args
         assert "where id = %s and status = %s" in sql.lower()
         # status=uploaded, error_message=None, error_debug=None, id, expected=failed
         assert params == ("uploaded", None, None, str(_DRAFT_ID), "failed")
@@ -333,3 +375,110 @@ class TestUpdateDraftStatusSqlShape:
         conn = MagicMock()
         conn.execute.return_value.rowcount = None
         assert update_draft_status(conn, _DRAFT_ID, "parsing") is False
+
+
+# ---------------------------------------------------------------------------
+# update_draft_status -- §4.2 cutover (#618 PR-B) version-aware write
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDraftStatusVersionCutover:
+    """The PR-B cutover splits the UPDATE into two statements: first the
+    latest ``draft_versions`` row, then the defensive ``drafts`` mirror.
+
+    These tests pin the per-statement shape so a future PR-D can safely
+    drop the second UPDATE without losing the per-version semantics.
+    """
+
+    def test_version_update_targets_latest_version_row(self):
+        """The version UPDATE must use ``ORDER BY version_number DESC LIMIT 1``
+        so a v3 status flip never bleeds into v2.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(conn, _DRAFT_ID, "ready")
+
+        version_call = next(
+            c for c in conn.execute.call_args_list if "draft_versions" in c.args[0].lower()
+        )
+        sql = version_call.args[0].lower()
+        assert "update draft_versions" in sql
+        assert "order by version_number desc" in sql
+        assert "limit 1" in sql
+
+    def test_version_update_runs_before_drafts_mirror(self):
+        """Order matters: version write first, drafts mirror second.
+
+        If the drafts mirror runs first and then version fails (e.g. a
+        never-backfilled draft has no v1 row), the rowcount-based
+        return value would still be True even though no version state
+        was actually persisted.  Test that the call order matches the
+        documented contract.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(conn, _DRAFT_ID, "parsing")
+
+        sql_calls = [c.args[0].lower() for c in conn.execute.call_args_list]
+        version_idx = next(i for i, s in enumerate(sql_calls) if "draft_versions" in s)
+        drafts_idx = next(i for i, s in enumerate(sql_calls) if "update drafts" in s)
+        assert version_idx < drafts_idx, (
+            f"draft_versions UPDATE must run before drafts mirror; order was {sql_calls!r}"
+        )
+
+    def test_parsed_text_encrypted_extra_mirrors_to_version(self):
+        """``parsed_text_encrypted`` lives on BOTH tables and must mirror.
+
+        The parse handler writes ``parsed_text_encrypted`` via ``extras``
+        as part of the ``parsing -> extracting`` transition; the version
+        row needs the same payload so per-version reads pick up the
+        decrypted text.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(
+            conn,
+            _DRAFT_ID,
+            "extracting",
+            extras={"parsed_text_encrypted": b"ciphertext"},
+        )
+
+        version_call = next(
+            c for c in conn.execute.call_args_list if "draft_versions" in c.args[0].lower()
+        )
+        sql, params = version_call.args
+        assert "parsed_text_encrypted = %s" in sql
+        # status, parsed_text_encrypted, draft_id
+        assert params == ("extracting", b"ciphertext", str(_DRAFT_ID))
+
+    def test_entity_count_extra_does_not_mirror_to_version(self):
+        """``entity_count`` lives only on ``drafts`` -- the version row
+        does not have this column and must NOT receive an UPDATE for it.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.rowcount = 1
+
+        update_draft_status(
+            conn,
+            _DRAFT_ID,
+            "analyzing",
+            extras={"entity_count": 12},
+        )
+
+        version_call = next(
+            c for c in conn.execute.call_args_list if "draft_versions" in c.args[0].lower()
+        )
+        sql = version_call.args[0]
+        assert "entity_count" not in sql, (
+            "entity_count must not appear in the draft_versions UPDATE; "
+            "the column does not exist on draft_versions."
+        )
+
+        # And the drafts mirror DOES include it.
+        drafts_call = next(
+            c for c in conn.execute.call_args_list if "update drafts" in c.args[0].lower()
+        )
+        assert "entity_count = %s" in drafts_call.args[0]

--- a/tests/test_docs_upload.py
+++ b/tests/test_docs_upload.py
@@ -108,6 +108,38 @@ def _make_conn_factory(conn: MagicMock):
     return factory
 
 
+def _wire_upload_conn(
+    *,
+    draft_row: tuple[Any, ...],
+    version_row: tuple[Any, ...],
+) -> MagicMock:
+    """Build a mock connection that handles BOTH inserts in handle_upload.
+
+    Post-#618 PR-B the upload flow runs two ``INSERT ... RETURNING``
+    statements (drafts then draft_versions) plus a few ``UPDATE``s.
+    A single ``fetchone.return_value`` no longer works because the
+    drafts INSERT expects 19 columns while the version INSERT expects
+    10.  The side_effect routes each fetchone() based on the SQL
+    actually being executed.
+    """
+    mock_conn = MagicMock()
+
+    def _execute_side_effect(sql: str, _params: object = None):
+        cursor = MagicMock()
+        sql_lower = sql.lower()
+        if "into drafts" in sql_lower and "returning" in sql_lower:
+            cursor.fetchone.return_value = draft_row
+        elif "into draft_versions" in sql_lower and "returning" in sql_lower:
+            cursor.fetchone.return_value = version_row
+        else:
+            cursor.fetchone.return_value = None
+        cursor.rowcount = 1
+        return cursor
+
+    mock_conn.execute.side_effect = _execute_side_effect
+    return mock_conn
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -117,14 +149,13 @@ class TestHandleUploadHappyPath:
     def test_happy_path_returns_draft_and_enqueues_job(self):
         import asyncio
 
-        mock_conn = MagicMock()
         draft_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
         user_uuid = uuid.UUID("22222222-2222-2222-2222-222222222222")
         org_uuid = uuid.UUID("33333333-3333-3333-3333-333333333333")
-        # First execute: INSERT ... RETURNING — return a tuple matching
-        # draft_model._DRAFT_COLUMNS order.
+        version_id = uuid.UUID("99999999-9999-9999-9999-999999999999")
         now = datetime.now(UTC)
-        insert_row = (
+        # _DRAFT_COLUMNS order (19 cols)
+        draft_row = (
             draft_id,
             user_uuid,
             org_uuid,
@@ -145,7 +176,46 @@ class TestHandleUploadHappyPath:
             None,  # parent_vtk_id (#639)
             None,  # processing_completed_at (#670)
         )
-        mock_conn.execute.return_value.fetchone.return_value = insert_row
+        # _VERSION_COLUMNS order (10 cols) for the v1 INSERT...RETURNING.
+        version_row = (
+            version_id,
+            draft_id,
+            1,
+            "vtk",
+            None,
+            "/tmp/encrypted.enc",
+            f"https://data.riik.ee/ontology/estleg/drafts/{draft_id}",
+            "uploaded",
+            now,
+            user_uuid,
+        )
+
+        # The handler calls execute() multiple times:
+        #   1. INSERT INTO drafts ... RETURNING -> draft_row (fetchone)
+        #   2. UPDATE drafts SET graph_uri ...  -> no fetch
+        #   3. INSERT INTO draft_versions ... RETURNING -> version_row (fetchone)
+        #
+        # We can't simply set fetchone.return_value because the SAME
+        # cursor mock is reused.  Instead, route fetchone via a side_effect
+        # that returns the right shape based on the SQL of the latest
+        # call.
+        mock_conn = MagicMock()
+        captured_sqls: list[str] = []
+
+        def _execute_side_effect(sql: str, _params: object = None):
+            captured_sqls.append(sql)
+            cursor = MagicMock()
+            sql_lower = sql.lower()
+            if "into drafts" in sql_lower and "returning" in sql_lower:
+                cursor.fetchone.return_value = draft_row
+            elif "into draft_versions" in sql_lower and "returning" in sql_lower:
+                cursor.fetchone.return_value = version_row
+            else:
+                cursor.fetchone.return_value = None
+            cursor.rowcount = 1
+            return cursor
+
+        mock_conn.execute.side_effect = _execute_side_effect
 
         stored = MagicMock(
             storage_path="/tmp/encrypted.enc",
@@ -183,6 +253,15 @@ class TestHandleUploadHappyPath:
 
         # DB transaction committed.
         mock_conn.commit.assert_called_once()
+
+        # #618 PR-B: a v1 draft_versions row must have been created in the
+        # SAME transaction as the drafts INSERT.
+        assert any(
+            "into draft_versions" in s.lower() and "returning" in s.lower() for s in captured_sqls
+        ), (
+            "handle_upload must INSERT into draft_versions for the v1 row of every "
+            "new draft (§4.2 cutover, #618 PR-B)"
+        )
 
         # Job was enqueued with the correct payload.
         mock_queue.enqueue.assert_called_once()
@@ -246,12 +325,13 @@ class TestHandleUploadValidation:
         # This test short-circuits before the DB insert because we mock
         # fetchone to return a row — so we only need to ensure no error
         # is raised during validation.
-        conn = MagicMock()
         now = datetime.now(UTC)
         draft_id = uuid.uuid4()
-        conn.execute.return_value.fetchone.return_value = (
+        version_id = uuid.uuid4()
+        user_uuid = uuid.UUID("44444444-4444-4444-4444-444444444444")
+        draft_row = (
             draft_id,
-            uuid.UUID("44444444-4444-4444-4444-444444444444"),
+            user_uuid,
             uuid.UUID("55555555-5555-5555-5555-555555555555"),
             "x" * 200,
             "eelnou.docx",
@@ -270,6 +350,19 @@ class TestHandleUploadValidation:
             None,  # parent_vtk_id (#639)
             None,  # processing_completed_at (#670)
         )
+        version_row = (
+            version_id,
+            draft_id,
+            1,
+            "vtk",
+            None,
+            "/tmp/x.enc",
+            f"https://data.riik.ee/ontology/estleg/drafts/{draft_id}",
+            "uploaded",
+            now,
+            user_uuid,
+        )
+        conn = _wire_upload_conn(draft_row=draft_row, version_row=version_row)
         import asyncio
 
         with patch("app.docs.upload.store_file") as mock_store:
@@ -366,12 +459,13 @@ class TestHandleUploadRollback:
         """
         import asyncio
 
-        mock_conn = MagicMock()
         draft_id = uuid.uuid4()
+        version_id = uuid.uuid4()
+        user_uuid = uuid.UUID("66666666-6666-6666-6666-666666666666")
         now = datetime.now(UTC)
-        mock_conn.execute.return_value.fetchone.return_value = (
+        draft_row = (
             draft_id,
-            uuid.UUID("66666666-6666-6666-6666-666666666666"),
+            user_uuid,
             uuid.UUID("77777777-7777-7777-7777-777777777777"),
             "Test eelnõu",
             "eelnou.docx",
@@ -390,6 +484,19 @@ class TestHandleUploadRollback:
             None,  # parent_vtk_id (#639)
             None,  # processing_completed_at (#670)
         )
+        version_row = (
+            version_id,
+            draft_id,
+            1,
+            "vtk",
+            None,
+            "/tmp/ok.enc",
+            f"https://data.riik.ee/ontology/estleg/drafts/{draft_id}",
+            "uploaded",
+            now,
+            user_uuid,
+        )
+        mock_conn = _wire_upload_conn(draft_row=draft_row, version_row=version_row)
 
         stored = MagicMock(
             storage_path="/tmp/ok.enc",

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -26,3 +26,35 @@ def test_migration_files_exist():
     assert len(files) >= 2
     assert files[0].stem == "001_initial"
     assert files[1].stem == "002_seed"
+
+
+def test_migration_032_impact_reports_version_fk_present():
+    """Migration 032 (#618 PR-B) adds the ``draft_version_id`` FK on
+    ``impact_reports`` so per-version diff/timeline (PR-C) can join.
+    The migration must:
+
+    * Add the column with ``IF NOT EXISTS`` (idempotent re-run).
+    * Reference ``draft_versions(id) ON DELETE CASCADE``.
+    * Backfill existing rows by linking to the LATEST version of their
+      parent draft.
+    """
+    migrations_dir = Path(__file__).parent.parent / "migrations"
+    migration = migrations_dir / "032_impact_reports_version_fk.sql"
+    assert migration.exists(), "migration 032 must exist for #618 PR-B"
+
+    body = migration.read_text()
+    body_lower = body.lower()
+
+    # Schema mutation (idempotent)
+    assert "alter table impact_reports" in body_lower
+    assert "add column if not exists draft_version_id" in body_lower
+    assert "references draft_versions(id) on delete cascade" in body_lower
+
+    # Index for the per-version lookup
+    assert "create index if not exists idx_impact_reports_draft_version" in body_lower
+
+    # Backfill: link existing reports to the latest version of their draft
+    assert "update impact_reports" in body_lower
+    assert "select id from draft_versions" in body_lower
+    assert "order by version_number desc" in body_lower
+    assert "where ir.draft_version_id is null" in body_lower

--- a/tests/test_upload_new_version.py
+++ b/tests/test_upload_new_version.py
@@ -149,9 +149,13 @@ class _StubUpload:
         ),
         contents: bytes = b"v2 contents",
     ):
-        self.filename = filename
-        self.content_type = content_type
-        self.size = len(contents)
+        # Annotated as ``... | None`` so pyright treats the stub as a
+        # structural match for ``app.docs.upload._UploadLike`` (which
+        # mirrors Starlette's ``UploadFile`` where these attributes are
+        # nullable).
+        self.filename: str | None = filename
+        self.content_type: str | None = content_type
+        self.size: int | None = len(contents)
         self._contents = contents
 
     async def read(self) -> bytes:

--- a/tests/test_upload_new_version.py
+++ b/tests/test_upload_new_version.py
@@ -1,0 +1,674 @@
+"""Tests for the new-version upload branch in ``app.docs.upload`` (#618 PR-B).
+
+These tests pin the §4.2 cutover behaviour for the version-upload path:
+when the uploader supplies ``parent_draft_id``, the handler creates a
+NEW ``draft_versions`` row tied to the existing parent draft instead of
+a brand-new ``drafts`` row.  All DB access is mocked via the same
+``_wire_upload_conn`` helper used by ``test_docs_upload`` so the tests
+never touch Postgres.
+
+Key invariants asserted here:
+
+    * Permission inheritance — new version uses parent's owner_id /
+      org_id, NOT the uploader's id (the audit trail of ownership stays
+      with the original drafter; the acting user lives in the audit
+      log only).
+    * Cross-org rejection — a parent owned by a different org surfaces
+      as a Estonian DraftUploadError; the same message covers
+      "doesn't exist" so cross-org existence is never disclosed.
+    * Status gate — only ``ready`` parents accept new versions; mid-
+      pipeline parents (parsing/extracting/analyzing) are rejected.
+    * Version-number allocation — new version is
+      ``MAX(version_number) + 1`` for that parent.
+    * Reading-stage progression — new version steps the parent's
+      latest reading_stage one notch forward.
+    * Graph URI scheme — §9.5 ``...drafts/{parent_id}/v{version_number}``.
+    * Audit log — ``draft.version.create`` event recorded with
+      uploader_id and parent_draft_id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.auth.provider import UserDict
+from app.docs.draft_model import Draft
+from app.docs.upload import DraftUploadError, handle_upload
+
+# ---------------------------------------------------------------------------
+# Shared identities
+# ---------------------------------------------------------------------------
+
+_PARENT_DRAFT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_PARENT_USER_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_PARENT_ORG_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_UPLOADER_USER_ID = "44444444-4444-4444-4444-444444444444"
+_OTHER_ORG_ID = uuid.UUID("99999999-9999-9999-9999-999999999999")
+
+# Sample row layouts for the get_draft JOIN result (#618 PR-B):
+# 19 columns matching _DRAFT_COLUMNS order.
+
+
+def _make_parent_row(*, status: str = "ready") -> tuple[Any, ...]:
+    """Build a draft row matching ``_row_to_draft``'s column order."""
+    now = datetime.now(UTC)
+    return (
+        _PARENT_DRAFT_ID,
+        _PARENT_USER_ID,
+        _PARENT_ORG_ID,
+        "Parent eelnõu pealkiri",
+        "parent.docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        2048,
+        "/storage/parent.enc",
+        f"https://data.riik.ee/ontology/estleg/drafts/{_PARENT_DRAFT_ID}",
+        status,
+        None,
+        None,
+        None,
+        now,
+        now,
+        now,
+        "eelnou",
+        None,
+        None,
+    )
+
+
+def _make_other_org_parent_row() -> tuple[Any, ...]:
+    """Parent row owned by a DIFFERENT org from the uploader."""
+    row = list(_make_parent_row(status="ready"))
+    row[2] = _OTHER_ORG_ID
+    return tuple(row)
+
+
+def _make_version_row(
+    *,
+    version_id: uuid.UUID | None = None,
+    version_number: int = 2,
+    reading_stage: str = "reading_1",
+    storage_path: str = "/storage/v2.enc",
+    graph_uri: str | None = None,
+) -> tuple[Any, ...]:
+    """Build a draft_versions row (10 columns)."""
+    now = datetime.now(UTC)
+    return (
+        version_id or uuid.uuid4(),
+        _PARENT_DRAFT_ID,
+        version_number,
+        reading_stage,
+        None,
+        storage_path,
+        graph_uri
+        or f"https://data.riik.ee/ontology/estleg/drafts/{_PARENT_DRAFT_ID}/v{version_number}",
+        "uploaded",
+        now,
+        _PARENT_USER_ID,
+    )
+
+
+_UNSET = object()
+
+
+def _uploader(*, org_id: Any = _UNSET) -> UserDict:
+    """Build an authed uploader UserDict.
+
+    ``org_id`` defaults to the parent org so the happy-path tests can
+    omit it.  Pass ``org_id=None`` explicitly to simulate an uploader
+    with no org membership (the upfront validation gate).
+    """
+    if org_id is _UNSET:
+        resolved = str(_PARENT_ORG_ID)
+    else:
+        resolved = org_id  # may be None
+    return {
+        "id": _UPLOADER_USER_ID,
+        "email": "uploader@seadusloome.ee",
+        "full_name": "Test uploader",
+        "role": "drafter",
+        "org_id": resolved,
+        "must_change_password": False,
+    }
+
+
+class _StubUpload:
+    """Minimal stand-in for Starlette's ``UploadFile``."""
+
+    def __init__(
+        self,
+        *,
+        filename: str = "v2.docx",
+        content_type: str = (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ),
+        contents: bytes = b"v2 contents",
+    ):
+        self.filename = filename
+        self.content_type = content_type
+        self.size = len(contents)
+        self._contents = contents
+
+    async def read(self) -> bytes:
+        return self._contents
+
+
+class _ConnectCM:
+    """Sync context-manager wrapper around a mock connection."""
+
+    def __init__(self, conn: MagicMock):
+        self.conn = conn
+
+    def __enter__(self) -> MagicMock:
+        return self.conn
+
+    def __exit__(self, *_: Any) -> bool:
+        return False
+
+
+def _wire_version_conn(
+    *,
+    parent_row: tuple[Any, ...] | None,
+    version_row: tuple[Any, ...] | None = None,
+    next_version_max: int = 1,
+    refreshed_row: tuple[Any, ...] | None = None,
+    latest_version_row: tuple[Any, ...] | None = None,
+) -> MagicMock:
+    """Build a mock connection that handles every SQL the version path runs.
+
+    The version branch hits the DB in this order:
+
+        1. SELECT ... FROM drafts d LEFT JOIN draft_versions ...
+           (initial get_draft for the parent)
+        2. SELECT COALESCE(MAX(version_number), 0) FROM draft_versions ...
+           (get_next_version_number)
+        3. SELECT ... FROM draft_versions ... ORDER BY version_number DESC
+           LIMIT 1   (get_latest_version)
+        4. INSERT INTO draft_versions ... RETURNING ...
+           (create_draft_version)
+        5. UPDATE drafts SET status = 'uploaded', filename, ...
+           (legacy mirror reset)
+        6. SELECT ... FROM drafts d LEFT JOIN draft_versions ...
+           (post-write get_draft to refresh)
+
+    The fixture routes each ``execute()`` call to the right return value
+    based on the SQL keywords.
+    """
+    mock_conn = MagicMock()
+    parent_select_count = {"value": 0}
+
+    def _execute_side_effect(sql: str, _params: object = None):
+        cursor = MagicMock()
+        cursor.rowcount = 1
+        sql_compact = " ".join(sql.split()).lower()
+
+        # 4. INSERT INTO draft_versions ... RETURNING ...
+        if "insert into draft_versions" in sql_compact and "returning" in sql_compact:
+            cursor.fetchone.return_value = version_row or _make_version_row()
+            return cursor
+
+        # 2. COALESCE(MAX(version_number), 0)
+        if "coalesce(max(version_number)" in sql_compact:
+            cursor.fetchone.return_value = (next_version_max,)
+            return cursor
+
+        # 3. ORDER BY version_number DESC LIMIT 1
+        if (
+            "from draft_versions" in sql_compact
+            and "order by version_number desc" in sql_compact
+            and "limit 1" in sql_compact
+        ):
+            cursor.fetchone.return_value = latest_version_row or _make_version_row(
+                version_number=1, reading_stage="vtk"
+            )
+            return cursor
+
+        # 1 + 6. JOIN-style get_draft.
+        if (
+            "from drafts d" in sql_compact
+            and "left join draft_versions" in sql_compact
+            and "where d.id" in sql_compact
+        ):
+            parent_select_count["value"] += 1
+            # Second invocation (post-insert refresh) returns the
+            # refreshed row when supplied so tests can verify the
+            # JOIN surfaces the new version's status / graph_uri.
+            if parent_select_count["value"] >= 2 and refreshed_row is not None:
+                cursor.fetchone.return_value = refreshed_row
+            else:
+                cursor.fetchone.return_value = parent_row
+            return cursor
+
+        # 5. UPDATE drafts ... (legacy mirror).
+        if "update drafts" in sql_compact:
+            return cursor
+
+        # Audit log inserts pass through silently.
+        if "insert into audit_log" in sql_compact:
+            return cursor
+
+        cursor.fetchone.return_value = None
+        return cursor
+
+    mock_conn.execute.side_effect = _execute_side_effect
+    return mock_conn
+
+
+def _make_conn_factory(conn: MagicMock):
+    def factory():
+        return _ConnectCM(conn)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestNewVersionHappyPath:
+    def test_v2_upload_creates_version_row_with_correct_metadata(self):
+        """Uploading v2 against a ``ready`` parent must:
+
+        * Create a draft_versions row with version_number=2.
+        * Step the reading_stage from the parent's latest (vtk -> reading_1).
+        * Use the §9.5 graph URI scheme: ``...drafts/{parent_id}/v2``.
+        * Inherit owner_id from the PARENT, not the uploader.
+        """
+        version_id = uuid.uuid4()
+        version_row = _make_version_row(
+            version_id=version_id,
+            version_number=2,
+            reading_stage="reading_1",
+            storage_path="/storage/encrypted.enc",
+            graph_uri=(f"https://data.riik.ee/ontology/estleg/drafts/{_PARENT_DRAFT_ID}/v2"),
+        )
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            version_row=version_row,
+            next_version_max=1,
+            latest_version_row=_make_version_row(version_number=1, reading_stage="vtk"),
+        )
+
+        stored = MagicMock(
+            storage_path="/storage/encrypted.enc",
+            size_bytes=11,
+            filename="v2.docx",
+        )
+        mock_queue = MagicMock()
+
+        with patch("app.docs.upload.store_file", return_value=stored):
+            asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "ignored title",  # versions inherit parent title
+                    _StubUpload(contents=b"v2 contents"),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=mock_queue,
+                    conn_factory=_make_conn_factory(conn),
+                )
+            )
+
+        # Locate the INSERT INTO draft_versions call.
+        insert_call = next(
+            c
+            for c in conn.execute.call_args_list
+            if "insert into draft_versions" in " ".join(c.args[0].split()).lower()
+        )
+        params = insert_call.args[1]
+        # (draft_id, version_number, reading_stage, parsed_text_encrypted,
+        #  storage_path, graph_uri, status, created_by)
+        assert params[0] == str(_PARENT_DRAFT_ID), "version row must point at the parent draft id"
+        assert params[1] == 2, "version_number must be MAX(version_number)+1 = 2"
+        assert params[2] == "reading_1", (
+            "reading_stage must step forward from parent's vtk -> reading_1"
+        )
+        assert params[4] == "/storage/encrypted.enc"
+        assert params[5] == (
+            f"https://data.riik.ee/ontology/estleg/drafts/{_PARENT_DRAFT_ID}/v2"
+        ), "graph_uri must follow §9.5 ...drafts/{parent_id}/v{version_number}"
+        assert params[6] == "uploaded", "new version starts at status='uploaded'"
+
+        # Inherit owner from parent, NOT uploader.
+        assert params[7] == str(_PARENT_USER_ID), (
+            "created_by must be the PARENT's owner_id, not the uploader's id"
+        )
+
+    def test_v3_upload_steps_reading_stage_from_reading_1_to_reading_2(self):
+        """Reading-stage progression chains through the legislative pipeline."""
+        version_row = _make_version_row(
+            version_number=3,
+            reading_stage="reading_2",
+            graph_uri=(f"https://data.riik.ee/ontology/estleg/drafts/{_PARENT_DRAFT_ID}/v3"),
+        )
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            version_row=version_row,
+            next_version_max=2,
+            latest_version_row=_make_version_row(version_number=2, reading_stage="reading_1"),
+        )
+
+        stored = MagicMock(storage_path="/x.enc", size_bytes=1, filename="v3.docx")
+        with patch("app.docs.upload.store_file", return_value=stored):
+            asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "",
+                    _StubUpload(contents=b"v3"),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=MagicMock(),
+                    conn_factory=_make_conn_factory(conn),
+                )
+            )
+
+        insert_call = next(
+            c
+            for c in conn.execute.call_args_list
+            if "insert into draft_versions" in " ".join(c.args[0].split()).lower()
+        )
+        assert insert_call.args[1][1] == 3
+        assert insert_call.args[1][2] == "reading_2"
+
+    def test_legacy_drafts_mirror_is_reset_to_uploaded(self):
+        """The drafts row's status / metadata get reset for the new pipeline run.
+
+        Without this update, the listing UI would still show the
+        previous version's terminal status (e.g. ``ready``) while the
+        new version is mid-pipeline.
+        """
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            next_version_max=1,
+        )
+        stored = MagicMock(
+            storage_path="/storage/v2.enc",
+            size_bytes=4,
+            filename="version-two.docx",
+        )
+
+        with patch("app.docs.upload.store_file", return_value=stored):
+            asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "",
+                    _StubUpload(
+                        filename="version-two.docx",
+                        contents=b"v2!!",
+                    ),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=MagicMock(),
+                    conn_factory=_make_conn_factory(conn),
+                )
+            )
+
+        update_call = next(
+            c
+            for c in conn.execute.call_args_list
+            if "update drafts" in " ".join(c.args[0].split()).lower()
+            and "set status = %s" in " ".join(c.args[0].split()).lower()
+        )
+        params = update_call.args[1]
+        # (status, filename, content_type, file_size, storage_path,
+        #  graph_uri, draft_id)
+        assert params[0] == "uploaded"
+        assert params[1] == "version-two.docx"
+        assert params[3] == 4  # file_size
+        assert params[4] == "/storage/v2.enc"
+        assert params[6] == str(_PARENT_DRAFT_ID)
+
+    def test_audit_log_records_draft_version_create(self):
+        """Every new version triggers ``draft.version.create`` in the audit log
+        with the uploader_id (acting user) AND the version metadata.
+        """
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            next_version_max=1,
+        )
+        stored = MagicMock(storage_path="/x.enc", size_bytes=1, filename="v.docx")
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.log_action") as mock_log,
+        ):
+            asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "",
+                    _StubUpload(contents=b"v"),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=MagicMock(),
+                    conn_factory=_make_conn_factory(conn),
+                )
+            )
+
+        # Log helper was invoked with the new-version event.
+        mock_log.assert_called_once()
+        actor_id, action, detail = mock_log.call_args.args
+        assert actor_id == _UPLOADER_USER_ID, (
+            "audit log must record the ACTING user (the uploader), not the parent owner"
+        )
+        assert action == "draft.version.create"
+        assert detail["draft_id"] == str(_PARENT_DRAFT_ID)
+        assert detail["version_number"] == 2
+        assert detail["reading_stage"] == "reading_1"
+        assert detail["uploader_id"] == _UPLOADER_USER_ID
+
+    def test_parse_job_is_enqueued_for_the_new_version(self):
+        """The parse pipeline starts for the new version's bytes."""
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            next_version_max=1,
+        )
+        stored = MagicMock(storage_path="/v2.enc", size_bytes=1, filename="v.docx")
+        mock_queue = MagicMock()
+
+        with patch("app.docs.upload.store_file", return_value=stored):
+            asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "",
+                    _StubUpload(contents=b"v"),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=mock_queue,
+                    conn_factory=_make_conn_factory(conn),
+                )
+            )
+
+        mock_queue.enqueue.assert_called_once()
+        call = mock_queue.enqueue.call_args
+        assert call.args[0] == "parse_draft"
+        # The parse job is keyed on the parent draft_id (not the version
+        # id) because the pipeline still treats the draft as the unit
+        # of work; the latest version is found via the JOIN in get_draft.
+        assert call.args[1] == {"draft_id": str(_PARENT_DRAFT_ID)}
+
+
+# ---------------------------------------------------------------------------
+# Validation rejections
+# ---------------------------------------------------------------------------
+
+
+class TestNewVersionRejections:
+    def test_cross_org_parent_returns_estonian_not_found_message(self):
+        """A parent owned by a DIFFERENT org must be invisible to the uploader.
+
+        Same Estonian message as "doesn't exist" so cross-org existence
+        is never disclosed.
+        """
+        conn = _wire_version_conn(
+            parent_row=_make_other_org_parent_row(),
+        )
+        stored = MagicMock(storage_path="/x.enc", size_bytes=1, filename="x.docx")
+        delete_calls: list[str] = []
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch(
+                "app.docs.upload.delete_file",
+                side_effect=lambda p: delete_calls.append(p),
+            ),
+        ):
+            with pytest.raises(DraftUploadError, match="Vanem-eelnõu ei ole kättesaadav"):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(),
+                        "",
+                        _StubUpload(contents=b"x"),
+                        parent_draft_id=_PARENT_DRAFT_ID,
+                        job_queue=MagicMock(),
+                        conn_factory=_make_conn_factory(conn),
+                    )
+                )
+
+        # The orphan file must be cleaned up on validation failure.
+        assert delete_calls == ["/x.enc"]
+
+    def test_missing_parent_returns_estonian_not_found_message(self):
+        """A parent_draft_id that does not exist surfaces the same message."""
+        conn = _wire_version_conn(parent_row=None)
+        stored = MagicMock(storage_path="/x.enc", size_bytes=1, filename="x.docx")
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.delete_file") as mock_delete,
+        ):
+            with pytest.raises(DraftUploadError, match="Vanem-eelnõu ei ole kättesaadav"):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(),
+                        "",
+                        _StubUpload(contents=b"x"),
+                        parent_draft_id=_PARENT_DRAFT_ID,
+                        job_queue=MagicMock(),
+                        conn_factory=_make_conn_factory(conn),
+                    )
+                )
+
+        mock_delete.assert_called_once_with("/x.enc")
+
+    @pytest.mark.parametrize(
+        "parent_status",
+        ["uploaded", "parsing", "extracting", "analyzing", "failed"],
+    )
+    def test_parent_not_ready_is_rejected(self, parent_status: str):
+        """Versions can only be layered on ``ready`` parents."""
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status=parent_status),
+        )
+        stored = MagicMock(storage_path="/x.enc", size_bytes=1, filename="x.docx")
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.delete_file") as mock_delete,
+        ):
+            with pytest.raises(DraftUploadError, match="analüüs on valmis"):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(),
+                        "",
+                        _StubUpload(contents=b"x"),
+                        parent_draft_id=_PARENT_DRAFT_ID,
+                        job_queue=MagicMock(),
+                        conn_factory=_make_conn_factory(conn),
+                    )
+                )
+
+        mock_delete.assert_called_once_with("/x.enc")
+
+    def test_uploader_without_org_is_rejected(self):
+        """The org_id check happens before any DB call -- no orphan file
+        is created because the validation fires before ``store_file``.
+        """
+        with patch("app.docs.upload.store_file") as mock_store:
+            with pytest.raises(DraftUploadError, match="organisatsiooni"):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(org_id=None),  # type: ignore[arg-type]
+                        "",
+                        _StubUpload(contents=b"x"),
+                        parent_draft_id=_PARENT_DRAFT_ID,
+                        job_queue=MagicMock(),
+                        conn_factory=_make_conn_factory(MagicMock()),
+                    )
+                )
+        mock_store.assert_not_called()
+
+    def test_invalid_parent_uuid_returns_not_found_message(self):
+        """Garbage in the parent_draft_id field is rejected -- the
+        upfront UUID parse means we never even look the parent up.
+        """
+        stored = MagicMock(storage_path="/x.enc", size_bytes=1, filename="x.docx")
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.delete_file") as mock_delete,
+        ):
+            with pytest.raises(DraftUploadError, match="Vanem-eelnõu ei ole kättesaadav"):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(),
+                        "",
+                        _StubUpload(contents=b"x"),
+                        parent_draft_id="not-a-uuid",
+                        job_queue=MagicMock(),
+                        conn_factory=_make_conn_factory(MagicMock()),
+                    )
+                )
+        mock_delete.assert_called_once_with("/x.enc")
+
+
+# ---------------------------------------------------------------------------
+# Returned Draft reflects the new version (post-cutover JOIN)
+# ---------------------------------------------------------------------------
+
+
+class TestReturnedDraftReflectsNewVersion:
+    def test_returned_draft_has_new_version_storage_path_and_graph_uri(self):
+        """The handler re-fetches the parent through ``get_draft`` so
+        the JOIN surfaces the new version's columns.  The returned
+        Draft must carry the NEW version's storage_path and graph_uri,
+        not the parent's pre-upload values.
+        """
+        # The "refreshed" row simulates what get_draft returns AFTER
+        # the version row is inserted -- its COALESCE picks up the new
+        # storage_path and graph_uri from draft_versions.
+        new_storage_path = "/storage/v2.enc"
+        new_graph_uri = f"https://data.riik.ee/ontology/estleg/drafts/{_PARENT_DRAFT_ID}/v2"
+        refreshed_row = list(_make_parent_row(status="uploaded"))
+        refreshed_row[7] = new_storage_path
+        refreshed_row[8] = new_graph_uri
+        refreshed_row[9] = "uploaded"  # status from latest version
+
+        conn = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            refreshed_row=tuple(refreshed_row),
+            next_version_max=1,
+        )
+
+        stored = MagicMock(
+            storage_path=new_storage_path,
+            size_bytes=1,
+            filename="v.docx",
+        )
+
+        with patch("app.docs.upload.store_file", return_value=stored):
+            result = asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "",
+                    _StubUpload(contents=b"v"),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=MagicMock(),
+                    conn_factory=_make_conn_factory(conn),
+                )
+            )
+
+        assert isinstance(result, Draft)
+        assert result.id == _PARENT_DRAFT_ID
+        assert result.storage_path == new_storage_path
+        assert result.graph_uri == new_graph_uri
+        assert result.status == "uploaded"

--- a/tests/test_version_model.py
+++ b/tests/test_version_model.py
@@ -16,9 +16,12 @@ import pytest
 from app.docs.version_model import (
     READING_STAGES,
     DraftVersion,
+    create_draft_version,
     get_draft_version,
     get_latest_version,
+    get_next_version_number,
     list_versions_for_draft,
+    next_reading_stage,
 )
 
 # ---------------------------------------------------------------------------
@@ -294,6 +297,186 @@ class TestGetLatestVersion:
 # ---------------------------------------------------------------------------
 # DraftVersion dataclass immutability
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# next_reading_stage (#618 PR-B)
+# ---------------------------------------------------------------------------
+
+
+class TestNextReadingStage:
+    @pytest.mark.parametrize(
+        ("current", "expected"),
+        [
+            ("vtk", "reading_1"),
+            ("reading_1", "reading_2"),
+            ("reading_2", "reading_3"),
+            ("reading_3", "enacted"),
+        ],
+    )
+    def test_steps_one_stage_forward(self, current: str, expected: str):
+        assert next_reading_stage(current) == expected
+
+    def test_enacted_is_terminal_returns_self(self):
+        # Republishing an enacted law is allowed but does not advance.
+        assert next_reading_stage("enacted") == "enacted"
+
+    def test_unknown_stage_raises(self):
+        with pytest.raises(ValueError, match="Unknown reading stage"):
+            next_reading_stage("not-a-stage")
+
+    def test_chain_is_walkable_to_terminal(self):
+        seen: list[str] = []
+        cursor = "vtk"
+        while cursor != "enacted":
+            assert cursor not in seen, "next_reading_stage chain has a cycle"
+            seen.append(cursor)
+            cursor = next_reading_stage(cursor)
+        assert cursor == "enacted"
+        assert len(seen) == 4  # vtk, reading_1, reading_2, reading_3
+
+
+# ---------------------------------------------------------------------------
+# create_draft_version (#618 PR-B)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDraftVersion:
+    def test_inserts_with_returning_and_returns_dataclass(self):
+        conn = MagicMock()
+        row = _make_version_row(version_id=_VERSION_ID, version_number=2)
+        conn.execute.return_value.fetchone.return_value = row
+
+        result = create_draft_version(
+            conn,
+            draft_id=_DRAFT_ID,
+            version_number=2,
+            reading_stage="reading_1",
+            storage_path="/storage/v2.enc",
+            graph_uri="urn:draft:test/v2",
+            status="uploaded",
+            created_by=_USER_ID,
+        )
+
+        assert isinstance(result, DraftVersion)
+        assert result.id == _VERSION_ID
+        assert result.version_number == 2
+
+        sql = conn.execute.call_args.args[0]
+        params = conn.execute.call_args.args[1]
+        assert "INSERT INTO draft_versions" in sql
+        assert "RETURNING" in sql
+        # Param order: draft_id, version_number, reading_stage, parsed_text_encrypted,
+        # storage_path, graph_uri, status, created_by
+        assert params == (
+            str(_DRAFT_ID),
+            2,
+            "reading_1",
+            None,
+            "/storage/v2.enc",
+            "urn:draft:test/v2",
+            "uploaded",
+            str(_USER_ID),
+        )
+
+    def test_rejects_unknown_reading_stage_before_sql(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Unknown reading stage"):
+            create_draft_version(
+                conn,
+                draft_id=_DRAFT_ID,
+                version_number=1,
+                reading_stage="bogus",
+                storage_path="/x",
+                graph_uri="urn:x",
+                status="uploaded",
+                created_by=_USER_ID,
+            )
+        conn.execute.assert_not_called()
+
+    def test_rejects_unknown_status_before_sql(self):
+        conn = MagicMock()
+        with pytest.raises(ValueError, match="Unknown draft status"):
+            create_draft_version(
+                conn,
+                draft_id=_DRAFT_ID,
+                version_number=1,
+                reading_stage="vtk",
+                storage_path="/x",
+                graph_uri="urn:x",
+                status="not-a-status",
+                created_by=_USER_ID,
+            )
+        conn.execute.assert_not_called()
+
+    def test_raises_when_returning_yields_no_row(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        with pytest.raises(RuntimeError, match="produced no row"):
+            create_draft_version(
+                conn,
+                draft_id=_DRAFT_ID,
+                version_number=1,
+                reading_stage="vtk",
+                storage_path="/x",
+                graph_uri="urn:x",
+                status="uploaded",
+                created_by=_USER_ID,
+            )
+
+    def test_parsed_text_encrypted_round_trips(self):
+        conn = MagicMock()
+        encrypted = b"\x01\x02ciphertext"
+        row = _make_version_row(version_id=_VERSION_ID, parsed_text_encrypted=encrypted)
+        conn.execute.return_value.fetchone.return_value = row
+
+        result = create_draft_version(
+            conn,
+            draft_id=_DRAFT_ID,
+            version_number=1,
+            reading_stage="vtk",
+            storage_path="/x",
+            graph_uri="urn:x",
+            status="extracting",
+            created_by=_USER_ID,
+            parsed_text_encrypted=encrypted,
+        )
+
+        assert result.parsed_text_encrypted == encrypted
+        assert conn.execute.call_args.args[1][3] == encrypted
+
+
+# ---------------------------------------------------------------------------
+# get_next_version_number (#618 PR-B)
+# ---------------------------------------------------------------------------
+
+
+class TestGetNextVersionNumber:
+    def test_returns_one_when_no_versions_exist(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0,)
+        assert get_next_version_number(conn, _DRAFT_ID) == 1
+
+    def test_returns_max_plus_one(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (3,)
+        assert get_next_version_number(conn, _DRAFT_ID) == 4
+
+    def test_handles_null_max_via_coalesce(self):
+        """The COALESCE in the SQL ensures we get 0 not NULL when empty."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (None,)
+        # COALESCE(MAX, 0) at SQL level always returns 0; the helper still
+        # defends against a None to keep tests independent.
+        assert get_next_version_number(conn, _DRAFT_ID) == 1
+
+    def test_uses_coalesce_max_query(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (1,)
+        get_next_version_number(conn, _DRAFT_ID)
+        sql = conn.execute.call_args.args[0]
+        assert "COALESCE(MAX(version_number), 0)" in sql
+        assert "WHERE draft_id = %s" in sql
 
 
 class TestDraftVersionDataclass:


### PR DESCRIPTION
## Summary

Implements **#618 PR-B** — the §4.2 atomic read+write cutover from `drafts.*` to `draft_versions.*` for status, parsed text, graph URI, and storage path. Ships the version-aware upload branch and pivots `impact_reports` to per-version FKs.

This is the **second of three #618 PRs** in the Eelnõud sprint plan (Days 5-7):

- **PR-A** (#701, `47e4f6c`) — `draft_versions` schema + idempotent backfill + read-only `version_model`. Done.
- **PR-B** (this PR) — atomic read+write cutover.
- **PR-C** (Days 8-9, separate PR) — diff view + timeline UI.
- **PR-D** (future, separate ticket) — drop `drafts.status` + defensive mirror.

## Read cutover (`app/docs/draft_model.py`)

- `get_draft` now JOINs `drafts LEFT JOIN draft_versions` on the latest `version_number`. Status / `parsed_text_encrypted` / `graph_uri` / `storage_path` come through `COALESCE(version.col, drafts.col)` so the `Draft` dataclass surface is unchanged for callers.
- New `list_versionable_drafts_for_org` helper for the upload form's "Versioneerimine" picker (org-scoped, `status='ready'` only).

## Write cutover (`app/docs/status.py`)

- `update_draft_status` writes `status` to **BOTH** the latest `draft_versions` row **AND** `drafts` in the same call.
- The `drafts` UPDATE is the **defensive mirror** PR-D will drop. It keeps legacy readers working for one release cycle and makes rollback to PR-A a one-line revert.
- `parsed_text_encrypted` extras mirror to both tables; `entity_count` only exists on `drafts` so it is written there only.
- The `§4.2 contract test` in `test_docs_status.py` flips from `"draft_versions" not in sql` → BOTH writes happen in the same call (with a comment explaining why).

## Upload pipeline (`app/docs/upload.py` + `routes/__init__.py`)

- New `parent_draft_id` parameter routes uploads through a **new `draft_versions` row** (no new `drafts` row) when supplied.
- Inherits `owner_id` / `org_id` from the parent — audit trail of ownership stays with the original drafter; the acting user is captured in the audit log only.
- Cross-org and non-`ready` parents are rejected with Estonian `DraftUploadError` messages (cross-org gets the same "Vanem-eelnõu ei ole kättesaadav" message as "doesn't exist" so existence is never disclosed).
- Allocates `MAX(version_number) + 1` and steps `reading_stage` via `next_reading_stage` (vtk → reading_1 → reading_2 → reading_3 → enacted).
- §9.5 graph URI scheme: `...drafts/{parent_id}/v{version_number}`.
- New uploads also create an explicit v1 `draft_versions` row in the same transaction (migration 030's backfill only handled pre-PR-A drafts).
- Audit log emits `draft.version.create` with `uploader_id`, `version_number`, and `reading_stage`.
- Upload form gains a new "Versioneerimine" `<select>` populated with the caller's org's `ready` drafts; the route handler validates the parent_draft_id UUID and forbids `doc_type='vtk'` + parent_draft_id combinations.

## Analyze pipeline (`app/docs/analyze_handler.py`)

- `impact_reports` INSERT now carries `draft_version_id` bound to the latest version (`get_latest_version`) inside the same transaction as the status flip.

## Schema (`migrations/032_impact_reports_version_fk.sql`)

- Adds NULLABLE `draft_version_id` FK on `impact_reports` with `ON DELETE CASCADE`.
- Backfill links every existing `impact_reports` row to v1 of its parent draft.
- Idempotent re-run safe (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, backfill scoped to `WHERE draft_version_id IS NULL`).

## Test plan

- [x] `uv run pytest tests/` — **2069 passed, 23 skipped** (full suite, including 15 new tests in `test_upload_new_version.py`, 16 new in `test_version_model.py`, 8 new in `test_docs_draft_model.py`, 4 new in `test_docs_status.py`, 1 new in `test_migrate.py`).
- [x] `uv run ruff check app/ tests/` — All checks passed.
- [x] `uv run ruff format --check app/ tests/ migrations/` — All formatted.
- [x] `uv run pyright app/docs/` — 0 errors, 0 warnings.
- [x] Migration 032 dry-run via test asserting structure (`test_migration_032_impact_reports_version_fk_present`).
- [ ] Manual smoke test on a staging DB (recommended before merge): upload a v1, verify `draft_versions` row exists, upload a v2 against the same parent, verify `version_number=2` + `reading_stage='reading_1'` + status flips on both tables.

## Hard guardrails honored

- Touched 7 application files: `app/docs/{analyze_handler,draft_model,routes/__init__,status,upload,version_model}.py` + `migrations/032_impact_reports_version_fk.sql`.
- Touched 9 test files: 1 new (`test_upload_new_version.py`) + 8 updates.
- Did NOT touch `app/annotations/` (#619 territory).
- Did NOT drop `drafts.status` (PR-D, future).
- Did NOT add diff view or timeline UI (PR-C).
- Did NOT add Fuseki copy logic (post-deploy job, §9.5).

Refs: #618, sprint plan §6 Days 5-7, §4.2 cutover sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)