### PR TITLE
feat(annotations): #619 PR-C — wire row-annotations into impact report + stale-flag automation

### DIFF
--- a/app/annotations/models.py
+++ b/app/annotations/models.py
@@ -711,3 +711,172 @@ def reopen_row_thread(
         )
         return 0
     return getattr(cursor, "rowcount", 0) or 0
+
+
+# ---------------------------------------------------------------------------
+# §9.4 row-annotation read aggregates (PR-C)
+# ---------------------------------------------------------------------------
+#
+# Two helpers used by the impact-report renderer + analyze pipeline:
+#
+#   - :func:`count_unresolved_for_version_row` powers the AnnotationButton
+#     badge ("3 unresolved messages on this row").
+#   - :func:`update_stale_flags_for_version` is invoked at the tail of the
+#     analyze handler to flip ``stale=true`` on annotations whose row no
+#     longer exists in the just-finished analyze.  Best-effort: any DB
+#     failure logs and returns 0 so a stale-flag glitch never derails an
+#     otherwise-successful analyze.
+# ---------------------------------------------------------------------------
+
+
+def count_unresolved_for_version_row(
+    conn: Any,
+    draft_version_id: uuid.UUID | str,
+    row_kind: str,
+    row_key: str,
+) -> int:
+    """Return the number of unresolved messages on a single impact-report row.
+
+    Used to render the badge on :func:`AnnotationButton` so the user sees
+    "5" before clicking.  ``stale`` rows still count — a stale-but-unresolved
+    annotation is the most important one to surface, not the least.
+
+    Returns:
+        Integer count (0 when no rows match or on any DB error so a
+        transient failure never crashes the report page).
+    """
+    if row_kind not in VALID_ROW_KINDS:
+        # The button MUST NOT raise on a malformed row_kind — that would
+        # crash the entire page render.  Treat it as "no annotations".
+        return 0
+    target_id = f"{row_kind}:{row_key}"
+    try:
+        row = conn.execute(
+            """
+            SELECT COUNT(*) FROM annotations
+            WHERE draft_version_id = %s
+              AND target_type = 'impact_report_item'
+              AND target_id = %s
+              AND resolved = FALSE
+            """,
+            (str(draft_version_id), target_id),
+        ).fetchone()
+    except Exception:
+        logger.exception(
+            "count_unresolved_for_version_row failed version=%s row_kind=%s row_key=%s",
+            draft_version_id,
+            row_kind,
+            row_key,
+        )
+        return 0
+    if row is None or row[0] is None:
+        return 0
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        return 0
+
+
+def update_stale_flags_for_version(
+    conn: Any,
+    draft_version_id: uuid.UUID | str,
+    current_row_keys: set[tuple[str, str]],
+) -> int:
+    """Reconcile ``annotations.stale`` for one version against the latest analyze.
+
+    Walks every ``impact_report_item`` annotation for the given version and
+    flips:
+
+        - ``stale = FALSE`` when ``(row_kind, row_key)`` IS in
+          *current_row_keys* (the row reappeared, e.g. after a re-analyze
+          surfaced the same conflict again).
+        - ``stale = TRUE`` when ``(row_kind, row_key)`` is NOT in
+          *current_row_keys* (the row vanished — the latest analyze did not
+          produce that finding).
+
+    The reconciliation is idempotent: running this twice with the same
+    *current_row_keys* set leaves the DB in the same state.
+
+    Best-effort failure handling: any DB error logs an exception and
+    returns 0 so a stale-flag glitch never aborts the analyze pipeline.
+
+    Args:
+        conn: Open psycopg connection. The caller commits.
+        draft_version_id: The version this analyze run produced.
+        current_row_keys: Set of ``(row_kind, row_key)`` tuples for every
+            row in the new impact report.
+
+    Returns:
+        The number of rows whose ``stale`` flag actually changed (0 on
+        no-op or on any DB error).
+    """
+    try:
+        annotation_rows = conn.execute(
+            """
+            SELECT id, target_id, stale
+            FROM annotations
+            WHERE draft_version_id = %s
+              AND target_type = 'impact_report_item'
+            """,
+            (str(draft_version_id),),
+        ).fetchall()
+    except Exception:
+        logger.exception(
+            "update_stale_flags_for_version: lookup failed version=%s",
+            draft_version_id,
+        )
+        return 0
+
+    if not annotation_rows:
+        return 0
+
+    to_set_stale: list[uuid.UUID] = []
+    to_clear_stale: list[uuid.UUID] = []
+    for row in annotation_rows:
+        ann_id_raw = row[0]
+        target_id = str(row[1] or "")
+        currently_stale = bool(row[2])
+        # target_id format is "{row_kind}:{row_key}"; split on the FIRST
+        # colon only because row_key (sha256 hex / URI) may contain
+        # colons of its own.
+        if ":" not in target_id:
+            continue
+        row_kind, row_key = target_id.split(":", 1)
+        is_present = (row_kind, row_key) in current_row_keys
+        try:
+            ann_id = coerce_uuid(ann_id_raw)
+        except Exception:
+            continue
+        if is_present and currently_stale:
+            to_clear_stale.append(ann_id)
+        elif not is_present and not currently_stale:
+            to_set_stale.append(ann_id)
+
+    changed = 0
+    if to_set_stale:
+        try:
+            conn.execute(
+                "UPDATE annotations SET stale = TRUE, updated_at = now() WHERE id = ANY(%s)",
+                ([str(uid) for uid in to_set_stale],),
+            )
+            changed += len(to_set_stale)
+        except Exception:
+            logger.exception(
+                "update_stale_flags_for_version: SET stale failed version=%s count=%d",
+                draft_version_id,
+                len(to_set_stale),
+            )
+    if to_clear_stale:
+        try:
+            conn.execute(
+                "UPDATE annotations SET stale = FALSE, updated_at = now() WHERE id = ANY(%s)",
+                ([str(uid) for uid in to_clear_stale],),
+            )
+            changed += len(to_clear_stale)
+        except Exception:
+            logger.exception(
+                "update_stale_flags_for_version: CLEAR stale failed version=%s count=%d",
+                draft_version_id,
+                len(to_clear_stale),
+            )
+    return changed

--- a/app/annotations/row_keys.py
+++ b/app/annotations/row_keys.py
@@ -1,0 +1,108 @@
+"""§9.4 row-key formulas for impact-report annotation threads.
+
+Locked-in contract from #619 PR-A:
+
+    target_type = 'impact_report_item'
+    target_id   = '{row_kind}:{row_key}'
+
+row_key formulas:
+    entity   → entity URI from ontology
+    eu       → EU directive URI
+    conflict → sha256(canonical_json([sorted_subject_uri,
+               sorted_object_uri, predicate_uri]))[:32]
+    gap      → sha256(canonical_json([gap_kind, sorted_required_uris]))[:32]
+
+Lives in :mod:`app.annotations` (not :mod:`app.docs`) because the keys
+ARE the annotation contract: both the report renderer (UI side) and the
+analyze pipeline (stale-flag side) consume them, and pulling them out
+of :mod:`app.docs.report_routes` keeps the analyze handler free of the
+FastHTML/UI import baggage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def stable_hash(parts: list[str]) -> str:
+    """Return the first 32 hex chars of sha256 over a canonical JSON list.
+
+    ``ensure_ascii=False`` + ``sort_keys=True`` matches the §9.4 contract so
+    server + client produce the same digest given the same logical inputs
+    even when strings contain non-ASCII Estonian characters.
+    """
+    raw = json.dumps(parts, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:32]
+
+
+def row_key_for_entity(entity: dict[str, Any]) -> str:
+    """row_key for an affected-entities row: the entity URI itself."""
+    return str(entity.get("uri") or "")
+
+
+def row_key_for_eu(eu: dict[str, Any]) -> str:
+    """row_key for an EU-compliance row: the EU directive URI.
+
+    Mirrors the docx exporter which also reads ``eu_act`` (the URI) as the
+    primary identity field.
+    """
+    return str(eu.get("eu_act") or "")
+
+
+def row_key_for_conflict(conflict: dict[str, Any]) -> str:
+    """row_key for a conflict row: deterministic sha256-32 over the conflict identity.
+
+    The analyzer emits ``draft_ref`` + ``conflicting_entity`` (sorted), with
+    ``reason`` truncated to 64 chars as a tie-breaker so two conflicts on
+    the same pair of entities but with different reasons get different
+    threads.
+    """
+    parts = sorted(
+        [
+            str(conflict.get("conflicting_entity") or ""),
+            str(conflict.get("draft_ref") or ""),
+        ]
+    ) + [str(conflict.get("reason") or "")[:64]]
+    return stable_hash(parts)
+
+
+def row_key_for_gap(gap: dict[str, Any]) -> str:
+    """row_key for a gap row: deterministic sha256-32 over the gap identity.
+
+    Currently keyed on ``topic_cluster`` (the cluster URI). The "gap_kind"
+    discriminator stays as a static string for now because the analyzer only
+    produces one kind of gap; future expansion can add more discriminators
+    without invalidating existing keys (the JSON-canonical form keeps the
+    sort order stable).
+    """
+    parts = ["gap_topic_cluster", str(gap.get("topic_cluster") or "")]
+    return stable_hash(parts)
+
+
+def collect_row_specs(findings: dict[str, Any]) -> list[tuple[str, str]]:
+    """Walk every section and emit (row_kind, row_key) pairs.
+
+    Used by both the report renderer (to bulk-load badge counts) and the
+    analyze handler (to drive stale-flag reconciliation).  Returns rows in
+    section order with empty keys filtered out.
+    """
+    specs: list[tuple[str, str]] = []
+    for entity in findings.get("affected_entities") or []:
+        key = row_key_for_entity(entity)
+        if key:
+            specs.append(("entity", key))
+    for conflict in findings.get("conflicts") or []:
+        key = row_key_for_conflict(conflict)
+        if key:
+            specs.append(("conflict", key))
+    for eu in findings.get("eu_compliance") or []:
+        key = row_key_for_eu(eu)
+        if key:
+            specs.append(("eu", key))
+    for gap in findings.get("gaps") or []:
+        key = row_key_for_gap(gap)
+        if key:
+            specs.append(("gap", key))
+    return specs

--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -36,6 +36,8 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID, uuid4
 
+from app.annotations.models import update_stale_flags_for_version
+from app.annotations.row_keys import collect_row_specs
 from app.auth.audit import log_action
 from app.db import get_connection
 from app.docs.draft_model import fetch_draft, get_draft, update_draft_status
@@ -181,6 +183,39 @@ def analyze_impact(
             # ``status='ready'`` row without its report.
             update_draft_status(conn, draft_id, "ready")
             conn.commit()
+
+        # ------------------------------------------------------------------
+        # #619 PR-C: stale-flag automation.  After a fresh analyze writes
+        # the new impact_reports row, walk every annotation on the same
+        # draft_version_id and flip ``stale``:
+        #   - row reappeared in the new findings → stale=false
+        #   - row vanished from the new findings → stale=true
+        # Wrapped in its own try/except so a stale-flag glitch never
+        # fails the analyze job; this is a UX signal, not a correctness
+        # invariant.  Runs in its own transaction (separate connection)
+        # so the impact_reports commit above is durable regardless.
+        # ------------------------------------------------------------------
+        if draft_version_id is not None:
+            try:
+                findings_dict = dataclasses.asdict(findings)
+                row_specs = collect_row_specs(findings_dict)
+                current_keys: set[tuple[str, str]] = set(row_specs)
+                with get_connection() as conn:
+                    changed = update_stale_flags_for_version(conn, draft_version_id, current_keys)
+                    conn.commit()
+                if changed:
+                    logger.info(
+                        "analyze_impact: reconciled stale flags for version=%s changed=%d",
+                        draft_version_id,
+                        changed,
+                    )
+            except Exception:
+                logger.warning(
+                    "analyze_impact: stale-flag reconcile failed for draft=%s version=%s",
+                    draft_id,
+                    draft_version_id,
+                    exc_info=True,
+                )
 
         # ------------------------------------------------------------------
         # #621: "sarnased eelnõud" — best-effort similarity compute.

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -27,6 +27,21 @@ from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
 from starlette.responses import FileResponse, Response
 
+from app.annotations.row_keys import (
+    collect_row_specs as _collect_row_specs,
+)
+from app.annotations.row_keys import (
+    row_key_for_conflict as _row_key_for_conflict,
+)
+from app.annotations.row_keys import (
+    row_key_for_entity as _row_key_for_entity,
+)
+from app.annotations.row_keys import (
+    row_key_for_eu as _row_key_for_eu,
+)
+from app.annotations.row_keys import (
+    row_key_for_gap as _row_key_for_gap,
+)
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_view_draft
@@ -115,6 +130,133 @@ def _short_type(uri: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Annotation side-panel container + per-row trigger button (PR-C)
+# ---------------------------------------------------------------------------
+#
+# Row-key formulas live in :mod:`app.annotations.row_keys` (the §9.4
+# contract) so both the renderer and the analyze handler share the SAME
+# code path.  Helpers below glue those keys to the side-panel UI.
+
+# Container ID matches ``app/annotations/routes.py::_SIDE_PANEL_ID`` so the
+# PR-B GET handler can swap its fragment in via hx_target.  Rendered ONCE per
+# report page below; every row's trigger button targets this same container.
+_ANNOTATION_SIDE_PANEL_ID = "annotation-side-panel"
+
+
+def _annotation_side_panel_container() -> Any:
+    """Render the empty side-panel container the row buttons swap into.
+
+    Lives once per report page right before the section cards.  When a
+    user clicks an AnnotationButton the PR-B GET handler returns the
+    side-panel fragment which HTMX swaps into ``innerHTML`` of this Div.
+    """
+    return Div(  # noqa: F405
+        id=_ANNOTATION_SIDE_PANEL_ID,
+        cls="annotation-side-panel",
+        # ARIA role keeps the empty container a valid landmark even
+        # before the first fragment lands inside it.
+        role="complementary",
+        aria_label="Märkuste paneel",
+    )
+
+
+def _row_annotation_button(
+    draft_version_id: str,
+    row_kind: str,
+    row_key: str,
+    unresolved_count: int,
+) -> Any:
+    """Per-row trigger button: opens the side panel for that row's thread.
+
+    Distinct from the canonical ``AnnotationButton`` primitive (which is
+    hard-coded to ``/api/annotations`` + a popover container) because the
+    row-annotation flow uses the §9.4 version-scoped routes from PR-B and
+    targets the page-wide :func:`_annotation_side_panel_container`.
+    Returns an empty string when ``draft_version_id`` or ``row_key`` is
+    missing — the row simply has no annotation affordance in that case
+    (e.g. a legacy report without a version FK).
+    """
+    if not draft_version_id or not row_key:
+        return ""
+
+    badge: Any = ""
+    if unresolved_count > 0:
+        badge = Badge(
+            str(unresolved_count),
+            variant="primary",
+            cls="annotation-count-badge",
+        )
+
+    base = f"/annotations/version/{draft_version_id}/{row_kind}/{row_key}"
+    return Button(  # noqa: F405
+        NotStr("&#128172;"),  # noqa: F405  # speech balloon glyph
+        badge,
+        type="button",
+        hx_get=base,
+        hx_target=f"#{_ANNOTATION_SIDE_PANEL_ID}",
+        hx_swap="innerHTML",
+        cls="annotation-button annotation-row-button",
+        aria_label=f"Ava märkuste paneel ({unresolved_count} lahendamata)",
+        title="Ava märkuste paneel",
+        # Data attrs make the button addressable from tests + future JS
+        # without parsing the URL again.
+        data_row_kind=row_kind,
+        data_row_key=row_key,
+        data_draft_version_id=draft_version_id,
+    )
+
+
+def _load_unresolved_counts(
+    draft_version_id: str,
+    row_specs: list[tuple[str, str]],
+) -> dict[tuple[str, str], int]:
+    """Bulk-load unresolved badge counts for every row in one report page.
+
+    One COUNT(*) per row would be O(rows) round-trips; we instead issue one
+    grouped query that returns the unresolved count per ``target_id`` and
+    then partition by ``row_kind``.  Falls back to an empty dict on any
+    failure so the page still renders without badges.
+    """
+    if not draft_version_id or not row_specs:
+        return {}
+    target_ids = [f"{kind}:{key}" for kind, key in row_specs if key]
+    if not target_ids:
+        return {}
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT target_id, COUNT(*)
+                FROM annotations
+                WHERE draft_version_id = %s
+                  AND target_type = 'impact_report_item'
+                  AND target_id = ANY(%s)
+                  AND resolved = FALSE
+                GROUP BY target_id
+                """,
+                (str(draft_version_id), target_ids),
+            ).fetchall()
+    except Exception:
+        logger.warning(
+            "_load_unresolved_counts failed for version=%s",
+            draft_version_id,
+            exc_info=True,
+        )
+        return {}
+    out: dict[tuple[str, str], int] = {}
+    for row in rows:
+        target_id = str(row[0] or "")
+        if ":" not in target_id:
+            continue
+        kind, key = target_id.split(":", 1)
+        try:
+            out[(kind, key)] = int(row[1])
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+# ---------------------------------------------------------------------------
 # DB helpers
 # ---------------------------------------------------------------------------
 
@@ -185,6 +327,37 @@ def _fetch_latest_report(draft_id: uuid.UUID) -> tuple | None:
     except Exception:
         logger.exception("_fetch_latest_report failed for draft=%s", draft_id)
         return None
+
+
+def _fetch_latest_report_version_id(report_id: uuid.UUID | str) -> str | None:
+    """Look up the ``draft_version_id`` for an ``impact_reports`` row.
+
+    Kept as a separate query (not folded into ``_REPORT_SELECT_COLUMNS``)
+    so the column-index contract shared with :mod:`app.docs.docx_export` —
+    and locked in by every existing report-page test — stays untouched.
+
+    Returns:
+        The version FK as a string, or ``None`` when missing / on DB error.
+        ``None`` is the right sentinel because :func:`_row_annotation_button`
+        gracefully renders no button when *draft_version_id* is empty, which
+        is exactly the legacy-row degraded behaviour we want.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT draft_version_id FROM impact_reports WHERE id = %s",
+                (str(report_id),),
+            ).fetchone()
+    except Exception:
+        logger.warning(
+            "_fetch_latest_report_version_id failed for report=%s",
+            report_id,
+            exc_info=True,
+        )
+        return None
+    if row is None or row[0] is None:
+        return None
+    return str(row[0])
 
 
 def _parse_report_data(raw: Any) -> dict[str, Any]:
@@ -277,7 +450,39 @@ _SECTION_EU = "eu"
 _SECTION_GAPS = "gaps"
 
 
-def _affected_columns() -> list[Column]:
+def _annotation_column(
+    row_kind: str,
+    draft_version_id: str,
+    counts: dict[tuple[str, str], int],
+    key_for_row: Any,
+) -> Column:
+    """Build the trailing "Märkused" column that hosts :func:`_row_annotation_button`.
+
+    Used by every section's ``_*_columns`` builder so the annotation button
+    sits in a consistent slot at the end of every table.  ``key_for_row``
+    is the row-kind-specific row_key formula (e.g. :func:`_row_key_for_entity`).
+    """
+
+    def _render(row: dict[str, Any]) -> Any:
+        row_key = key_for_row(row)
+        if not row_key:
+            return ""
+        unresolved = counts.get((row_kind, row_key), 0)
+        return _row_annotation_button(draft_version_id, row_kind, row_key, unresolved)
+
+    return Column(
+        key="_annotation",
+        label="Märkused",
+        sortable=False,
+        align="center",
+        render=_render,
+    )
+
+
+def _affected_columns(
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> list[Column]:
     def _type_cell(row: dict[str, Any]):
         return _short_type(str(row.get("type", "")))
 
@@ -294,14 +499,22 @@ def _affected_columns() -> list[Column]:
             cls="data-table-link",
         )
 
-    return [
+    cols: list[Column] = [
         Column(key="type", label="Tüüp", sortable=False, render=_type_cell),
         Column(key="label", label="Nimetus", sortable=False, render=_label_cell),
         Column(key="uri", label="URI", sortable=False, render=_uri_cell),
     ]
+    if draft_version_id:
+        cols.append(
+            _annotation_column("entity", draft_version_id, counts or {}, _row_key_for_entity)
+        )
+    return cols
 
 
-def _conflicts_columns() -> list[Column]:
+def _conflicts_columns(
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> list[Column]:
     def _draft_ref(row: dict[str, Any]):
         return str(row.get("draft_ref") or "—")
 
@@ -319,7 +532,7 @@ def _conflicts_columns() -> list[Column]:
     def _reason(row: dict[str, Any]):
         return str(row.get("reason") or "—")
 
-    return [
+    cols: list[Column] = [
         Column(key="draft_ref", label="Eelnõu viide", sortable=False, render=_draft_ref),
         Column(
             key="conflicting_entity",
@@ -329,9 +542,17 @@ def _conflicts_columns() -> list[Column]:
         ),
         Column(key="reason", label="Põhjus", sortable=False, render=_reason),
     ]
+    if draft_version_id:
+        cols.append(
+            _annotation_column("conflict", draft_version_id, counts or {}, _row_key_for_conflict)
+        )
+    return cols
 
 
-def _eu_columns() -> list[Column]:
+def _eu_columns(
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> list[Column]:
     def _eu_act(row: dict[str, Any]):
         uri = str(row.get("eu_act") or "")
         label = str(row.get("eu_label") or uri or "—")
@@ -349,14 +570,20 @@ def _eu_columns() -> list[Column]:
     def _status(row: dict[str, Any]):
         return str(row.get("transposition_status") or "—")
 
-    return [
+    cols: list[Column] = [
         Column(key="eu_act", label="EL õigusakt", sortable=False, render=_eu_act),
         Column(key="provision", label="Eesti säte", sortable=False, render=_ee_provision),
         Column(key="status", label="Staatus", sortable=False, render=_status),
     ]
+    if draft_version_id:
+        cols.append(_annotation_column("eu", draft_version_id, counts or {}, _row_key_for_eu))
+    return cols
 
 
-def _gaps_columns() -> list[Column]:
+def _gaps_columns(
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> list[Column]:
     def _cluster(row: dict[str, Any]):
         return str(row.get("topic_cluster_label") or row.get("topic_cluster") or "—")
 
@@ -366,36 +593,52 @@ def _gaps_columns() -> list[Column]:
     def _description(row: dict[str, Any]):
         return str(row.get("description") or "—")
 
-    return [
+    cols: list[Column] = [
         Column(key="cluster", label="Teemaklaster", sortable=False, render=_cluster),
         Column(key="coverage", label="Sätete kaetus", sortable=False, render=_coverage),
         Column(key="description", label="Kirjeldus", sortable=False, render=_description),
     ]
+    if draft_version_id:
+        cols.append(_annotation_column("gap", draft_version_id, counts or {}, _row_key_for_gap))
+    return cols
 
 
-# Section → (findings key, columns builder, empty message). Used by
-# the "Näita rohkem" route to look up the source rows + column shape
-# from just the URL slug.
-_SECTION_CONFIG: dict[str, tuple[str, Any, str]] = {
+# Section → (findings key, columns builder, empty message, row_kind, key_for_row).
+# Used by the "Näita rohkem" route to look up the source rows + column shape
+# + per-row annotation row_key formula from just the URL slug.
+#
+# row_kind / key_for_row are required because the paginated fragment must
+# also render the AnnotationButton column with the correct §9.4 keys.  The
+# columns builder accepts ``draft_version_id`` and ``counts`` so the
+# annotation column can attach its badge state.
+_SECTION_CONFIG: dict[str, tuple[str, Any, str, str, Any]] = {
     _SECTION_AFFECTED: (
         "affected_entities",
         _affected_columns,
         "Mõjutatud üksuseid ei tuvastatud.",
+        "entity",
+        _row_key_for_entity,
     ),
     _SECTION_CONFLICTS: (
         "conflicts",
         _conflicts_columns,
         "Konflikte ei tuvastatud.",
+        "conflict",
+        _row_key_for_conflict,
     ),
     _SECTION_EU: (
         "eu_compliance",
         _eu_columns,
         "EL-i õigusaktide seoseid ei tuvastatud.",
+        "eu",
+        _row_key_for_eu,
     ),
     _SECTION_GAPS: (
         "gaps",
         _gaps_columns,
         "Lünki ei tuvastatud.",
+        "gap",
+        _row_key_for_gap,
     ),
 }
 
@@ -439,7 +682,13 @@ def _section_pager(
     return Div(*children, id=pager_id, cls="section-pager")  # noqa: F405
 
 
-def _affected_entities_section(findings: dict[str, Any], draft_id: str = "") -> Any:
+def _affected_entities_section(
+    findings: dict[str, Any],
+    draft_id: str = "",
+    *,
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> Any:
     """Build the "Mõjutatud üksused" data table section."""
     rows = list(findings.get("affected_entities") or [])
     total = len(rows)
@@ -448,7 +697,7 @@ def _affected_entities_section(findings: dict[str, Any], draft_id: str = "") -> 
 
     body_children: list = [
         DataTable(
-            columns=_affected_columns(),
+            columns=_affected_columns(draft_version_id, counts),
             rows=table_rows,
             empty_message="Mõjutatud üksuseid ei tuvastatud.",
         ),
@@ -462,7 +711,13 @@ def _affected_entities_section(findings: dict[str, Any], draft_id: str = "") -> 
     )
 
 
-def _conflicts_section(findings: dict[str, Any], draft_id: str = "") -> Any:
+def _conflicts_section(
+    findings: dict[str, Any],
+    draft_id: str = "",
+    *,
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> Any:
     """Build the "Konfliktid" section."""
     rows = list(findings.get("conflicts") or [])
     total = len(rows)
@@ -476,7 +731,7 @@ def _conflicts_section(findings: dict[str, Any], draft_id: str = "") -> Any:
     else:
         visible = rows[:_MAX_INLINE_ROWS]
         body = DataTable(
-            columns=_conflicts_columns(),
+            columns=_conflicts_columns(draft_version_id, counts),
             rows=visible,
             empty_message="Konflikte ei tuvastatud.",
         )
@@ -502,7 +757,13 @@ def _conflicts_section(findings: dict[str, Any], draft_id: str = "") -> Any:
     )
 
 
-def _eu_compliance_section(findings: dict[str, Any], draft_id: str = "") -> Any:
+def _eu_compliance_section(
+    findings: dict[str, Any],
+    draft_id: str = "",
+    *,
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> Any:
     """Build the "EL-i õigusaktide vastavus" section."""
     rows = list(findings.get("eu_compliance") or [])
     total = len(rows)
@@ -510,7 +771,7 @@ def _eu_compliance_section(findings: dict[str, Any], draft_id: str = "") -> Any:
 
     body_children: list = [
         DataTable(
-            columns=_eu_columns(),
+            columns=_eu_columns(draft_version_id, counts),
             rows=visible,
             empty_message="EL-i õigusaktide seoseid ei tuvastatud.",
         ),
@@ -534,7 +795,13 @@ def _eu_compliance_section(findings: dict[str, Any], draft_id: str = "") -> Any:
     )
 
 
-def _gaps_section(findings: dict[str, Any], draft_id: str = "") -> Any:
+def _gaps_section(
+    findings: dict[str, Any],
+    draft_id: str = "",
+    *,
+    draft_version_id: str = "",
+    counts: dict[tuple[str, str], int] | None = None,
+) -> Any:
     """Build the "Lüngad" section."""
     rows = list(findings.get("gaps") or [])
     total = len(rows)
@@ -542,7 +809,7 @@ def _gaps_section(findings: dict[str, Any], draft_id: str = "") -> Any:
 
     body_children: list = [
         DataTable(
-            columns=_gaps_columns(),
+            columns=_gaps_columns(draft_version_id, counts),
             rows=visible,
             empty_message="Lünki ei tuvastatud.",
         ),
@@ -657,6 +924,17 @@ def draft_report_page(req: Request, draft_id: str):
 
     findings = _parse_report_data(report_row[6])
 
+    # #619 PR-C: per-row annotations.  Look up the version FK that PR-A
+    # backfilled so each row's AnnotationButton can target the §9.4
+    # /annotations/version/{id}/{kind}/{key} routes.  Bulk-load the
+    # unresolved counts in one DB round-trip so badge rendering is O(1)
+    # per row instead of O(N) queries.
+    draft_version_id = _fetch_latest_report_version_id(report_row[0]) or ""
+    row_specs = _collect_row_specs(findings)
+    unresolved_counts = (
+        _load_unresolved_counts(draft_version_id, row_specs) if draft_version_id else {}
+    )
+
     # #612: detect ontology-version drift. The report's snapshot tag
     # lives in report_row[7]; if it no longer matches the live Jena
     # sync_log snapshot, surface a banner offering a one-click re-run.
@@ -743,10 +1021,34 @@ def draft_report_page(req: Request, draft_id: str):
     )
     return PageShell(
         *shell_children,
-        _affected_entities_section(findings, draft_id=str(draft.id)),
-        _conflicts_section(findings, draft_id=str(draft.id)),
-        _eu_compliance_section(findings, draft_id=str(draft.id)),
-        _gaps_section(findings, draft_id=str(draft.id)),
+        # #619 PR-C: side-panel container is rendered ONCE on the page.
+        # Every row's AnnotationButton swaps the PR-B fragment into this
+        # element.  Empty-state skeleton until the user clicks a row.
+        _annotation_side_panel_container(),
+        _affected_entities_section(
+            findings,
+            draft_id=str(draft.id),
+            draft_version_id=draft_version_id,
+            counts=unresolved_counts,
+        ),
+        _conflicts_section(
+            findings,
+            draft_id=str(draft.id),
+            draft_version_id=draft_version_id,
+            counts=unresolved_counts,
+        ),
+        _eu_compliance_section(
+            findings,
+            draft_id=str(draft.id),
+            draft_version_id=draft_version_id,
+            counts=unresolved_counts,
+        ),
+        _gaps_section(
+            findings,
+            draft_id=str(draft.id),
+            draft_version_id=draft_version_id,
+            counts=unresolved_counts,
+        ),
         _export_section(draft),
         # #610: progressive enhancement — opens a WebSocket subscription
         # to /ws/drafts/export-progress when the spinner fragment lands
@@ -857,7 +1159,7 @@ def report_section_fragment(req: Request, draft_id: str, section: str):
     config = _SECTION_CONFIG.get(section)
     if config is None:
         return _not_found_page(req)
-    findings_key, columns_builder, empty_message = config
+    findings_key, columns_builder, empty_message, row_kind, key_for_row = config
 
     try:
         offset = max(0, int(req.query_params.get("offset", "0")))
@@ -882,11 +1184,22 @@ def report_section_fragment(req: Request, draft_id: str, section: str):
     if section == _SECTION_AFFECTED:
         batch = [{"_": True, **row} for row in batch]
 
+    # #619 PR-C: bulk-load the unresolved-count badges for just this
+    # paginated slice so the AnnotationButton renders with the right
+    # state when the user clicks "Näita rohkem".
+    draft_version_id = _fetch_latest_report_version_id(report_row[0]) or ""
+    batch_specs: list[tuple[str, str]] = []
+    for raw_row in batch:
+        key = key_for_row(raw_row)
+        if key:
+            batch_specs.append((row_kind, key))
+    counts = _load_unresolved_counts(draft_version_id, batch_specs) if draft_version_id else {}
+
     children: list = []
     if batch:
         children.append(
             DataTable(
-                columns=columns_builder(),
+                columns=columns_builder(draft_version_id, counts),
                 rows=batch,
                 empty_message=empty_message,
             )

--- a/tests/test_annotations_row_integration.py
+++ b/tests/test_annotations_row_integration.py
@@ -1,0 +1,941 @@
+"""Integration tests for #619 PR-C: row-annotations wired into the report.
+
+Covers three deliverables from the sprint plan §6 Days 3-4:
+
+    1. ``app/annotations/row_keys`` — deterministic row_key formulas
+       (entity / eu / conflict / gap) per the §9.4 contract locked in
+       PR-A.
+    2. ``app/docs/report_routes`` — AnnotationButton injection into
+       every impact-report row, side-panel container rendered once,
+       version-scoped /annotations/version/... HTMX wiring.
+    3. ``app/docs/analyze_handler`` — best-effort stale-flag automation
+       at analyze tail (annotation row vanished → stale=true; row
+       reappeared → stale=false).
+
+Patterns follow ``tests/test_docs_report_routes.py`` (TestClient with a
+patched auth provider + mocked DB lookups) and
+``tests/test_docs_analyze_handler.py`` (mock the get_connection chain).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.annotations.models import (
+    count_unresolved_for_version_row,
+    update_stale_flags_for_version,
+)
+from app.annotations.row_keys import (
+    collect_row_specs,
+    row_key_for_conflict,
+    row_key_for_entity,
+    row_key_for_eu,
+    row_key_for_gap,
+    stable_hash,
+)
+from app.docs.draft_model import Draft
+from app.docs.impact.analyzer import ImpactFindings
+from app.docs.version_model import DraftVersion
+
+# ---------------------------------------------------------------------------
+# Constants + fixtures
+# ---------------------------------------------------------------------------
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_OTHER_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_DRAFT_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+_REPORT_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+_VERSION_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "koostaja@seadusloome.ee",
+        "full_name": "Test Koostaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _make_draft(
+    *,
+    org_id: str = _ORG_ID,
+    title: str = "Test eelnõu",
+    status: str = "ready",
+) -> Draft:
+    now = datetime.now(UTC)
+    return Draft(
+        id=_DRAFT_ID,
+        user_id=uuid.UUID(_USER_ID),
+        org_id=uuid.UUID(org_id),
+        title=title,
+        filename="eelnou.docx",
+        content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        file_size=2048,
+        storage_path="/tmp/cipher.enc",
+        graph_uri=f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}",
+        status=status,
+        parsed_text_encrypted=None,
+        entity_count=None,
+        error_message=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_findings(
+    *,
+    affected: int = 2,
+    conflicts: int = 1,
+    eu: int = 1,
+    gaps: int = 1,
+) -> dict[str, Any]:
+    """Build an in-memory ``report_data`` dict matching the JSONB shape."""
+    return {
+        "affected_entities": [
+            {
+                "uri": f"urn:entity:{i}",
+                "label": f"Säte {i}",
+                "type": "https://data.riik.ee/ontology/estleg#EnactedLaw",
+            }
+            for i in range(affected)
+        ],
+        "conflicts": [
+            {
+                "draft_ref": f"Eelnõu § {i}",
+                "conflicting_entity": f"urn:conflict:{i}",
+                "conflicting_label": f"Vana säte {i}",
+                "reason": f"Vastuolu {i}",
+            }
+            for i in range(conflicts)
+        ],
+        "eu_compliance": [
+            {
+                "eu_act": f"urn:eu:act:{i}",
+                "eu_label": f"Direktiiv {i}",
+                "estonian_provision": f"urn:ee:{i}",
+                "provision_label": f"§ {i}",
+                "transposition_status": "linked",
+            }
+            for i in range(eu)
+        ],
+        "gaps": [
+            {
+                "topic_cluster": f"urn:cluster:{i}",
+                "topic_cluster_label": f"Klaster {i}",
+                "total_provisions": "10",
+                "referenced_provisions": "2",
+                "description": f"Lünk {i}",
+            }
+            for i in range(gaps)
+        ],
+    }
+
+
+def _make_report_row(findings: dict[str, Any] | None = None) -> tuple:
+    """9-tuple matching ``_REPORT_SELECT_COLUMNS`` order in report_routes."""
+    return (
+        _REPORT_ID,
+        _DRAFT_ID,
+        2,  # affected_count
+        1,  # conflict_count
+        1,  # gap_count
+        42,  # impact_score
+        findings if findings is not None else _make_findings(),
+        "2026-04-09T12:00+00:00@1061123",
+        datetime(2026, 4, 9, 12, 0, tzinfo=UTC),
+    )
+
+
+def _authed_client():
+    """Return a TestClient with a stub session cookie."""
+    from starlette.testclient import TestClient
+
+    client = TestClient(__import__("app.main", fromlist=["app"]).app, follow_redirects=False)
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+# ===========================================================================
+# 1. Row-key formulas — determinism + stability
+# ===========================================================================
+
+
+class TestRowKeyDeterminism:
+    """The §9.4 contract requires stable hashes across runs and machines."""
+
+    def test_entity_returns_uri(self):
+        row = {"uri": "urn:entity:42", "label": "X", "type": "T"}
+        assert row_key_for_entity(row) == "urn:entity:42"
+
+    def test_entity_empty_uri_yields_empty_string(self):
+        # Empty key signals "no annotation affordance"; the renderer
+        # gracefully drops the button rather than rendering one with a
+        # zero-length target_id.
+        assert row_key_for_entity({}) == ""
+        assert row_key_for_entity({"uri": ""}) == ""
+
+    def test_eu_returns_eu_act_uri(self):
+        row = {"eu_act": "https://eur-lex.europa.eu/eli/dir/2016/679"}
+        assert row_key_for_eu(row) == "https://eur-lex.europa.eu/eli/dir/2016/679"
+
+    def test_eu_empty_yields_empty_string(self):
+        assert row_key_for_eu({}) == ""
+
+    def test_conflict_is_deterministic_across_calls(self):
+        """Same inputs MUST produce the same hash on every call."""
+        row = {
+            "draft_ref": "Eelnõu § 5",
+            "conflicting_entity": "urn:law/123",
+            "reason": "Vastuolu KarS § 133-ga",
+        }
+        first = row_key_for_conflict(row)
+        second = row_key_for_conflict(row)
+        third = row_key_for_conflict(dict(row))  # fresh dict, same data
+        assert first == second == third
+        # 32 hex chars matches the spec length.
+        assert len(first) == 32
+        assert all(c in "0123456789abcdef" for c in first)
+
+    def test_conflict_sort_normalises_subject_object_order(self):
+        """sorted([draft_ref, conflicting_entity]) means swapping them
+        does NOT change the hash — the key is identity-of-edge, not
+        directionality."""
+        row_a = {
+            "draft_ref": "AAA",
+            "conflicting_entity": "BBB",
+            "reason": "r",
+        }
+        row_b = {
+            "draft_ref": "BBB",
+            "conflicting_entity": "AAA",
+            "reason": "r",
+        }
+        assert row_key_for_conflict(row_a) == row_key_for_conflict(row_b)
+
+    def test_conflict_reason_is_truncated_to_64_chars(self):
+        """A novel reason longer than 64 chars in the prefix shifts the
+        hash; identical 64-char prefixes with different suffixes do NOT.
+        """
+        base_reason = "x" * 64
+        long_a = {"draft_ref": "d", "conflicting_entity": "e", "reason": base_reason + "AAA"}
+        long_b = {"draft_ref": "d", "conflicting_entity": "e", "reason": base_reason + "BBB"}
+        # Truncated at 64 → identical truncated tie-breaker → identical hash.
+        assert row_key_for_conflict(long_a) == row_key_for_conflict(long_b)
+
+    def test_conflict_different_reasons_give_different_keys(self):
+        """Different short reasons must NOT collide."""
+        row_a = {"draft_ref": "d", "conflicting_entity": "e", "reason": "alpha"}
+        row_b = {"draft_ref": "d", "conflicting_entity": "e", "reason": "beta"}
+        assert row_key_for_conflict(row_a) != row_key_for_conflict(row_b)
+
+    def test_gap_is_deterministic_across_calls(self):
+        row = {"topic_cluster": "urn:cluster:andmekaitse"}
+        assert row_key_for_gap(row) == row_key_for_gap(row)
+        assert len(row_key_for_gap(row)) == 32
+
+    def test_gap_different_clusters_give_different_keys(self):
+        a = {"topic_cluster": "urn:cluster:1"}
+        b = {"topic_cluster": "urn:cluster:2"}
+        assert row_key_for_gap(a) != row_key_for_gap(b)
+
+    def test_stable_hash_is_unicode_safe(self):
+        """Estonian-letter inputs MUST produce the same hash on every
+        run (canonical_json with ensure_ascii=False)."""
+        a = stable_hash(["Aäoõu", "Šžütõ"])
+        b = stable_hash(["Aäoõu", "Šžütõ"])
+        assert a == b
+        assert len(a) == 32
+
+
+class TestCollectRowSpecs:
+    def test_walks_every_section_in_order(self):
+        findings = _make_findings(affected=2, conflicts=1, eu=1, gaps=1)
+        specs = collect_row_specs(findings)
+        # All five expected: 2 entity + 1 conflict + 1 eu + 1 gap = 5.
+        assert len(specs) == 5
+        kinds = [k for k, _ in specs]
+        # Order: entity → conflict → eu → gap (matches the section render order).
+        assert kinds == ["entity", "entity", "conflict", "eu", "gap"]
+
+    def test_empty_findings_yields_empty_list(self):
+        assert collect_row_specs({}) == []
+        assert collect_row_specs({"affected_entities": [], "conflicts": []}) == []
+
+    def test_skips_rows_with_empty_keys(self):
+        findings = {
+            "affected_entities": [{"uri": ""}, {"uri": "urn:x"}],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+        }
+        specs = collect_row_specs(findings)
+        # The empty-uri row was dropped; only the urn:x row survives.
+        assert len(specs) == 1
+        assert specs[0] == ("entity", "urn:x")
+
+
+# ===========================================================================
+# 2. Report-page rendering — AnnotationButton injection + side panel
+# ===========================================================================
+
+
+class TestReportPageRendersAnnotationButtons:
+    """The report HTML must carry a per-row AnnotationButton for every
+    section, plus a single side-panel container."""
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_renders_side_panel_container_once(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        # The side-panel container id matches PR-B's _SIDE_PANEL_ID so
+        # the version-scoped routes can swap into it.
+        assert resp.text.count('id="annotation-side-panel"') == 1
+        # The complementary ARIA role keeps it a valid landmark even
+        # when empty.
+        assert "annotation-side-panel" in resp.text
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_each_row_carries_version_scoped_hx_get(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        """Every row's button MUST point at the §9.4 PR-B route, not
+        the legacy /api/annotations endpoint."""
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row(_make_findings(affected=1))
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        # Per-row buttons must use the version-scoped path; the
+        # affected-entities row_key for "urn:entity:0" is the URI itself.
+        expected = f"/annotations/version/{_VERSION_ID}/entity/urn:entity:0"
+        assert expected in resp.text
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_conflict_row_uses_hashed_row_key(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        findings = _make_findings(affected=0, conflicts=1, eu=0, gaps=0)
+        mock_fetch_report.return_value = _make_report_row(findings)
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        # The conflict row's row_key is a sha256-32 hex digest.
+        expected_key = row_key_for_conflict(findings["conflicts"][0])
+        assert f"/annotations/version/{_VERSION_ID}/conflict/{expected_key}" in resp.text
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_eu_row_uses_eu_act_uri(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        findings = _make_findings(affected=0, conflicts=0, eu=1, gaps=0)
+        mock_fetch_report.return_value = _make_report_row(findings)
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        assert f"/annotations/version/{_VERSION_ID}/eu/urn:eu:act:0" in resp.text
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_gap_row_uses_hashed_row_key(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        findings = _make_findings(affected=0, conflicts=0, eu=0, gaps=1)
+        mock_fetch_report.return_value = _make_report_row(findings)
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        expected_key = row_key_for_gap(findings["gaps"][0])
+        assert f"/annotations/version/{_VERSION_ID}/gap/{expected_key}" in resp.text
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_unresolved_count_renders_badge(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        """When the bulk count helper reports unresolved messages, the
+        badge must show the number."""
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        findings = _make_findings(affected=1, conflicts=0, eu=0, gaps=0)
+        mock_fetch_report.return_value = _make_report_row(findings)
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        # 7 unresolved messages on the lone affected-entity row.
+        mock_load_counts.return_value = {("entity", "urn:entity:0"): 7}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        assert "annotation-count-badge" in resp.text
+        # The badge text should literally say "7".
+        assert ">7<" in resp.text or '">7<' in resp.text
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_version_id_skips_per_row_buttons(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        """Legacy reports without a draft_version_id FK MUST NOT crash;
+        the page renders without the per-row buttons (graceful degrade).
+        """
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+        mock_fetch_version.return_value = None  # no version FK
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        # No per-row buttons because version_id is missing.
+        assert "/annotations/version/" not in resp.text
+        # ...but the side panel still renders (so PR-D / future code can
+        # still hook into it).
+        assert 'id="annotation-side-panel"' in resp.text
+
+
+# ===========================================================================
+# 3. count_unresolved_for_version_row + bulk loader
+# ===========================================================================
+
+
+class TestCountUnresolvedForVersionRow:
+    def test_returns_count_from_db(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (5,)
+
+        result = count_unresolved_for_version_row(conn, _VERSION_ID, "conflict", "abc-123")
+
+        assert result == 5
+        # The query must filter by all four §9.4 dimensions.
+        sql = conn.execute.call_args.args[0].lower()
+        assert "draft_version_id" in sql
+        assert "target_type" in sql
+        assert "target_id" in sql
+        assert "resolved" in sql
+        # Bound params: version_id, "conflict:abc-123"
+        params = conn.execute.call_args.args[1]
+        assert params == (str(_VERSION_ID), "conflict:abc-123")
+
+    def test_zero_when_no_rows(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        assert count_unresolved_for_version_row(conn, _VERSION_ID, "entity", "k") == 0
+
+    def test_zero_on_db_error(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("boom")
+        # MUST NOT raise — would crash the report page.
+        assert count_unresolved_for_version_row(conn, _VERSION_ID, "entity", "k") == 0
+
+    def test_invalid_row_kind_returns_zero_without_db_call(self):
+        """A bad row_kind must not even hit the DB."""
+        conn = MagicMock()
+        result = count_unresolved_for_version_row(conn, _VERSION_ID, "INVALID", "k")
+        assert result == 0
+        conn.execute.assert_not_called()
+
+
+# ===========================================================================
+# 4. update_stale_flags_for_version — analyze-time automation
+# ===========================================================================
+
+
+class TestUpdateStaleFlagsForVersion:
+    def test_flips_stale_true_when_row_vanished(self):
+        """Annotation present in DB but NOT in the new analyze → stale=true."""
+        conn = MagicMock()
+        ann_id = uuid.UUID("88888888-8888-8888-8888-888888888888")
+        # One annotation on a conflict row that no longer exists.
+        conn.execute.return_value.fetchall.return_value = [
+            (ann_id, "conflict:vanished-key", False),
+        ]
+        # The new analyze produced ZERO matching rows.
+        current = set()
+
+        changed = update_stale_flags_for_version(conn, _VERSION_ID, current)
+
+        assert changed == 1
+        # SET stale = TRUE was issued.
+        update_calls = [
+            c for c in conn.execute.call_args_list if "stale = true" in c.args[0].lower()
+        ]
+        assert len(update_calls) == 1
+        # The bound param must include our annotation id (cast to str).
+        bound = update_calls[0].args[1]
+        assert any(str(ann_id) in str(arg) for arg in bound)
+
+    def test_flips_stale_false_when_row_reappeared(self):
+        conn = MagicMock()
+        ann_id = uuid.UUID("99999999-9999-9999-9999-999999999999")
+        conn.execute.return_value.fetchall.return_value = [
+            (ann_id, "entity:urn:e", True),  # currently stale
+        ]
+        # Re-analyze surfaced the same entity again.
+        current = {("entity", "urn:e")}
+
+        changed = update_stale_flags_for_version(conn, _VERSION_ID, current)
+
+        assert changed == 1
+        clear_calls = [
+            c for c in conn.execute.call_args_list if "stale = false" in c.args[0].lower()
+        ]
+        assert len(clear_calls) == 1
+
+    def test_no_op_when_state_already_matches(self):
+        """Idempotency: rows whose stale flag already matches the new
+        analyze must NOT be updated."""
+        conn = MagicMock()
+        a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        b = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        # a: present in new set, currently NOT stale → no-op
+        # b: absent from new set, currently stale → no-op
+        conn.execute.return_value.fetchall.return_value = [
+            (a, "entity:urn:present", False),
+            (b, "entity:urn:absent", True),
+        ]
+        current = {("entity", "urn:present")}
+
+        changed = update_stale_flags_for_version(conn, _VERSION_ID, current)
+
+        assert changed == 0
+        # No UPDATE calls beyond the SELECT.
+        update_calls = [
+            c for c in conn.execute.call_args_list if "update annotations" in c.args[0].lower()
+        ]
+        assert update_calls == []
+
+    def test_running_twice_with_same_set_is_no_op_on_second_call(self):
+        """Idempotent: after one reconciliation the stale flags match
+        the current set, so a follow-up call with the same set is a no-op.
+        """
+        # Round 1: row vanished → stale=true
+        conn1 = MagicMock()
+        ann_id = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+        conn1.execute.return_value.fetchall.return_value = [
+            (ann_id, "conflict:k", False),
+        ]
+        update_stale_flags_for_version(conn1, _VERSION_ID, set())
+        # Round 2: same set, but DB now reflects stale=true already.
+        conn2 = MagicMock()
+        conn2.execute.return_value.fetchall.return_value = [
+            (ann_id, "conflict:k", True),  # already stale
+        ]
+        changed = update_stale_flags_for_version(conn2, _VERSION_ID, set())
+        assert changed == 0
+
+    def test_swallows_db_errors(self):
+        """A DB error during the reconciliation must NOT raise; analyze
+        keeps a clean exit path even when stale-flag bookkeeping breaks.
+        """
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("connection reset")
+        # MUST NOT raise.
+        result = update_stale_flags_for_version(conn, _VERSION_ID, {("entity", "urn:x")})
+        assert result == 0
+
+    def test_no_annotations_short_circuits(self):
+        """When the version has zero annotations the function returns 0
+        without issuing any UPDATE."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        result = update_stale_flags_for_version(conn, _VERSION_ID, {("entity", "urn:x")})
+        assert result == 0
+        # Only the initial SELECT happened.
+        assert conn.execute.call_count == 1
+
+    def test_skips_rows_with_malformed_target_id(self):
+        """target_id without a colon cannot be parsed → skipped silently."""
+        conn = MagicMock()
+        ann_id = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+        conn.execute.return_value.fetchall.return_value = [
+            (ann_id, "no_colon_at_all", False),
+        ]
+        result = update_stale_flags_for_version(conn, _VERSION_ID, set())
+        # No update because the row was unparseable.
+        assert result == 0
+
+
+# ===========================================================================
+# 5. analyze_handler integration — stale-flag wiring
+# ===========================================================================
+
+
+class _ConnectCM:
+    """Context-manager wrapper around a cursor-ish mock (mirrors the
+    helper in tests/test_docs_analyze_handler.py)."""
+
+    def __init__(self, conn: MagicMock):
+        self.conn = conn
+
+    def __enter__(self) -> MagicMock:
+        return self.conn
+
+    def __exit__(self, *_: Any) -> bool:
+        return False
+
+
+def _make_version() -> DraftVersion:
+    return DraftVersion(
+        id=_VERSION_ID,
+        draft_id=_DRAFT_ID,
+        version_number=1,
+        reading_stage="vtk",
+        parsed_text_encrypted=None,
+        storage_path="/tmp/cipher.enc",
+        graph_uri=f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}",
+        status="analyzing",
+        created_at=datetime.now(UTC),
+        created_by=uuid.UUID(_USER_ID),
+    )
+
+
+def _findings_with_one_conflict() -> ImpactFindings:
+    return ImpactFindings(
+        affected_entities=[],
+        conflicts=[
+            {
+                "draft_ref": "Eelnõu § 1",
+                "conflicting_entity": "urn:c:1",
+                "reason": "vastuolu",
+            }
+        ],
+        gaps=[],
+        eu_compliance=[],
+        affected_count=0,
+        conflict_count=1,
+        gap_count=0,
+    )
+
+
+class TestAnalyzeHandlerStaleFlagWiring:
+    def test_reconciles_stale_flags_after_successful_analyze(self):
+        """The analyze handler MUST call update_stale_flags_for_version
+        with the new (row_kind, row_key) set after the impact_reports
+        insert commits."""
+        from app.docs.analyze_handler import analyze_impact
+
+        load_conn = MagicMock()
+        load_conn.execute.return_value.fetchall.return_value = []
+        sync_conn = MagicMock()
+        sync_conn.execute.return_value.fetchone.return_value = (
+            datetime(2026, 4, 9, 12, 0, tzinfo=UTC),
+            42,
+        )
+        insert_conn = MagicMock()
+        insert_conn.execute.return_value.rowcount = 1
+        stale_conn = MagicMock()
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=_make_draft()),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
+            patch("app.docs.analyze_handler.build_draft_graph", return_value="# ttl"),
+            patch("app.docs.analyze_handler.put_named_graph", return_value=True),
+            patch("app.docs.analyze_handler.write_doc_lineage", return_value=None),
+            patch("app.docs.analyze_handler.fetch_draft", return_value=None),
+            patch(
+                "app.docs.analyze_handler.ImpactAnalyzer",
+                return_value=MagicMock(
+                    analyze=MagicMock(return_value=_findings_with_one_conflict())
+                ),
+            ),
+            patch("app.docs.analyze_handler.calculate_impact_score", return_value=42),
+            patch("app.docs.analyze_handler.update_stale_flags_for_version") as mock_stale,
+        ):
+            mock_get_conn.side_effect = [
+                _ConnectCM(load_conn),
+                _ConnectCM(sync_conn),
+                _ConnectCM(insert_conn),
+                _ConnectCM(stale_conn),
+            ]
+            mock_stale.return_value = 0
+
+            analyze_impact({"draft_id": str(_DRAFT_ID)})
+
+        # update_stale_flags_for_version was called exactly once.
+        assert mock_stale.call_count == 1
+        call_args = mock_stale.call_args
+        # version_id matches the latest version of the draft.
+        assert call_args.args[1] == str(_VERSION_ID)
+        # current_keys is a set with exactly one ("conflict", <hash>) tuple.
+        current_keys = call_args.args[2]
+        assert isinstance(current_keys, set)
+        assert len(current_keys) == 1
+        only = next(iter(current_keys))
+        assert only[0] == "conflict"
+        # row_key is the deterministic 32-hex-char hash.
+        assert len(only[1]) == 32
+
+    def test_stale_flag_failure_does_not_fail_analyze(self):
+        """update_stale_flags_for_version raising MUST NOT bubble up; the
+        analyze handler returns its happy-path result regardless."""
+        from app.docs.analyze_handler import analyze_impact
+
+        load_conn = MagicMock()
+        load_conn.execute.return_value.fetchall.return_value = []
+        sync_conn = MagicMock()
+        sync_conn.execute.return_value.fetchone.return_value = None
+        insert_conn = MagicMock()
+        insert_conn.execute.return_value.rowcount = 1
+
+        # The 4th connection raises during __enter__ to simulate a DB
+        # outage on the stale-flag transaction. This is a realistic
+        # failure shape (psycopg can fail at acquire-time).
+        broken_cm = MagicMock()
+        broken_cm.__enter__ = MagicMock(side_effect=RuntimeError("DB down"))
+        broken_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=_make_draft()),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
+            patch("app.docs.analyze_handler.build_draft_graph", return_value="# ttl"),
+            patch("app.docs.analyze_handler.put_named_graph", return_value=True),
+            patch("app.docs.analyze_handler.write_doc_lineage", return_value=None),
+            patch("app.docs.analyze_handler.fetch_draft", return_value=None),
+            patch(
+                "app.docs.analyze_handler.ImpactAnalyzer",
+                return_value=MagicMock(
+                    analyze=MagicMock(return_value=_findings_with_one_conflict())
+                ),
+            ),
+            patch("app.docs.analyze_handler.calculate_impact_score", return_value=42),
+        ):
+            mock_get_conn.side_effect = [
+                _ConnectCM(load_conn),
+                _ConnectCM(sync_conn),
+                _ConnectCM(insert_conn),
+                broken_cm,
+            ]
+
+            # MUST NOT raise — best-effort contract.
+            result = analyze_impact({"draft_id": str(_DRAFT_ID)})
+
+        assert result["draft_id"] == str(_DRAFT_ID)
+        assert result["impact_score"] == 42
+
+    def test_skips_stale_flag_when_version_id_missing(self):
+        """If the analyze run has no draft_version_id (legacy / pre-PR-B),
+        we MUST skip the stale-flag update entirely so we don't issue a
+        spurious WHERE draft_version_id = NULL query."""
+        from app.docs.analyze_handler import analyze_impact
+
+        load_conn = MagicMock()
+        load_conn.execute.return_value.fetchall.return_value = []
+        sync_conn = MagicMock()
+        sync_conn.execute.return_value.fetchone.return_value = None
+        insert_conn = MagicMock()
+        insert_conn.execute.return_value.rowcount = 1
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=_make_draft()),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=None),  # no version
+            patch("app.docs.analyze_handler.build_draft_graph", return_value="# ttl"),
+            patch("app.docs.analyze_handler.put_named_graph", return_value=True),
+            patch("app.docs.analyze_handler.write_doc_lineage", return_value=None),
+            patch("app.docs.analyze_handler.fetch_draft", return_value=None),
+            patch(
+                "app.docs.analyze_handler.ImpactAnalyzer",
+                return_value=MagicMock(
+                    analyze=MagicMock(return_value=_findings_with_one_conflict())
+                ),
+            ),
+            patch("app.docs.analyze_handler.calculate_impact_score", return_value=42),
+            patch("app.docs.analyze_handler.update_stale_flags_for_version") as mock_stale,
+        ):
+            mock_get_conn.side_effect = [
+                _ConnectCM(load_conn),
+                _ConnectCM(sync_conn),
+                _ConnectCM(insert_conn),
+            ]
+
+            analyze_impact({"draft_id": str(_DRAFT_ID)})
+
+        # update_stale_flags_for_version was NOT called because the
+        # draft_version_id is None.
+        mock_stale.assert_not_called()
+
+
+# ===========================================================================
+# 6. Section-pagination fragment carries annotation buttons too
+# ===========================================================================
+
+
+class TestSectionPagerFragment:
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_paginated_batch_renders_annotation_buttons(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        """The "Näita rohkem" fragment route must also wire the
+        AnnotationButton column for the slice it returns."""
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row(_make_findings(affected=3))
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {("entity", "urn:entity:1"): 2}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report/section/affected?offset=1&limit=1")
+
+        assert resp.status_code == 200
+        # The fragment renders a per-row button targeting the version-scoped route.
+        assert f"/annotations/version/{_VERSION_ID}/entity/urn:entity:1" in resp.text
+
+
+# ===========================================================================
+# Smoke: fixtures exercise (catches collection errors early)
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "row,expected_kind",
+    [
+        ({"uri": "u"}, "entity"),
+        ({"eu_act": "x"}, "eu"),
+    ],
+)
+def test_row_key_helpers_smoke(row: dict[str, Any], expected_kind: str):
+    """Sanity check that the row-key helpers can be called across kinds
+    without raising on minimal inputs."""
+    if expected_kind == "entity":
+        assert row_key_for_entity(row) == "u"
+    else:
+        assert row_key_for_eu(row) == "x"
+
+
+def test_findings_json_roundtrip_preserves_keys():
+    """The report_data JSONB roundtrip must preserve the field names the
+    row-key helpers depend on."""
+    findings = _make_findings(affected=1, conflicts=1, eu=1, gaps=1)
+    roundtripped = json.loads(json.dumps(findings))
+    assert "affected_entities" in roundtripped
+    assert "conflicts" in roundtripped
+    assert "eu_compliance" in roundtripped
+    assert "gaps" in roundtripped
+    # row_key formulas must produce the same key before / after JSON.
+    assert row_key_for_entity(findings["affected_entities"][0]) == row_key_for_entity(
+        roundtripped["affected_entities"][0]
+    )
+    assert row_key_for_conflict(findings["conflicts"][0]) == row_key_for_conflict(
+        roundtripped["conflicts"][0]
+    )


### PR DESCRIPTION
## Summary

Closes the #619 trio: **PR-A** (#702 schema, `4c79bfa`) + **PR-B** (#706 routes + side panel, `9141422`) + **this PR-C** wires the impact-report rows into the version-scoped annotation threads and reconciles the `stale` flag at the tail of every analyze run.

References: #619, sprint plan §6 Days 3-4, §9.4 row-key contract locked in PR-A.

### What changed

- **`app/annotations/row_keys.py`** (new, 92 lines) — §9.4 row-key formulas shared by the renderer + analyze pipeline. Deterministic sha256-32 hex digests for `conflict` + `gap` rows so the SAME conflict across re-analyze runs maps to the SAME annotation thread (users do not lose context).

- **`app/annotations/models.py`** (+169) — adds:
  - `count_unresolved_for_version_row(conn, draft_version_id, row_kind, row_key) -> int` powers the AnnotationButton badge
  - `update_stale_flags_for_version(conn, draft_version_id, current_row_keys) -> int` best-effort reconciliation: vanished rows → `stale=true`, reappeared rows → `stale=false`. Idempotent; swallows DB errors.

- **`app/docs/report_routes.py`** (+369 / -28):
  - Side-panel container `Div(id="annotation-side-panel")` rendered ONCE per page (matches PR-B `_SIDE_PANEL_ID` so the version-scoped GET fragment swaps in cleanly)
  - Per-row `_row_annotation_button` targets `/annotations/version/{id}/{kind}/{key}` (PR-B routes)
  - One bulk SELECT loads unresolved counts for every row on the page (avoids O(N) round-trips)
  - `draft_version_id` + counts threaded through every section + the paginated "Näita rohkem" fragment route
  - Legacy reports without a `draft_version_id` FK gracefully skip the per-row buttons (page still renders + side panel still mounts)

- **`app/docs/analyze_handler.py`** (+35) — invokes `update_stale_flags_for_version` after the impact_reports insert commits, in its own transaction + try/except so a stale-flag glitch never aborts an otherwise-successful analyze (best-effort UX, not correctness invariant).

- **`tests/test_annotations_row_integration.py`** (new, 39 tests):
  - Row-key determinism: hash stability across calls, ascii-safety with Estonian letters, 64-char reason truncation, subject/object sort-normalisation
  - AnnotationButton injection per section (entity / conflict / eu / gap)
  - Unresolved badge count rendering
  - Side-panel container exists exactly once
  - `update_stale_flags_for_version`: stale flips both directions, idempotency, no-op when state matches, best-effort error swallow, malformed `target_id` skip
  - `analyze_handler` wiring: stale reconciliation called with the right keys after analyze commits, failure does NOT fail the job, missing version_id skips the call entirely
  - Paginated section fragment also carries the buttons

## Test plan

- [x] `uv run ruff format` + `ruff check` — clean (5 files)
- [x] `uv run pyright app/docs/report_routes.py app/docs/analyze_handler.py app/annotations/models.py app/annotations/row_keys.py tests/test_annotations_row_integration.py` — 0 errors
- [x] `uv run pytest` — 2178 passed, 23 skipped (baseline 2069+ + 39 new tests)
- [x] No regression in `test_docs_report_routes.py` (25 pre-existing tests still pass — column-index contract preserved)
- [x] No regression in `test_docs_analyze_handler.py` (12 pre-existing tests still pass — best-effort wrapping is transparent to existing mock chains)
- [x] PR-B routes (`tests/test_annotations_version_routes.py`) untouched — confirmed by 37 tests still passing

## Hard guardrails respected

- 5 files touched (4 in `app/` + 1 new test file)
- Did NOT touch `app/annotations/routes.py` (PR-B territory)
- Did NOT add new tables (schema is migration 031 + 032)
- Did NOT add an annotations backfill (prod has 0 rows)

## Do NOT merge

This is the final #619 PR. Awaiting review before sprint-plan close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)