### PR TITLE
feat(explorer): #714 PR-D — honor ?focus=<uri> in Õiguskaart + URL-encode the report links

### DIFF
--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -22,6 +22,7 @@ import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
@@ -127,6 +128,20 @@ def _short_type(uri: str) -> str:
         return "—"
     short = uri.rsplit("#", 1)[-1] if "#" in uri else uri.rsplit("/", 1)[-1]
     return _TYPE_LABELS_ET.get(short, short)
+
+
+def explorer_focus_url(uri: str, draft_id: str | None = None) -> str:
+    """Build an ``/explorer?focus=…`` link with the entity URI URL-encoded (#719).
+
+    ``estleg:`` URIs contain ``#``, so interpolating them raw makes the
+    browser treat everything after ``#`` as a fragment and the ``focus``
+    param ends up truncated. ``quote(..., safe="")`` percent-encodes the
+    ``#`` (and ``/``, ``:``) so the whole URI survives the round-trip.
+    """
+    qs = f"focus={quote(uri, safe='')}"
+    if draft_id:
+        qs += f"&draft={quote(str(draft_id), safe='')}"
+    return f"/explorer?{qs}"
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +510,7 @@ def _affected_columns(
             return "—"
         return A(  # noqa: F405
             uri,
-            href=f"/explorer?focus={uri}",
+            href=explorer_focus_url(uri),
             cls="data-table-link",
         )
 
@@ -525,7 +540,7 @@ def _conflicts_columns(
             return label
         return A(  # noqa: F405
             label,
-            href=f"/explorer?focus={uri}",
+            href=explorer_focus_url(uri),
             cls="data-table-link",
         )
 
@@ -560,7 +575,7 @@ def _eu_columns(
             return label
         return A(  # noqa: F405
             label,
-            href=f"/explorer?focus={uri}",
+            href=explorer_focus_url(uri),
             cls="data-table-link",
         )
 

--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -169,15 +169,28 @@ def explorer_page(req: Request):
     ``d3-node-highlighted`` class to matching nodes. Cross-org or
     malformed draft params are silently dropped (no error UI) so the
     page stays usable as a generic ontology browser even when the
-    overlay can't be applied. The page itself requires authentication
-    via the global ``auth_before`` middleware (see #442).
+    overlay can't be applied.
+
+    When called with ``?focus=<uri>`` (URL-encoded — see
+    :func:`app.docs.report_routes.explorer_focus_url`) the JS loads that
+    entity's neighbourhood and opens the detail panel on it. ``focus``
+    and ``draft`` may be combined. The page itself requires
+    authentication via the global ``auth_before`` middleware (see #442).
     """
     draft_param = req.query_params.get("draft", "").strip()
+    focus_param = req.query_params.get("focus", "").strip()
     overlay_uris: list[str] = []
     if draft_param:
         overlay_uris = _fetch_draft_overlay(req, draft_param)
 
     overlay_tags: list = []
+    # #719: hand the focus URI to the JS. We don't resolve it here — the
+    # ``/api/explorer/entity/{uri}`` endpoint validates it server-side —
+    # but embedding it (escaped) keeps the contract explicit and lets the
+    # JS read it without re-parsing ``location.search``.
+    if focus_param.startswith("http"):
+        focus_payload = json.dumps(focus_param).replace("</", "<\\/")
+        overlay_tags.append(Script(f"window.__explorerFocus={focus_payload};"))
     if overlay_uris:
         # #464: escape any closing-tag and Unicode line-separator
         # sequences in the JSON payload before embedding in a
@@ -262,7 +275,7 @@ def explorer_page(req: Request):
 
     # Optional draft tip
     draft_tip = None
-    if not overlay_uris and not draft_param:
+    if not overlay_uris and not draft_param and not focus_param:
         draft_tip = Div(
             Div(
                 Span(
@@ -517,6 +530,16 @@ def explorer_page(req: Request):
                 Div(id="toast-container"),
                 # ----- Detail panel (right sidebar) -----
                 Div(
+                    # #719: shown only when the page was opened via
+                    # ?focus= (i.e. from an impact report / analysis) —
+                    # explorer.js unhides it and sets the label/target.
+                    A(
+                        "← Tagasi",
+                        id="panel-back",
+                        href="#",
+                        cls="panel-back",
+                        style="display:none;",
+                    ),
                     Div(
                         H2(id="panel-title"),
                         Button(

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -167,6 +167,13 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 }
 #detail-panel.open { transform: translateX(0); }
 
+/* #719: "back to report/analysis" link, shown when opened via ?focus= */
+#detail-panel .panel-back {
+  display: block; margin-bottom: 12px;
+  font-size: 12px; color: #94a3b8; text-decoration: none;
+}
+#detail-panel .panel-back:hover { color: #e2e8f0; text-decoration: underline; }
+
 #detail-panel .panel-header {
   display: flex; align-items: flex-start; justify-content: space-between;
   margin-bottom: 20px;

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -909,6 +909,89 @@ function closeDetail() {
   detailPanel.classList.remove('open');
 }
 
+// ---------------------------------------------------------------------------
+// #719: open the explorer focused on a specific entity (from ?focus=<uri>,
+// e.g. a link in an impact report / analysis). Loads the entity's
+// neighbourhood, opens the detail panel on it, centers the view, and
+// reveals the "back" link.
+// ---------------------------------------------------------------------------
+function _fallbackLabel(uri) {
+  try {
+    return decodeURIComponent(String(uri)).split('/').pop().split('#').pop() || String(uri);
+  } catch (e) {
+    return String(uri);
+  }
+}
+
+function _showBackLink() {
+  var back = document.getElementById('panel-back');
+  if (!back) return;
+  var ref = document.referrer || '';
+  if (ref.indexOf('/report') !== -1) {
+    back.textContent = '← Tagasi aruandesse';
+  } else if (ref.indexOf('/analyysikeskus') !== -1) {
+    back.textContent = '← Tagasi analüüsi';
+  } else {
+    back.textContent = '← Tagasi';
+  }
+  back.style.display = '';
+  back.onclick = function(e) {
+    e.preventDefault();
+    if (document.referrer) {
+      window.location.href = document.referrer;
+    } else {
+      window.history.back();
+    }
+  };
+}
+
+async function focusOnEntity(uri) {
+  if (!uri) return;
+  // Reuse an existing overview node if it's already on the graph.
+  var datum = state.nodes.find(function(n) { return (n.uri || n.id) === uri; });
+  if (!datum) {
+    datum = {
+      id: uri,
+      uri: uri,
+      label: _fallbackLabel(uri),
+      category: categoryFromUri(uri),
+      desc: '',
+      count: 0,
+      r: 16,
+      isCategory: false,
+      x: (window.innerWidth || 1200) / 2,
+      y: (window.innerHeight || 800) / 2,
+    };
+    if (state.nodes.length < MAX_NODES) {
+      state.nodes.push(datum);
+      render();
+    }
+  }
+  try {
+    await showEntityDetail(datum);
+  } catch (e) {
+    showToast('Üksust ei õnnestunud avada — kuvan ülevaate.', 'warning');
+    return;
+  }
+  // Upgrade the panel title from real metadata when we have it (the
+  // datum's fallback label is just the URI fragment).
+  var meta = (state.selectedEntityData && state.selectedEntityData.metadata) || null;
+  if (meta) {
+    var labelKey = Object.keys(meta).find(function(k) {
+      var kl = k.toLowerCase();
+      return kl.indexOf('label') !== -1 || kl.indexOf('title') !== -1 ||
+        kl.indexOf('pealkiri') !== -1 || kl.indexOf('nimetus') !== -1;
+    });
+    if (labelKey && meta[labelKey]) {
+      var titleEl = document.getElementById('panel-title');
+      if (titleEl) titleEl.textContent = String(meta[labelKey]);
+      datum.label = String(meta[labelKey]);
+    }
+  }
+  _showBackLink();
+  setTimeout(function() { zoomToFit(600); }, 400);
+}
+
 function collapseToOverview(resetView) {
   // Remove all non-category nodes and their links
   state.nodes = state.nodes.filter(n => n.isCategory);
@@ -1544,8 +1627,20 @@ async function init() {
   updateBreadcrumb();
   render();
 
-  // Center the graph once the simulation settles
-  setTimeout(function() { zoomToFit(600); }, 800);
+  // #719: arrived via ?focus=<uri> (e.g. a link from an impact report)?
+  // Jump straight to that entity instead of leaving the user on the
+  // generic overview.
+  var focusUri = window.__explorerFocus;
+  if (!focusUri) {
+    try { focusUri = new URLSearchParams(window.location.search).get('focus'); }
+    catch (e) { focusUri = null; }
+  }
+  if (focusUri) {
+    await focusOnEntity(focusUri);
+  } else {
+    // Center the graph once the simulation settles
+    setTimeout(function() { zoomToFit(600); }, 800);
+  }
 
   // Start WebSocket connection once
   if (!wsInitialized) {

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -945,8 +945,44 @@ function _showBackLink() {
   };
 }
 
+// Pan/zoom so *d* sits at the centre of the viewport (#719 — the generic
+// zoomToFit() only frames the bounding box of *all* nodes, which won't
+// centre the focused entity when overview/neighbour nodes are present).
+function centerOnNode(d, duration) {
+  if (!d) return;
+  duration = duration || 500;
+  var x = (d.x != null) ? d.x : 0;
+  var y = (d.y != null) ? d.y : 0;
+  var scale = 1.1;
+  var transform = d3.zoomIdentity
+    .translate(width / 2, height / 2)
+    .scale(scale)
+    .translate(-x, -y);
+  svg.transition().duration(duration).call(zoomBehavior.transform, transform);
+}
+
 async function focusOnEntity(uri) {
   if (!uri) return;
+  // Pre-flight: confirm the entity exists before touching the panel.
+  // Raw fetch (not apiFetch) so a stale URI from an old report link
+  // doesn't console.error — #719 DoD: unknown URI → toast + the plain
+  // overview, no console noise.
+  var found = false;
+  try {
+    var resp = await fetch('/api/explorer/entity/' + encodeURIComponent(uri));
+    if (resp.ok) {
+      var j = await resp.json();
+      found = !!(j && j.data);
+    }
+  } catch (e) {
+    found = false;
+  }
+  if (!found) {
+    showToast('Üksust ei leitud — kuvan ülevaate.', 'warning');
+    closeDetail();
+    return;
+  }
+
   // Reuse an existing overview node if it's already on the graph.
   var datum = state.nodes.find(function(n) { return (n.uri || n.id) === uri; });
   if (!datum) {
@@ -967,12 +1003,7 @@ async function focusOnEntity(uri) {
       render();
     }
   }
-  try {
-    await showEntityDetail(datum);
-  } catch (e) {
-    showToast('Üksust ei õnnestunud avada — kuvan ülevaate.', 'warning');
-    return;
-  }
+  await showEntityDetail(datum);
   // Upgrade the panel title from real metadata when we have it (the
   // datum's fallback label is just the URI fragment).
   var meta = (state.selectedEntityData && state.selectedEntityData.metadata) || null;
@@ -989,7 +1020,9 @@ async function focusOnEntity(uri) {
     }
   }
   _showBackLink();
-  setTimeout(function() { zoomToFit(600); }, 400);
+  // Centre on the focused node once the simulation has placed neighbours
+  // (mirrors init()'s 800ms settle wait).
+  setTimeout(function() { centerOnNode(datum, 600); }, 800);
 }
 
 function collapseToOverview(resetView) {

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -961,18 +961,30 @@ function centerOnNode(d, duration) {
   svg.transition().duration(duration).call(zoomBehavior.transform, transform);
 }
 
+function _entityHasContent(d) {
+  if (!d) return false;
+  var hasMeta = d.metadata && typeof d.metadata === 'object' &&
+    Object.keys(d.metadata).length > 0;
+  var hasOut = Array.isArray(d.outgoing) && d.outgoing.length > 0;
+  var hasIn = Array.isArray(d.incoming) && d.incoming.length > 0;
+  return !!(hasMeta || hasOut || hasIn);
+}
+
 async function focusOnEntity(uri) {
   if (!uri) return;
-  // Pre-flight: confirm the entity exists before touching the panel.
-  // Raw fetch (not apiFetch) so a stale URI from an old report link
-  // doesn't console.error — #719 DoD: unknown URI → toast + the plain
-  // overview, no console noise.
+  // Pre-flight: confirm the entity actually exists in the graph before
+  // touching the panel. /api/explorer/entity/{uri} returns a (non-null)
+  // data object for *any* syntactically valid URI, with everything empty
+  // when the URI isn't in the ontology — so "found" means the response
+  // carries some metadata / a relation, not just HTTP 200. Raw fetch (not
+  // apiFetch) so a stale URI from an old report link doesn't console.error.
+  // #719 DoD: unknown URI → toast + the plain overview, no console noise.
   var found = false;
   try {
     var resp = await fetch('/api/explorer/entity/' + encodeURIComponent(uri));
     if (resp.ok) {
       var j = await resp.json();
-      found = !!(j && j.data);
+      found = !!(j && _entityHasContent(j.data));
     }
   } catch (e) {
     found = false;

--- a/tests/test_docs_report_routes.py
+++ b/tests/test_docs_report_routes.py
@@ -799,3 +799,41 @@ class TestOntologyDriftBanner:
         resp = client.post(f"/drafts/{_DRAFT_ID}/report/reanalyze")
         assert resp.status_code == 200
         assert "Eelnõu ei leitud" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# explorer_focus_url — URL-encoding of estleg URIs in ?focus= links (#719)
+# ---------------------------------------------------------------------------
+
+
+class TestExplorerFocusUrl:
+    def test_encodes_hash_so_uri_is_not_truncated(self):
+        from app.docs.report_routes import explorer_focus_url
+
+        uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+        url = explorer_focus_url(uri)
+        # The fragment-marker must be percent-encoded, otherwise the
+        # browser treats "#KarS_par_133" as a fragment and ``focus`` is
+        # silently truncated to ".../estleg".
+        assert "#" not in url
+        assert url.startswith("/explorer?focus=")
+        assert "%23" in url  # encoded '#'
+        # Round-trips back to the original URI.
+        from urllib.parse import parse_qs, urlsplit
+
+        q = parse_qs(urlsplit(url).query)
+        assert q["focus"] == [uri]
+
+    def test_encodes_slashes_and_colons(self):
+        from app.docs.report_routes import explorer_focus_url
+
+        url = explorer_focus_url("https://example.org/a/b")
+        assert "%2F" in url or "%2f" in url
+        assert "%3A" in url or "%3a" in url
+
+    def test_appends_draft_id_when_given(self):
+        from app.docs.report_routes import explorer_focus_url
+
+        url = explorer_focus_url("https://data.riik.ee/ontology/estleg#X", draft_id="abc-123")
+        assert "&draft=abc-123" in url
+        assert url.index("focus=") < url.index("draft=")

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -66,3 +66,26 @@ def test_explorer_page_timeline_is_clearly_labelled():
     assert "timeline-slider" in html
     # "Keelatud" was a confusing label for "no time filter active".
     assert "Keelatud" not in html
+
+
+def test_explorer_page_focus_param_is_handed_to_js():
+    from app.explorer.pages import explorer_page
+
+    uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+    # ``focus`` arrives already URL-decoded in req.query_params.
+    html = to_xml(explorer_page(_req(f"focus={uri}")))
+    assert "window.__explorerFocus" in html
+    assert uri in html
+    # The "?draft=ID …" tip is suppressed when the user came here to
+    # look at a specific entity.
+    assert "?draft=ID" not in html
+    # The back-link element is in the DOM (explorer.js unhides it).
+    assert 'id="panel-back"' in html
+
+
+def test_explorer_page_no_focus_keeps_the_draft_tip():
+    from app.explorer.pages import explorer_page
+
+    html = to_xml(explorer_page(_req()))
+    assert "window.__explorerFocus" not in html
+    assert "?draft=ID" in html


### PR DESCRIPTION
Implements **#719** — wires up `?focus=<uri>` so a click in an impact report lands on that entity in the graph, and fixes the long-standing encoding bug in those links. Part of epic **#714**.

> **Stacked on #728 (PR-C → PR-A).** Base is `feat/714-pr-c-oiguskaart`; re-targets up the chain as PRs merge. Diff below is PR-D only.

## The bug it fixes
`app/docs/report_routes.py` emitted `href=f"/explorer?focus={uri}"` with the URI interpolated **raw**. `estleg:` URIs contain `#`, so the browser treated everything after it as a fragment and the `focus` param arrived truncated. And `explorer/pages.py` / `explorer.js` never read `focus` anyway — so the links were doubly dead.

## What changed
- **`report_routes.py`** — new `explorer_focus_url(uri, draft_id=None)` helper: `quote(uri, safe="")` percent-encodes `#`/`/`/`:` so the whole URI round-trips; appends `&draft=` when given. The three link sites (affected entities, conflicts, EU acts) now use it.
- **`explorer/pages.py`** — parses `?focus=`; embeds it (escaped) as `window.__explorerFocus`; suppresses the "add `?draft=ID`" tip when focusing; adds a hidden `#panel-back` link to the detail panel. `?focus=` and `?draft=` may be combined.
- **`explorer.js`** — on `init()`, if a focus URI is present: load that entity's neighbourhood, open the detail panel on it, upgrade the panel title from real metadata (the URL only carries the URI), reveal the back link (`← Tagasi aruandesse` when the referrer is a report, `← Tagasi analüüsi` for the analysis hub, else `← Tagasi`), and center the view. On error → toast + fall back to the overview.
- **`explorer.css`** — styles the `.panel-back` link.

## Tests
- `tests/test_docs_report_routes.py` — `explorer_focus_url` round-trips a `#`-bearing URI, encodes `/`/`:`, appends `&draft=`.
- `tests/test_explorer_pages.py` — `/explorer?focus=<uri>` hands the URI to the JS, suppresses the draft tip, has the `#panel-back` element; no-focus keeps the tip.
- Full suite: `2198 passed, 23 skipped`. `ruff` + `pyright` clean.

That's Phase A complete bar **#717** (dashboard rewrite). Refs #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)