### PR TITLE
feat(dashboard): #714 PR-E — rewrite Töölaud as an operational work queue

### DIFF
--- a/app/admin/cost_dashboard.py
+++ b/app/admin/cost_dashboard.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _FEATURE_LABELS: dict[str, str] = {
     "drafter_clarify": "Koostaja tapsustamine",
     "drafter_draft": "Koostaja mustand",
-    "chat": "Vestlus",
+    "chat": "Nõustaja",
     "extraction": "Eraldamine",
 }
 

--- a/app/admin/sync.py
+++ b/app/admin/sync.py
@@ -146,7 +146,7 @@ def _sync_explainer():
                 rel="noopener",
             ),
             ") ja laadib selle Apache Jena Fuseki triplestore'i. "
-            "P\u00e4rast l\u00f5ppemist kajastab Uurija ja AI-vestlus "
+            "P\u00e4rast l\u00f5ppemist kajastavad \u00d5iguskaart ja N\u00f5ustaja "
             "uusimaid seaduseid, kohtuotsuseid ja EL-i \u00f5igusakte.",
         ),
         Details(  # noqa: F405

--- a/app/analyysikeskus/__init__.py
+++ b/app/analyysikeskus/__init__.py
@@ -1,0 +1,11 @@
+"""Analüüsikeskus — the legal-analysis workflow hub (#714).
+
+This package currently exposes only a placeholder landing page; the
+workflow directory and the individual analysis workflows land in the
+follow-up issues (#720 landing page, #722 Normi mõjuahel, #723 EL
+ülevõtt).
+"""
+
+from app.analyysikeskus.routes import register_analyysikeskus_routes
+
+__all__ = ["register_analyysikeskus_routes"]

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -1,0 +1,40 @@
+"""Analüüsikeskus routes (#714).
+
+For now this is a single placeholder page so the new ``Analüüsikeskus``
+navigation entry resolves. The workflow directory (#720) replaces this
+body; the individual workflows (#722 Normi mõjuahel, #723 EL ülevõtt)
+register their own sub-routes here later.
+"""
+
+from fasthtml.common import *  # noqa: F403
+from starlette.requests import Request
+
+from app.ui.layout import PageShell
+from app.ui.surfaces.info_box import InfoBox
+from app.ui.theme import get_theme_from_request
+
+
+def analyysikeskus_page(req: Request):
+    """GET /analyysikeskus — placeholder for the legal-analysis workflow hub."""
+    auth = req.scope.get("auth") or None
+    theme = get_theme_from_request(req)
+    return PageShell(
+        H1("Analüüsikeskus", cls="page-title"),  # noqa: F405
+        InfoBox(
+            P(  # noqa: F405
+                "Analüüsikeskus koondab õigusliku analüüsi töövood — "
+                "normi mõjuahel, EL õiguse ülevõtt ja teised — ühte kohta. "
+                "Tulekul."
+            ),
+            variant="info",
+        ),
+        title="Analüüsikeskus",
+        user=auth,
+        theme=theme,
+        active_nav="/analyysikeskus",
+    )
+
+
+def register_analyysikeskus_routes(rt) -> None:  # type: ignore[no-untyped-def]
+    """Register Analüüsikeskus routes on the FastHTML route decorator *rt*."""
+    rt("/analyysikeskus", methods=["GET"])(analyysikeskus_page)

--- a/app/chat/export.py
+++ b/app/chat/export.py
@@ -115,7 +115,7 @@ def conversation_to_markdown(
     System messages are skipped. Assistant content is emitted verbatim
     (already markdown from the LLM).
     """
-    title = (conversation.title or "Vestlus").strip() or "Vestlus"
+    title = (conversation.title or "Nõustamine").strip() or "Nõustamine"
     parts: list[str] = [
         f"# {title}",
         "",
@@ -223,7 +223,7 @@ def conversation_to_docx_bytes(
     The returned bytes are a valid ZIP archive (.docx is a zipped OOXML
     bundle) so the caller can stream them directly as a file download.
     """
-    title = (conversation.title or "Vestlus").strip() or "Vestlus"
+    title = (conversation.title or "Nõustamine").strip() or "Nõustamine"
 
     doc = Document()
     doc.add_heading(title, level=0)

--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -926,7 +926,7 @@ def _render_search_results(conversations: list[Conversation], term: str) -> Any:
         items.append(
             Li(
                 A(
-                    conv.title or "Vestlus",
+                    conv.title or "Nõustamine",
                     href=f"/chat/{conv.id}",
                     cls="chat-search-result-link",
                 ),

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -595,7 +595,9 @@ def new_conversation(req: Request):
     # Optional draft context
     draft_param = req.query_params.get("draft")
     context_draft_id: uuid.UUID | None = None
-    title = "Vestlus"
+    # #714: conversations live under the "Nõustaja" section, so generated
+    # titles use that framing rather than the old "Vestlus" prefix.
+    title = "Nõustamine"
 
     if draft_param:
         parsed_draft = _parse_uuid(draft_param)
@@ -604,7 +606,7 @@ def new_conversation(req: Request):
             draft_title = _get_draft_title(str(parsed_draft), org_id)
             if draft_title is not None:
                 context_draft_id = parsed_draft
-                title = f"Vestlus \u2014 {draft_title}"
+                title = f"N\u00f5ustamine \u2014 {draft_title}"
             else:
                 # Draft not found or belongs to another org — ignore it
                 logger.warning(
@@ -616,7 +618,7 @@ def new_conversation(req: Request):
     if not context_draft_id:
         from app.ui.time import now_tallinn
 
-        title = f"Vestlus \u2014 {now_tallinn().strftime('%d.%m.%Y %H:%M')}"
+        title = f"N\u00f5ustamine \u2014 {now_tallinn().strftime('%d.%m.%Y %H:%M')}"
 
     try:
         with _connect() as conn:

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -507,7 +507,7 @@ def chat_list_page(req: Request):
         cls="chat-list-toolbar",
     )
 
-    header_children: list = [H1("Vestlused", cls="page-title")]  # noqa: F405
+    header_children: list = [H1("Nõustaja", cls="page-title")]  # noqa: F405
     header_children.append(
         InfoBox(
             P(
@@ -563,7 +563,7 @@ def chat_list_page(req: Request):
             CardHeader(H3("Minu vestlused", cls="card-title")),  # noqa: F405
             CardBody(*card_body_children),
         ),
-        title="Vestlused",
+        title="Nõustaja",
         user=auth,
         theme=theme,
         active_nav="/chat",

--- a/app/docs/impact/scoring.py
+++ b/app/docs/impact/scoring.py
@@ -34,7 +34,55 @@ Notes on the simplification:
 
 from __future__ import annotations
 
+from typing import Literal
+
 from app.docs.impact.analyzer import ImpactFindings
+
+#: Impact band identifier — the four severity tiers described in the module
+#: docstring.  Surfaced to the UI as Estonian labels via :data:`IMPACT_BAND_LABELS_ET`.
+ImpactBand = Literal["low", "medium", "high", "critical"]
+
+#: Estonian labels for each :data:`ImpactBand`. The dashboard's "Kõrge riskiga
+#: leiud" widget renders these as Badges; only ``high`` / ``critical`` rows
+#: surface there.
+IMPACT_BAND_LABELS_ET: dict[ImpactBand, str] = {
+    "low": "Madal mõju",
+    "medium": "Keskmine mõju",
+    "high": "Kõrge risk",
+    "critical": "Kriitiline",
+}
+
+
+def impact_band(score: int) -> ImpactBand:
+    """Map a 0-100 impact score to its severity band.
+
+    The thresholds mirror the module docstring (and the Phase 2 spec §8.5):
+
+        0-20    -> ``"low"``     (routine amendment)
+        21-50   -> ``"medium"``  (requires review)
+        51-80   -> ``"high"``    (significant review needed)
+        81-100  -> ``"critical"`` (major legislative change)
+
+    This is the single source of truth for the band logic — callers that
+    need to know whether a report is "high-risk" (the dashboard work queue,
+    list-page colour coding) should use this rather than re-deriving the
+    cut-offs.
+
+    Args:
+        score: The integer stored in ``impact_reports.impact_score``. Values
+            outside ``[0, 100]`` are clamped before banding.
+
+    Returns:
+        One of the four :data:`ImpactBand` literals.
+    """
+    clamped = min(100, max(0, int(score)))
+    if clamped <= 20:
+        return "low"
+    if clamped <= 50:
+        return "medium"
+    if clamped <= 80:
+        return "high"
+    return "critical"
 
 
 def calculate_impact_score(findings: ImpactFindings) -> int:

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -984,13 +984,13 @@ def draft_report_page(req: Request, draft_id: str):
             ),
             Div(
                 LinkButton(
-                    "Ava uurijas →",
+                    "Ava õiguskaardil →",
                     href=f"/explorer?draft={draft.id}",
                     variant="secondary",
                     title="Visualiseeri eelnõu ja mõjutatud sätted graafil.",
                 ),
                 # #614: one-line helper below the button so reviewers
-                # know what "Ava uurijas" actually does before clicking.
+                # know what "Ava õiguskaardil" actually does before clicking.
                 Small(  # noqa: F405
                     "Visualiseeri eelnõu ja mõjutatud sätted graafil.",
                     cls="muted-text explorer-cta-hint",

--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -296,7 +296,7 @@ def explorer_page(req: Request):
         Head(
             Meta(charset="UTF-8"),
             Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
-            Title("Eesti õiguse ontoloogia — Explorer"),
+            Title("Õiguskaart — Eesti õiguse ontoloogia"),
             # D3.js v7
             Script(
                 src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js",
@@ -321,7 +321,7 @@ def explorer_page(req: Request):
             Header(
                 Div(
                     H1("Eesti õiguse ontoloogia"),
-                    Span("Uurija", cls="badge"),
+                    Span("Õiguskaart", cls="badge"),
                     Span("D3.js", cls="badge"),
                     # Search box
                     Div(
@@ -380,6 +380,12 @@ def explorer_page(req: Request):
                         role="link",
                     ),
                     A(
+                        "Analüüsikeskus",
+                        href="/analyysikeskus",
+                        cls="nav-btn",
+                        role="link",
+                    ),
+                    A(
                         "Eelnõud",
                         href="/drafts",
                         cls="nav-btn",
@@ -392,7 +398,7 @@ def explorer_page(req: Request):
                         role="link",
                     ),
                     A(
-                        "Vestlus",
+                        "Nõustaja",
                         href="/chat",
                         cls="nav-btn",
                         role="link",

--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -237,7 +237,7 @@ def explorer_page(req: Request):
                 aria_hidden="true",
             ),
             Div(
-                "See on Eesti õiguse ontoloogia uurija. "
+                "See on õiguskaart — Eesti õiguse ontoloogia visuaalne vaade. "
                 "Klõpsake kategooriatele, et uurida seadusi, kohtuotsuseid "
                 "ja EL-i õigusakte. Kasutage otsingut konkreetsete "
                 "sätete leidmiseks.",
@@ -320,8 +320,8 @@ def explorer_page(req: Request):
             # ----- Top bar (banner landmark) -----
             Header(
                 Div(
-                    H1("Eesti õiguse ontoloogia"),
-                    Span("Õiguskaart", cls="badge"),
+                    H1("Õiguskaart"),
+                    Span("Eesti õiguse ontoloogia", cls="explorer-tagline"),
                     Span("D3.js", cls="badge"),
                     # Search box
                     Div(

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from starlette.staticfiles import StaticFiles
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from app.admin import register_admin_routes
+from app.analyysikeskus import register_analyysikeskus_routes
 from app.annotations.routes import register_annotation_routes
 from app.auth.middleware import SKIP_PATHS, auth_before
 from app.auth.organizations import register_org_routes
@@ -239,6 +240,7 @@ register_explorer_pages(rt)
 register_ws_routes(app)
 register_webhook_routes(app)
 register_dashboard_routes(rt)
+register_analyysikeskus_routes(rt)
 register_admin_routes(rt)
 register_validation_routes(rt)
 register_design_system_routes(rt)

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -20,6 +20,8 @@ svg#canvas { width: 100%; height: 100vh; display: block; }
   display: flex; align-items: center; gap: 16px;
 }
 #topbar h1 { font-size: 16px; font-weight: 600; color: #f1f5f9; white-space: nowrap; }
+/* #714: descriptive subtitle next to the "Õiguskaart" page heading */
+#topbar .explorer-tagline { font-size: 13px; color: #94a3b8; white-space: nowrap; }
 #topbar .badge {
   font-size: 11px; background: rgba(251,146,60,0.15); color: #fdba74;
   padding: 3px 10px; border-radius: 99px; border: 1px solid rgba(251,146,60,0.25);

--- a/app/templates/dashboard.py
+++ b/app/templates/dashboard.py
@@ -1,9 +1,27 @@
-"""Personal dashboard for authenticated users."""
+"""Operational work queue for authenticated users — the ``/dashboard`` ("Töölaud") page.
+
+Issue #717 (epic #714, design doc ``docs/2026-05-11-ministry-lawyer-ui-structure.md``):
+the dashboard is no longer a welcome page. It is a daily work queue that answers
+"what should I do next" by synthesising signals already present in the database:
+
+    - active drafter sessions          → "jätka koostajas"
+    - high/critical impact reports      → "vaata mõjuaruannet"
+    - stale (post-re-analyze) annotations → "analüüsi uuesti"
+    - recent ontology syncs             → "uued ontoloogia muudatused"
+    - completed export jobs             → "hiljutised ekspordid"
+    - drafts with unresolved annotations → "lahtised märkused"
+    - personal bookmarks                → unchanged from the old dashboard
+
+Every query is org-scoped (except ``sync_log``, which is global system-wide
+state) and wrapped in try/except → log + return empty, mirroring the helper
+pattern used across ``app/docs/draft_model.py`` and friends. No new migration
+or schema change — everything is derivable from existing tables.
+"""
 
 from __future__ import annotations
 
-import json
 import logging
+from datetime import datetime
 from typing import Any
 
 from fasthtml.common import *
@@ -12,47 +30,303 @@ from starlette.responses import RedirectResponse
 
 from app.auth.audit import log_action
 from app.db import get_connection as _connect
+from app.docs.impact.scoring import IMPACT_BAND_LABELS_ET, ImpactBand, impact_band
+from app.drafter.state_machine import STEP_LABELS_ET, Step
 from app.ui.data.data_table import Column, DataTable
 from app.ui.forms.app_form import AppForm
 from app.ui.forms.form_field import FormField
 from app.ui.layout import PageShell
-from app.ui.primitives.badge import Badge
+from app.ui.primitives.badge import Badge, BadgeVariant
 from app.ui.primitives.button import Button
+from app.ui.primitives.link_button import LinkButton
 from app.ui.surfaces.card import Card, CardBody, CardHeader
-from app.ui.surfaces.info_box import InfoBox
 from app.ui.theme import get_theme_from_request
 from app.ui.time import format_tallinn
 
 logger = logging.getLogger(__name__)
 
 
+# How many synthesised "next action" rows to surface at the top of the page.
+_MAX_NEXT_ACTIONS = 8
+
+# Per-widget row caps for the supporting sections (kept small so the page
+# stays dense-but-calm — see the design doc's "Visual Design Direction").
+_MAX_HIGH_RISK = 8
+_MAX_STALE = 8
+_MAX_SYNCS = 5
+_MAX_EXPORTS = 5
+_MAX_UNRESOLVED = 8
+
+
 # ---------------------------------------------------------------------------
-# DB helpers
+# DB helpers — work-queue widgets
 # ---------------------------------------------------------------------------
 
 
-def _get_recent_activity(user_id: str) -> list[dict]:  # type: ignore[type-arg]
-    """Return the last 20 audit_log entries for the given user."""
+def _get_active_drafter_sessions(user_id: str, org_id: str | None) -> list[dict]:  # type: ignore[type-arg]
+    """Return the user's active drafter sessions, newest first.
+
+    Org-scoped at the SQL layer so a stray cross-org session can never appear
+    in the work queue. Returns ``[{id, current_step, updated_at}]`` (only the
+    fields the "jätka koostajas" row needs).
+    """
+    if not user_id or not org_id:
+        return []
     try:
         with _connect() as conn:
             rows = conn.execute(
-                "SELECT id, action, detail, created_at "
-                "FROM audit_log WHERE user_id = %s "
-                "ORDER BY created_at DESC LIMIT 20",
-                (user_id,),
+                """
+                SELECT id, current_step, updated_at
+                FROM drafting_sessions
+                WHERE user_id = %s AND org_id = %s AND status = 'active'
+                ORDER BY updated_at DESC
+                LIMIT %s
+                """,
+                (user_id, org_id, _MAX_NEXT_ACTIONS),
+            ).fetchall()
+        return [{"id": str(r[0]), "current_step": int(r[1]), "updated_at": r[2]} for r in rows]
+    except Exception:
+        logger.exception("Failed to fetch active drafter sessions for user %s", user_id)
+        return []
+
+
+def _get_high_risk_reports(org_id: str | None, *, limit: int = _MAX_HIGH_RISK) -> list[dict]:  # type: ignore[type-arg]
+    """Return recent High/Critical impact reports for the org.
+
+    "High/Critical" is decided by :func:`app.docs.impact.scoring.impact_band`
+    (the 51-80 / 81-100 bands) — the SQL filter uses ``impact_score > 50`` as a
+    cheap pre-filter and the band helper produces the user-facing label so the
+    cut-offs are never duplicated.
+
+    Returns one row per draft (the latest report for that draft) ordered by the
+    most recent analysis first.
+    """
+    if not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT DISTINCT ON (ir.draft_id)
+                       ir.draft_id, d.title, ir.impact_score,
+                       ir.conflict_count, ir.affected_count, ir.gap_count,
+                       ir.generated_at
+                FROM impact_reports ir
+                JOIN drafts d ON d.id = ir.draft_id
+                WHERE d.org_id = %s AND ir.impact_score > 50
+                ORDER BY ir.draft_id, ir.generated_at DESC
+                """,
+                (org_id,),
+            ).fetchall()
+    except Exception:
+        logger.exception("Failed to fetch high-risk reports for org %s", org_id)
+        return []
+    out = [
+        {
+            "draft_id": str(r[0]),
+            "title": r[1] or "Pealkirjata eelnõu",
+            "impact_score": int(r[2] or 0),
+            "conflict_count": int(r[3] or 0),
+            "affected_count": int(r[4] or 0),
+            "gap_count": int(r[5] or 0),
+            "generated_at": r[6],
+        }
+        for r in rows
+    ]
+    # DISTINCT ON returns draft-grouped rows in draft_id order; re-sort by
+    # recency and apply the widget cap.
+    out.sort(key=lambda d: d["generated_at"] or datetime.min, reverse=True)
+    return out[:limit]
+
+
+def _get_stale_analysis_drafts(org_id: str | None, *, limit: int = _MAX_STALE) -> list[dict]:  # type: ignore[type-arg]
+    """Return drafts that have a ``stale=true`` unresolved annotation row.
+
+    The ``stale`` flag is set by
+    :func:`app.annotations.models.update_stale_flags_for_version` after a
+    re-analyze removes a finding the user was discussing — it means "the
+    ontology moved on; this analysis is out of date". Joins through
+    ``draft_versions`` to recover the parent draft id + title.
+
+    Org-scoped via ``annotations.org_id`` (and re-checked against
+    ``drafts.org_id`` in the JOIN, which is harmless belt-and-braces).
+    Returns ``[{draft_id, title, stale_count}]`` newest-draft first.
+    """
+    if not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT d.id, d.title, COUNT(*) AS stale_count,
+                       MAX(a.updated_at) AS last_change
+                FROM annotations a
+                JOIN draft_versions v ON v.id = a.draft_version_id
+                JOIN drafts d ON d.id = v.draft_id
+                WHERE a.org_id = %s
+                  AND a.stale = TRUE
+                  AND a.resolved = FALSE
+                  AND a.draft_version_id IS NOT NULL
+                GROUP BY d.id, d.title
+                ORDER BY last_change DESC
+                LIMIT %s
+                """,
+                (org_id, limit),
             ).fetchall()
         return [
             {
-                "id": r[0],
-                "action": r[1],
-                "detail": r[2],
-                "created_at": r[3],
+                "draft_id": str(r[0]),
+                "title": r[1] or "Pealkirjata eelnõu",
+                "stale_count": int(r[2] or 0),
             }
             for r in rows
         ]
     except Exception:
-        logger.exception("Failed to fetch recent activity for user %s", user_id)
+        logger.exception("Failed to fetch stale-analysis drafts for org %s", org_id)
         return []
+
+
+def _get_recent_syncs(*, limit: int = _MAX_SYNCS) -> list[dict]:  # type: ignore[type-arg]
+    """Return recent successful ontology syncs.
+
+    ⚠ ``sync_log`` is global system-wide state — there is no ``org_id`` column
+    and no org scoping. That is fine: a fresh ontology snapshot is information
+    everyone should see. Returns ``[{id, finished_at, entity_count}]`` newest
+    first.
+    """
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, finished_at, started_at, entity_count
+                FROM sync_log
+                WHERE status = 'success'
+                ORDER BY started_at DESC
+                LIMIT %s
+                """,
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "id": int(r[0]),
+                # finished_at can be NULL on a row that crashed between status
+                # flip and timestamp write; fall back to started_at.
+                "finished_at": r[1] or r[2],
+                "entity_count": int(r[3]) if r[3] is not None else None,
+            }
+            for r in rows
+        ]
+    except Exception:
+        logger.exception("Failed to fetch recent ontology syncs")
+        return []
+
+
+def _get_recent_exports(org_id: str | None, *, limit: int = _MAX_EXPORTS) -> list[dict]:  # type: ignore[type-arg]
+    """Return recently completed report-export jobs for the org.
+
+    The ``background_jobs`` table is not org-scoped, so we recover the org via
+    the ``draft_id`` carried in the job payload (``payload->>'draft_id'``) and
+    join to ``drafts``. Only ``export_report`` jobs in the ``success`` state
+    are surfaced.
+
+    Returns ``[{draft_id, title, finished_at}]`` newest first — the row links
+    to ``/drafts/{id}/report`` (the report page hosts the download button), so
+    we don't need the docx path here.
+    """
+    if not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT j.payload->>'draft_id' AS draft_id, d.title, j.finished_at
+                FROM background_jobs j
+                JOIN drafts d ON d.id = (j.payload->>'draft_id')::uuid
+                WHERE j.job_type = 'export_report'
+                  AND j.status = 'success'
+                  AND d.org_id = %s
+                ORDER BY j.finished_at DESC NULLS LAST
+                LIMIT %s
+                """,
+                (org_id, limit),
+            ).fetchall()
+        return [
+            {
+                "draft_id": str(r[0]),
+                "title": r[1] or "Pealkirjata eelnõu",
+                "finished_at": r[2],
+            }
+            for r in rows
+        ]
+    except Exception:
+        # Payloads with a missing/garbled draft_id make the ``::uuid`` cast
+        # throw — log it and degrade to an empty widget rather than 500.
+        logger.exception("Failed to fetch recent exports for org %s", org_id)
+        return []
+
+
+def _get_unresolved_annotation_drafts(  # type: ignore[type-arg]
+    org_id: str | None, *, limit: int = _MAX_UNRESOLVED
+) -> list[dict]:
+    """Return drafts that have one or more ``resolved=false`` annotations.
+
+    Covers every annotation whose ``target_type`` resolves to a draft —
+    impact-report row annotations carry a ``draft_version_id`` (joined through
+    ``draft_versions``), while older ``target_type='draft'`` annotations carry
+    the draft id directly in ``target_id``. Org-scoped via ``annotations.org_id``.
+
+    Returns ``[{draft_id, title, unresolved_count}]`` ordered by the busiest
+    draft first.
+    """
+    if not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT d.id, d.title, COUNT(*) AS unresolved_count
+                FROM annotations a
+                JOIN draft_versions v ON v.id = a.draft_version_id
+                JOIN drafts d ON d.id = v.draft_id
+                WHERE a.org_id = %s
+                  AND a.resolved = FALSE
+                  AND a.draft_version_id IS NOT NULL
+                GROUP BY d.id, d.title
+
+                UNION ALL
+
+                SELECT d.id, d.title, COUNT(*) AS unresolved_count
+                FROM annotations a
+                JOIN drafts d ON d.id = a.target_id::uuid
+                WHERE a.org_id = %s
+                  AND a.resolved = FALSE
+                  AND a.target_type = 'draft'
+                GROUP BY d.id, d.title
+                """,
+                (org_id, org_id),
+            ).fetchall()
+    except Exception:
+        # ``target_id::uuid`` can throw on a non-UUID legacy value — degrade
+        # to an empty widget rather than crashing the whole dashboard.
+        logger.exception("Failed to fetch drafts with unresolved annotations for org %s", org_id)
+        return []
+    # Merge the two UNION branches per draft (a draft could in theory have both
+    # impact-report-row and draft-level annotations).
+    merged: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        draft_id = str(r[0])
+        entry = merged.setdefault(
+            draft_id,
+            {"draft_id": draft_id, "title": r[1] or "Pealkirjata eelnõu", "unresolved_count": 0},
+        )
+        entry["unresolved_count"] += int(r[2] or 0)
+    out = sorted(merged.values(), key=lambda d: d["unresolved_count"], reverse=True)
+    return out[:limit]
+
+
+# ---------------------------------------------------------------------------
+# DB helpers — kept verbatim from the welcome-page era
+# ---------------------------------------------------------------------------
 
 
 def _get_bookmarks(user_id: str) -> list[dict]:  # type: ignore[type-arg]
@@ -143,36 +417,6 @@ def _remove_bookmark(bookmark_id: str, user_id: str) -> bool:
         return False
 
 
-def _get_dashboard_counts(user_id: str, org_id: str | None) -> dict[str, int]:
-    """Return counts for drafts, drafter sessions, and conversations."""
-    counts: dict[str, int] = {"drafts": 0, "drafter_sessions": 0, "conversations": 0}
-    if not user_id:
-        return counts
-    try:
-        with _connect() as conn:
-            if org_id:
-                row = conn.execute(
-                    "SELECT COUNT(*) FROM drafts WHERE org_id = %s",
-                    (org_id,),
-                ).fetchone()
-                counts["drafts"] = row[0] if row else 0
-
-                row = conn.execute(
-                    "SELECT COUNT(*) FROM drafting_sessions WHERE user_id = %s AND org_id = %s",
-                    (user_id, org_id),
-                ).fetchone()
-                counts["drafter_sessions"] = row[0] if row else 0
-
-            row = conn.execute(
-                "SELECT COUNT(*) FROM conversations WHERE user_id = %s",
-                (user_id,),
-            ).fetchone()
-            counts["conversations"] = row[0] if row else 0
-    except Exception:
-        logger.exception("Failed to fetch dashboard counts for user %s", user_id)
-    return counts
-
-
 # ---------------------------------------------------------------------------
 # Rendering helpers
 # ---------------------------------------------------------------------------
@@ -184,143 +428,277 @@ _ROLE_LABELS = {
     "drafter": "Koostaja",
 }
 
-# Map common audit-detail dict keys to Estonian labels for the
-# recent-activity table.  Keys not in this mapping fall through to the
-# first key/value pair so we don't silently drop interesting data.
-_AUDIT_DETAIL_LABELS: dict[str, str] = {
-    "draft_id": "Eelnõu",
-    "user_id": "Kasutaja",
-    "report_id": "Aruanne",
-    "filename": "Fail",
-    "title": "Pealkiri",
-    "role": "Roll",
-    "entity_uri": "URI",
-    "label": "Nimi",
-    "bookmark_id": "Järjehoidja",
-    "session_id": "Sessioon",
-    "conversation_id": "Vestlus",
-    "org_id": "Organisatsioon",
+# Badge variant per impact band — restrained colour, matches the design doc's
+# "clear status and risk coding" guidance.
+_BAND_VARIANT: dict[ImpactBand, BadgeVariant] = {
+    "low": "default",
+    "medium": "warning",
+    "high": "danger",
+    "critical": "danger",
 }
 
 
-def _audit_detail_summary(action: str, detail: Any) -> str:
-    """Return an Estonian-friendly one-line summary of an audit detail payload.
-
-    The audit_log.detail column is a JSONB value (typically a dict) that
-    psycopg returns as a Python dict.  Older rows or test fixtures may pass
-    in a JSON string, so we accept both and degrade gracefully when the
-    payload is empty / unparsable.
-
-    Args:
-        action: The audit action label (kept for forward-compatible context;
-            currently unused but reserved so callers don't need to change
-            shape if we add per-action formatters).
-        detail: The raw payload — dict, JSON string, or ``None``.
-
-    Returns:
-        A short human-readable string. ``"—"`` when ``detail`` is empty.
-    """
-    del action  # reserved for future per-action overrides
-
-    if detail is None or detail == "":
-        return "—"
-
-    if isinstance(detail, str):
-        # Some legacy code paths may stash a raw JSON string; try to parse
-        # it but fall back to the literal text rather than crashing.
-        try:
-            detail = json.loads(detail)
-        except (TypeError, ValueError):
-            return detail
-
-    if not isinstance(detail, dict):
-        return str(detail)
-
-    parts: list[str] = []
-    for key, label in _AUDIT_DETAIL_LABELS.items():
-        if key in detail and detail[key] not in (None, ""):
-            value = str(detail[key])
-            # Truncate UUIDs to the first 8 chars for at-a-glance display;
-            # full value is still available in the disclosure below.
-            if len(value) == 36 and value.count("-") == 4:
-                value = value[:8] + "…"
-            parts.append(f"{label}: {value}")
-
-    if not parts:
-        # Surface SOMETHING for unmapped payloads instead of an empty cell.
-        first = next(iter(detail.items()), None)
-        if first is not None:
-            parts.append(f"{first[0]}: {first[1]}")
-
-    return " · ".join(parts) or "—"
+# A muted single-line "nothing here" row shared by every collapsible section.
+def _empty_row(text: str):  # type: ignore[no-untyped-def]
+    return P(text, cls="muted-text")
 
 
-def _audit_detail_cell(row: dict[str, Any]):
-    """Render the recent-activity ``Detailid`` cell.
-
-    Shows a readable Estonian summary plus a ``<details>`` disclosure
-    containing the raw JSON for power users who need the exact payload.
-    Empty / scalar payloads collapse to the summary alone.
-    """
-    action = row.get("action", "")
-    raw = row.get("detail_raw")
-    summary = _audit_detail_summary(action, raw)
-
-    if raw in (None, ""):
-        return summary
-
-    if isinstance(raw, dict):
-        raw_str = json.dumps(raw, indent=2, ensure_ascii=False, default=str)
-    else:
-        raw_str = str(raw)
-
-    return Details(
-        Summary(summary),
-        Pre(raw_str, cls="audit-detail-json"),
-        cls="audit-detail",
-    )
+def _step_label(step_number: int) -> str:
+    """Estonian label for a drafter step number, falling back to the bare number."""
+    try:
+        return STEP_LABELS_ET.get(Step(step_number), str(step_number))
+    except ValueError:
+        return str(step_number)
 
 
-def _activity_card(activity: list[dict]):  # type: ignore[type-arg]
-    """Render the recent activity card."""
-    if not activity:
-        body = P("Tegevusi ei leitud.", cls="muted-text")
-    else:
-        columns = [
-            Column(key="time", label="Aeg", sortable=False),
-            Column(key="action", label="Tegevus", sortable=False),
-            Column(
-                key="detail",
-                label="Detailid",
-                sortable=False,
-                render=_audit_detail_cell,
-            ),
-        ]
-        rows = []
-        for entry in activity:
-            ts = entry["created_at"]
-            rows.append(
-                {
-                    "time": format_tallinn(ts),
-                    "action": entry["action"],
-                    # Carry the raw payload so the render callback can produce
-                    # both the summary and the disclosure.  The ``detail`` key
-                    # itself is unused by the renderer but kept for
-                    # backwards-compatibility with any consumer that still
-                    # reads the row dict directly.
-                    "detail": "",
-                    "detail_raw": entry["detail"],
-                }
-            )
-        body = DataTable(
-            columns=columns,
-            rows=rows,
-            empty_message="Tegevusi ei leitud.",
-        )
+def _section_card(title: str, body):  # type: ignore[no-untyped-def]
+    """A compact section card — ``Card(CardHeader(H3(...)), CardBody(...))``."""
     return Card(
-        CardHeader(H3("Viimased tegevused", cls="card-title")),
+        CardHeader(H3(title, cls="card-title")),
         CardBody(body),
     )
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Minu järgmised tegevused
+# ---------------------------------------------------------------------------
+
+
+def _build_next_actions(
+    sessions: list[dict],  # type: ignore[type-arg]
+    high_risk: list[dict],  # type: ignore[type-arg]
+    stale: list[dict],  # type: ignore[type-arg]
+) -> list[dict]:  # type: ignore[type-arg]
+    """Synthesise the "what should I do next" list from existing signals.
+
+    This is *not* a new data source — it folds three already-loaded widget
+    result sets into one prioritised list of ``{text, href, link_label}``
+    dicts, capped at :data:`_MAX_NEXT_ACTIONS`. Order: drafter sessions
+    first (you have unfinished work), then high-risk reports (something needs
+    review), then stale analyses (the ontology moved on).
+    """
+    actions: list[dict[str, str]] = []
+
+    for s in sessions:
+        step_num = s["current_step"]
+        actions.append(
+            {
+                "text": f"Jätka koostajas — {step_num}. samm: {_step_label(step_num)}",
+                "href": f"/drafter/{s['id']}",
+                "link_label": "Ava koostaja",
+            }
+        )
+
+    for r in high_risk:
+        conflicts = r["conflict_count"]
+        title = r["title"]
+        if conflicts > 0:
+            text = f"Vaata mõjuaruannet «{title}» — {conflicts} konflikti vajavad ülevaatust"
+        else:
+            band_label = IMPACT_BAND_LABELS_ET[impact_band(r["impact_score"])].lower()
+            text = f"Vaata mõjuaruannet «{title}» — {band_label} (skoor {r['impact_score']}/100)"
+        actions.append(
+            {"text": text, "href": f"/drafts/{r['draft_id']}/report", "link_label": "Ava aruanne"}
+        )
+
+    for st in stale:
+        actions.append(
+            {
+                "text": (
+                    f"«{st['title']}»: ontoloogia uuenes pärast aruande koostamist. "
+                    "Analüüsi uuesti."
+                ),
+                "href": f"/drafts/{st['draft_id']}/report",
+                "link_label": "Ava aruanne",
+            }
+        )
+
+    return actions[:_MAX_NEXT_ACTIONS]
+
+
+def _next_actions_card(actions: list[dict]):  # type: ignore[type-arg, no-untyped-def]
+    if not actions:
+        return _section_card("Minu järgmised tegevused", _empty_row("Hetkel pole midagi ootel."))
+    items = [
+        Li(
+            Span(a["text"], cls="next-action-text"),
+            LinkButton(a["link_label"], href=a["href"], variant="secondary", size="sm"),
+            cls="next-action-item",
+        )
+        for a in actions
+    ]
+    return _section_card("Minu järgmised tegevused", Ul(*items, cls="next-action-list"))
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Kõrge riskiga leiud
+# ---------------------------------------------------------------------------
+
+
+def _high_risk_card(reports: list[dict]):  # type: ignore[type-arg, no-untyped-def]
+    if not reports:
+        return _section_card(
+            "Kõrge riskiga leiud", _empty_row("Kõrge riskiga mõjuaruandeid hetkel pole.")
+        )
+    columns = [
+        Column(key="title", label="Eelnõu", sortable=False),
+        Column(
+            key="band",
+            label="Risk",
+            sortable=False,
+            render=lambda r: Badge(r["band_label"], variant=r["band_variant"]),
+        ),
+        Column(key="counts", label="Leiud", sortable=False),
+        Column(key="generated_at", label="Analüüsitud", sortable=False),
+        Column(
+            key="actions",
+            label="",
+            sortable=False,
+            render=lambda r: A("Vaata aruannet", href=r["href"], cls="table-link"),
+        ),
+    ]
+    rows = []
+    for r in reports:
+        band = impact_band(r["impact_score"])
+        rows.append(
+            {
+                "title": r["title"],
+                "band_label": IMPACT_BAND_LABELS_ET[band],
+                "band_variant": _BAND_VARIANT[band],
+                "counts": (
+                    f"{r['conflict_count']} konflikti · {r['affected_count']} mõjutatud · "
+                    f"{r['gap_count']} lünka"
+                ),
+                "generated_at": format_tallinn(r["generated_at"]),
+                "href": f"/drafts/{r['draft_id']}/report",
+            }
+        )
+    return _section_card("Kõrge riskiga leiud", DataTable(columns=columns, rows=rows))
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Aegunud analüüsid
+# ---------------------------------------------------------------------------
+
+
+def _stale_card(drafts: list[dict]):  # type: ignore[type-arg, no-untyped-def]
+    if not drafts:
+        return _section_card("Aegunud analüüsid", _empty_row("Aegunud analüüse pole."))
+    items = [
+        Li(
+            Span(
+                f"«{d['title']}» — ontoloogia uuenes, analüüsi uuesti "
+                f"({d['stale_count']} aegunud märkust).",
+                cls="stale-text",
+            ),
+            LinkButton(
+                "Ava aruanne",
+                href=f"/drafts/{d['draft_id']}/report",
+                variant="secondary",
+                size="sm",
+            ),
+            cls="stale-item",
+        )
+        for d in drafts
+    ]
+    return _section_card("Aegunud analüüsid", Ul(*items, cls="stale-list"))
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Uued ontoloogia muudatused
+# ---------------------------------------------------------------------------
+
+
+def _syncs_card(syncs: list[dict]):  # type: ignore[type-arg, no-untyped-def]
+    if not syncs:
+        return _section_card(
+            "Uued ontoloogia muudatused", _empty_row("Hiljutisi ontoloogia uuendusi pole.")
+        )
+    columns = [
+        Column(key="finished_at", label="Uuendatud", sortable=False),
+        Column(key="entity_count", label="Olemeid ontoloogias", sortable=False),
+    ]
+    rows = [
+        {
+            "finished_at": format_tallinn(s["finished_at"]),
+            "entity_count": (
+                f"{s['entity_count']:,}".replace(",", " ")
+                if s["entity_count"] is not None
+                else "—"
+            ),
+        }
+        for s in syncs
+    ]
+    return _section_card("Uued ontoloogia muudatused", DataTable(columns=columns, rows=rows))
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Hiljutised ekspordid
+# ---------------------------------------------------------------------------
+
+
+def _exports_card(exports: list[dict]):  # type: ignore[type-arg, no-untyped-def]
+    if not exports:
+        return _section_card("Hiljutised ekspordid", _empty_row("Hiljutisi eksporte pole."))
+    items = [
+        Li(
+            Span(
+                f"«{e['title']}» mõjuaruanne eksporditud"
+                + (f" — {format_tallinn(e['finished_at'])}" if e["finished_at"] else ""),
+                cls="export-text",
+            ),
+            LinkButton(
+                "Ava aruanne",
+                href=f"/drafts/{e['draft_id']}/report",
+                variant="secondary",
+                size="sm",
+            ),
+            cls="export-item",
+        )
+        for e in exports
+    ]
+    return _section_card("Hiljutised ekspordid", Ul(*items, cls="export-list"))
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Eelnõud lahtiste märkustega
+# ---------------------------------------------------------------------------
+
+
+def _unresolved_card(drafts: list[dict]):  # type: ignore[type-arg, no-untyped-def]
+    if not drafts:
+        return _section_card(
+            "Eelnõud lahtiste märkustega", _empty_row("Lahtiste märkustega eelnõusid pole.")
+        )
+    columns = [
+        Column(key="title", label="Eelnõu", sortable=False),
+        Column(
+            key="unresolved_count",
+            label="Lahtisi märkusi",
+            sortable=False,
+            render=lambda r: Badge(str(r["unresolved_count"]), variant="warning"),
+        ),
+        Column(
+            key="actions",
+            label="",
+            sortable=False,
+            render=lambda r: A("Vaata aruannet", href=r["href"], cls="table-link"),
+        ),
+    ]
+    rows = [
+        {
+            "title": d["title"],
+            "unresolved_count": d["unresolved_count"],
+            "href": f"/drafts/{d['draft_id']}/report",
+        }
+        for d in drafts
+    ]
+    return _section_card("Eelnõud lahtiste märkustega", DataTable(columns=columns, rows=rows))
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Minu järjehoidjad — KEPT VERBATIM
+# ---------------------------------------------------------------------------
 
 
 def _bookmarks_card(bookmarks: list[dict]):  # type: ignore[type-arg]
@@ -378,75 +756,52 @@ def _bookmarks_card(bookmarks: list[dict]):  # type: ignore[type-arg]
     )
 
 
-def _org_card(org_info: dict | None):  # type: ignore[type-arg]
-    """Render the organisation info card."""
-    if org_info is None:
-        body = P("Te ei kuulu ühtegi organisatsiooni.", cls="muted-text")
-    else:
-        body = Dl(
-            Dt("Organisatsioon"),
-            Dd(org_info["org_name"]),
-            Dt("Teie roll"),
-            Dd(
-                Badge(
-                    _ROLE_LABELS.get(org_info["role"], org_info["role"]),
-                    variant="primary",
-                )
-            ),
-            Dt("Liikmeid"),
-            Dd(str(org_info["member_count"])),
-            cls="info-list",
-        )
-    return Card(
-        CardHeader(H3("Organisatsioon", cls="card-title")),
-        CardBody(body),
-    )
-
-
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
 
 
 def dashboard_page(req: Request):
-    """GET /dashboard — personal dashboard for authenticated users."""
+    """GET /dashboard — operational work queue for authenticated users."""
     auth = req.scope.get("auth", {})
     theme = get_theme_from_request(req)
     user_id = auth.get("id")
+    org_id = auth.get("org_id")
     full_name = auth.get("full_name", "Kasutaja")
+    first_name = (full_name or "Kasutaja").split()[0] if full_name else "Kasutaja"
 
-    activity = _get_recent_activity(user_id) if user_id else []
-    bookmarks = _get_bookmarks(user_id) if user_id else []
-    org_info = _get_user_org_info(user_id) if user_id else None
-    counts = _get_dashboard_counts(user_id, auth.get("org_id")) if user_id else {}
+    if user_id:
+        sessions = _get_active_drafter_sessions(user_id, org_id)
+        high_risk = _get_high_risk_reports(org_id)
+        stale = _get_stale_analysis_drafts(org_id)
+        syncs = _get_recent_syncs()
+        exports = _get_recent_exports(org_id)
+        unresolved = _get_unresolved_annotation_drafts(org_id)
+        bookmarks = _get_bookmarks(user_id)
+        org_info = _get_user_org_info(user_id)
+    else:
+        sessions = high_risk = stale = syncs = exports = unresolved = bookmarks = []
+        org_info = None
 
-    # Build the counts summary line
-    draft_count = counts.get("drafts", 0)
-    session_count = counts.get("drafter_sessions", 0)
-    conv_count = counts.get("conversations", 0)
+    next_actions = _build_next_actions(sessions, high_risk, stale)
+
+    # Compact header — no marketing hero. H1 + a small org/role line.
+    if org_info is not None:
+        role_label = _ROLE_LABELS.get(org_info["role"], org_info["role"])
+        subtitle = Small(f"{org_info['org_name']} · {role_label}", cls="page-subtitle")
+    else:
+        subtitle = Small("Te ei kuulu ühtegi organisatsiooni.", cls="page-subtitle")
 
     content = (
-        H1(f"Tere tulemast, {full_name}!", cls="page-title"),
-        InfoBox(
-            P(
-                "Tere tulemast Seadusloome s\u00fcsteemi! "
-                "Siit leiate kiirlingid teie eeln\u00f5udele, koostajale ja vestlustele. "
-                "Kasutage vasakul olevat men\u00fc\u00fcd navigeerimiseks."
-            ),
-            P(
-                f"Teil on {draft_count} eeln\u00f5u"
-                f"{'d' if draft_count != 1 else ''}"
-                f", {session_count} koostaja sessiooni"
-                f" ja {conv_count} vestlus"
-                f"{'t' if conv_count != 1 else ''}"
-                "."
-            ),
-            variant="info",
-            dismissible=True,
-        ),
-        _org_card(org_info),
+        H1(f"Tere, {first_name}", cls="page-title"),
+        subtitle,
+        _next_actions_card(next_actions),
+        _high_risk_card(high_risk),
+        _stale_card(stale),
+        _syncs_card(syncs),
+        _exports_card(exports),
+        _unresolved_card(unresolved),
         _bookmarks_card(bookmarks),
-        _activity_card(activity),
     )
 
     return PageShell(

--- a/app/templates/dashboard.py
+++ b/app/templates/dashboard.py
@@ -21,7 +21,6 @@ or schema change — everything is derivable from existing tables.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import Any
 
 from fasthtml.common import *
@@ -52,6 +51,7 @@ _MAX_NEXT_ACTIONS = 8
 # Per-widget row caps for the supporting sections (kept small so the page
 # stays dense-but-calm — see the design doc's "Visual Design Direction").
 _MAX_HIGH_RISK = 8
+_MAX_UNVIEWED = 8
 _MAX_STALE = 8
 _MAX_SYNCS = 5
 _MAX_EXPORTS = 5
@@ -105,23 +105,35 @@ def _get_high_risk_reports(org_id: str | None, *, limit: int = _MAX_HIGH_RISK) -
         return []
     try:
         with _connect() as conn:
+            # Pick the *latest* report per draft first, THEN filter by score —
+            # so a draft re-analysed from high risk down to medium/low drops
+            # off the list instead of clinging to its stale high-risk row.
             rows = conn.execute(
                 """
-                SELECT DISTINCT ON (ir.draft_id)
-                       ir.draft_id, d.title, ir.impact_score,
-                       ir.conflict_count, ir.affected_count, ir.gap_count,
-                       ir.generated_at
-                FROM impact_reports ir
-                JOIN drafts d ON d.id = ir.draft_id
-                WHERE d.org_id = %s AND ir.impact_score > 50
-                ORDER BY ir.draft_id, ir.generated_at DESC
+                WITH latest_report AS (
+                    SELECT DISTINCT ON (ir.draft_id)
+                           ir.draft_id, ir.impact_score, ir.conflict_count,
+                           ir.affected_count, ir.gap_count, ir.generated_at
+                    FROM impact_reports ir
+                    JOIN drafts d ON d.id = ir.draft_id
+                    WHERE d.org_id = %s
+                    ORDER BY ir.draft_id, ir.generated_at DESC
+                )
+                SELECT lr.draft_id, d.title, lr.impact_score,
+                       lr.conflict_count, lr.affected_count, lr.gap_count,
+                       lr.generated_at
+                FROM latest_report lr
+                JOIN drafts d ON d.id = lr.draft_id
+                WHERE lr.impact_score > 50
+                ORDER BY lr.generated_at DESC
+                LIMIT %s
                 """,
-                (org_id,),
+                (org_id, limit),
             ).fetchall()
     except Exception:
         logger.exception("Failed to fetch high-risk reports for org %s", org_id)
         return []
-    out = [
+    return [
         {
             "draft_id": str(r[0]),
             "title": r[1] or "Pealkirjata eelnõu",
@@ -133,10 +145,71 @@ def _get_high_risk_reports(org_id: str | None, *, limit: int = _MAX_HIGH_RISK) -
         }
         for r in rows
     ]
-    # DISTINCT ON returns draft-grouped rows in draft_id order; re-sort by
-    # recency and apply the widget cap.
-    out.sort(key=lambda d: d["generated_at"] or datetime.min, reverse=True)
-    return out[:limit]
+
+
+def _get_unviewed_reports(  # type: ignore[type-arg]
+    user_id: str, org_id: str | None, *, limit: int = _MAX_UNVIEWED
+) -> list[dict]:
+    """Return drafts whose latest impact report this user hasn't opened.
+
+    Implements the "report ready but not viewed" next-action source from #717,
+    derived from the ``draft.report.view`` audit_log entry that
+    :func:`app.docs.report_routes.draft_report_page` already writes (no schema
+    change). A draft surfaces when the current user has *never* opened its
+    report, or last opened it before the latest (re-)analysis — so a fresh
+    re-analysis re-appears in the queue.
+
+    ``detail->>'draft_id'`` is compared as text against ``draft_id::text`` —
+    no cast of the JSON field, so a stray non-UUID detail value can't take the
+    whole query down. Returns ``[{draft_id, title, impact_score,
+    conflict_count, generated_at, reanalyzed}]`` newest first.
+    """
+    if not user_id or not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                WITH latest_report AS (
+                    SELECT DISTINCT ON (ir.draft_id)
+                           ir.draft_id, ir.impact_score, ir.conflict_count,
+                           ir.generated_at
+                    FROM impact_reports ir
+                    JOIN drafts d ON d.id = ir.draft_id
+                    WHERE d.org_id = %s
+                    ORDER BY ir.draft_id, ir.generated_at DESC
+                ),
+                last_view AS (
+                    SELECT a.detail->>'draft_id' AS draft_id, MAX(a.created_at) AS viewed_at
+                    FROM audit_log a
+                    WHERE a.user_id = %s AND a.action = 'draft.report.view'
+                    GROUP BY a.detail->>'draft_id'
+                )
+                SELECT lr.draft_id, d.title, lr.impact_score, lr.conflict_count,
+                       lr.generated_at, (lv.viewed_at IS NOT NULL) AS reanalyzed
+                FROM latest_report lr
+                JOIN drafts d ON d.id = lr.draft_id
+                LEFT JOIN last_view lv ON lv.draft_id = lr.draft_id::text
+                WHERE lv.viewed_at IS NULL OR lv.viewed_at < lr.generated_at
+                ORDER BY lr.generated_at DESC
+                LIMIT %s
+                """,
+                (org_id, user_id, limit),
+            ).fetchall()
+    except Exception:
+        logger.exception("Failed to fetch unviewed reports for user %s", user_id)
+        return []
+    return [
+        {
+            "draft_id": str(r[0]),
+            "title": r[1] or "Pealkirjata eelnõu",
+            "impact_score": int(r[2] or 0),
+            "conflict_count": int(r[3] or 0),
+            "generated_at": r[4],
+            "reanalyzed": bool(r[5]),
+        }
+        for r in rows
+    ]
 
 
 def _get_stale_analysis_drafts(org_id: str | None, *, limit: int = _MAX_STALE) -> list[dict]:  # type: ignore[type-arg]
@@ -226,8 +299,10 @@ def _get_recent_exports(org_id: str | None, *, limit: int = _MAX_EXPORTS) -> lis
 
     The ``background_jobs`` table is not org-scoped, so we recover the org via
     the ``draft_id`` carried in the job payload (``payload->>'draft_id'``) and
-    join to ``drafts``. Only ``export_report`` jobs in the ``success`` state
-    are surfaced.
+    join to ``drafts``. The join compares ``drafts.id::text`` against the raw
+    payload string — no cast of the JSON value to ``uuid``, so a single
+    malformed payload can't fail the query and hide every valid export. Only
+    ``export_report`` jobs in the ``success`` state are surfaced.
 
     Returns ``[{draft_id, title, finished_at}]`` newest first — the row links
     to ``/drafts/{id}/report`` (the report page hosts the download button), so
@@ -241,7 +316,7 @@ def _get_recent_exports(org_id: str | None, *, limit: int = _MAX_EXPORTS) -> lis
                 """
                 SELECT j.payload->>'draft_id' AS draft_id, d.title, j.finished_at
                 FROM background_jobs j
-                JOIN drafts d ON d.id = (j.payload->>'draft_id')::uuid
+                JOIN drafts d ON d.id::text = (j.payload->>'draft_id')
                 WHERE j.job_type = 'export_report'
                   AND j.status = 'success'
                   AND d.org_id = %s
@@ -273,7 +348,10 @@ def _get_unresolved_annotation_drafts(  # type: ignore[type-arg]
     Covers every annotation whose ``target_type`` resolves to a draft —
     impact-report row annotations carry a ``draft_version_id`` (joined through
     ``draft_versions``), while older ``target_type='draft'`` annotations carry
-    the draft id directly in ``target_id``. Org-scoped via ``annotations.org_id``.
+    the draft id directly in ``target_id``. That branch joins on
+    ``drafts.id::text = a.target_id`` (text comparison — no ``::uuid`` cast),
+    so a single malformed legacy ``target_id`` can't fail the query and hide
+    every draft. Org-scoped via ``annotations.org_id``.
 
     Returns ``[{draft_id, title, unresolved_count}]`` ordered by the busiest
     draft first.
@@ -297,7 +375,7 @@ def _get_unresolved_annotation_drafts(  # type: ignore[type-arg]
 
                 SELECT d.id, d.title, COUNT(*) AS unresolved_count
                 FROM annotations a
-                JOIN drafts d ON d.id = a.target_id::uuid
+                JOIN drafts d ON d.id::text = a.target_id
                 WHERE a.org_id = %s
                   AND a.resolved = FALSE
                   AND a.target_type = 'draft'
@@ -306,8 +384,6 @@ def _get_unresolved_annotation_drafts(  # type: ignore[type-arg]
                 (org_id, org_id),
             ).fetchall()
     except Exception:
-        # ``target_id::uuid`` can throw on a non-UUID legacy value — degrade
-        # to an empty widget rather than crashing the whole dashboard.
         logger.exception("Failed to fetch drafts with unresolved annotations for org %s", org_id)
         return []
     # Merge the two UNION branches per draft (a draft could in theory have both
@@ -468,16 +544,21 @@ def _build_next_actions(
     sessions: list[dict],  # type: ignore[type-arg]
     high_risk: list[dict],  # type: ignore[type-arg]
     stale: list[dict],  # type: ignore[type-arg]
+    unviewed: list[dict],  # type: ignore[type-arg]
 ) -> list[dict]:  # type: ignore[type-arg]
     """Synthesise the "what should I do next" list from existing signals.
 
-    This is *not* a new data source — it folds three already-loaded widget
+    This is *not* a new data source — it folds four already-loaded widget
     result sets into one prioritised list of ``{text, href, link_label}``
-    dicts, capped at :data:`_MAX_NEXT_ACTIONS`. Order: drafter sessions
-    first (you have unfinished work), then high-risk reports (something needs
-    review), then stale analyses (the ontology moved on).
+    dicts, capped at :data:`_MAX_NEXT_ACTIONS`. Order, and one row per draft
+    (a draft that qualifies for several sources gets only the most-urgent
+    framing): drafter sessions first (unfinished work), then stale analyses
+    (the ontology moved on — re-analyse, even if the now-outdated report
+    flags high risk), then high-risk reports (conflicts to review), then
+    reports you simply haven't opened yet.
     """
     actions: list[dict[str, str]] = []
+    seen_drafts: set[str] = set()
 
     for s in sessions:
         step_num = s["current_step"]
@@ -489,7 +570,27 @@ def _build_next_actions(
             }
         )
 
+    for st in stale:
+        did = st["draft_id"]
+        if did in seen_drafts:
+            continue
+        seen_drafts.add(did)
+        actions.append(
+            {
+                "text": (
+                    f"«{st['title']}»: ontoloogia uuenes pärast aruande koostamist. "
+                    "Analüüsi uuesti."
+                ),
+                "href": f"/drafts/{did}/report",
+                "link_label": "Ava aruanne",
+            }
+        )
+
     for r in high_risk:
+        did = r["draft_id"]
+        if did in seen_drafts:
+            continue
+        seen_drafts.add(did)
         conflicts = r["conflict_count"]
         title = r["title"]
         if conflicts > 0:
@@ -498,19 +599,21 @@ def _build_next_actions(
             band_label = IMPACT_BAND_LABELS_ET[impact_band(r["impact_score"])].lower()
             text = f"Vaata mõjuaruannet «{title}» — {band_label} (skoor {r['impact_score']}/100)"
         actions.append(
-            {"text": text, "href": f"/drafts/{r['draft_id']}/report", "link_label": "Ava aruanne"}
+            {"text": text, "href": f"/drafts/{did}/report", "link_label": "Ava aruanne"}
         )
 
-    for st in stale:
+    for u in unviewed:
+        did = u["draft_id"]
+        if did in seen_drafts:
+            continue
+        seen_drafts.add(did)
+        title = u["title"]
+        if u["reanalyzed"]:
+            text = f"«{title}»: eelnõu analüüsiti uuesti — vaata uut mõjuaruannet."
+        else:
+            text = f"Mõjuaruanne valmis: «{title}». Vaata aruannet."
         actions.append(
-            {
-                "text": (
-                    f"«{st['title']}»: ontoloogia uuenes pärast aruande koostamist. "
-                    "Analüüsi uuesti."
-                ),
-                "href": f"/drafts/{st['draft_id']}/report",
-                "link_label": "Ava aruanne",
-            }
+            {"text": text, "href": f"/drafts/{did}/report", "link_label": "Ava aruanne"}
         )
 
     return actions[:_MAX_NEXT_ACTIONS]
@@ -773,6 +876,7 @@ def dashboard_page(req: Request):
     if user_id:
         sessions = _get_active_drafter_sessions(user_id, org_id)
         high_risk = _get_high_risk_reports(org_id)
+        unviewed = _get_unviewed_reports(user_id, org_id)
         stale = _get_stale_analysis_drafts(org_id)
         syncs = _get_recent_syncs()
         exports = _get_recent_exports(org_id)
@@ -780,10 +884,10 @@ def dashboard_page(req: Request):
         bookmarks = _get_bookmarks(user_id)
         org_info = _get_user_org_info(user_id)
     else:
-        sessions = high_risk = stale = syncs = exports = unresolved = bookmarks = []
+        sessions = high_risk = unviewed = stale = syncs = exports = unresolved = bookmarks = []
         org_info = None
 
-    next_actions = _build_next_actions(sessions, high_risk, stale)
+    next_actions = _build_next_actions(sessions, high_risk, stale, unviewed)
 
     # Compact header — no marketing hero. H1 + a small org/role line.
     if org_info is not None:

--- a/app/ui/layout/sidebar.py
+++ b/app/ui/layout/sidebar.py
@@ -6,12 +6,18 @@ from app.auth.provider import UserDict
 
 # Navigation items with required roles.
 # Each item: (label, href, icon, allowed_roles)
+#
+# #714: the user-facing labels are framed around legal work, not internal
+# module names. URLs are unchanged (relabel-in-place) — ``/explorer`` is
+# still ``/explorer`` even though it now reads "Õiguskaart", etc.
+_ALL_ROLES = {"drafter", "reviewer", "org_admin", "admin"}
 NAV_ITEMS: list[tuple[str, str, str, set[str]]] = [
-    ("Töölaud", "/dashboard", "home", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Uurija", "/explorer", "graph", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Eelnõud", "/drafts", "file-text", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Koostaja", "/drafter", "edit", {"drafter", "reviewer", "org_admin", "admin"}),
-    ("Vestlus", "/chat", "message-circle", {"drafter", "reviewer", "org_admin", "admin"}),
+    ("Töölaud", "/dashboard", "home", _ALL_ROLES),
+    ("Analüüsikeskus", "/analyysikeskus", "search", _ALL_ROLES),
+    ("Eelnõud", "/drafts", "file-text", _ALL_ROLES),
+    ("Õiguskaart", "/explorer", "graph", _ALL_ROLES),
+    ("Koostaja", "/drafter", "edit", _ALL_ROLES),
+    ("Nõustaja", "/chat", "message-circle", _ALL_ROLES),
     ("Kasutajad", "/org/users", "users", {"org_admin", "admin"}),
     ("Administraator", "/admin", "shield", {"admin"}),
 ]

--- a/app/ui/layout/top_bar.py
+++ b/app/ui/layout/top_bar.py
@@ -109,10 +109,11 @@ def TopBar(  # noqa: ANN201
                 cls="logo",
             ),
             Nav(  # noqa: F405
-                A("Uurija", href="/explorer"),  # noqa: F405
+                A("Analüüsikeskus", href="/analyysikeskus"),  # noqa: F405
                 A("Eelnõud", href="/drafts"),  # noqa: F405
+                A("Õiguskaart", href="/explorer"),  # noqa: F405
                 A("Koostaja", href="/drafter"),  # noqa: F405
-                A("Vestlus", href="/chat"),  # noqa: F405
+                A("Nõustaja", href="/chat"),  # noqa: F405
                 cls="top-nav",
             )
             if user

--- a/docs/2026-05-11-ministry-lawyer-ui-structure.md
+++ b/docs/2026-05-11-ministry-lawyer-ui-structure.md
@@ -6,6 +6,16 @@ Scope: Product and UI structure for Seadusloome as a legal advisory workbench fo
 
 Reference context: Section 7 of `eesti-oigusontoloogia-ulevaade.pdf` describes ministry use cases: norm impact chains, EU coordination, KOV policy comparison, competence audits, sanctions comparison, legislative burden management, crisis/internal-security legal mapping, and public-service full views.
 
+## Status — 2026-05-11 (epic [#714](https://github.com/henrikaavik/Seadusloome/issues/714))
+
+This document is the design rationale; the scope **actually committed** for the first round is narrower than everything described below. Read the rest of the doc as the long-term direction, but note:
+
+- **In scope now:** the *Phase A* framing changes (nav reframe in place, `Töölaud` → work queue, `Õiguskaart` control relabel + `?focus=` wiring, diacritics) **and** *Phase B done honestly* — the **two** `Analüüsikeskus` workflows that have backing ontology data today: `Normi mõjuahel` and `EL ülevõtt ja harmoneerimine`.
+- **Workflows 3–8 (`Pädevused`, `Sanktsioonid`, `Halduskoormus`, `KOV võrdlus`, `Avaliku teenuse tervikvaade`, `Kriisikaart`) are deferred** to a follow-up epic — **including the one this doc's Phase B list names (`Pädevused`)**. Their *ontology data* largely already exists in the `estonian-legal-ontology` source repo (`Sanction` nodes with structured penalty values, institution-authority nodes, KOV, …, well ahead of `estonian-legal-ontology-plan.md`); what's missing is the **app-side SPARQL + UI integration**. The follow-up epic should re-audit the ontology repo, not the plan doc. No placeholder cards for these workflows in the meantime.
+- **`EL ülevõtt` MVP is act/provision-level, not the article/obligation matrix** described under "Workflow 2" / "Concrete Page Recommendations" below: the ontology models `transposesDirective` / `transposedBy` / `transpositionStatus` at the act (and, where present, provision via `harmonisedWith`) level — there is no EU Article/Obligation entity model. The article-level matrix is its own ontology-enrichment ticket.
+- **Also deferred:** `Ülevaatus` review queue (Phase E), the LLM advice / suggested-fix engine (Phase D — `Soovitatud tegevused` is a *static* action set for now), the `Koostaja` `Lahendusvariandid` step, a light reading theme.
+- **URLs are relabelled in place** — `/explorer`, `/chat`, `/drafts`, `/drafter` keep their paths; only nav text, page titles, and headings change. The new `Analüüsikeskus` page gets a fresh route (`/analyysikeskus`).
+
 ## Executive Direction
 
 Seadusloome should be structured around legal work, not around technical modules.

--- a/docs/2026-05-11-ministry-lawyer-ui-structure.md
+++ b/docs/2026-05-11-ministry-lawyer-ui-structure.md
@@ -1,0 +1,1102 @@
+# Seadusloome UI Structure for Ministry Lawyers
+
+Date: 2026-05-11
+
+Scope: Product and UI structure for Seadusloome as a legal advisory workbench for lawyers and officials in Estonian ministries.
+
+Reference context: Section 7 of `eesti-oigusontoloogia-ulevaade.pdf` describes ministry use cases: norm impact chains, EU coordination, KOV policy comparison, competence audits, sanctions comparison, legislative burden management, crisis/internal-security legal mapping, and public-service full views.
+
+## Executive Direction
+
+Seadusloome should be structured around legal work, not around technical modules.
+
+The current application exposes the internal system shape:
+
+- `Uurija`
+- `Eelnõud`
+- `Koostaja`
+- `Vestlus`
+
+That is understandable to a development team, but it makes ministry lawyers translate their task into a tool choice. A lawyer does not start with "I need a graph explorer" or "I need a RAG chat". They start with:
+
+- "I need to know what this amendment affects."
+- "I need to check whether an EU directive is fully transposed."
+- "I need to compare KOV regulations."
+- "I need to know which agency is responsible for supervision."
+- "I need to see whether this sanction level is consistent."
+- "I need advice on how to fix the draft."
+
+The product should therefore present itself as a legal advisory workbench. The technical modules still exist underneath, but the user-facing structure should be organized by ministry workflows.
+
+The central design rule:
+
+> The system offers legal analysis, options, and recommended next actions. It should not ask lawyers technical questions.
+
+This means the UI must not ask about SPARQL, RDF classes, named graphs, graph URIs, embedding search, ontology predicates, background jobs, or other implementation details. When the system needs more information, it should ask legal or policy questions in ordinary ministry language.
+
+## Primary Users
+
+The primary users are lawyers and officials who work in ministries and participate in law creation, legal analysis, coordination, review, and impact assessment.
+
+They may be skilled lawyers, but they should not need to understand the ontology technology. The product should treat ontology, RAG, graph traversal, and SPARQL as invisible infrastructure.
+
+The expected user goals are:
+
+- analyze a legislative idea before drafting;
+- upload and assess a draft law or VTK;
+- understand legal dependencies and conflicts;
+- identify EU, KOV, court-practice, competence, and sanction implications;
+- get advice on legal solutions;
+- create or improve draft text;
+- prepare evidence for internal review or coordination.
+
+## Product Principle
+
+Seadusloome should behave like a senior legal analyst with access to the full legal ontology.
+
+The system should:
+
+- infer likely context from the user's draft, idea, ministry, and selected topic;
+- run the relevant ontology analyses automatically;
+- show findings in a legally meaningful order;
+- recommend what to do next;
+- ask clarifying questions only when legal judgment is genuinely needed;
+- always expose evidence and source links;
+- make it easy to export, annotate, assign, and continue drafting.
+
+The system should not:
+
+- ask the user to choose technical query types;
+- expose raw ontology identifiers as primary UI;
+- require users to know which module can answer a legal question;
+- make the graph the only way to understand relationships;
+- make the chat the main access point for structured analysis;
+- leave users with findings but no proposed solution.
+
+## Recommended Top-Level Navigation
+
+Proposed primary navigation:
+
+1. `Töölaud`
+2. `Analüüsikeskus`
+3. `Eelnõud`
+4. `Õiguskaart`
+5. `Koostaja`
+6. `Nõustaja`
+7. `Ülevaatus`
+8. `Admin`
+
+### Why This Structure
+
+`Töölaud` is the user's daily queue.
+
+It should answer:
+
+- what needs my attention today;
+- which drafts are waiting for review;
+- which analyses changed after ontology updates;
+- which findings are unresolved;
+- what the system recommends next.
+
+`Analüüsikeskus` is the main new structure.
+
+It should be the home for ministry use cases from Section 7. Instead of asking the user to pick a technical feature, it offers legal analysis workflows.
+
+`Eelnõud` remains the document workspace.
+
+It should handle uploads, versions, VTK links, processing status, impact reports, exports, retention, and deletion.
+
+`Õiguskaart` is the visual ontology map.
+
+It should no longer be framed as the primary "Explorer". It should be a supporting evidence view that opens from analyses with context already applied.
+
+`Koostaja` remains the drafting workflow.
+
+It should use the analysis workflows as inputs and should propose legal structure, clauses, alternatives, and risk notes.
+
+`Nõustaja` is a better label than `Vestlus`.
+
+The user is not looking for "chat"; the user is asking for legal advice. The assistant should also appear inside reports and draft pages, not only as a separate page.
+
+`Ülevaatus` is the collaboration and legal validation area.
+
+It should collect unresolved findings, annotations, ministry confirmations, assigned legal checks, and review decisions.
+
+`Admin` stays technical/administrative and should be hidden from normal lawyers.
+
+## Core UI Pattern for Every Workflow
+
+Every legal workflow should follow the same structure:
+
+1. `Sisend`
+2. `Ulatus`
+3. `Tulemused`
+4. `Tõendid`
+5. `Soovitatud tegevused`
+
+### 1. Sisend
+
+The user gives a legal object or describes a legal issue:
+
+- draft law;
+- VTK;
+- paragraph reference;
+- CELEX number;
+- institution;
+- sanction type;
+- public service;
+- topic such as waste management, cybersecurity, or social benefits.
+
+The UI should accept natural language and structured references.
+
+Good input examples:
+
+- "Muudame AvTS § 35."
+- "Kontrolli AI määruse ülevõttu."
+- "Võrdle jäätmehoolduseeskirju KOVide lõikes."
+- "Millistel asutustel on selle valdkonna järelevalvepädevus?"
+
+Bad input examples:
+
+- "Select RDF class."
+- "Enter graph URI."
+- "Choose SPARQL traversal depth."
+- "Pick embedding index."
+
+### 2. Ulatus
+
+The system should choose a sensible default scope and let the user adjust it in legal terms.
+
+Scope controls should be legal:
+
+- current law vs historical redactions;
+- Estonia only vs Estonia + EU;
+- all ministries vs my organization;
+- national law vs national + KOV regulations;
+- court practice included or excluded;
+- draft lifecycle stage;
+- time period.
+
+The system can say:
+
+> Analüüsin kehtivat õigust, seotud eelnõusid, Riigikohtu praktikat ja EL õigusakte. Võite ulatust muuta.
+
+It should not ask:
+
+> Which named graphs should be included?
+
+### 3. Tulemused
+
+The first result screen should be decision-oriented.
+
+It should not start with a table of raw entities. It should start with:
+
+- key findings;
+- risk level;
+- recommended next action;
+- legal rationale;
+- confidence;
+- what changed compared with earlier analysis, if relevant.
+
+Example:
+
+> Kavandatav muudatus mõjutab vähemalt 18 sätet, 3 pooleliolevat eelnõu ja 2 Riigikohtu lahendit. Kõrgeim risk on vastuolu AvTS § 35 erandite süsteemiga. Soovitus: täpsustada andmekoosseisude avalikustamise erandit ja lisada üleminekusäte.
+
+### 4. Tõendid
+
+Every claim must be auditable.
+
+The UI should show:
+
+- source provision;
+- linked draft;
+- court decision;
+- EU act;
+- relation type in legal language;
+- quote/snippet where available;
+- date/version;
+- source link;
+- why the system thinks this is relevant.
+
+The evidence view can use tables, timelines, and graph views, but the first layer should be legally readable.
+
+### 5. Soovitatud Tegevused
+
+Every workflow should end with a useful action set.
+
+Examples:
+
+- `Paranda eelnõu`
+- `Koosta alternatiivne sõnastus`
+- `Lisa ülevaatusele`
+- `Määra kolleegile`
+- `Ava õiguskaardil`
+- `Küsi nõustajalt`
+- `Ekspordi memo`
+- `Lisa seletuskirja mõjuanalüüsi`
+- `Märgi kontrollituks`
+
+This is critical: the system should not merely find issues. It should help solve them.
+
+## Analüüsikeskus
+
+`Analüüsikeskus` should be the central page for Section 7 workflows.
+
+It should present legal tasks as large, clear workflow entries, but not as marketing cards. This is an operational tool, so the layout should be dense, scan-friendly, and task-first.
+
+Recommended workflows:
+
+1. `Normi mõjuahel`
+2. `EL ülevõtt ja harmoneerimine`
+3. `KOV võrdlus`
+4. `Pädevused ja järelevalve`
+5. `Sanktsioonide võrdlus`
+6. `Kohustused, keelud ja halduskoormus`
+7. `Kriisi- ja siseturvalisuse õiguskaart`
+8. `Avaliku teenuse tervikvaade`
+
+Each workflow should have:
+
+- a one-line legal purpose;
+- one primary input field;
+- example inputs;
+- last used or recommended scope;
+- recent analyses;
+- a primary action: `Alusta analüüsi`.
+
+## Workflow 1: Normi Mõjuahel
+
+Section 7 use case: before changing a law, the user can see which provisions refer to the changed paragraph, which drafts affect it, and which Supreme Court practice is connected.
+
+### User Intent
+
+The lawyer wants to know what happens if a provision, draft, or idea changes.
+
+### Inputs
+
+- provision reference, such as `AvTS § 35`;
+- draft file;
+- draft ID;
+- natural-language idea;
+- selected entity from a report or graph.
+
+### System Logic
+
+The system should automatically:
+
+- resolve the referenced provision or idea to ontology entities;
+- find incoming and outgoing references;
+- find drafts that touch the same provisions;
+- find related court decisions;
+- find EU links;
+- detect possible conflicts;
+- show likely downstream effects;
+- rank findings by legal risk and relevance.
+
+### UI Output
+
+The first screen should show:
+
+- `Peamised mõjud`
+- `Kõrge riskiga seosed`
+- `Seotud eelnõud`
+- `Riigikohtu praktika`
+- `EL seosed`
+- `Soovitatud parandused`
+
+The graph should be available as `Ava õiguskaardil`, not be the default interpretation layer.
+
+### Recommended Actions
+
+- `Koosta mõju memo`
+- `Lisa seletuskirja`
+- `Koosta alternatiivne säte`
+- `Märgi risk ülevaatusele`
+- `Ava seotud eelnõu`
+
+## Workflow 2: EL Ülevõtt ja Harmoneerimine
+
+Section 7 use case: directives transposition view helps find which Estonian provisions are connected to a CELEX act and where transposition or harmonization gaps exist.
+
+### User Intent
+
+The lawyer or EU coordinator wants to understand whether Estonian law fully covers an EU obligation.
+
+### Inputs
+
+- CELEX number;
+- EU regulation/directive title;
+- draft law;
+- policy area;
+- natural-language question.
+
+### System Logic
+
+The system should:
+
+- resolve CELEX or EU act title;
+- list linked Estonian provisions;
+- identify relevant draft legislation;
+- detect missing or weak links;
+- show court practice where relevant;
+- compare current law to draft changes;
+- highlight obligations, deadlines, and affected institutions if available.
+
+### UI Output
+
+The first result should be a transposition matrix:
+
+- EU article or obligation;
+- Estonian provision;
+- status: covered, partial, missing, unclear;
+- evidence;
+- responsible institution;
+- recommended action.
+
+### Recommended Actions
+
+- `Täpsusta ülevõtu seos`
+- `Lisa puuduv säte`
+- `Koosta kooskõla memo`
+- `Saada EL koordinaatorile ülevaatuseks`
+- `Küsi nõustajalt parandust`
+
+## Workflow 3: KOV Võrdlus
+
+Section 7 use case: KOV regulations can be compared by municipality, issuer, and normalized titles, for example waste-management rules or social-benefit procedures.
+
+### User Intent
+
+The lawyer wants to see how local governments regulate the same topic and whether there are outliers, inconsistencies, or reusable patterns.
+
+### Inputs
+
+- policy area;
+- regulation title;
+- municipality;
+- institution;
+- natural-language service or obligation.
+
+### System Logic
+
+The system should:
+
+- normalize KOV regulation titles;
+- group similar regulations;
+- compare obligations, definitions, procedures, deadlines, and sanctions;
+- identify outliers;
+- identify common model wording;
+- show regional coverage and missing regulation areas.
+
+### UI Output
+
+The result should show:
+
+- comparison table by KOV;
+- common clauses;
+- divergent clauses;
+- missing or unusual provisions;
+- recommended harmonization options.
+
+### Recommended Actions
+
+- `Koosta võrdlusmemo`
+- `Paku ühtlustatud sõnastus`
+- `Märgi erisused ülevaatuseks`
+- `Ekspordi tabel`
+
+## Workflow 4: Pädevused ja Järelevalve
+
+Section 7 use case: competence mapping shows which institutions have permit, supervision, procedure, or enforcement tasks.
+
+### User Intent
+
+The lawyer wants to know who is responsible for doing what, whether responsibilities overlap, and whether a draft creates unclear competence.
+
+### Inputs
+
+- institution name;
+- policy area;
+- draft law;
+- task type: license, supervision, enforcement, procedure;
+- public service.
+
+### System Logic
+
+The system should:
+
+- extract institutions and task verbs;
+- classify competence type;
+- find source provisions;
+- identify overlaps between institutions;
+- identify missing implementing authority;
+- identify KOV vs national responsibility;
+- compare current law and draft changes.
+
+### UI Output
+
+The result should show a competence map:
+
+- institution;
+- task;
+- legal basis;
+- task type;
+- affected area;
+- related draft changes;
+- risk: overlap, gap, unclear mandate.
+
+### Recommended Actions
+
+- `Täpsusta volitusnorm`
+- `Lisa rakendusvastutus`
+- `Koosta pädevusmemo`
+- `Määra asutusele ülevaatus`
+
+## Workflow 5: Sanktsioonide Võrdlus
+
+Section 7 use case: sanctions index allows comparing fines, penalty payments, imprisonment, and other sanctions by field or legal act.
+
+### User Intent
+
+The lawyer wants to know whether a proposed sanction is proportionate and consistent with similar areas.
+
+### Inputs
+
+- sanction amount or type;
+- draft provision;
+- legal act;
+- policy area;
+- violation description.
+
+### System Logic
+
+The system should:
+
+- classify sanction type;
+- find comparable sanctions;
+- compare amount ranges and severity;
+- show legal act and field;
+- flag outliers;
+- show related court practice where available;
+- recommend consistency adjustments.
+
+### UI Output
+
+The result should show:
+
+- sanction comparison matrix;
+- severity bands;
+- comparable provisions;
+- outliers;
+- proportionality notes;
+- recommended alternative wording.
+
+### Recommended Actions
+
+- `Paku proportsionaalne sanktsioon`
+- `Lisa põhjendus seletuskirja`
+- `Võrdle valdkonna praktikaga`
+- `Saada karistusõiguse ülevaatusele`
+
+## Workflow 6: Kohustused, Keelud ja Halduskoormus
+
+Section 7 use case: deontic classification helps find concentrations of obligations, prohibitions, permissions, and rights, useful for evaluating administrative burden.
+
+### User Intent
+
+The lawyer wants to understand whether a draft adds too many obligations, unclear prohibitions, or administrative burden.
+
+### Inputs
+
+- draft law;
+- public service;
+- target group;
+- policy area.
+
+### System Logic
+
+The system should:
+
+- classify provisions as obligation, prohibition, permission, right, competence, sanction;
+- identify affected groups;
+- count new or changed obligations;
+- compare with current law;
+- show burden concentration by target group and institution;
+- recommend simplification.
+
+### UI Output
+
+The result should show:
+
+- burden summary;
+- obligations by target group;
+- obligations by institution;
+- new vs existing duties;
+- potential duplication;
+- simplification suggestions.
+
+### Recommended Actions
+
+- `Vähenda dubleerivat kohustust`
+- `Koosta halduskoormuse lõik`
+- `Täpsusta adressaat`
+- `Lisa erand või üleminekusäte`
+
+## Workflow 7: Kriisi- ja Siseturvalisuse Õiguskaart
+
+Section 7 use case: cross-references and competences can bring crisis, police, rescue, data protection, and local-level norms into one work view.
+
+### User Intent
+
+The lawyer wants a consolidated legal map for a crisis or internal-security scenario.
+
+### Inputs
+
+- scenario, such as cyber incident, flood, evacuation, public-order event;
+- institution;
+- draft;
+- legal act.
+
+### System Logic
+
+The system should:
+
+- map relevant laws, regulations, KOV norms, EU acts, and court practice;
+- identify responsible institutions;
+- identify emergency powers and limits;
+- identify data protection constraints;
+- identify conflicting or unclear mandates;
+- show time-sensitive legal dependencies.
+
+### UI Output
+
+The result should show:
+
+- scenario map;
+- institution responsibility table;
+- emergency powers;
+- data protection constraints;
+- KOV/national split;
+- risks and recommended clarifications.
+
+### Recommended Actions
+
+- `Koosta kriisiõiguse memo`
+- `Täpsusta pädevusjaotus`
+- `Lisa andmekaitse kontroll`
+- `Ava õiguskaardil`
+
+## Workflow 8: Avaliku Teenuse Tervikvaade
+
+Section 7 use case: laws, regulations, KOV procedures, court practice, and EU acts regulating a service can be combined into one query instead of searching separate portals manually.
+
+### User Intent
+
+The lawyer wants to understand the full legal environment around a public service.
+
+### Inputs
+
+- public service name;
+- institution;
+- policy area;
+- draft;
+- citizen or business obligation.
+
+### System Logic
+
+The system should:
+
+- identify the service;
+- find national laws;
+- find regulations;
+- find KOV procedures;
+- find EU obligations;
+- find related court practice;
+- map responsible institutions;
+- show service lifecycle steps;
+- identify legal gaps and duplication.
+
+### UI Output
+
+The result should show:
+
+- service legal map;
+- process steps;
+- legal basis per step;
+- responsible institution;
+- citizen/business obligations;
+- court and EU links;
+- risks and improvement suggestions.
+
+### Recommended Actions
+
+- `Koosta teenuse õigusmemo`
+- `Paku lihtsustatud regulatsiooni`
+- `Lisa mõjuanalüüsi`
+- `Saada asutusele ülevaatuseks`
+
+## Eelnõud Workspace
+
+`Eelnõud` should remain the place for actual documents, but it should become more action-oriented.
+
+Current useful parts:
+
+- upload `.docx` or `.pdf`;
+- distinguish `Eelnõu` and `VTK`;
+- link eelnõu to VTK;
+- show processing status;
+- show impact report;
+- show similar drafts;
+- show version history;
+- export reports.
+
+Recommended improvements:
+
+- rename the page description from generic upload language to "document workspace";
+- show unresolved findings directly in the list;
+- show next action per draft;
+- show whether analysis is stale after ontology updates;
+- show whether draft has unresolved EU, conflict, competence, or burden risks;
+- make `Vaata mõjuaruannet`, `Küsi nõustajalt`, and `Paranda koostajaga` primary actions;
+- make version comparison more prominent for legislative lifecycle work.
+
+List row should show:
+
+- title;
+- type: eelnõu or VTK;
+- lifecycle stage;
+- analysis status;
+- highest legal risk;
+- unresolved review count;
+- owner;
+- last change;
+- next action.
+
+## Õiguskaart
+
+The current Explorer should become `Õiguskaart`.
+
+The value of the graph is high, but it should be a contextual evidence view, not the first place a lawyer has to interpret results.
+
+Recommended behavior:
+
+- opened from analysis results with focus already applied;
+- shows selected provision/draft/service/institution as the center;
+- uses legal filters: laws, drafts, court practice, EU, KOV, competences, sanctions;
+- offers predefined views: impact chain, EU links, competence map, version timeline;
+- detail panel explains relation meaning in Estonian legal language;
+- graph controls use domain words, not simulation words.
+
+Replace controls such as:
+
+- `Taaskäivita simulatsioon`
+- `Lülita silte`
+- `Rühmita`
+
+With:
+
+- `Näita mõjuahelat`
+- `Näita EL seoseid`
+- `Näita pädevusi`
+- `Näita kohtupraktikat`
+- `Näita eelnõusid`
+- `Näita ajalist vaadet`
+
+Technical graph controls can remain under `Vaate seaded`.
+
+## Koostaja
+
+The AI drafter should not feel like an isolated wizard. It should be a drafting workspace informed by prior analysis.
+
+Recommended structure:
+
+1. `Kavatsus`
+2. `Õiguslik eeluuring`
+3. `Lahendusvariandid`
+4. `Struktuur`
+5. `Sätted`
+6. `Kontroll ja mõju`
+7. `Eksport`
+
+The most important addition is `Lahendusvariandid`.
+
+Before drafting clauses, the system should propose legal options:
+
+- amend existing law;
+- create new act;
+- use regulation instead of law;
+- add competence rule;
+- add exception;
+- add transitional provision;
+- no legislative change needed;
+- policy or administrative measure may be sufficient.
+
+For each option, show:
+
+- when this option is appropriate;
+- legal risks;
+- affected institutions;
+- EU implications;
+- drafting effort;
+- recommended choice.
+
+The system should ask clarifying questions only in legal terms:
+
+Good:
+
+- "Millist sihtrühma muudatus peamiselt puudutab?"
+- "Kas eesmärk on luua uus kohustus või täpsustada olemasolevat?"
+- "Kas muudatus peab jõustuma kindlal kuupäeval?"
+
+Bad:
+
+- "Millist ontology classi kasutada?"
+- "Kas otsida Jena named graphist?"
+- "Millise SPARQL päringu käivitan?"
+
+## Nõustaja
+
+The current `Vestlus` should be renamed or reframed as `Nõustaja`.
+
+It should support natural-language advice, but it should not become the only way to access structured workflows. Lawyers should not need to invent the correct prompt.
+
+Recommended design:
+
+- keep free chat;
+- add suggested legal tasks;
+- support context-aware questions from any report row;
+- let the user ask "Mida ma peaksin parandama?";
+- let the system propose actions after answering;
+- show sources and confidence;
+- create annotations or drafting tasks from an answer.
+
+Suggested commands should map to ministry workflows:
+
+- `/mõjuahel`
+- `/el-ülevõtt`
+- `/kov-võrdlus`
+- `/pädevused`
+- `/sanktsioonid`
+- `/halduskoormus`
+- `/seletuskiri`
+
+The command list should be optional. The UI should also show these as buttons or suggestions in normal language.
+
+## Ülevaatus
+
+Ministry legal work is collaborative. Findings need review, confirmation, and sometimes legal judgment.
+
+`Ülevaatus` should collect:
+
+- unresolved impact findings;
+- row-level annotations;
+- assigned reviews;
+- competence confirmations;
+- EU transposition confirmations;
+- sanctions/proportionality confirmations;
+- draft sections waiting for legal review;
+- decisions already marked as accepted, rejected, or fixed.
+
+Recommended review states:
+
+- `Uus leid`
+- `Vajab kontrolli`
+- `Kinnitatud`
+- `Parandus koostamisel`
+- `Lahendatud`
+- `Ei kohaldu`
+
+Every finding should allow:
+
+- assign to person;
+- add note;
+- ask advisor;
+- open evidence;
+- create drafting task;
+- mark decision.
+
+## Töölaud
+
+The dashboard should stop being a welcome page and become an operational work queue.
+
+Recommended dashboard sections:
+
+- `Minu järgmised tegevused`
+- `Kõrge riskiga leiud`
+- `Ülevaatust ootavad eelnõud`
+- `Aegunud analüüsid`
+- `Uued ontoloogia muudatused`
+- `Hiljutised ekspordid`
+- `Minu järjehoidjad`
+
+Each item should include a recommended action.
+
+Examples:
+
+- "AI eelnõu mõjuanalüüs valmis. 3 konflikti vajavad ülevaatust. Ava aruanne."
+- "EL AI määruse seos on ebaselge. Kontrolli ülevõttu."
+- "VTK ootab lahendusvariandi valikut. Jätka koostajas."
+- "Ontoloogia uuenes pärast aruande koostamist. Analüüsi uuesti."
+
+## Advice-First Interaction Model
+
+The most important UX shift is that Seadusloome should not merely show data. It should advise.
+
+For every finding, the UI should answer:
+
+1. What is the issue?
+2. Why does it matter legally?
+3. How serious is it?
+4. What evidence supports it?
+5. What should the lawyer do next?
+6. Can the system draft a possible fix?
+
+Example finding:
+
+> Eelnõu võib luua kattuva järelevalvepädevuse Tarbijakaitse ja Tehnilise Järelevalve Ameti ning Andmekaitse Inspektsiooni vahel.
+
+Advice:
+
+> Soovitus: täpsustada, milline asutus kontrollib läbipaistvuskohustust ja milline isikuandmete töötlemise õiguspärasust. Lisa volitusnormi lõppu eristav lause.
+
+Action:
+
+- `Koosta parandussõnastus`
+- `Lisa pädevusmemo`
+- `Märgi ülevaatuseks`
+
+## Clarifying Questions
+
+When the system needs clarification, it should ask about legal intent, policy scope, or institutional choice.
+
+Allowed question types:
+
+- policy goal;
+- target group;
+- affected institution;
+- intended legal instrument;
+- timeframe;
+- risk tolerance;
+- EU obligation;
+- whether the change creates, removes, or clarifies obligations;
+- whether KOV autonomy is affected.
+
+Avoided question types:
+
+- database query choices;
+- ontology class choices;
+- graph traversal depth;
+- prompt-engineering choices;
+- model/provider choices;
+- embedding or vector search details;
+- internal pipeline stage choices.
+
+If a technical decision is necessary, the system should choose a default and explain it in legal terms.
+
+Example:
+
+> Kasutan vaikimisi kehtivat õigust, seotud eelnõusid, Riigikohtu praktikat ja EL õigusakte, sest need on selle mõjuanalüüsi jaoks tavaliselt olulised.
+
+## Result Ranking Logic
+
+Findings should be ranked by legal usefulness, not by raw graph distance.
+
+Suggested ranking criteria:
+
+- direct legal dependency;
+- current validity;
+- same policy area;
+- same target group;
+- same institution;
+- EU obligation link;
+- court interpretation link;
+- draft lifecycle relevance;
+- severity of conflict;
+- likelihood of real-world impact;
+- user ministry relevance;
+- recent change.
+
+The UI can expose this as:
+
+- `Kõrge risk`
+- `Vajab kontrolli`
+- `Taustateave`
+- `Väike mõju`
+
+Do not expose it as:
+
+- score vector;
+- graph weight;
+- SPARQL match;
+- embedding similarity.
+
+## Evidence and Trust
+
+Legal users will not trust black-box advice without evidence.
+
+Each recommendation should include:
+
+- source;
+- quote or snippet where possible;
+- relation explanation;
+- version/date;
+- confidence or status;
+- human confirmation status.
+
+Confidence should be framed carefully:
+
+- `Tugev seos`
+- `Tõenäoline seos`
+- `Vajab kontrolli`
+- `Nõrk seos`
+
+Avoid model-like phrasing such as:
+
+- `embedding score`;
+- `LLM confidence`;
+- `cosine similarity`.
+
+## Visual Design Direction
+
+This should feel like a professional government workbench.
+
+Design direction:
+
+- dense but calm;
+- restrained color;
+- strong hierarchy;
+- clear status and risk coding;
+- tables for comparison;
+- timelines for version/lifecycle;
+- side panels for evidence;
+- graph only when relationships matter visually;
+- no marketing-style hero sections;
+- no oversized decorative cards;
+- no playful visual language.
+
+The dark theme can work, but legal analysis screens may benefit from a lighter reading mode later because lawyers read long text and tables for long periods.
+
+## Concrete Page Recommendations
+
+### Analysis Result Page
+
+Recommended layout:
+
+- top: title, input summary, scope, status;
+- left/main: findings grouped by legal issue;
+- right side panel: recommended actions and evidence preview;
+- tabs or segmented control: `Kokkuvõte`, `Tõendid`, `Õiguskaart`, `Ülevaatus`, `Eksport`;
+- sticky action bar for `Paranda`, `Ekspordi`, `Määra`, `Küsi nõustajalt`.
+
+### Draft Detail Page
+
+Recommended layout:
+
+- title and lifecycle stage;
+- status/processing;
+- highest legal risks;
+- next recommended action;
+- linked VTK and versions;
+- analyses;
+- unresolved review items;
+- exports.
+
+### Impact Report Page
+
+Current sections are useful but should be reframed:
+
+- `Kokkuvõte`
+- `Soovitatud tegevused`
+- `Kõrge riskiga leiud`
+- `Mõjuahel`
+- `Konfliktid`
+- `EL ülevõtt`
+- `Lüngad`
+- `Pädevused`
+- `Sanktsioonid`
+- `Halduskoormus`
+- `Tõendid`
+- `Eksport`
+
+Not every report needs every section. Empty sections should collapse into a short "no issue found" row.
+
+### Graph Detail Panel
+
+The detail panel should explain:
+
+- what the entity is;
+- why it is relevant;
+- which workflow surfaced it;
+- what action the user can take.
+
+It should not lead with raw URI.
+
+## Implementation Phasing
+
+### Phase A: Navigation and Framing
+
+- Rename or reframe `Vestlus` as `Nõustaja`.
+- Add `Analüüsikeskus`.
+- Reframe `Uurija` as `Õiguskaart`.
+- Rewrite dashboard as a work queue.
+- Fix Estonian diacritics in UI copy.
+
+### Phase B: Analysis Center MVP
+
+Implement workflow shells first, even if some reuse existing analysis backend:
+
+- `Normi mõjuahel`;
+- `EL ülevõtt`;
+- `Pädevused`.
+
+These align closely with existing affected entities, EU links, and graph relationships.
+
+### Phase C: Expanded Section 7 Workflows
+
+Add:
+
+- `KOV võrdlus`;
+- `Sanktsioonide võrdlus`;
+- `Halduskoormus`;
+- `Avaliku teenuse tervikvaade`;
+- `Kriisiõiguse kaart`.
+
+These may require additional ontology enrichment and extraction, but the UI structure can be introduced earlier.
+
+### Phase D: Advice and Solution Layer
+
+For each finding:
+
+- generate legal explanation;
+- propose solution options;
+- draft suggested wording;
+- link to evidence;
+- allow review/assignment.
+
+### Phase E: Review Operations
+
+Add `Ülevaatus`:
+
+- review queue;
+- assigned findings;
+- status transitions;
+- ministry confirmations;
+- exportable decisions.
+
+## Success Criteria
+
+The new UI is successful if a ministry lawyer can:
+
+- start with a legal question, not a technical tool;
+- get a useful first analysis without prompt engineering;
+- see recommended legal actions;
+- inspect evidence quickly;
+- ask for proposed wording;
+- assign findings to review;
+- export a memo or report;
+- understand how a draft affects law, EU obligations, KOV rules, institutions, sanctions, and administrative burden.
+
+The product should feel less like "search plus graph plus chat" and more like:
+
+> A legal analysis and drafting workbench that uses the Estonian legal ontology to advise ministry lawyers during law creation.
+

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -1,0 +1,59 @@
+"""Tests for the Analüüsikeskus placeholder route (#714, PR-A).
+
+Follows the auth-mocking pattern from ``tests/test_chat_routes.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": "11111111-1111-1111-1111-111111111111",
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+def test_analyysikeskus_redirects_unauthenticated():
+    from starlette.testclient import TestClient
+
+    from app.main import app
+
+    client = TestClient(app, follow_redirects=False)
+    resp = client.get("/analyysikeskus")
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/auth/login"
+
+
+@patch("app.auth.middleware._get_provider")
+def test_analyysikeskus_renders_placeholder(mock_provider: MagicMock):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus")
+    assert resp.status_code == 200
+    assert "Analüüsikeskus" in resp.text
+    assert "Tulekul" in resp.text
+    # Sidebar marks the new nav item active.
+    assert 'aria-current="page"' in resp.text

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -271,11 +271,16 @@ class TestChatNew:
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
         conv = _make_conversation()
-        with patch("app.chat.routes.create_conversation", return_value=conv):
+        with patch("app.chat.routes.create_conversation", return_value=conv) as mock_create:
             client = _authed_client()
             resp = client.get("/chat/new")
             assert resp.status_code == 303
             assert f"/chat/{conv.id}" in resp.headers["location"]
+
+            # #714: the generated title uses the "Nõustaja" framing, not "Vestlus".
+            generated_title = mock_create.call_args.kwargs.get("title", "")
+            assert generated_title.startswith("Nõustamine")
+            assert "Vestlus" not in generated_title
 
         mock_audit.assert_called_once()
 
@@ -300,6 +305,8 @@ class TestChatNew:
             # Verify draft_id was passed to create_conversation
             call_args = mock_create.call_args
             assert call_args.kwargs.get("context_draft_id") == _DRAFT_ID
+            # #714: title is "Nõustamine — <draft>", not "Vestlus — <draft>".
+            assert call_args.kwargs.get("title") == "Nõustamine — Eelnou X"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -196,6 +196,7 @@ class TestAdminDashboard:
 _WIDGET_HELPERS = (
     "_get_active_drafter_sessions",
     "_get_high_risk_reports",
+    "_get_unviewed_reports",
     "_get_stale_analysis_drafts",
     "_get_recent_syncs",
     "_get_recent_exports",
@@ -339,6 +340,82 @@ class TestDashboardWorkQueue:
         # Stale-analysis row → "analüüsi uuesti" copy + report link.
         assert "Analüüsi uuesti." in html
         assert "/drafts/cccc3333-0000-0000-0000-000000000003/report" in html
+
+    def test_next_actions_include_unviewed_reports(self):
+        from datetime import UTC, datetime
+
+        now = datetime(2026, 5, 11, 9, 0, tzinfo=UTC)
+        html = _render_dashboard(
+            {
+                "_get_user_org_info": _ORG_INFO,
+                "_get_unviewed_reports": [
+                    {
+                        "draft_id": "dddd4444-0000-0000-0000-000000000004",
+                        "title": "Liiklusseaduse muudatus",
+                        "impact_score": 25,
+                        "conflict_count": 0,
+                        "generated_at": now,
+                        "reanalyzed": False,
+                    },
+                    {
+                        "draft_id": "eeee5555-0000-0000-0000-000000000005",
+                        "title": "Maksuseadus",
+                        "impact_score": 40,
+                        "conflict_count": 0,
+                        "generated_at": now,
+                        "reanalyzed": True,
+                    },
+                ],
+            }
+        )
+        # A never-opened low/medium report still surfaces as a next action…
+        assert "Mõjuaruanne valmis: «Liiklusseaduse muudatus»." in html
+        assert "/drafts/dddd4444-0000-0000-0000-000000000004/report" in html
+        # …and a re-analysed-since-last-view one gets the "uuesti" framing.
+        assert "Maksuseadus»: eelnõu analüüsiti uuesti" in html
+        assert "/drafts/eeee5555-0000-0000-0000-000000000005/report" in html
+
+    def test_next_actions_dedupe_by_draft(self):
+        """A draft that qualifies for several sources gets one row — the
+        most-urgent framing wins (stale > high-risk > unviewed)."""
+        from datetime import UTC, datetime
+
+        now = datetime(2026, 5, 11, 9, 0, tzinfo=UTC)
+        did = "ffff6666-0000-0000-0000-000000000006"
+        html = _render_dashboard(
+            {
+                "_get_user_org_info": _ORG_INFO,
+                "_get_high_risk_reports": [
+                    {
+                        "draft_id": did,
+                        "title": "Topelt eelnõu",
+                        "impact_score": 80,
+                        "conflict_count": 3,
+                        "affected_count": 10,
+                        "gap_count": 0,
+                        "generated_at": now,
+                    },
+                ],
+                "_get_stale_analysis_drafts": [
+                    {"draft_id": did, "title": "Topelt eelnõu", "stale_count": 1},
+                ],
+                "_get_unviewed_reports": [
+                    {
+                        "draft_id": did,
+                        "title": "Topelt eelnõu",
+                        "impact_score": 80,
+                        "conflict_count": 3,
+                        "generated_at": now,
+                        "reanalyzed": False,
+                    },
+                ],
+            }
+        )
+        # Stale wins → "analüüsi uuesti" copy appears…
+        assert "Topelt eelnõu»: ontoloogia uuenes" in html
+        # …and the high-risk / unviewed framings for the same draft do NOT.
+        assert "3 konflikti vajavad ülevaatust" not in html
+        assert "Mõjuaruanne valmis: «Topelt eelnõu»." not in html
 
     def test_high_risk_widget_renders_band_badge_and_link(self):
         from datetime import UTC, datetime

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -186,169 +186,229 @@ class TestAdminDashboard:
 
 
 # ---------------------------------------------------------------------------
-# Recent-activity detail cell formatting (P3 UI fix)
+# Dashboard work-queue page (#717) — render the new operational sections
 # ---------------------------------------------------------------------------
 
-
-class TestAuditDetailSummary:
-    """``_audit_detail_summary`` produces an Estonian one-line preview of
-    audit-log payloads. It must never crash on weird inputs (empty, plain
-    string, non-dict) and should map common keys to friendly labels."""
-
-    def test_returns_dash_for_none(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        assert _audit_detail_summary("draft.upload", None) == "—"
-
-    def test_returns_dash_for_empty_string(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        assert _audit_detail_summary("draft.upload", "") == "—"
-
-    def test_maps_known_keys_to_estonian_labels(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        result = _audit_detail_summary(
-            "draft.upload",
-            {"draft_id": "abc-uuid-123", "filename": "akt.docx"},
-        )
-        assert "Eelnõu:" in result
-        assert "Fail: akt.docx" in result
-        # Two parts joined with a middle dot separator
-        assert " · " in result
-
-    def test_truncates_uuid_values(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        uuid = "11111111-2222-3333-4444-555555555555"
-        result = _audit_detail_summary("draft.upload", {"draft_id": uuid})
-        # First 8 chars + ellipsis, full UUID NOT in summary
-        assert "11111111" in result
-        assert "…" in result
-        assert uuid not in result
-
-    def test_falls_back_to_first_key_for_unknown_keys(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        result = _audit_detail_summary("custom.event", {"custom_field": "value-x"})
-        assert "custom_field" in result
-        assert "value-x" in result
-
-    def test_parses_json_string_payload(self):
-        """Legacy or weird code paths may pass a JSON-encoded string."""
-        from app.templates.dashboard import _audit_detail_summary
-
-        result = _audit_detail_summary("draft.upload", '{"filename": "test.docx"}')
-        assert "Fail: test.docx" in result
-
-    def test_returns_string_payload_verbatim_on_parse_failure(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        result = _audit_detail_summary("draft.upload", "not json at all")
-        assert result == "not json at all"
-
-    def test_handles_non_dict_non_string(self):
-        from app.templates.dashboard import _audit_detail_summary
-
-        # Lists, ints — should not crash; convert to str
-        assert _audit_detail_summary("x", [1, 2, 3]) == "[1, 2, 3]"
-        assert _audit_detail_summary("x", 42) == "42"
+# Helper names patched at ``app.templates.dashboard.<name>`` per the
+# patch-where-used contract — these are the DB-touching widget loaders the
+# page calls; mocking them lets us render ``dashboard_page`` with a fake
+# Request and no live DB.
+_WIDGET_HELPERS = (
+    "_get_active_drafter_sessions",
+    "_get_high_risk_reports",
+    "_get_stale_analysis_drafts",
+    "_get_recent_syncs",
+    "_get_recent_exports",
+    "_get_unresolved_annotation_drafts",
+    "_get_bookmarks",
+    "_get_user_org_info",
+)
 
 
-class TestAuditDetailCell:
-    """``_audit_detail_cell`` renders the table cell.  Empty payloads
-    collapse to a plain string; non-empty payloads wrap the summary in a
-    ``<details>`` element with the raw JSON inside ``<pre>``."""
+def _make_dashboard_request():
+    """Build a minimal ASGI ``Request`` carrying an ``auth`` scope.
 
-    def test_empty_detail_returns_plain_string(self):
-        from app.templates.dashboard import _audit_detail_cell
+    Mirrors the pattern in ``tests/test_admin_analytics.py`` — the
+    Beforeware that normally populates ``req.scope['auth']`` is bypassed by
+    constructing the scope directly, so ``dashboard_page(req)`` can be
+    invoked without a TestClient round-trip.
+    """
+    from starlette.requests import Request
 
-        assert _audit_detail_cell({"action": "x", "detail_raw": None}) == "—"
-
-    def test_non_empty_detail_renders_details_disclosure(self):
-        from fasthtml.common import to_xml
-
-        from app.templates.dashboard import _audit_detail_cell
-
-        cell = _audit_detail_cell(
-            {
-                "action": "draft.upload",
-                "detail_raw": {"draft_id": "abc-uuid", "filename": "akt.docx"},
-            }
-        )
-        html = to_xml(cell)
-        assert "<details" in html
-        assert "audit-detail" in html
-        # Summary visible up-front
-        assert "<summary>" in html
-        assert "Fail: akt.docx" in html
-        # Raw JSON in the disclosure
-        assert "<pre" in html
-        assert '"draft_id"' in html
-        assert "audit-detail-json" in html
-
-    def test_raw_json_uses_unicode_friendly_dump(self):
-        """Estonian characters in JSON payloads must NOT render as
-        \\u escapes inside the disclosure."""
-        from fasthtml.common import to_xml
-
-        from app.templates.dashboard import _audit_detail_cell
-
-        cell = _audit_detail_cell(
-            {"action": "draft.upload", "detail_raw": {"title": "Eelnõu õigusakt"}}
-        )
-        html = to_xml(cell)
-        # FastHTML escapes ``õ`` to its HTML entity but the raw JSON should
-        # NOT contain the \u-escape form ensure_ascii=True would emit.
-        assert "\\u" not in html
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/dashboard",
+        "headers": [],
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "auth": {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "email": "kasutaja@seadusloome.ee",
+            "full_name": "Test Kasutaja",
+            "role": "drafter",
+            "org_id": "11111111-1111-1111-1111-111111111111",
+        },
+    }
+    return Request(scope)
 
 
-class TestActivityCardRenderUsesDisclosure:
-    """End-to-end: the activity card columns wire ``_audit_detail_cell``
-    into the DataTable so the rendered HTML contains the disclosure for
-    rows whose detail payload is non-empty."""
+def _render_dashboard(returns: dict[str, object]) -> str:
+    """Render ``dashboard_page`` with every widget helper patched.
 
-    def test_card_renders_details_for_dict_detail(self):
+    ``returns`` maps a subset of :data:`_WIDGET_HELPERS` names to their
+    return value; unspecified helpers default to ``[]`` (or ``None`` for
+    ``_get_user_org_info``).
+    """
+    from contextlib import ExitStack
+
+    from fasthtml.common import to_xml
+
+    from app.templates.dashboard import dashboard_page
+
+    with ExitStack() as stack:
+        for name in _WIDGET_HELPERS:
+            default: object = None if name == "_get_user_org_info" else []
+            stack.enter_context(
+                patch(f"app.templates.dashboard.{name}", return_value=returns.get(name, default))
+            )
+        result = dashboard_page(_make_dashboard_request())
+    return to_xml(result)
+
+
+_ORG_INFO = {"org_name": "Justiitsministeerium", "role": "drafter", "member_count": 4}
+
+
+class TestDashboardWorkQueue:
+    """``/dashboard`` is now an operational work queue, not a welcome page."""
+
+    def test_dropped_welcome_hero(self):
+        """The marketing-style 'Tere tulemast Seadusloome süsteemi' InfoBox
+        is gone — replaced by a plain H1 + a small org/role line."""
+        html = _render_dashboard({"_get_user_org_info": _ORG_INFO})
+        assert "Tere tulemast Seadusloome" not in html
+        # Compact greeting + org line instead.
+        assert "Tere, Test" in html
+        assert "Justiitsministeerium" in html
+
+    def test_all_section_headers_render(self):
+        html = _render_dashboard({"_get_user_org_info": _ORG_INFO})
+        for header in (
+            "Minu järgmised tegevused",
+            "Kõrge riskiga leiud",
+            "Aegunud analüüsid",
+            "Uued ontoloogia muudatused",
+            "Hiljutised ekspordid",
+            "Eelnõud lahtiste märkustega",
+            "Järjehoidjad",
+        ):
+            assert header in html, header
+
+    def test_empty_data_shows_calm_empty_states(self):
+        html = _render_dashboard({})
+        # The synthesised next-action list collapses to the calm one-liner.
+        assert "Hetkel pole midagi ootel." in html
+        # Supporting widgets each show their own muted empty row, never a
+        # leftover hero or scary banner.
+        assert "Kõrge riskiga mõjuaruandeid hetkel pole." in html
+        assert "Aegunud analüüse pole." in html
+        assert "Hiljutisi ontoloogia uuendusi pole." in html
+
+    def test_next_actions_synthesised_from_signals(self):
         from datetime import UTC, datetime
 
-        from fasthtml.common import to_xml
-
-        from app.templates.dashboard import _activity_card
-
-        activity = [
+        now = datetime(2026, 5, 11, 9, 0, tzinfo=UTC)
+        html = _render_dashboard(
             {
-                "id": 1,
-                "action": "draft.upload",
-                "detail": {"draft_id": "abc-uuid", "filename": "akt.docx"},
-                "created_at": datetime(2026, 4, 29, 10, 0, tzinfo=UTC),
+                "_get_user_org_info": _ORG_INFO,
+                "_get_active_drafter_sessions": [
+                    {
+                        "id": "aaaa1111-0000-0000-0000-000000000001",
+                        "current_step": 3,
+                        "updated_at": now,
+                    },
+                ],
+                "_get_high_risk_reports": [
+                    {
+                        "draft_id": "bbbb2222-0000-0000-0000-000000000002",
+                        "title": "Andmekaitse eelnõu",
+                        "impact_score": 75,
+                        "conflict_count": 2,
+                        "affected_count": 18,
+                        "gap_count": 1,
+                        "generated_at": now,
+                    },
+                ],
+                "_get_stale_analysis_drafts": [
+                    {
+                        "draft_id": "cccc3333-0000-0000-0000-000000000003",
+                        "title": "Jäätmeseaduse muudatus",
+                        "stale_count": 1,
+                    },
+                ],
             }
-        ]
-        html = to_xml(_activity_card(activity))
-        assert "<details" in html
-        assert "audit-detail" in html
-        # The raw Python dict ``str()`` (with single quotes, "{'k': 'v'}")
-        # must NOT appear — that was the pre-fix behaviour.
-        assert "{'draft_id'" not in html
+        )
+        # Drafter-session row with the resolved step label.
+        assert "Jätka koostajas — 3. samm: Uurimine" in html
+        assert "/drafter/aaaa1111-0000-0000-0000-000000000001" in html
+        # High-risk report row, conflict-count phrasing + report link.
+        assert "2 konflikti vajavad ülevaatust" in html
+        assert "/drafts/bbbb2222-0000-0000-0000-000000000002/report" in html
+        # Stale-analysis row → "analüüsi uuesti" copy + report link.
+        assert "Analüüsi uuesti." in html
+        assert "/drafts/cccc3333-0000-0000-0000-000000000003/report" in html
 
-    def test_card_renders_dash_for_empty_detail(self):
+    def test_high_risk_widget_renders_band_badge_and_link(self):
         from datetime import UTC, datetime
 
-        from fasthtml.common import to_xml
-
-        from app.templates.dashboard import _activity_card
-
-        activity = [
+        now = datetime(2026, 5, 11, 9, 0, tzinfo=UTC)
+        html = _render_dashboard(
             {
-                "id": 1,
-                "action": "user.login",
-                "detail": None,
-                "created_at": datetime(2026, 4, 29, 10, 0, tzinfo=UTC),
+                "_get_user_org_info": _ORG_INFO,
+                "_get_high_risk_reports": [
+                    {
+                        "draft_id": "dddd4444-0000-0000-0000-000000000004",
+                        "title": "Karistusseadustiku muudatus",
+                        "impact_score": 90,
+                        "conflict_count": 0,
+                        "affected_count": 40,
+                        "gap_count": 0,
+                        "generated_at": now,
+                    },
+                ],
             }
-        ]
-        html = to_xml(_activity_card(activity))
-        # No disclosure for an empty payload
-        assert "<details" not in html
-        assert "—" in html
+        )
+        assert "Karistusseadustiku muudatus" in html
+        # 90 → critical band label.
+        assert "Kriitiline" in html
+        assert "/drafts/dddd4444-0000-0000-0000-000000000004/report" in html
+
+    def test_sync_widget_shows_date_and_entity_count(self):
+        from datetime import UTC, datetime
+
+        html = _render_dashboard(
+            {
+                "_get_user_org_info": _ORG_INFO,
+                "_get_recent_syncs": [
+                    {
+                        "id": 7,
+                        "finished_at": datetime(2026, 5, 10, 6, 30, tzinfo=UTC),
+                        "entity_count": 90123,
+                    },
+                ],
+            }
+        )
+        # Entity count rendered with a thin-space thousands separator.
+        assert "90 123" in html
+        # The sync card no longer shows the calm empty row when data exists.
+        assert "Hiljutisi ontoloogia uuendusi pole." not in html
+
+    def test_unresolved_annotations_widget_renders_count_and_link(self):
+        html = _render_dashboard(
+            {
+                "_get_user_org_info": _ORG_INFO,
+                "_get_unresolved_annotation_drafts": [
+                    {
+                        "draft_id": "eeee5555-0000-0000-0000-000000000005",
+                        "title": "Sotsiaalhoolekande eelnõu",
+                        "unresolved_count": 4,
+                    },
+                ],
+            }
+        )
+        assert "Sotsiaalhoolekande eelnõu" in html
+        assert ">4<" in html  # the Badge with the unresolved count
+        assert "/drafts/eeee5555-0000-0000-0000-000000000005/report" in html
+
+    def test_renders_when_user_has_no_org(self):
+        """A user with no organisation still gets the page (no crash) — the
+        org-scoped widgets just come back empty."""
+        html = _render_dashboard({"_get_user_org_info": None})
+        assert "Töölaud" in html
+        assert "Te ei kuulu ühtegi organisatsiooni." in html
+        assert "Hetkel pole midagi ootel." in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -65,12 +65,16 @@ def test_sidebar_drafter_sees_subset():
     sidebar = Sidebar(user=_user("drafter"))
     assert sidebar is not None
     html = to_xml(sidebar)
-    # Drafter visible items
+    # Drafter visible items (#714: legal-work labels, URLs unchanged)
     assert "Töölaud" in html
-    assert "Uurija" in html
+    assert "Analüüsikeskus" in html
     assert "Eelnõud" in html
+    assert "Õiguskaart" in html
     assert "Koostaja" in html
-    assert "Vestlus" in html
+    assert "Nõustaja" in html
+    # Old module names no longer used as nav labels
+    assert "Uurija" not in html
+    assert "Vestlus" not in html
     # Hidden from drafter
     assert "Kasutajad" not in html
     assert "Administraator" not in html
@@ -151,11 +155,12 @@ def test_topbar_with_user_shows_user_menu_and_nav():
     assert "user-menu" in html
     # Logout form posts to /auth/logout
     assert 'action="/auth/logout"' in html
-    # Top nav links visible
-    assert "Uurija" in html
+    # Top nav links visible (#714 labels)
+    assert "Analüüsikeskus" in html
     assert "Eelnõud" in html
+    assert "Õiguskaart" in html
     assert "Koostaja" in html
-    assert "Vestlus" in html
+    assert "Nõustaja" in html
     # Notification bell rendered
     assert "notification-bell" in html
 

--- a/tests/test_ui_link_button.py
+++ b/tests/test_ui_link_button.py
@@ -42,7 +42,7 @@ def test_link_button_custom_cls_is_appended():
 def test_link_button_kwargs_pass_through():
     html = to_xml(
         LinkButton(
-            "Ava uurijas",
+            "Ava õiguskaardil",
             href="/explorer?draft=1",
             title="Visualiseeri eelnõu",
             hx_boost="true",


### PR DESCRIPTION
Implements **#717** — turns `/dashboard` ("Töölaud") from a welcome page into an operational work queue. Part of epic **#714**; completes Phase A.

> **Stacked on #726 (PR-A).** Re-targets to `main` once #726 merges. Diff below is PR-E only.

## Before → after
The dashboard was a welcome page: a "Tere tulemast Seadusloome süsteemi!" hero `InfoBox`, an org card, the bookmarks widget, and a raw `audit_log` table. Now it's a work queue — what needs my attention, with a recommended action + link on each row.

## Sections
1. **Minu järgmised tegevused** — synthesised in-memory (not a new data source) from the loaded widgets: active drafter sessions → "Jätka koostajas — N. samm: …" (label via `STEP_LABELS_ET`); High/Critical reports with open conflicts → "Vaata mõjuaruannet «…» — N konflikti vajavad ülevaatust"; drafts with a stale analysis → "Ontoloogia uuenes pärast aruande koostamist. Analüüsi uuesti." Capped at 8; empty → "Hetkel pole midagi ootel."
2. **Kõrge riskiga leiud** — recent `impact_reports` (org-scoped) with `impact_score > 50`; band label/Badge (`Kõrge risk` / `Kriitiline`) from `scoring.impact_band()` so the 51–80 / 81–100 cut-offs live in one place.
3. **Aegunud analüüsid** — drafts with a `stale=true`, `resolved=false` annotation row.
4. **Uued ontoloogia muudatused** — recent `status='success'` rows from `sync_log` (global — no `org_id`; noted in the helper).
5. **Hiljutised ekspordid** — recently-completed `export_report` jobs, org-scoped via `payload->>'draft_id'` → `drafts`.
6. **Eelnõud lahtiste märkustega** — drafts with one or more unresolved annotations + the per-draft count.
7. **Minu järjehoidjad** — `_bookmarks_card` kept verbatim.

Every query is org-scoped (except `sync_log`) and wrapped in try/except → log + return empty. **No schema change.** Header is now a compact `H1("Tere, {name}")` + `Small("{org} · {role}")` — no hero. Dropped the raw audit-log table (still at `/admin/...`) and its helpers.

## Also
- `app/docs/impact/scoring.py` gains `impact_band(score) -> ImpactBand` + `IMPACT_BAND_LABELS_ET` — the bands the module docstring already described, now a callable so the dashboard never re-implements the cut-offs.

## Tests
- `tests/test_dashboard.py` — removed the three audit-detail test classes (their target helpers are gone); added `TestDashboardWorkQueue` (renders `dashboard_page` with each `_get_*` helper patched; asserts the hero is gone, the seven sections render, empty data → calm empty states, non-empty → rows + links + the right copy/badges, and the no-org user renders).
- Full suite: `2185 passed, 23 skipped`. `ruff` + `pyright` clean.

That's **Phase A complete** (#715/#716/#718/#719/#717 → PRs #726/#727/#728/#729/this). Refs #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)