### PR TITLE
fix(i18n): #714 PR-B — restore Estonian diacritics in user-facing copy

### DIFF
--- a/app/admin/analytics.py
+++ b/app/admin/analytics.py
@@ -161,10 +161,10 @@ def admin_analytics_page(req: Request):
 
         summary_dl = Dl(  # noqa: F405
             Dt("Perioodi pikkus"),  # noqa: F405
-            Dd(Badge(f"{summary['days']} paeva", variant="default")),  # noqa: F405
-            Dt("Uleslaadimisi kokku"),  # noqa: F405
+            Dd(Badge(f"{summary['days']} päeva", variant="default")),  # noqa: F405
+            Dt("Üleslaadimisi kokku"),  # noqa: F405
             Dd(Badge(str(summary["total_uploads"]), variant="primary")),  # noqa: F405
-            Dt("Vestluse sonumeid kokku"),  # noqa: F405
+            Dt("Vestluse sõnumeid kokku"),  # noqa: F405
             Dd(Badge(str(summary["total_chat_messages"]), variant="primary")),  # noqa: F405
             Dt("Koostamise seansse kokku"),  # noqa: F405
             Dd(Badge(str(summary["total_drafter_sessions"]), variant="primary")),  # noqa: F405
@@ -172,18 +172,18 @@ def admin_analytics_page(req: Request):
         )
 
         # Charts
-        uploads_chart = _svg_bar_chart(data, "uploads", "Uleslaadimised paevas", "#0066cc")
-        chat_chart = _svg_bar_chart(data, "chat_messages", "Vestluse sonumid paevas", "#2e8b57")
+        uploads_chart = _svg_bar_chart(data, "uploads", "Üleslaadimised päevas", "#0066cc")
+        chat_chart = _svg_bar_chart(data, "chat_messages", "Vestluse sõnumid päevas", "#2e8b57")
         drafter_chart = _svg_bar_chart(
-            data, "drafter_sessions", "Koostamise seansid paevas", "#9b59b6"
+            data, "drafter_sessions", "Koostamise seansid päevas", "#9b59b6"
         )
 
         # Detail table
         if data:
             columns = [
-                Column(key="day", label="Kuupaev", sortable=False),
-                Column(key="uploads", label="Uleslaadimised", sortable=False),
-                Column(key="chat_messages", label="Vestluse sonumid", sortable=False),
+                Column(key="day", label="Kuupäev", sortable=False),
+                Column(key="uploads", label="Üleslaadimised", sortable=False),
+                Column(key="chat_messages", label="Vestluse sõnumid", sortable=False),
                 Column(key="drafter_sessions", label="Koostamise seansid", sortable=False),
             ]
             rows = [
@@ -204,12 +204,13 @@ def admin_analytics_page(req: Request):
             table = P("Kasutusandmed puuduvad.", cls="muted-text")  # noqa: F405
 
         content = (
-            H1("Kasutusanaluutika", cls="page-title"),  # noqa: F405
+            H1("Kasutusanal\u00fc\u00fctika", cls="page-title"),  # noqa: F405
             P(A("\u2190 Tagasi adminipaneelile", href="/admin"), cls="back-link"),  # noqa: F405
             InfoBox(
                 P(  # noqa: F405
-                    "Kasutusanaluutika naitab uleslaadimiste, vestluse sonumite "
-                    "ja koostamise seansside statistikat paevade kaupa."
+                    "Kasutusanal\u00fc\u00fctika n\u00e4itab \u00fcleslaadimiste, "
+                    "vestluse s\u00f5numite ja koostamise seansside "
+                    "statistikat p\u00e4evade kaupa."
                 ),
                 variant="info",
                 dismissible=True,
@@ -217,8 +218,8 @@ def admin_analytics_page(req: Request):
             Card(
                 CardHeader(
                     H3(  # noqa: F405
-                        "Kokkuvote",
-                        _tooltip(f"Viimased {days} paeva"),
+                        "Kokkuv\u00f5te",
+                        _tooltip(f"Viimased {days} p\u00e4eva"),
                         cls="card-title",
                     )
                 ),

--- a/app/admin/cost_dashboard.py
+++ b/app/admin/cost_dashboard.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 # Feature labels in Estonian for the cost breakdown.
 _FEATURE_LABELS: dict[str, str] = {
-    "drafter_clarify": "Koostaja tapsustamine",
+    "drafter_clarify": "Koostaja täpsustamine",
     "drafter_draft": "Koostaja mustand",
     "chat": "Nõustaja",
     "extraction": "Eraldamine",
@@ -337,8 +337,8 @@ def admin_cost_page(req: Request):
             ),
             InfoBox(
                 P(  # noqa: F405
-                    "LLM kulude ulevaade naitab jooksva kuu kulusid organisatsioonide, "
-                    "funktsioonide ja mudelite loikes ning igakuist trendi."
+                    "LLM kulude ülevaade näitab jooksva kuu kulusid organisatsioonide, "
+                    "funktsioonide ja mudelite lõikes ning igakuist trendi."
                 ),
                 variant="info",
                 dismissible=True,

--- a/app/admin/cost_dashboard.py
+++ b/app/admin/cost_dashboard.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _FEATURE_LABELS: dict[str, str] = {
     "drafter_clarify": "Koostaja tapsustamine",
     "drafter_draft": "Koostaja mustand",
-    "chat": "Vestlus",
+    "chat": "Nõustaja",
     "extraction": "Eraldamine",
 }
 

--- a/app/admin/sync.py
+++ b/app/admin/sync.py
@@ -146,7 +146,7 @@ def _sync_explainer():
                 rel="noopener",
             ),
             ") ja laadib selle Apache Jena Fuseki triplestore'i. "
-            "P\u00e4rast l\u00f5ppemist kajastab Uurija ja AI-vestlus "
+            "P\u00e4rast l\u00f5ppemist kajastavad \u00d5iguskaart ja N\u00f5ustaja "
             "uusimaid seaduseid, kohtuotsuseid ja EL-i \u00f5igusakte.",
         ),
         Details(  # noqa: F405

--- a/app/analyysikeskus/__init__.py
+++ b/app/analyysikeskus/__init__.py
@@ -1,0 +1,11 @@
+"""Analüüsikeskus — the legal-analysis workflow hub (#714).
+
+This package currently exposes only a placeholder landing page; the
+workflow directory and the individual analysis workflows land in the
+follow-up issues (#720 landing page, #722 Normi mõjuahel, #723 EL
+ülevõtt).
+"""
+
+from app.analyysikeskus.routes import register_analyysikeskus_routes
+
+__all__ = ["register_analyysikeskus_routes"]

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -1,0 +1,40 @@
+"""Analüüsikeskus routes (#714).
+
+For now this is a single placeholder page so the new ``Analüüsikeskus``
+navigation entry resolves. The workflow directory (#720) replaces this
+body; the individual workflows (#722 Normi mõjuahel, #723 EL ülevõtt)
+register their own sub-routes here later.
+"""
+
+from fasthtml.common import *  # noqa: F403
+from starlette.requests import Request
+
+from app.ui.layout import PageShell
+from app.ui.surfaces.info_box import InfoBox
+from app.ui.theme import get_theme_from_request
+
+
+def analyysikeskus_page(req: Request):
+    """GET /analyysikeskus — placeholder for the legal-analysis workflow hub."""
+    auth = req.scope.get("auth") or None
+    theme = get_theme_from_request(req)
+    return PageShell(
+        H1("Analüüsikeskus", cls="page-title"),  # noqa: F405
+        InfoBox(
+            P(  # noqa: F405
+                "Analüüsikeskus koondab õigusliku analüüsi töövood — "
+                "normi mõjuahel, EL õiguse ülevõtt ja teised — ühte kohta. "
+                "Tulekul."
+            ),
+            variant="info",
+        ),
+        title="Analüüsikeskus",
+        user=auth,
+        theme=theme,
+        active_nav="/analyysikeskus",
+    )
+
+
+def register_analyysikeskus_routes(rt) -> None:  # type: ignore[no-untyped-def]
+    """Register Analüüsikeskus routes on the FastHTML route decorator *rt*."""
+    rt("/analyysikeskus", methods=["GET"])(analyysikeskus_page)

--- a/app/chat/export.py
+++ b/app/chat/export.py
@@ -115,7 +115,7 @@ def conversation_to_markdown(
     System messages are skipped. Assistant content is emitted verbatim
     (already markdown from the LLM).
     """
-    title = (conversation.title or "Vestlus").strip() or "Vestlus"
+    title = (conversation.title or "Nõustamine").strip() or "Nõustamine"
     parts: list[str] = [
         f"# {title}",
         "",
@@ -223,7 +223,7 @@ def conversation_to_docx_bytes(
     The returned bytes are a valid ZIP archive (.docx is a zipped OOXML
     bundle) so the caller can stream them directly as a file download.
     """
-    title = (conversation.title or "Vestlus").strip() or "Vestlus"
+    title = (conversation.title or "Nõustamine").strip() or "Nõustamine"
 
     doc = Document()
     doc.add_heading(title, level=0)

--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -926,7 +926,7 @@ def _render_search_results(conversations: list[Conversation], term: str) -> Any:
         items.append(
             Li(
                 A(
-                    conv.title or "Vestlus",
+                    conv.title or "Nõustamine",
                     href=f"/chat/{conv.id}",
                     cls="chat-search-result-link",
                 ),

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -595,7 +595,9 @@ def new_conversation(req: Request):
     # Optional draft context
     draft_param = req.query_params.get("draft")
     context_draft_id: uuid.UUID | None = None
-    title = "Vestlus"
+    # #714: conversations live under the "Nõustaja" section, so generated
+    # titles use that framing rather than the old "Vestlus" prefix.
+    title = "Nõustamine"
 
     if draft_param:
         parsed_draft = _parse_uuid(draft_param)
@@ -604,7 +606,7 @@ def new_conversation(req: Request):
             draft_title = _get_draft_title(str(parsed_draft), org_id)
             if draft_title is not None:
                 context_draft_id = parsed_draft
-                title = f"Vestlus \u2014 {draft_title}"
+                title = f"N\u00f5ustamine \u2014 {draft_title}"
             else:
                 # Draft not found or belongs to another org — ignore it
                 logger.warning(
@@ -616,7 +618,7 @@ def new_conversation(req: Request):
     if not context_draft_id:
         from app.ui.time import now_tallinn
 
-        title = f"Vestlus \u2014 {now_tallinn().strftime('%d.%m.%Y %H:%M')}"
+        title = f"N\u00f5ustamine \u2014 {now_tallinn().strftime('%d.%m.%Y %H:%M')}"
 
     try:
         with _connect() as conn:

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -507,7 +507,7 @@ def chat_list_page(req: Request):
         cls="chat-list-toolbar",
     )
 
-    header_children: list = [H1("Vestlused", cls="page-title")]  # noqa: F405
+    header_children: list = [H1("Nõustaja", cls="page-title")]  # noqa: F405
     header_children.append(
         InfoBox(
             P(
@@ -563,7 +563,7 @@ def chat_list_page(req: Request):
             CardHeader(H3("Minu vestlused", cls="card-title")),  # noqa: F405
             CardBody(*card_body_children),
         ),
-        title="Vestlused",
+        title="Nõustaja",
         user=auth,
         theme=theme,
         active_nav="/chat",

--- a/app/chat/system_prompt.py
+++ b/app/chat/system_prompt.py
@@ -52,7 +52,7 @@ def build_system_prompt(
     parts = [_BASE_SYSTEM_PROMPT]
 
     if draft_context_id:
-        summary_text = impact_summary or "Moju-analuusi aruanne pole saadaval."
+        summary_text = impact_summary or "Mõjuanalüüsi aruanne pole saadaval."
         parts.append(
             _DRAFT_CONTEXT_TEMPLATE.format(
                 draft_id=draft_context_id,

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -984,13 +984,13 @@ def draft_report_page(req: Request, draft_id: str):
             ),
             Div(
                 LinkButton(
-                    "Ava uurijas →",
+                    "Ava õiguskaardil →",
                     href=f"/explorer?draft={draft.id}",
                     variant="secondary",
                     title="Visualiseeri eelnõu ja mõjutatud sätted graafil.",
                 ),
                 # #614: one-line helper below the button so reviewers
-                # know what "Ava uurijas" actually does before clicking.
+                # know what "Ava õiguskaardil" actually does before clicking.
                 Small(  # noqa: F405
                     "Visualiseeri eelnõu ja mõjutatud sätted graafil.",
                     cls="muted-text explorer-cta-hint",

--- a/app/drafter/docx_builder.py
+++ b/app/drafter/docx_builder.py
@@ -167,13 +167,13 @@ def build_drafter_docx(
     # Appendix B: Impact summary (if available)
     if impact_summary:
         doc.add_section(WD_SECTION.NEW_PAGE)
-        doc.add_heading("Lisa B: Mojuanaluusi kokkuvote", level=1)
+        doc.add_heading("Lisa B: Mõjuanalüüsi kokkuvõte", level=1)
 
         score = impact_summary.get("impact_score", "N/A")
-        doc.add_paragraph(f"Mojuskoor: {score}/100")
-        doc.add_paragraph(f"Mojutatud uksuste arv: {impact_summary.get('affected_count', 0)}")
+        doc.add_paragraph(f"Mõjuskoor: {score}/100")
+        doc.add_paragraph(f"Mõjutatud üksuste arv: {impact_summary.get('affected_count', 0)}")
         doc.add_paragraph(f"Tuvastatud konfliktide arv: {impact_summary.get('conflict_count', 0)}")
-        doc.add_paragraph(f"Tuvastatud lunkade arv: {impact_summary.get('gap_count', 0)}")
+        doc.add_paragraph(f"Tuvastatud lünkade arv: {impact_summary.get('gap_count', 0)}")
 
     _add_page_number_footer(doc)
 

--- a/app/drafter/handlers.py
+++ b/app/drafter/handlers.py
@@ -350,13 +350,13 @@ def drafter_clarify(
     if not questions:
         # Fallback: generate minimal questions
         questions = [
-            {"question": "Milliseid asutusi see seadus mojutab?", "rationale": "scope"},
+            {"question": "Milliseid asutusi see seadus mõjutab?", "rationale": "scope"},
             {
-                "question": "Kas see taiendab voi asendab olemasolevat seadust?",
+                "question": "Kas see täiendab või asendab olemasolevat seadust?",
                 "rationale": "relationship",
             },
             {
-                "question": "Kas on EL-i noudeid, mida tuleb arvestada?",
+                "question": "Kas on EL-i nõudeid, mida tuleb arvestada?",
                 "rationale": "EU compliance",
             },
         ]

--- a/app/drafter/routes.py
+++ b/app/drafter/routes.py
@@ -159,7 +159,7 @@ def _not_found_page(req: Request):
     return PageShell(
         H1("Koostamissessioon ei leitud", cls="page-title"),  # noqa: F405
         Alert(
-            "Otsitud koostamissessioon ei ole olemas voi Te ei oma selle vaatamise oigust.",
+            "Otsitud koostamissessioon ei ole olemas või Te ei oma selle vaatamise õigust.",
             variant="warning",
         ),
         P(A("< Tagasi koostaja nimekirja", href="/drafter"), cls="back-link"),  # noqa: F405
@@ -214,13 +214,13 @@ def _session_list_columns() -> list[Column]:
 
     def _actions_cell(row: dict[str, Any]):
         return A(  # noqa: F405
-            "Jatka",
+            "Jätka",
             href=f"/drafter/{row['id']}",
             cls="btn btn-secondary btn-sm",
         )
 
     return [
-        Column(key="workflow_type", label="Toovoog", sortable=False, render=_workflow_cell),
+        Column(key="workflow_type", label="Töövoog", sortable=False, render=_workflow_cell),
         Column(key="current_step_label", label="Samm", sortable=False, render=_step_cell),
         Column(key="status", label="Staatus", sortable=False, render=_status_cell),
         Column(key="created_at", label="Loodud", sortable=False),
@@ -246,7 +246,7 @@ def drafter_list_page(req: Request):
 
     if not org_id or not user_id:
         body: Any = Alert(
-            "Te ei kuulu uhtegi organisatsiooni.",
+            "Te ei kuulu ühtegi organisatsiooni.",
             variant="warning",
         )
         pagination = None
@@ -258,7 +258,7 @@ def drafter_list_page(req: Request):
         if total == 0:
             body = Div(  # noqa: F405
                 P(  # noqa: F405
-                    "Teil ei ole veel uhtegi koostamissessiooni.",
+                    "Teil ei ole veel ühtegi koostamissessiooni.",
                     cls="muted-text",
                 ),
                 A(  # noqa: F405
@@ -335,7 +335,7 @@ def _workflow_form(*, error: str | None = None):
 
     return AppForm(
         Div(  # noqa: F405
-            Label("Toovoo tyyp", cls="form-field-label"),  # noqa: F405
+            Label("Töövoo tüüp", cls="form-field-label"),  # noqa: F405
             Div(  # noqa: F405
                 Label(  # noqa: F405
                     Input(  # noqa: F405
@@ -345,9 +345,9 @@ def _workflow_form(*, error: str | None = None):
                         checked=True,
                         cls="radio-input",
                     ),
-                    Span("Taielik seadus", cls="radio-label"),  # noqa: F405
+                    Span("Täielik seadus", cls="radio-label"),  # noqa: F405
                     P(  # noqa: F405
-                        "Koostab terve seaduse kavatsusest kuni valmis eelnouks.",
+                        "Koostab terve seaduse kavatsusest kuni valmis eelnõuks.",
                         cls="radio-description muted-text",
                     ),
                     cls="radio-option",
@@ -359,9 +359,9 @@ def _workflow_form(*, error: str | None = None):
                         value="vtk",
                         cls="radio-input",
                     ),
-                    Span("VTK eelanaluus", cls="radio-label"),  # noqa: F405
+                    Span("VTK eelanalüüs", cls="radio-label"),  # noqa: F405
                     P(  # noqa: F405
-                        "Koostab vabariigi valitsuse korralduse eelanaluusi dokumendi.",
+                        "Koostab vabariigi valitsuse korralduse eelanalüüsi dokumendi.",
                         cls="radio-description muted-text",
                     ),
                     cls="radio-option",
@@ -372,7 +372,7 @@ def _workflow_form(*, error: str | None = None):
         ),
         Div(  # noqa: F405
             Button("Alusta koostamist", type="submit", variant="primary"),
-            A("Tuhista", href="/drafter", cls="btn btn-ghost btn-md"),  # noqa: F405
+            A("Tühista", href="/drafter", cls="btn btn-ghost btn-md"),  # noqa: F405
             cls="form-actions",
         ),
         method="post",
@@ -391,7 +391,7 @@ def new_session_page(req: Request):
         return PageShell(
             H1("Uus koostamine", cls="page-title"),  # noqa: F405
             Alert(
-                "Te ei kuulu uhtegi organisatsiooni.",
+                "Te ei kuulu ühtegi organisatsiooni.",
                 variant="warning",
             ),
             title="Uus koostamine",
@@ -441,7 +441,7 @@ async def create_session_handler(req: Request):
     if not org_id or not user_id:
         return PageShell(
             H1("Uus koostamine", cls="page-title"),  # noqa: F405
-            Alert("Te ei kuulu uhtegi organisatsiooni.", variant="warning"),
+            Alert("Te ei kuulu ühtegi organisatsiooni.", variant="warning"),
             title="Uus koostamine",
             user=auth,
             active_nav="/drafter",
@@ -473,10 +473,10 @@ async def create_session_handler(req: Request):
             conn.commit()
     except Exception:
         logger.exception("Failed to create drafting session")
-        form, _ = _workflow_form(error="Sessiooni loomine ebaonnestus. Palun proovige uuesti.")
+        form, _ = _workflow_form(error="Sessiooni loomine ebaõnnestus. Palun proovige uuesti.")
         return PageShell(
             H1("Uus koostamine", cls="page-title"),  # noqa: F405
-            Alert("Sessiooni loomine ebaonnestus.", variant="danger"),
+            Alert("Sessiooni loomine ebaõnnestus.", variant="danger"),
             Card(CardBody(form)),
             title="Uus koostamine",
             user=auth,
@@ -566,18 +566,18 @@ def _step_1_content(
                 placeholder=(
                     "Nt: Soovin koostada seaduse, mis reguleerib tehisintellekti "
                     "kasutamist avalikus sektoris, sealhulgas andmekaitse "
-                    "noudeid ja labi\u00adpaistvuse kohustust."
+                    "n\u00f5udeid ja l\u00e4bi\u00adpaistvuse kohustust."
                 ),
                 cls="input textarea",
             ),
             Small(  # noqa: F405
-                f"Kuni {_INTENT_MAX_LENGTH} tahemarki.",
+                f"Kuni {_INTENT_MAX_LENGTH} tähemärki.",
                 cls="form-field-help",
             ),
             cls="form-field",
         ),
         Div(  # noqa: F405
-            Button("Jatka tapsustamisega", type="submit", variant="primary"),
+            Button("Jätka täpsustamisega", type="submit", variant="primary"),
             A("Tagasi", href="/drafter", cls="btn btn-ghost btn-md"),  # noqa: F405
             cls="form-actions",
         ),
@@ -680,17 +680,17 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
         job = _find_latest_job(session.id, "drafter_clarify")
         if job is None:
             # No job enqueued yet — shouldn't happen, but show a waiting state
-            return _step_waiting_page(session, 2, auth, "Kusimuste genereerimine...")
+            return _step_waiting_page(session, 2, auth, "Küsimuste genereerimine...")
 
         if job["status"] in ("pending", "claimed", "running"):
-            return _step_waiting_page(session, 2, auth, "Kusimuste genereerimine...")
+            return _step_waiting_page(session, 2, auth, "Küsimuste genereerimine...")
 
         if job["status"] == "failed":
             return _step_error_page(
                 session,
                 2,
                 auth,
-                job.get("error_message") or "Kusimuste genereerimine ebaonnestus.",
+                job.get("error_message") or "Küsimuste genereerimine ebaõnnestus.",
             )
 
     # Find the first unanswered question
@@ -726,12 +726,12 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
             AppForm(
                 Div(  # noqa: F405
                     P(  # noqa: F405
-                        Strong(f"Kusimus {unanswered_idx + 1}/{len(clarifications)}: "),  # noqa: F405
+                        Strong(f"Küsimus {unanswered_idx + 1}/{len(clarifications)}: "),  # noqa: F405
                         q,
                         cls="clarification-question current",
                     ),
                     Small(  # noqa: F405
-                        f"{remaining} kusimust vastamata",
+                        f"{remaining} küsimust vastamata",
                         cls="form-field-help",
                     ),
                     Textarea(  # noqa: F405
@@ -759,11 +759,11 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
         children.append(
             Div(  # noqa: F405
                 Alert(
-                    "Koik kusimused on vastatud. Voite jatkata uurimise sammuga.",
+                    "Kõik küsimused on vastatud. Võite jätkata uurimise sammuga.",
                     variant="success",
                 ),
                 AppForm(
-                    Button("Jatka uurimisega", type="submit", variant="primary"),
+                    Button("Jätka uurimisega", type="submit", variant="primary"),
                     Input(type="hidden", name="action", value="advance"),  # noqa: F405
                     method="post",
                     action=f"/drafter/{session.id}/step/2",
@@ -773,7 +773,7 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
         )
 
     return PageShell(
-        H1("Tapsustamine", cls="page-title"),  # noqa: F405
+        H1("T\u00e4psustamine", cls="page-title"),  # noqa: F405
         _step_tracker(session.current_step),
         InfoBox(
             P(
@@ -784,15 +784,15 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
             dismissible=True,
         ),
         Card(
-            CardHeader(H3("2. samm: Tapsustamine", cls="card-title")),  # noqa: F405
+            CardHeader(H3("2. samm: T\u00e4psustamine", cls="card-title")),  # noqa: F405
             CardBody(*children)
             if children
             else CardBody(
-                P("Kusimusi ei leitud.", cls="muted-text")  # noqa: F405
+                P("K\u00fcsimusi ei leitud.", cls="muted-text")  # noqa: F405
             ),
         ),
         P(A("\u2190 Tagasi koostaja nimekirja", href="/drafter"), cls="back-link"),  # noqa: F405
-        title="Tapsustamine",
+        title="T\u00e4psustamine",
         user=auth,
         active_nav="/drafter",
     )
@@ -815,7 +815,7 @@ def _step_3_page(session: DraftingSession, auth: UserDict):
                 session,
                 3,
                 auth,
-                job.get("error_message") or "Uurimine ebaonnestus.",
+                job.get("error_message") or "Uurimine ebaõnnestus.",
             )
 
     # Decrypt and show research results
@@ -834,14 +834,14 @@ def _step_3_page(session: DraftingSession, auth: UserDict):
     cards: list[Any] = []
 
     # Summary cards for each category
-    cards.append(_research_category_card("Oigusaktide satted", provisions, "provision"))
-    cards.append(_research_category_card("EL-i oigusaktid", eu_directives, "eu"))
+    cards.append(_research_category_card("Õigusaktide sätted", provisions, "provision"))
+    cards.append(_research_category_card("EL-i õigusaktid", eu_directives, "eu"))
     cards.append(_research_category_card("Kohtulahendid", court_decisions, "court"))
     cards.append(_research_category_card("Teemaklastrid", topic_clusters, "cluster"))
 
     # Advance button
     advance_form = AppForm(
-        Button("Jatka struktuuriga", type="submit", variant="primary"),
+        Button("Jätka struktuuriga", type="submit", variant="primary"),
         Input(type="hidden", name="action", value="advance"),  # noqa: F405
         method="post",
         action=f"/drafter/{session.id}/step/3",
@@ -911,7 +911,7 @@ def _step_4_page(session: DraftingSession, auth: UserDict):
                 session,
                 4,
                 auth,
-                job.get("error_message") or "Struktuuri genereerimine ebaonnestus.",
+                job.get("error_message") or "Struktuuri genereerimine ebaõnnestus.",
             )
 
     structure = session.proposed_structure or {}
@@ -985,7 +985,7 @@ def _step_4_page(session: DraftingSession, auth: UserDict):
         Input(type="hidden", name="chapter_count", value=str(len(chapters))),  # noqa: F405
         Div(*tree_items, cls="structure-tree"),  # noqa: F405
         Div(  # noqa: F405
-            Button("Salvesta ja jatka koostamisega", type="submit", variant="primary"),
+            Button("Salvesta ja jätka koostamisega", type="submit", variant="primary"),
             cls="form-actions",
         ),
         method="post",
@@ -1032,7 +1032,7 @@ def _step_5_page(session: DraftingSession, auth: UserDict):
                 session,
                 5,
                 auth,
-                job.get("error_message") or "Koostamine ebaonnestus.",
+                job.get("error_message") or "Koostamine ebaõnnestus.",
             )
 
     # Decrypt clauses
@@ -1068,13 +1068,13 @@ def _step_5_page(session: DraftingSession, auth: UserDict):
         clause_items.append(
             Div(  # noqa: F405
                 H4(f"{para} {title}", cls="clause-heading"),  # noqa: F405
-                Small(f"Peatukk: {chapter} {chapter_title}", cls="clause-chapter-ref muted-text"),  # noqa: F405
+                Small(f"Peatükk: {chapter} {chapter_title}", cls="clause-chapter-ref muted-text"),  # noqa: F405
                 Div(  # noqa: F405
                     P(text, cls="clause-text") if text else P("(Sisu puudub)", cls="muted-text"),  # noqa: F405
                     cls="clause-body",
                 ),
                 Div(*citation_links, cls="clause-citations") if citation_links else None,  # noqa: F405
-                P(Em(f"Markus: {notes}"), cls="clause-notes muted-text") if notes else None,  # noqa: F405
+                P(Em(f"Märkus: {notes}"), cls="clause-notes muted-text") if notes else None,  # noqa: F405
                 Div(  # noqa: F405
                     Button(  # noqa: F405
                         "Muuda",
@@ -1102,7 +1102,7 @@ def _step_5_page(session: DraftingSession, auth: UserDict):
 
     # Advance form
     advance_form = AppForm(
-        Button("Jatka ulevaatega", type="submit", variant="primary"),
+        Button("Jätka ülevaatega", type="submit", variant="primary"),
         Input(type="hidden", name="action", value="advance"),  # noqa: F405
         method="post",
         action=f"/drafter/{session.id}/step/5",
@@ -1148,7 +1148,7 @@ def _step_6_page(session: DraftingSession, auth: UserDict):
     if session.integrated_draft_id is None:
         # Not yet triggered — show the trigger button
         return PageShell(
-            H1("Integreeritud ulevaade", cls="page-title"),  # noqa: F405
+            H1("Integreeritud \u00fclevaade", cls="page-title"),  # noqa: F405
             _step_tracker(session.current_step),
             InfoBox(
                 P(
@@ -1160,23 +1160,29 @@ def _step_6_page(session: DraftingSession, auth: UserDict):
                 dismissible=True,
             ),
             Card(
-                CardHeader(H3("6. samm: Ulevaade", cls="card-title")),  # noqa: F405
+                CardHeader(H3("6. samm: \u00dclevaade", cls="card-title")),  # noqa: F405
                 CardBody(
                     P(  # noqa: F405
-                        "Selles sammus labitakse koostatud eelnou Phase 2 mojuanaluusi "
-                        "torustiku kaudu. See loob eelnou (.docx), parsib selle, "
-                        "tuvastab viited ja kuvab mojuanaluusi.",
+                        "Selles sammus l\u00e4bitakse koostatud "
+                        "eeln\u00f5u Phase 2 m\u00f5juanal\u00fc\u00fcsi torustiku "
+                        "kaudu. See loob eeln\u00f5u (.docx), parsib "
+                        "selle, tuvastab viited ja kuvab "
+                        "m\u00f5juanal\u00fc\u00fcsi.",
                         cls="page-lead",
                     ),
                     AppForm(
-                        Button("Kaivita mojuanaluus", type="submit", variant="primary"),
+                        Button(
+                            "K\u00e4ivita m\u00f5juanal\u00fc\u00fcs",
+                            type="submit",
+                            variant="primary",
+                        ),
                         method="post",
                         action=f"/drafter/{session.id}/step/6",
                     ),
                 ),
             ),
             P(A("\u2190 Tagasi koostaja nimekirja", href="/drafter"), cls="back-link"),  # noqa: F405
-            title="Ulevaade",
+            title="\u00dclevaade",
             user=auth,
             active_nav="/drafter",
         )
@@ -1185,7 +1191,7 @@ def _step_6_page(session: DraftingSession, auth: UserDict):
     draft_id = str(session.integrated_draft_id)
 
     return PageShell(
-        H1("Integreeritud ulevaade", cls="page-title"),  # noqa: F405
+        H1("Integreeritud \u00fclevaade", cls="page-title"),  # noqa: F405
         _step_tracker(session.current_step),
         InfoBox(
             P(
@@ -1197,12 +1203,12 @@ def _step_6_page(session: DraftingSession, auth: UserDict):
             dismissible=True,
         ),
         Card(
-            CardHeader(H3("6. samm: Ulevaade", cls="card-title")),  # noqa: F405
+            CardHeader(H3("6. samm: \u00dclevaade", cls="card-title")),  # noqa: F405
             CardBody(
-                Alert("Mojuanaluus on seotud eelnouga.", variant="success"),
+                Alert("M\u00f5juanal\u00fc\u00fcs on seotud eeln\u00f5uga.", variant="success"),
                 P(  # noqa: F405
                     A(  # noqa: F405
-                        "Vaata mojuanaluusi aruannet",
+                        "Vaata m\u00f5juanal\u00fc\u00fcsi aruannet",
                         href=f"/drafts/{draft_id}/report",
                         cls="btn btn-secondary btn-md",
                     ),
@@ -1215,7 +1221,7 @@ def _step_6_page(session: DraftingSession, auth: UserDict):
                 ),
                 Div(  # noqa: F405
                     AppForm(
-                        Button("Jatka ekspordiga", type="submit", variant="primary"),
+                        Button("J\u00e4tka ekspordiga", type="submit", variant="primary"),
                         Input(type="hidden", name="action", value="advance"),  # noqa: F405
                         method="post",
                         action=f"/drafter/{session.id}/step/6",
@@ -1225,7 +1231,7 @@ def _step_6_page(session: DraftingSession, auth: UserDict):
             ),
         ),
         P(A("< Tagasi koostaja nimekirja", href="/drafter"), cls="back-link"),  # noqa: F405
-        title="Ulevaade",
+        title="\u00dclevaade",
         user=auth,
         active_nav="/drafter",
     )
@@ -1254,7 +1260,7 @@ def _step_7_page(session: DraftingSession, auth: UserDict):
             CardHeader(H3("7. samm: Eksport", cls="card-title")),  # noqa: F405
             CardBody(
                 P(  # noqa: F405
-                    "Teie eelnou on valmis. Laadige alla .docx fail.",
+                    "Teie eelnõu on valmis. Laadige alla .docx fail.",
                     cls="page-lead",
                 ),
                 A(  # noqa: F405
@@ -1429,7 +1435,7 @@ async def submit_intent(req: Request, session_id: str):
             auth,
             error=(
                 f"Kavatsuse kirjeldus on liiga pikk "
-                f"(maksimaalselt {_INTENT_MAX_LENGTH} tahemarki)."
+                f"(maksimaalselt {_INTENT_MAX_LENGTH} tähemärki)."
             ),
             intent_value=intent,
         )
@@ -1456,7 +1462,7 @@ async def submit_intent(req: Request, session_id: str):
         return _step_1_content(
             session,
             auth,
-            error="Kavatsuse salvestamine ebaonnestus. Palun proovige uuesti.",
+            error="Kavatsuse salvestamine ebaõnnestus. Palun proovige uuesti.",
             intent_value=intent,
         )
 
@@ -1528,7 +1534,7 @@ def step_status_fragment(req: Request, session_id: str, n: str):
                 headers={"HX-Redirect": f"/drafter/{session_id}/step/{step_num}"},
             )
         if job and job["status"] == "failed":
-            error_msg = job.get("error_message") or "Tootlus ebaonnestus."
+            error_msg = job.get("error_message") or "Töötlus ebaõnnestus."
             return Div(  # noqa: F405
                 Alert(error_msg, variant="danger"),
                 id="step-status",
@@ -1536,7 +1542,7 @@ def step_status_fragment(req: Request, session_id: str, n: str):
 
     # Still running — keep polling
     _step_messages = {
-        2: "Kusimuste genereerimine...",
+        2: "Küsimuste genereerimine...",
         3: "Ontoloogia uurimine...",
         4: "Struktuuri genereerimine...",
         5: "Seaduseteksti koostamine...",
@@ -1907,17 +1913,17 @@ async def submit_review(req: Request, session_id: str):
     except Exception:
         logger.exception("Failed to trigger integrated review for session %s", session_id)
         return PageShell(
-            H1("Integreeritud ulevaade", cls="page-title"),  # noqa: F405
+            H1("Integreeritud ülevaade", cls="page-title"),  # noqa: F405
             _step_tracker(session.current_step),
             Card(
                 CardBody(
                     Alert(
-                        "Mojuanaluusi kaivitamine ebaonnestus. Palun proovige uuesti.",
+                        "Mõjuanalüüsi käivitamine ebaõnnestus. Palun proovige uuesti.",
                         variant="danger",
                     ),
                 ),
             ),
-            title="Ulevaade",
+            title="Ülevaade",
             user=auth,
             active_nav="/drafter",
         )
@@ -1943,7 +1949,7 @@ def _trigger_integrated_review(session: DraftingSession, auth: UserDict) -> uuid
         clauses = data.get("clauses", [])
 
     structure = session.proposed_structure or {}
-    title = structure.get("title", session.intent or "Eelnou")
+    title = structure.get("title", session.intent or "Eelnõu")
 
     # Build .docx
     docx_path = build_drafter_docx(
@@ -2035,7 +2041,7 @@ def export_docx(req: Request, session_id: str):
             logger.warning("Could not decrypt draft content for export, session %s", session.id)
 
     structure = session.proposed_structure or {}
-    title = structure.get("title", session.intent or "Eelnou")
+    title = structure.get("title", session.intent or "Eelnõu")
 
     # Try to get impact summary if available
     impact_summary: dict[str, Any] | None = None
@@ -2148,7 +2154,7 @@ def clause_edit_form(req: Request, session_id: str, clause_idx: str):
             Div(  # noqa: F405
                 Button("Salvesta", type="submit", variant="primary", size="sm"),
                 Button(  # noqa: F405
-                    "Tuhista",
+                    "Tühista",
                     hx_get=f"/drafter/{session_id}/step/5",
                     hx_target="body",
                     hx_swap="outerHTML",
@@ -2281,7 +2287,7 @@ def regenerate_clause(req: Request, session_id: str, clause_idx: str):
             idx,
         )
         return Div(  # noqa: F405
-            Alert("Uuesti genereerimine ebaonnestus.", variant="danger"),
+            Alert("Uuesti genereerimine ebaõnnestus.", variant="danger"),
             id=f"clause-{clause_idx}",
         )
 
@@ -2356,7 +2362,7 @@ def regenerate_clause_status(req: Request, session_id: str, clause_idx: str):
                     cls="clause-heading",
                 ),  # noqa: F405
                 Small(  # noqa: F405
-                    f"Peatukk: {clause.get('chapter', '')} {clause.get('chapter_title', '')}",
+                    f"Peatükk: {clause.get('chapter', '')} {clause.get('chapter_title', '')}",
                     cls="clause-chapter-ref muted-text",
                 ),
                 Div(  # noqa: F405
@@ -2371,7 +2377,7 @@ def regenerate_clause_status(req: Request, session_id: str, clause_idx: str):
 
     if job and job["status"] == "failed":
         return Div(  # noqa: F405
-            Alert("Uuesti genereerimine ebaonnestus.", variant="danger"),
+            Alert("Uuesti genereerimine ebaõnnestus.", variant="danger"),
             id=f"clause-{clause_idx}",
         )
 

--- a/app/drafter/state_machine.py
+++ b/app/drafter/state_machine.py
@@ -38,11 +38,11 @@ class Step(IntEnum):
 
 STEP_LABELS_ET: dict[Step, str] = {
     Step.INTENT: "Kavatsus",
-    Step.CLARIFY: "Tapsustamine",
+    Step.CLARIFY: "Täpsustamine",
     Step.RESEARCH: "Uurimine",
     Step.STRUCTURE: "Struktuur",
     Step.DRAFT: "Koostamine",
-    Step.REVIEW: "Ulevaade",
+    Step.REVIEW: "Ülevaade",
     Step.EXPORT: "Eksport",
 }
 

--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -296,7 +296,7 @@ def explorer_page(req: Request):
         Head(
             Meta(charset="UTF-8"),
             Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
-            Title("Eesti õiguse ontoloogia — Explorer"),
+            Title("Õiguskaart — Eesti õiguse ontoloogia"),
             # D3.js v7
             Script(
                 src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js",
@@ -321,7 +321,7 @@ def explorer_page(req: Request):
             Header(
                 Div(
                     H1("Eesti õiguse ontoloogia"),
-                    Span("Uurija", cls="badge"),
+                    Span("Õiguskaart", cls="badge"),
                     Span("D3.js", cls="badge"),
                     # Search box
                     Div(
@@ -380,6 +380,12 @@ def explorer_page(req: Request):
                         role="link",
                     ),
                     A(
+                        "Analüüsikeskus",
+                        href="/analyysikeskus",
+                        cls="nav-btn",
+                        role="link",
+                    ),
+                    A(
                         "Eelnõud",
                         href="/drafts",
                         cls="nav-btn",
@@ -392,7 +398,7 @@ def explorer_page(req: Request):
                         role="link",
                     ),
                     A(
-                        "Vestlus",
+                        "Nõustaja",
                         href="/chat",
                         cls="nav-btn",
                         role="link",

--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -237,7 +237,7 @@ def explorer_page(req: Request):
                 aria_hidden="true",
             ),
             Div(
-                "See on Eesti õiguse ontoloogia uurija. "
+                "See on õiguskaart — Eesti õiguse ontoloogia visuaalne vaade. "
                 "Klõpsake kategooriatele, et uurida seadusi, kohtuotsuseid "
                 "ja EL-i õigusakte. Kasutage otsingut konkreetsete "
                 "sätete leidmiseks.",
@@ -320,8 +320,8 @@ def explorer_page(req: Request):
             # ----- Top bar (banner landmark) -----
             Header(
                 Div(
-                    H1("Eesti õiguse ontoloogia"),
-                    Span("Õiguskaart", cls="badge"),
+                    H1("Õiguskaart"),
+                    Span("Eesti õiguse ontoloogia", cls="explorer-tagline"),
                     Span("D3.js", cls="badge"),
                     # Search box
                     Div(

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from starlette.staticfiles import StaticFiles
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from app.admin import register_admin_routes
+from app.analyysikeskus import register_analyysikeskus_routes
 from app.annotations.routes import register_annotation_routes
 from app.auth.middleware import SKIP_PATHS, auth_before
 from app.auth.organizations import register_org_routes
@@ -239,6 +240,7 @@ register_explorer_pages(rt)
 register_ws_routes(app)
 register_webhook_routes(app)
 register_dashboard_routes(rt)
+register_analyysikeskus_routes(rt)
 register_admin_routes(rt)
 register_validation_routes(rt)
 register_design_system_routes(rt)

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -20,6 +20,8 @@ svg#canvas { width: 100%; height: 100vh; display: block; }
   display: flex; align-items: center; gap: 16px;
 }
 #topbar h1 { font-size: 16px; font-weight: 600; color: #f1f5f9; white-space: nowrap; }
+/* #714: descriptive subtitle next to the "Õiguskaart" page heading */
+#topbar .explorer-tagline { font-size: 13px; color: #94a3b8; white-space: nowrap; }
 #topbar .badge {
   font-size: 11px; background: rgba(251,146,60,0.15); color: #fdba74;
   padding: 3px 10px; border-radius: 99px; border: 1px solid rgba(251,146,60,0.25);

--- a/app/ui/layout/sidebar.py
+++ b/app/ui/layout/sidebar.py
@@ -6,12 +6,18 @@ from app.auth.provider import UserDict
 
 # Navigation items with required roles.
 # Each item: (label, href, icon, allowed_roles)
+#
+# #714: the user-facing labels are framed around legal work, not internal
+# module names. URLs are unchanged (relabel-in-place) — ``/explorer`` is
+# still ``/explorer`` even though it now reads "Õiguskaart", etc.
+_ALL_ROLES = {"drafter", "reviewer", "org_admin", "admin"}
 NAV_ITEMS: list[tuple[str, str, str, set[str]]] = [
-    ("Töölaud", "/dashboard", "home", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Uurija", "/explorer", "graph", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Eelnõud", "/drafts", "file-text", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Koostaja", "/drafter", "edit", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Vestlus", "/chat", "message-circle", {"drafter", "reviewer", "org_admin", "admin"}),
+    ("Töölaud", "/dashboard", "home", _ALL_ROLES),
+    ("Analüüsikeskus", "/analyysikeskus", "search", _ALL_ROLES),
+    ("Eelnõud", "/drafts", "file-text", _ALL_ROLES),
+    ("Õiguskaart", "/explorer", "graph", _ALL_ROLES),
+    ("Koostaja", "/drafter", "edit", _ALL_ROLES),
+    ("Nõustaja", "/chat", "message-circle", _ALL_ROLES),
     ("Kasutajad", "/org/users", "users", {"org_admin", "admin"}),
     ("Administraator", "/admin", "shield", {"admin"}),
 ]

--- a/app/ui/layout/top_bar.py
+++ b/app/ui/layout/top_bar.py
@@ -109,10 +109,11 @@ def TopBar(  # noqa: ANN201
                 cls="logo",
             ),
             Nav(  # noqa: F405
-                A("Uurija", href="/explorer"),  # noqa: F405
+                A("Analüüsikeskus", href="/analyysikeskus"),  # noqa: F405
                 A("Eelnõud", href="/drafts"),  # noqa: F405
+                A("Õiguskaart", href="/explorer"),  # noqa: F405
                 A("Koostaja", href="/drafter"),  # noqa: F405
-                A("Vestlus", href="/chat"),  # noqa: F405
+                A("Nõustaja", href="/chat"),  # noqa: F405
                 cls="top-nav",
             )
             if user

--- a/docs/2026-05-11-ministry-lawyer-ui-structure.md
+++ b/docs/2026-05-11-ministry-lawyer-ui-structure.md
@@ -6,6 +6,16 @@ Scope: Product and UI structure for Seadusloome as a legal advisory workbench fo
 
 Reference context: Section 7 of `eesti-oigusontoloogia-ulevaade.pdf` describes ministry use cases: norm impact chains, EU coordination, KOV policy comparison, competence audits, sanctions comparison, legislative burden management, crisis/internal-security legal mapping, and public-service full views.
 
+## Status — 2026-05-11 (epic [#714](https://github.com/henrikaavik/Seadusloome/issues/714))
+
+This document is the design rationale; the scope **actually committed** for the first round is narrower than everything described below. Read the rest of the doc as the long-term direction, but note:
+
+- **In scope now:** the *Phase A* framing changes (nav reframe in place, `Töölaud` → work queue, `Õiguskaart` control relabel + `?focus=` wiring, diacritics) **and** *Phase B done honestly* — the **two** `Analüüsikeskus` workflows that have backing ontology data today: `Normi mõjuahel` and `EL ülevõtt ja harmoneerimine`.
+- **Workflows 3–8 (`Pädevused`, `Sanktsioonid`, `Halduskoormus`, `KOV võrdlus`, `Avaliku teenuse tervikvaade`, `Kriisikaart`) are deferred** to a follow-up epic — **including the one this doc's Phase B list names (`Pädevused`)**. Their *ontology data* largely already exists in the `estonian-legal-ontology` source repo (`Sanction` nodes with structured penalty values, institution-authority nodes, KOV, …, well ahead of `estonian-legal-ontology-plan.md`); what's missing is the **app-side SPARQL + UI integration**. The follow-up epic should re-audit the ontology repo, not the plan doc. No placeholder cards for these workflows in the meantime.
+- **`EL ülevõtt` MVP is act/provision-level, not the article/obligation matrix** described under "Workflow 2" / "Concrete Page Recommendations" below: the ontology models `transposesDirective` / `transposedBy` / `transpositionStatus` at the act (and, where present, provision via `harmonisedWith`) level — there is no EU Article/Obligation entity model. The article-level matrix is its own ontology-enrichment ticket.
+- **Also deferred:** `Ülevaatus` review queue (Phase E), the LLM advice / suggested-fix engine (Phase D — `Soovitatud tegevused` is a *static* action set for now), the `Koostaja` `Lahendusvariandid` step, a light reading theme.
+- **URLs are relabelled in place** — `/explorer`, `/chat`, `/drafts`, `/drafter` keep their paths; only nav text, page titles, and headings change. The new `Analüüsikeskus` page gets a fresh route (`/analyysikeskus`).
+
 ## Executive Direction
 
 Seadusloome should be structured around legal work, not around technical modules.

--- a/docs/2026-05-11-ministry-lawyer-ui-structure.md
+++ b/docs/2026-05-11-ministry-lawyer-ui-structure.md
@@ -1,0 +1,1102 @@
+# Seadusloome UI Structure for Ministry Lawyers
+
+Date: 2026-05-11
+
+Scope: Product and UI structure for Seadusloome as a legal advisory workbench for lawyers and officials in Estonian ministries.
+
+Reference context: Section 7 of `eesti-oigusontoloogia-ulevaade.pdf` describes ministry use cases: norm impact chains, EU coordination, KOV policy comparison, competence audits, sanctions comparison, legislative burden management, crisis/internal-security legal mapping, and public-service full views.
+
+## Executive Direction
+
+Seadusloome should be structured around legal work, not around technical modules.
+
+The current application exposes the internal system shape:
+
+- `Uurija`
+- `Eelnõud`
+- `Koostaja`
+- `Vestlus`
+
+That is understandable to a development team, but it makes ministry lawyers translate their task into a tool choice. A lawyer does not start with "I need a graph explorer" or "I need a RAG chat". They start with:
+
+- "I need to know what this amendment affects."
+- "I need to check whether an EU directive is fully transposed."
+- "I need to compare KOV regulations."
+- "I need to know which agency is responsible for supervision."
+- "I need to see whether this sanction level is consistent."
+- "I need advice on how to fix the draft."
+
+The product should therefore present itself as a legal advisory workbench. The technical modules still exist underneath, but the user-facing structure should be organized by ministry workflows.
+
+The central design rule:
+
+> The system offers legal analysis, options, and recommended next actions. It should not ask lawyers technical questions.
+
+This means the UI must not ask about SPARQL, RDF classes, named graphs, graph URIs, embedding search, ontology predicates, background jobs, or other implementation details. When the system needs more information, it should ask legal or policy questions in ordinary ministry language.
+
+## Primary Users
+
+The primary users are lawyers and officials who work in ministries and participate in law creation, legal analysis, coordination, review, and impact assessment.
+
+They may be skilled lawyers, but they should not need to understand the ontology technology. The product should treat ontology, RAG, graph traversal, and SPARQL as invisible infrastructure.
+
+The expected user goals are:
+
+- analyze a legislative idea before drafting;
+- upload and assess a draft law or VTK;
+- understand legal dependencies and conflicts;
+- identify EU, KOV, court-practice, competence, and sanction implications;
+- get advice on legal solutions;
+- create or improve draft text;
+- prepare evidence for internal review or coordination.
+
+## Product Principle
+
+Seadusloome should behave like a senior legal analyst with access to the full legal ontology.
+
+The system should:
+
+- infer likely context from the user's draft, idea, ministry, and selected topic;
+- run the relevant ontology analyses automatically;
+- show findings in a legally meaningful order;
+- recommend what to do next;
+- ask clarifying questions only when legal judgment is genuinely needed;
+- always expose evidence and source links;
+- make it easy to export, annotate, assign, and continue drafting.
+
+The system should not:
+
+- ask the user to choose technical query types;
+- expose raw ontology identifiers as primary UI;
+- require users to know which module can answer a legal question;
+- make the graph the only way to understand relationships;
+- make the chat the main access point for structured analysis;
+- leave users with findings but no proposed solution.
+
+## Recommended Top-Level Navigation
+
+Proposed primary navigation:
+
+1. `Töölaud`
+2. `Analüüsikeskus`
+3. `Eelnõud`
+4. `Õiguskaart`
+5. `Koostaja`
+6. `Nõustaja`
+7. `Ülevaatus`
+8. `Admin`
+
+### Why This Structure
+
+`Töölaud` is the user's daily queue.
+
+It should answer:
+
+- what needs my attention today;
+- which drafts are waiting for review;
+- which analyses changed after ontology updates;
+- which findings are unresolved;
+- what the system recommends next.
+
+`Analüüsikeskus` is the main new structure.
+
+It should be the home for ministry use cases from Section 7. Instead of asking the user to pick a technical feature, it offers legal analysis workflows.
+
+`Eelnõud` remains the document workspace.
+
+It should handle uploads, versions, VTK links, processing status, impact reports, exports, retention, and deletion.
+
+`Õiguskaart` is the visual ontology map.
+
+It should no longer be framed as the primary "Explorer". It should be a supporting evidence view that opens from analyses with context already applied.
+
+`Koostaja` remains the drafting workflow.
+
+It should use the analysis workflows as inputs and should propose legal structure, clauses, alternatives, and risk notes.
+
+`Nõustaja` is a better label than `Vestlus`.
+
+The user is not looking for "chat"; the user is asking for legal advice. The assistant should also appear inside reports and draft pages, not only as a separate page.
+
+`Ülevaatus` is the collaboration and legal validation area.
+
+It should collect unresolved findings, annotations, ministry confirmations, assigned legal checks, and review decisions.
+
+`Admin` stays technical/administrative and should be hidden from normal lawyers.
+
+## Core UI Pattern for Every Workflow
+
+Every legal workflow should follow the same structure:
+
+1. `Sisend`
+2. `Ulatus`
+3. `Tulemused`
+4. `Tõendid`
+5. `Soovitatud tegevused`
+
+### 1. Sisend
+
+The user gives a legal object or describes a legal issue:
+
+- draft law;
+- VTK;
+- paragraph reference;
+- CELEX number;
+- institution;
+- sanction type;
+- public service;
+- topic such as waste management, cybersecurity, or social benefits.
+
+The UI should accept natural language and structured references.
+
+Good input examples:
+
+- "Muudame AvTS § 35."
+- "Kontrolli AI määruse ülevõttu."
+- "Võrdle jäätmehoolduseeskirju KOVide lõikes."
+- "Millistel asutustel on selle valdkonna järelevalvepädevus?"
+
+Bad input examples:
+
+- "Select RDF class."
+- "Enter graph URI."
+- "Choose SPARQL traversal depth."
+- "Pick embedding index."
+
+### 2. Ulatus
+
+The system should choose a sensible default scope and let the user adjust it in legal terms.
+
+Scope controls should be legal:
+
+- current law vs historical redactions;
+- Estonia only vs Estonia + EU;
+- all ministries vs my organization;
+- national law vs national + KOV regulations;
+- court practice included or excluded;
+- draft lifecycle stage;
+- time period.
+
+The system can say:
+
+> Analüüsin kehtivat õigust, seotud eelnõusid, Riigikohtu praktikat ja EL õigusakte. Võite ulatust muuta.
+
+It should not ask:
+
+> Which named graphs should be included?
+
+### 3. Tulemused
+
+The first result screen should be decision-oriented.
+
+It should not start with a table of raw entities. It should start with:
+
+- key findings;
+- risk level;
+- recommended next action;
+- legal rationale;
+- confidence;
+- what changed compared with earlier analysis, if relevant.
+
+Example:
+
+> Kavandatav muudatus mõjutab vähemalt 18 sätet, 3 pooleliolevat eelnõu ja 2 Riigikohtu lahendit. Kõrgeim risk on vastuolu AvTS § 35 erandite süsteemiga. Soovitus: täpsustada andmekoosseisude avalikustamise erandit ja lisada üleminekusäte.
+
+### 4. Tõendid
+
+Every claim must be auditable.
+
+The UI should show:
+
+- source provision;
+- linked draft;
+- court decision;
+- EU act;
+- relation type in legal language;
+- quote/snippet where available;
+- date/version;
+- source link;
+- why the system thinks this is relevant.
+
+The evidence view can use tables, timelines, and graph views, but the first layer should be legally readable.
+
+### 5. Soovitatud Tegevused
+
+Every workflow should end with a useful action set.
+
+Examples:
+
+- `Paranda eelnõu`
+- `Koosta alternatiivne sõnastus`
+- `Lisa ülevaatusele`
+- `Määra kolleegile`
+- `Ava õiguskaardil`
+- `Küsi nõustajalt`
+- `Ekspordi memo`
+- `Lisa seletuskirja mõjuanalüüsi`
+- `Märgi kontrollituks`
+
+This is critical: the system should not merely find issues. It should help solve them.
+
+## Analüüsikeskus
+
+`Analüüsikeskus` should be the central page for Section 7 workflows.
+
+It should present legal tasks as large, clear workflow entries, but not as marketing cards. This is an operational tool, so the layout should be dense, scan-friendly, and task-first.
+
+Recommended workflows:
+
+1. `Normi mõjuahel`
+2. `EL ülevõtt ja harmoneerimine`
+3. `KOV võrdlus`
+4. `Pädevused ja järelevalve`
+5. `Sanktsioonide võrdlus`
+6. `Kohustused, keelud ja halduskoormus`
+7. `Kriisi- ja siseturvalisuse õiguskaart`
+8. `Avaliku teenuse tervikvaade`
+
+Each workflow should have:
+
+- a one-line legal purpose;
+- one primary input field;
+- example inputs;
+- last used or recommended scope;
+- recent analyses;
+- a primary action: `Alusta analüüsi`.
+
+## Workflow 1: Normi Mõjuahel
+
+Section 7 use case: before changing a law, the user can see which provisions refer to the changed paragraph, which drafts affect it, and which Supreme Court practice is connected.
+
+### User Intent
+
+The lawyer wants to know what happens if a provision, draft, or idea changes.
+
+### Inputs
+
+- provision reference, such as `AvTS § 35`;
+- draft file;
+- draft ID;
+- natural-language idea;
+- selected entity from a report or graph.
+
+### System Logic
+
+The system should automatically:
+
+- resolve the referenced provision or idea to ontology entities;
+- find incoming and outgoing references;
+- find drafts that touch the same provisions;
+- find related court decisions;
+- find EU links;
+- detect possible conflicts;
+- show likely downstream effects;
+- rank findings by legal risk and relevance.
+
+### UI Output
+
+The first screen should show:
+
+- `Peamised mõjud`
+- `Kõrge riskiga seosed`
+- `Seotud eelnõud`
+- `Riigikohtu praktika`
+- `EL seosed`
+- `Soovitatud parandused`
+
+The graph should be available as `Ava õiguskaardil`, not be the default interpretation layer.
+
+### Recommended Actions
+
+- `Koosta mõju memo`
+- `Lisa seletuskirja`
+- `Koosta alternatiivne säte`
+- `Märgi risk ülevaatusele`
+- `Ava seotud eelnõu`
+
+## Workflow 2: EL Ülevõtt ja Harmoneerimine
+
+Section 7 use case: directives transposition view helps find which Estonian provisions are connected to a CELEX act and where transposition or harmonization gaps exist.
+
+### User Intent
+
+The lawyer or EU coordinator wants to understand whether Estonian law fully covers an EU obligation.
+
+### Inputs
+
+- CELEX number;
+- EU regulation/directive title;
+- draft law;
+- policy area;
+- natural-language question.
+
+### System Logic
+
+The system should:
+
+- resolve CELEX or EU act title;
+- list linked Estonian provisions;
+- identify relevant draft legislation;
+- detect missing or weak links;
+- show court practice where relevant;
+- compare current law to draft changes;
+- highlight obligations, deadlines, and affected institutions if available.
+
+### UI Output
+
+The first result should be a transposition matrix:
+
+- EU article or obligation;
+- Estonian provision;
+- status: covered, partial, missing, unclear;
+- evidence;
+- responsible institution;
+- recommended action.
+
+### Recommended Actions
+
+- `Täpsusta ülevõtu seos`
+- `Lisa puuduv säte`
+- `Koosta kooskõla memo`
+- `Saada EL koordinaatorile ülevaatuseks`
+- `Küsi nõustajalt parandust`
+
+## Workflow 3: KOV Võrdlus
+
+Section 7 use case: KOV regulations can be compared by municipality, issuer, and normalized titles, for example waste-management rules or social-benefit procedures.
+
+### User Intent
+
+The lawyer wants to see how local governments regulate the same topic and whether there are outliers, inconsistencies, or reusable patterns.
+
+### Inputs
+
+- policy area;
+- regulation title;
+- municipality;
+- institution;
+- natural-language service or obligation.
+
+### System Logic
+
+The system should:
+
+- normalize KOV regulation titles;
+- group similar regulations;
+- compare obligations, definitions, procedures, deadlines, and sanctions;
+- identify outliers;
+- identify common model wording;
+- show regional coverage and missing regulation areas.
+
+### UI Output
+
+The result should show:
+
+- comparison table by KOV;
+- common clauses;
+- divergent clauses;
+- missing or unusual provisions;
+- recommended harmonization options.
+
+### Recommended Actions
+
+- `Koosta võrdlusmemo`
+- `Paku ühtlustatud sõnastus`
+- `Märgi erisused ülevaatuseks`
+- `Ekspordi tabel`
+
+## Workflow 4: Pädevused ja Järelevalve
+
+Section 7 use case: competence mapping shows which institutions have permit, supervision, procedure, or enforcement tasks.
+
+### User Intent
+
+The lawyer wants to know who is responsible for doing what, whether responsibilities overlap, and whether a draft creates unclear competence.
+
+### Inputs
+
+- institution name;
+- policy area;
+- draft law;
+- task type: license, supervision, enforcement, procedure;
+- public service.
+
+### System Logic
+
+The system should:
+
+- extract institutions and task verbs;
+- classify competence type;
+- find source provisions;
+- identify overlaps between institutions;
+- identify missing implementing authority;
+- identify KOV vs national responsibility;
+- compare current law and draft changes.
+
+### UI Output
+
+The result should show a competence map:
+
+- institution;
+- task;
+- legal basis;
+- task type;
+- affected area;
+- related draft changes;
+- risk: overlap, gap, unclear mandate.
+
+### Recommended Actions
+
+- `Täpsusta volitusnorm`
+- `Lisa rakendusvastutus`
+- `Koosta pädevusmemo`
+- `Määra asutusele ülevaatus`
+
+## Workflow 5: Sanktsioonide Võrdlus
+
+Section 7 use case: sanctions index allows comparing fines, penalty payments, imprisonment, and other sanctions by field or legal act.
+
+### User Intent
+
+The lawyer wants to know whether a proposed sanction is proportionate and consistent with similar areas.
+
+### Inputs
+
+- sanction amount or type;
+- draft provision;
+- legal act;
+- policy area;
+- violation description.
+
+### System Logic
+
+The system should:
+
+- classify sanction type;
+- find comparable sanctions;
+- compare amount ranges and severity;
+- show legal act and field;
+- flag outliers;
+- show related court practice where available;
+- recommend consistency adjustments.
+
+### UI Output
+
+The result should show:
+
+- sanction comparison matrix;
+- severity bands;
+- comparable provisions;
+- outliers;
+- proportionality notes;
+- recommended alternative wording.
+
+### Recommended Actions
+
+- `Paku proportsionaalne sanktsioon`
+- `Lisa põhjendus seletuskirja`
+- `Võrdle valdkonna praktikaga`
+- `Saada karistusõiguse ülevaatusele`
+
+## Workflow 6: Kohustused, Keelud ja Halduskoormus
+
+Section 7 use case: deontic classification helps find concentrations of obligations, prohibitions, permissions, and rights, useful for evaluating administrative burden.
+
+### User Intent
+
+The lawyer wants to understand whether a draft adds too many obligations, unclear prohibitions, or administrative burden.
+
+### Inputs
+
+- draft law;
+- public service;
+- target group;
+- policy area.
+
+### System Logic
+
+The system should:
+
+- classify provisions as obligation, prohibition, permission, right, competence, sanction;
+- identify affected groups;
+- count new or changed obligations;
+- compare with current law;
+- show burden concentration by target group and institution;
+- recommend simplification.
+
+### UI Output
+
+The result should show:
+
+- burden summary;
+- obligations by target group;
+- obligations by institution;
+- new vs existing duties;
+- potential duplication;
+- simplification suggestions.
+
+### Recommended Actions
+
+- `Vähenda dubleerivat kohustust`
+- `Koosta halduskoormuse lõik`
+- `Täpsusta adressaat`
+- `Lisa erand või üleminekusäte`
+
+## Workflow 7: Kriisi- ja Siseturvalisuse Õiguskaart
+
+Section 7 use case: cross-references and competences can bring crisis, police, rescue, data protection, and local-level norms into one work view.
+
+### User Intent
+
+The lawyer wants a consolidated legal map for a crisis or internal-security scenario.
+
+### Inputs
+
+- scenario, such as cyber incident, flood, evacuation, public-order event;
+- institution;
+- draft;
+- legal act.
+
+### System Logic
+
+The system should:
+
+- map relevant laws, regulations, KOV norms, EU acts, and court practice;
+- identify responsible institutions;
+- identify emergency powers and limits;
+- identify data protection constraints;
+- identify conflicting or unclear mandates;
+- show time-sensitive legal dependencies.
+
+### UI Output
+
+The result should show:
+
+- scenario map;
+- institution responsibility table;
+- emergency powers;
+- data protection constraints;
+- KOV/national split;
+- risks and recommended clarifications.
+
+### Recommended Actions
+
+- `Koosta kriisiõiguse memo`
+- `Täpsusta pädevusjaotus`
+- `Lisa andmekaitse kontroll`
+- `Ava õiguskaardil`
+
+## Workflow 8: Avaliku Teenuse Tervikvaade
+
+Section 7 use case: laws, regulations, KOV procedures, court practice, and EU acts regulating a service can be combined into one query instead of searching separate portals manually.
+
+### User Intent
+
+The lawyer wants to understand the full legal environment around a public service.
+
+### Inputs
+
+- public service name;
+- institution;
+- policy area;
+- draft;
+- citizen or business obligation.
+
+### System Logic
+
+The system should:
+
+- identify the service;
+- find national laws;
+- find regulations;
+- find KOV procedures;
+- find EU obligations;
+- find related court practice;
+- map responsible institutions;
+- show service lifecycle steps;
+- identify legal gaps and duplication.
+
+### UI Output
+
+The result should show:
+
+- service legal map;
+- process steps;
+- legal basis per step;
+- responsible institution;
+- citizen/business obligations;
+- court and EU links;
+- risks and improvement suggestions.
+
+### Recommended Actions
+
+- `Koosta teenuse õigusmemo`
+- `Paku lihtsustatud regulatsiooni`
+- `Lisa mõjuanalüüsi`
+- `Saada asutusele ülevaatuseks`
+
+## Eelnõud Workspace
+
+`Eelnõud` should remain the place for actual documents, but it should become more action-oriented.
+
+Current useful parts:
+
+- upload `.docx` or `.pdf`;
+- distinguish `Eelnõu` and `VTK`;
+- link eelnõu to VTK;
+- show processing status;
+- show impact report;
+- show similar drafts;
+- show version history;
+- export reports.
+
+Recommended improvements:
+
+- rename the page description from generic upload language to "document workspace";
+- show unresolved findings directly in the list;
+- show next action per draft;
+- show whether analysis is stale after ontology updates;
+- show whether draft has unresolved EU, conflict, competence, or burden risks;
+- make `Vaata mõjuaruannet`, `Küsi nõustajalt`, and `Paranda koostajaga` primary actions;
+- make version comparison more prominent for legislative lifecycle work.
+
+List row should show:
+
+- title;
+- type: eelnõu or VTK;
+- lifecycle stage;
+- analysis status;
+- highest legal risk;
+- unresolved review count;
+- owner;
+- last change;
+- next action.
+
+## Õiguskaart
+
+The current Explorer should become `Õiguskaart`.
+
+The value of the graph is high, but it should be a contextual evidence view, not the first place a lawyer has to interpret results.
+
+Recommended behavior:
+
+- opened from analysis results with focus already applied;
+- shows selected provision/draft/service/institution as the center;
+- uses legal filters: laws, drafts, court practice, EU, KOV, competences, sanctions;
+- offers predefined views: impact chain, EU links, competence map, version timeline;
+- detail panel explains relation meaning in Estonian legal language;
+- graph controls use domain words, not simulation words.
+
+Replace controls such as:
+
+- `Taaskäivita simulatsioon`
+- `Lülita silte`
+- `Rühmita`
+
+With:
+
+- `Näita mõjuahelat`
+- `Näita EL seoseid`
+- `Näita pädevusi`
+- `Näita kohtupraktikat`
+- `Näita eelnõusid`
+- `Näita ajalist vaadet`
+
+Technical graph controls can remain under `Vaate seaded`.
+
+## Koostaja
+
+The AI drafter should not feel like an isolated wizard. It should be a drafting workspace informed by prior analysis.
+
+Recommended structure:
+
+1. `Kavatsus`
+2. `Õiguslik eeluuring`
+3. `Lahendusvariandid`
+4. `Struktuur`
+5. `Sätted`
+6. `Kontroll ja mõju`
+7. `Eksport`
+
+The most important addition is `Lahendusvariandid`.
+
+Before drafting clauses, the system should propose legal options:
+
+- amend existing law;
+- create new act;
+- use regulation instead of law;
+- add competence rule;
+- add exception;
+- add transitional provision;
+- no legislative change needed;
+- policy or administrative measure may be sufficient.
+
+For each option, show:
+
+- when this option is appropriate;
+- legal risks;
+- affected institutions;
+- EU implications;
+- drafting effort;
+- recommended choice.
+
+The system should ask clarifying questions only in legal terms:
+
+Good:
+
+- "Millist sihtrühma muudatus peamiselt puudutab?"
+- "Kas eesmärk on luua uus kohustus või täpsustada olemasolevat?"
+- "Kas muudatus peab jõustuma kindlal kuupäeval?"
+
+Bad:
+
+- "Millist ontology classi kasutada?"
+- "Kas otsida Jena named graphist?"
+- "Millise SPARQL päringu käivitan?"
+
+## Nõustaja
+
+The current `Vestlus` should be renamed or reframed as `Nõustaja`.
+
+It should support natural-language advice, but it should not become the only way to access structured workflows. Lawyers should not need to invent the correct prompt.
+
+Recommended design:
+
+- keep free chat;
+- add suggested legal tasks;
+- support context-aware questions from any report row;
+- let the user ask "Mida ma peaksin parandama?";
+- let the system propose actions after answering;
+- show sources and confidence;
+- create annotations or drafting tasks from an answer.
+
+Suggested commands should map to ministry workflows:
+
+- `/mõjuahel`
+- `/el-ülevõtt`
+- `/kov-võrdlus`
+- `/pädevused`
+- `/sanktsioonid`
+- `/halduskoormus`
+- `/seletuskiri`
+
+The command list should be optional. The UI should also show these as buttons or suggestions in normal language.
+
+## Ülevaatus
+
+Ministry legal work is collaborative. Findings need review, confirmation, and sometimes legal judgment.
+
+`Ülevaatus` should collect:
+
+- unresolved impact findings;
+- row-level annotations;
+- assigned reviews;
+- competence confirmations;
+- EU transposition confirmations;
+- sanctions/proportionality confirmations;
+- draft sections waiting for legal review;
+- decisions already marked as accepted, rejected, or fixed.
+
+Recommended review states:
+
+- `Uus leid`
+- `Vajab kontrolli`
+- `Kinnitatud`
+- `Parandus koostamisel`
+- `Lahendatud`
+- `Ei kohaldu`
+
+Every finding should allow:
+
+- assign to person;
+- add note;
+- ask advisor;
+- open evidence;
+- create drafting task;
+- mark decision.
+
+## Töölaud
+
+The dashboard should stop being a welcome page and become an operational work queue.
+
+Recommended dashboard sections:
+
+- `Minu järgmised tegevused`
+- `Kõrge riskiga leiud`
+- `Ülevaatust ootavad eelnõud`
+- `Aegunud analüüsid`
+- `Uued ontoloogia muudatused`
+- `Hiljutised ekspordid`
+- `Minu järjehoidjad`
+
+Each item should include a recommended action.
+
+Examples:
+
+- "AI eelnõu mõjuanalüüs valmis. 3 konflikti vajavad ülevaatust. Ava aruanne."
+- "EL AI määruse seos on ebaselge. Kontrolli ülevõttu."
+- "VTK ootab lahendusvariandi valikut. Jätka koostajas."
+- "Ontoloogia uuenes pärast aruande koostamist. Analüüsi uuesti."
+
+## Advice-First Interaction Model
+
+The most important UX shift is that Seadusloome should not merely show data. It should advise.
+
+For every finding, the UI should answer:
+
+1. What is the issue?
+2. Why does it matter legally?
+3. How serious is it?
+4. What evidence supports it?
+5. What should the lawyer do next?
+6. Can the system draft a possible fix?
+
+Example finding:
+
+> Eelnõu võib luua kattuva järelevalvepädevuse Tarbijakaitse ja Tehnilise Järelevalve Ameti ning Andmekaitse Inspektsiooni vahel.
+
+Advice:
+
+> Soovitus: täpsustada, milline asutus kontrollib läbipaistvuskohustust ja milline isikuandmete töötlemise õiguspärasust. Lisa volitusnormi lõppu eristav lause.
+
+Action:
+
+- `Koosta parandussõnastus`
+- `Lisa pädevusmemo`
+- `Märgi ülevaatuseks`
+
+## Clarifying Questions
+
+When the system needs clarification, it should ask about legal intent, policy scope, or institutional choice.
+
+Allowed question types:
+
+- policy goal;
+- target group;
+- affected institution;
+- intended legal instrument;
+- timeframe;
+- risk tolerance;
+- EU obligation;
+- whether the change creates, removes, or clarifies obligations;
+- whether KOV autonomy is affected.
+
+Avoided question types:
+
+- database query choices;
+- ontology class choices;
+- graph traversal depth;
+- prompt-engineering choices;
+- model/provider choices;
+- embedding or vector search details;
+- internal pipeline stage choices.
+
+If a technical decision is necessary, the system should choose a default and explain it in legal terms.
+
+Example:
+
+> Kasutan vaikimisi kehtivat õigust, seotud eelnõusid, Riigikohtu praktikat ja EL õigusakte, sest need on selle mõjuanalüüsi jaoks tavaliselt olulised.
+
+## Result Ranking Logic
+
+Findings should be ranked by legal usefulness, not by raw graph distance.
+
+Suggested ranking criteria:
+
+- direct legal dependency;
+- current validity;
+- same policy area;
+- same target group;
+- same institution;
+- EU obligation link;
+- court interpretation link;
+- draft lifecycle relevance;
+- severity of conflict;
+- likelihood of real-world impact;
+- user ministry relevance;
+- recent change.
+
+The UI can expose this as:
+
+- `Kõrge risk`
+- `Vajab kontrolli`
+- `Taustateave`
+- `Väike mõju`
+
+Do not expose it as:
+
+- score vector;
+- graph weight;
+- SPARQL match;
+- embedding similarity.
+
+## Evidence and Trust
+
+Legal users will not trust black-box advice without evidence.
+
+Each recommendation should include:
+
+- source;
+- quote or snippet where possible;
+- relation explanation;
+- version/date;
+- confidence or status;
+- human confirmation status.
+
+Confidence should be framed carefully:
+
+- `Tugev seos`
+- `Tõenäoline seos`
+- `Vajab kontrolli`
+- `Nõrk seos`
+
+Avoid model-like phrasing such as:
+
+- `embedding score`;
+- `LLM confidence`;
+- `cosine similarity`.
+
+## Visual Design Direction
+
+This should feel like a professional government workbench.
+
+Design direction:
+
+- dense but calm;
+- restrained color;
+- strong hierarchy;
+- clear status and risk coding;
+- tables for comparison;
+- timelines for version/lifecycle;
+- side panels for evidence;
+- graph only when relationships matter visually;
+- no marketing-style hero sections;
+- no oversized decorative cards;
+- no playful visual language.
+
+The dark theme can work, but legal analysis screens may benefit from a lighter reading mode later because lawyers read long text and tables for long periods.
+
+## Concrete Page Recommendations
+
+### Analysis Result Page
+
+Recommended layout:
+
+- top: title, input summary, scope, status;
+- left/main: findings grouped by legal issue;
+- right side panel: recommended actions and evidence preview;
+- tabs or segmented control: `Kokkuvõte`, `Tõendid`, `Õiguskaart`, `Ülevaatus`, `Eksport`;
+- sticky action bar for `Paranda`, `Ekspordi`, `Määra`, `Küsi nõustajalt`.
+
+### Draft Detail Page
+
+Recommended layout:
+
+- title and lifecycle stage;
+- status/processing;
+- highest legal risks;
+- next recommended action;
+- linked VTK and versions;
+- analyses;
+- unresolved review items;
+- exports.
+
+### Impact Report Page
+
+Current sections are useful but should be reframed:
+
+- `Kokkuvõte`
+- `Soovitatud tegevused`
+- `Kõrge riskiga leiud`
+- `Mõjuahel`
+- `Konfliktid`
+- `EL ülevõtt`
+- `Lüngad`
+- `Pädevused`
+- `Sanktsioonid`
+- `Halduskoormus`
+- `Tõendid`
+- `Eksport`
+
+Not every report needs every section. Empty sections should collapse into a short "no issue found" row.
+
+### Graph Detail Panel
+
+The detail panel should explain:
+
+- what the entity is;
+- why it is relevant;
+- which workflow surfaced it;
+- what action the user can take.
+
+It should not lead with raw URI.
+
+## Implementation Phasing
+
+### Phase A: Navigation and Framing
+
+- Rename or reframe `Vestlus` as `Nõustaja`.
+- Add `Analüüsikeskus`.
+- Reframe `Uurija` as `Õiguskaart`.
+- Rewrite dashboard as a work queue.
+- Fix Estonian diacritics in UI copy.
+
+### Phase B: Analysis Center MVP
+
+Implement workflow shells first, even if some reuse existing analysis backend:
+
+- `Normi mõjuahel`;
+- `EL ülevõtt`;
+- `Pädevused`.
+
+These align closely with existing affected entities, EU links, and graph relationships.
+
+### Phase C: Expanded Section 7 Workflows
+
+Add:
+
+- `KOV võrdlus`;
+- `Sanktsioonide võrdlus`;
+- `Halduskoormus`;
+- `Avaliku teenuse tervikvaade`;
+- `Kriisiõiguse kaart`.
+
+These may require additional ontology enrichment and extraction, but the UI structure can be introduced earlier.
+
+### Phase D: Advice and Solution Layer
+
+For each finding:
+
+- generate legal explanation;
+- propose solution options;
+- draft suggested wording;
+- link to evidence;
+- allow review/assignment.
+
+### Phase E: Review Operations
+
+Add `Ülevaatus`:
+
+- review queue;
+- assigned findings;
+- status transitions;
+- ministry confirmations;
+- exportable decisions.
+
+## Success Criteria
+
+The new UI is successful if a ministry lawyer can:
+
+- start with a legal question, not a technical tool;
+- get a useful first analysis without prompt engineering;
+- see recommended legal actions;
+- inspect evidence quickly;
+- ask for proposed wording;
+- assign findings to review;
+- export a memo or report;
+- understand how a draft affects law, EU obligations, KOV rules, institutions, sanctions, and administrative burden.
+
+The product should feel less like "search plus graph plus chat" and more like:
+
+> A legal analysis and drafting workbench that uses the Estonian legal ontology to advise ministry lawyers during law creation.
+

--- a/tests/test_admin_analytics.py
+++ b/tests/test_admin_analytics.py
@@ -139,8 +139,8 @@ class TestAnalyticsPageRender:
         result = admin_analytics_page(req)
         html = to_xml(result)
 
-        assert "Kasutusanaluutika" in html
-        assert "Kokkuvote" in html
+        assert "Kasutusanalüütika" in html
+        assert "Kokkuvõte" in html
         assert "Trendid" in html
         assert "Detailne tabel" in html
 
@@ -172,7 +172,7 @@ class TestAnalyticsPageRender:
         result = admin_analytics_page(req)
         html = to_xml(result)
 
-        assert "Kasutusanaluutika" in html
+        assert "Kasutusanalüütika" in html
         assert "puuduvad" in html.lower()
 
 

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -1,0 +1,59 @@
+"""Tests for the Analüüsikeskus placeholder route (#714, PR-A).
+
+Follows the auth-mocking pattern from ``tests/test_chat_routes.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": "11111111-1111-1111-1111-111111111111",
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+def test_analyysikeskus_redirects_unauthenticated():
+    from starlette.testclient import TestClient
+
+    from app.main import app
+
+    client = TestClient(app, follow_redirects=False)
+    resp = client.get("/analyysikeskus")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+
+
+@patch("app.auth.middleware._get_provider")
+def test_analyysikeskus_renders_placeholder(mock_provider: MagicMock):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus")
+    assert resp.status_code == 200
+    assert "Analüüsikeskus" in resp.text
+    assert "Tulekul" in resp.text
+    # Sidebar marks the new nav item active.
+    assert 'aria-current="page"' in resp.text

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -271,11 +271,16 @@ class TestChatNew:
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        with patch("app.chat.routes.create_conversation", return_value=conv):
+        with patch("app.chat.routes.create_conversation", return_value=conv) as mock_create:
             client = _authed_client()
             resp = client.get("/chat/new")
             assert resp.status_code == 303
             assert f"/chat/{conv.id}" in resp.headers["location"]
+
+            # #714: the generated title uses the "Nõustaja" framing, not "Vestlus".
+            generated_title = mock_create.call_args.kwargs.get("title", "")
+            assert generated_title.startswith("Nõustamine")
+            assert "Vestlus" not in generated_title
 
         mock_audit.assert_called_once()
 
@@ -300,6 +305,8 @@ class TestChatNew:
             # Verify draft_id was passed to create_conversation
             call_args = mock_create.call_args
             assert call_args.kwargs.get("context_draft_id") == _DRAFT_ID
+            # #714: title is "Nõustamine — <draft>", not "Vestlus — <draft>".
+            assert call_args.kwargs.get("title") == "Nõustamine — Eelnou X"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_drafter_routes.py
+++ b/tests/test_drafter_routes.py
@@ -329,7 +329,7 @@ class TestStepPage:
         resp = client.get(f"/drafter/{_SESSION_ID}/step/2")
 
         assert resp.status_code == 200
-        assert "Kusimuste genereerimine" in resp.text
+        assert "Küsimuste genereerimine" in resp.text
 
     @patch("app.drafter.routes._find_latest_job")
     @patch("app.drafter.routes.fetch_session")
@@ -380,7 +380,7 @@ class TestStepPage:
         resp = client.get(f"/drafter/{_SESSION_ID}/step/2")
 
         assert resp.status_code == 200
-        assert "Jatka uurimisega" in resp.text
+        assert "Jätka uurimisega" in resp.text
 
     @patch("app.drafter.routes.fetch_session")
     @patch("app.auth.middleware._get_provider")
@@ -616,7 +616,7 @@ class TestStep3Page:
 
         assert resp.status_code == 200
         assert "TsiviilS" in resp.text
-        assert "Jatka struktuuriga" in resp.text
+        assert "Jätka struktuuriga" in resp.text
 
 
 # ---------------------------------------------------------------------------
@@ -730,7 +730,7 @@ class TestStep6Page:
         resp = client.get(f"/drafter/{_SESSION_ID}/step/6")
 
         assert resp.status_code == 200
-        assert "Kaivita mojuanaluus" in resp.text
+        assert "Käivita mõjuanalüüs" in resp.text
 
     @patch("app.drafter.routes.fetch_session")
     @patch("app.auth.middleware._get_provider")
@@ -749,7 +749,7 @@ class TestStep6Page:
         resp = client.get(f"/drafter/{_SESSION_ID}/step/6")
 
         assert resp.status_code == 200
-        assert "Vaata mojuanaluusi" in resp.text
+        assert "Vaata mõjuanalüüsi" in resp.text
         assert str(draft_id) in resp.text
 
 

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -65,12 +65,16 @@ def test_sidebar_drafter_sees_subset():
     sidebar = Sidebar(user=_user("drafter"))
     assert sidebar is not None
     html = to_xml(sidebar)
-    # Drafter visible items
+    # Drafter visible items (#714: legal-work labels, URLs unchanged)
     assert "Töölaud" in html
-    assert "Uurija" in html
+    assert "Analüüsikeskus" in html
     assert "Eelnõud" in html
+    assert "Õiguskaart" in html
     assert "Koostaja" in html
-    assert "Vestlus" in html
+    assert "Nõustaja" in html
+    # Old module names no longer used as nav labels
+    assert "Uurija" not in html
+    assert "Vestlus" not in html
     # Hidden from drafter
     assert "Kasutajad" not in html
     assert "Administraator" not in html
@@ -151,11 +155,12 @@ def test_topbar_with_user_shows_user_menu_and_nav():
     assert "user-menu" in html
     # Logout form posts to /auth/logout
     assert 'action="/auth/logout"' in html
-    # Top nav links visible
-    assert "Uurija" in html
+    # Top nav links visible (#714 labels)
+    assert "Analüüsikeskus" in html
     assert "Eelnõud" in html
+    assert "Õiguskaart" in html
     assert "Koostaja" in html
-    assert "Vestlus" in html
+    assert "Nõustaja" in html
     # Notification bell rendered
     assert "notification-bell" in html
 

--- a/tests/test_ui_link_button.py
+++ b/tests/test_ui_link_button.py
@@ -42,7 +42,7 @@ def test_link_button_custom_cls_is_appended():
 def test_link_button_kwargs_pass_through():
     html = to_xml(
         LinkButton(
-            "Ava uurijas",
+            "Ava õiguskaardil",
             href="/explorer?draft=1",
             title="Visualiseeri eelnõu",
             hx_boost="true",


### PR DESCRIPTION
Implements **#716** — restores ASCII-folded Estonian (õ/ä/ö/ü) in strings shown to users. Part of epic **#714**.

> **Stacked on #726 (PR-A).** Base is `feat/714-pr-a-nav-reframe`; GitHub will re-target this to `main` once #726 merges. The diff below is PR-B only.

## What changed
- **Drafter step labels** — `Tapsustamine` → `Täpsustamine`, `Ulevaade` → `Ülevaade` (`app/drafter/state_machine.py`).
- **Drafter fallback clarification questions** — `mojutab` → `mõjutab`, `taiendab voi` → `täiendab või`, `noudeid` → `nõudeid` (`app/drafter/handlers.py`).
- **~50 drafter-wizard display strings** in `app/drafter/routes.py` — button labels (`Jätka …`, `Käivita mõjuanalüüs`), page titles & headings (`Täpsustamine`, `Ülevaade`, `Integreeritud ülevaade`), alerts, status/error messages (`… ebaõnnestus`), info copy.
- **Generated .docx appendix** — `Lisa B: Mõjuanalüüsi kokkuvõte`, `Mõjuskoor`, `Mõjutatud üksuste arv`, `Tuvastatud lünkade arv` (`app/drafter/docx_builder.py`).
- **Admin analytics** — chart/table labels and the intro copy (`Üleslaadimised päevas`, `Vestluse sõnumid päevas`, `Kuupäev`, `Kasutusanalüütika näitab …`, `Kokkuvõte`) (`app/admin/analytics.py`).
- **Admin cost dashboard** — `Koostaja täpsustamine`, intro copy (`LLM kulude ülevaade näitab …`) (`app/admin/cost_dashboard.py`).
- **Chat system prompt** — fallback line `Mõjuanalüüsi aruanne pole saadaval.` (`app/chat/system_prompt.py`).

## Deliberately left alone
- **`app/drafter/prompts.py` VTK template section titles** (`Mojutatud sihtryhm`, `Sotsiaalne moju`, …) — these strings double as the keys of `VTK_SECTION_PROMPTS`, so renaming them would break the per-section preamble lookup (and any in-flight drafting session whose stored `proposed_structure` carries the old titles). Fixing properly needs a resilient-lookup change first — out of scope for a diacritics sweep; flagged for a follow-up.
- Comments (e.g. a regex-doc comment in `app/chat/sanitize.py`), identifiers, enum values, dict keys, `hx_*` attributes, the `eelnou-<id>.docx` download filename (ASCII filenames are safer for `Content-Disposition`).

## Tests
- Updated assertions in `tests/test_drafter_routes.py` (5) and `tests/test_admin_analytics.py` (3) that checked the old folded copy.
- Full suite: `2190 passed, 23 skipped`. `ruff format` + `ruff check` + `pyright` clean.

Refs #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)