### PR TITLE
feat(analyysikeskus): #714 PR-F — Analüüsikeskus directory + analysis-result shell

### DIFF
--- a/app/analyysikeskus/__init__.py
+++ b/app/analyysikeskus/__init__.py
@@ -1,11 +1,12 @@
 """Analüüsikeskus — the legal-analysis workflow hub (#714).
 
-This package currently exposes only a placeholder landing page; the
-workflow directory and the individual analysis workflows land in the
-follow-up issues (#720 landing page, #722 Normi mõjuahel, #723 EL
-ülevõtt).
+Exposes the workflow directory (#720), the reusable analysis-result
+shell (#721), and two stub workflows — ``Normi mõjuahel`` (#722 fills it
+in) and ``EL ülevõtt ja harmoneerimine`` (#723 fills it in). The other
+six Section-7 workflows are deferred to a follow-up epic.
 """
 
+from app.analyysikeskus.result_shell import analysis_result_shell
 from app.analyysikeskus.routes import register_analyysikeskus_routes
 
-__all__ = ["register_analyysikeskus_routes"]
+__all__ = ["analysis_result_shell", "register_analyysikeskus_routes"]

--- a/app/analyysikeskus/result_shell.py
+++ b/app/analyysikeskus/result_shell.py
@@ -68,15 +68,20 @@ def _muted_missing_row(text: str) -> Any:
 
 
 def _block_body(content: Any, *, empty_text: str) -> Any:
-    """Render *content*, or a one-line muted fallback when it's falsy.
+    """Render *content*, or a one-line muted fallback when it's empty.
 
     Keeps an empty block from rendering as an empty card body (per the
-    #721 spec). For the stub workflows ``content`` is always the
-    "koostamisel" placeholder so this mostly matters once #722/#723 start
-    passing real (and occasionally empty) findings.
+    #721 spec). ``None``, a blank string, and an empty list/tuple all
+    count as empty; a non-empty list/tuple is wrapped in a ``Div`` so it
+    nests cleanly inside ``CardBody`` rather than rendering as a bare
+    Python list. Matters once #722/#723 pass computed finding lists here.
     """
-    if content is None or (isinstance(content, str) and not content.strip()):
+    if content is None:
         return _muted_missing_row(empty_text)
+    if isinstance(content, str):
+        return content if content.strip() else _muted_missing_row(empty_text)
+    if isinstance(content, (list, tuple)):
+        return Div(*content) if content else _muted_missing_row(empty_text)  # noqa: F405
     return content
 
 

--- a/app/analyysikeskus/result_shell.py
+++ b/app/analyysikeskus/result_shell.py
@@ -1,0 +1,257 @@
+"""The analysis-result shell — the 5-block layout every Analüüsikeskus workflow uses (#721).
+
+Epic #714, design doc ``docs/2026-05-11-ministry-lawyer-ui-structure.md``
+("Core UI Pattern for Every Workflow"). Every legal-analysis workflow
+result page is the same five cards, in this order:
+
+    1. ``Sisend``               — echoes what the user gave us
+    2. ``Ulatus``               — legal-language scope controls + explanation
+    3. ``Tulemused``            — key findings / risk level / recommended action
+    4. ``Tõendid``              — sources, relations, dates, links
+    5. ``Soovitatud tegevused`` — a *static* action set (no LLM advice — Phase D)
+
+For the stub workflows (#722 Normi mõjuahel, #723 EL ülevõtt) ``results_block``
+and ``evidence_block`` carry a "koostamisel — tulekul" placeholder; those
+issues replace the placeholders with real computed findings + evidence.
+
+Critically — per the design doc — the ``Ulatus`` controls read as
+legal/policy scope, never as query configuration. No SPARQL, RDF,
+named-graph, embedding, or "graph URI" language anywhere on this page.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from fasthtml.common import *  # noqa: F403
+
+from app.auth.provider import UserDict
+from app.ui.layout import PageShell
+from app.ui.primitives.button import Button  # noqa: E402  (re-import after wildcard)
+from app.ui.primitives.input import Checkbox, Input, Select
+from app.ui.surfaces.card import Card, CardBody, CardHeader
+
+# Explanatory sentence shown above the scope controls — straight from the
+# design doc's "Ulatus" section. Says what the default scope is in legal
+# terms and that the user may change it.
+_SCOPE_EXPLANATION = (
+    "Analüüsin vaikimisi kehtivat õigust, seotud eelnõusid, Riigikohtu "
+    "praktikat ja EL õigusakte. Võite ulatust muuta."
+)
+
+# "Õigus" select — current law (default) vs. current + earlier redactions.
+# Legal language only; this is "which redactions of the law count", not a
+# version-graph picker.
+_LAW_SCOPE_OPTIONS: list[tuple[str, str]] = [
+    ("current", "Kehtiv õigus"),
+    ("current_plus_history", "Kehtiv + varasemad redaktsioonid"),
+]
+
+
+def _card(heading: str, content: Any) -> Any:
+    """A compact section card — ``Card(CardHeader(H3(...)), CardBody(...))``.
+
+    Mirrors ``app/templates/dashboard.py::_section_card`` so the
+    Analüüsikeskus pages share the dense-but-calm card rhythm with the
+    rest of ``app/``.
+    """
+    return Card(
+        CardHeader(H3(heading, cls="card-title")),  # noqa: F405
+        CardBody(content),
+    )
+
+
+def _muted_missing_row(text: str) -> Any:
+    """A one-line muted "…ei leitud" row used in place of an empty card body."""
+    return P(text, cls="muted-text")  # noqa: F405
+
+
+def _block_body(content: Any, *, empty_text: str) -> Any:
+    """Render *content*, or a one-line muted fallback when it's falsy.
+
+    Keeps an empty block from rendering as an empty card body (per the
+    #721 spec). For the stub workflows ``content`` is always the
+    "koostamisel" placeholder so this mostly matters once #722/#723 start
+    passing real (and occasionally empty) findings.
+    """
+    if content is None or (isinstance(content, str) and not content.strip()):
+        return _muted_missing_row(empty_text)
+    return content
+
+
+def _scope_block(scope_block: Any) -> Any:
+    """Render the ``Ulatus`` card body.
+
+    When the caller passes its own ``scope_block`` we use that verbatim
+    (a richer workflow-specific control set). Otherwise we render the
+    default legal-language scope form described in the #721 spec — the
+    controls exist but don't re-run the analysis yet (that wiring lands
+    in #722). All copy is legal/policy language; nothing here mentions
+    SPARQL, named graphs, embeddings, or graph URIs.
+    """
+    if scope_block is not None:
+        return scope_block
+
+    return Form(  # noqa: F405
+        P(_SCOPE_EXPLANATION, cls="muted-text"),  # noqa: F405
+        # "Õigus" — which redactions of the law count.
+        Div(  # noqa: F405
+            Label("Õigus", fr="analyysikeskus-scope-law"),  # noqa: F405
+            Select(
+                "oigus",
+                _LAW_SCOPE_OPTIONS,
+                value="current",
+                id="analyysikeskus-scope-law",
+            ),
+            cls="form-field",
+        ),
+        # Toggles — EU law + court practice on by default (the default
+        # scope sentence above promises both).
+        Checkbox(
+            "kaasa_el",
+            checked=True,
+            label="Kaasa EL õigus",
+        ),
+        Checkbox(
+            "kaasa_kohtupraktika",
+            checked=True,
+            label="Kaasa kohtupraktika",
+        ),
+        # Org-wide drafts off by default → only the user's own drafts are
+        # in scope unless they opt in. Stated in the helper text below.
+        Checkbox(
+            "kogu_organisatsioon",
+            checked=False,
+            label="Kogu organisatsiooni eelnõud",
+        ),
+        Small(  # noqa: F405
+            "Vaikimisi vaatan ainult teie enda eelnõusid; märkige see, et "
+            "kaasata kogu organisatsiooni eelnõud.",
+            cls="muted-text",
+        ),
+        # KOV regulations — not wired yet; disabled with a "Tulekul" tooltip.
+        Checkbox(
+            "kaasa_kov",
+            checked=False,
+            label="Kaasa KOV regulatsioonid",
+            disabled=True,
+            title="Tulekul",
+        ),
+        # Optional time range.
+        Div(  # noqa: F405
+            Label("Ajavahemik (valikuline)"),  # noqa: F405
+            Span(  # noqa: F405
+                Input("ajavahemik_algus", type="date", aria_label="Alguskuupäev"),
+                Span(" – ", cls="muted-text"),  # noqa: F405
+                Input("ajavahemik_lopp", type="date", aria_label="Lõppkuupäev"),
+                cls="analyysikeskus-date-range",
+            ),
+            cls="form-field",
+        ),
+        # No submit yet — the controls are inert in this round (#722 wires
+        # the re-run). A disabled button keeps the form visually complete
+        # and signals the affordance is coming.
+        Button(
+            "Uuenda ulatust",
+            type="submit",
+            variant="secondary",
+            size="sm",
+            disabled=True,
+            title="Tulekul",
+        ),
+        method="get",
+        cls="analyysikeskus-scope-form",
+    )
+
+
+def _actions_block(actions: Sequence[Mapping[str, str]] | None) -> Any:
+    """Render the ``Soovitatud tegevused`` card body from ``{label, href}`` dicts.
+
+    Always a *static* action set in this round — no LLM-generated
+    recommendations (that's Phase D). Each entry becomes a secondary
+    link-styled button.
+    """
+    items = list(actions or [])
+    if not items:
+        return _muted_missing_row("Soovitatud tegevusi pole.")
+    links = [
+        A(  # noqa: F405
+            str(a.get("label") or "Tegevus"),
+            href=str(a.get("href") or "#"),
+            cls="btn btn-secondary btn-md",
+        )
+        for a in items
+    ]
+    return Div(*links, cls="analyysikeskus-actions")  # noqa: F405
+
+
+def analysis_result_shell(
+    *,
+    workflow_title: str,
+    input_summary: Any,
+    results_block: Any,
+    evidence_block: Any,
+    actions: Sequence[Mapping[str, str]],
+    user: UserDict | None,
+    theme: str = "dark",
+    scope_block: Any | None = None,
+) -> Any:
+    """Build a workflow result page: a :func:`PageShell` with the 5-block layout.
+
+    Args:
+        workflow_title: The workflow's display name (e.g. ``"Normi mõjuahel"``).
+            Used in both the page ``<title>`` and the ``H1``.
+        input_summary: FT content for the ``Sisend`` card — for the stub
+            workflows just ``P(f"Sisestasite: «{sisend}»")``; #722/#723 pass
+            a richer resolved summary.
+        results_block: FT content for the ``Tulemused`` card. Stubs pass an
+            ``Alert``/``InfoBox`` saying the computation is "koostamisel".
+        evidence_block: FT content for the ``Tõendid`` card.
+        actions: A list of ``{"label": ..., "href": ...}`` dicts rendered as
+            buttons in the ``Soovitatud tegevused`` card. Static — never
+            LLM-generated.
+        user: The authenticated user dict (forwarded to ``PageShell``).
+        theme: Theme name (forwarded to ``PageShell``; the UI is dark-only).
+        scope_block: Optional FT content for the ``Ulatus`` card. When omitted
+            the default legal-language scope form is rendered.
+
+    Returns:
+        The ``PageShell(...)`` tree — a full page with a back-link near the
+        top followed by the five cards in order.
+    """
+    back_link = A(  # noqa: F405
+        "← Analüüsikeskus",
+        href="/analyysikeskus",
+        cls="back-link",
+    )
+
+    header = Div(  # noqa: F405
+        back_link,
+        H1(workflow_title, cls="page-title"),  # noqa: F405
+        cls="analyysikeskus-result-header",
+    )
+
+    return PageShell(
+        header,
+        # 1. Sisend — what the user gave us.
+        _card("Sisend", _block_body(input_summary, empty_text="Sisendit ei leitud.")),
+        # 2. Ulatus — legal-language scope controls + explanation.
+        _card("Ulatus", _scope_block(scope_block)),
+        # 3. Tulemused — key findings / risk / recommended action.
+        _card(
+            "Tulemused",
+            _block_body(results_block, empty_text="Tulemusi ei leitud."),
+        ),
+        # 4. Tõendid — sources, relations, dates, links.
+        _card(
+            "Tõendid",
+            _block_body(evidence_block, empty_text="Tõendeid ei leitud."),
+        ),
+        # 5. Soovitatud tegevused — static action set.
+        _card("Soovitatud tegevused", _actions_block(actions)),
+        title=f"{workflow_title} — Analüüsikeskus",
+        user=user,
+        theme=theme,
+        active_nav="/analyysikeskus",
+    )

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -1,33 +1,319 @@
 """Analüüsikeskus routes (#714).
 
-For now this is a single placeholder page so the new ``Analüüsikeskus``
-navigation entry resolves. The workflow directory (#720) replaces this
-body; the individual workflows (#722 Normi mõjuahel, #723 EL ülevõtt)
-register their own sub-routes here later.
+The Analüüsikeskus is the legal-analysis workflow hub — the design
+rationale lives in ``docs/2026-05-11-ministry-lawyer-ui-structure.md``.
+This module hosts:
+
+    GET  /analyysikeskus                         — workflow directory (#720)
+    GET  /analyysikeskus/normi-mojuahel          — Normi mõjuahel stub (#722 fills it in)
+    GET  /analyysikeskus/el-ulevott              — EL ülevõtt stub (#723 fills it in)
+
+Only the two workflows with backing ontology data today (``Normi
+mõjuahel`` and ``EL ülevõtt ja harmoneerimine``) are wired here; the
+other six Section-7 workflows are deferred to a follow-up epic and get
+no placeholder cards in the meantime.
+
+Auth is handled by the global ``auth_before`` middleware — none of these
+paths are in ``SKIP_PATHS`` so an unauthenticated request is redirected
+to ``/auth/login`` before any handler runs.
 """
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
+from starlette.responses import RedirectResponse
 
+from app.analyysikeskus.result_shell import analysis_result_shell
+from app.db import get_connection as _connect
+from app.docs.impact.scoring import IMPACT_BAND_LABELS_ET, impact_band
+from app.drafter.state_machine import STEP_LABELS_ET, Step
+from app.ui.data.data_table import Column, DataTable
 from app.ui.layout import PageShell
-from app.ui.surfaces.info_box import InfoBox
+from app.ui.primitives.button import Button  # noqa: E402  (re-import after wildcard)
+from app.ui.primitives.input import Input
+from app.ui.surfaces.alert import Alert
+from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.theme import get_theme_from_request
+from app.ui.time import format_tallinn
+
+logger = logging.getLogger(__name__)
+
+# How many "Hiljutised analüüsid" rows to surface (newest first, merged
+# across impact reports + drafter sessions). Kept small so the directory
+# page stays dense-but-calm.
+_MAX_RECENT_ANALYSES = 10
+
+# Stub copy reused by both workflow result pages until #722 / #723 land
+# the real computation.
+_RESULTS_STUB_TEXT = "Selle töövoo tulemuste arvutus on koostamisel — tulekul."
+_EVIDENCE_STUB_TEXT = (
+    "Tõendid (allikad, seosed, kuupäevad, lingid) kuvatakse siin, kui tulemused on arvutatud."
+)
+
+# Static action set every stub workflow ends with — no LLM-generated
+# recommendations (that's Phase D). ``{label, href}`` dicts.
+_STUB_ACTIONS: list[dict[str, str]] = [
+    {"label": "Küsi nõustajalt", "href": "/chat/new"},
+    {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
+]
+
+
+# ---------------------------------------------------------------------------
+# DB helper — "Hiljutised analüüsid"
+# ---------------------------------------------------------------------------
+
+
+def _step_label(step_number: int) -> str:
+    """Estonian label for a drafter step number, falling back to the bare number."""
+    try:
+        return STEP_LABELS_ET.get(Step(step_number), str(step_number))
+    except (ValueError, TypeError):
+        return str(step_number)
+
+
+def _get_recent_analyses(user_id: str | None, org_id: str | None) -> list[dict[str, Any]]:
+    """Return recent analysis activity for the directory page, newest first.
+
+    Two small org-scoped raw-SQL queries — mirroring the try/except → log
+    + return ``[]`` pattern from ``app/templates/dashboard.py``'s widget
+    loaders — merged into one list capped at :data:`_MAX_RECENT_ANALYSES`:
+
+    * **Impact reports** — the latest report per draft for the org (via a
+      ``DISTINCT ON (ir.draft_id)`` CTE, then re-sorted by ``generated_at``
+      DESC). Each row links to ``/drafts/{id}/report`` and carries the
+      draft title, the risk-band label, and the ``generated_at`` timestamp.
+    * **Drafter sessions** — the current user's active/completed sessions
+      for the org. Each row links to ``/drafter/{id}`` and carries the
+      "Koostaja — {N}. samm" label and ``updated_at``.
+
+    Returns a list of dicts shaped::
+
+        {"kind": "report"|"session", "href": str, "title": str,
+         "detail": str, "when": datetime|None, "_sort": datetime}
+
+    ``[]`` on any DB error so the directory page degrades to the empty
+    state rather than 500.
+    """
+    out: list[dict[str, Any]] = []
+
+    # --- recent impact reports (org-scoped) ---------------------------------
+    if org_id:
+        try:
+            with _connect() as conn:
+                rows = conn.execute(
+                    """
+                    WITH latest_report AS (
+                        SELECT DISTINCT ON (ir.draft_id)
+                               ir.draft_id, ir.impact_score, ir.generated_at
+                        FROM impact_reports ir
+                        JOIN drafts d ON d.id = ir.draft_id
+                        WHERE d.org_id = %s
+                        ORDER BY ir.draft_id, ir.generated_at DESC
+                    )
+                    SELECT lr.draft_id, d.title, lr.impact_score, lr.generated_at
+                    FROM latest_report lr
+                    JOIN drafts d ON d.id = lr.draft_id
+                    ORDER BY lr.generated_at DESC
+                    LIMIT %s
+                    """,
+                    (org_id, _MAX_RECENT_ANALYSES),
+                ).fetchall()
+            for r in rows:
+                score = int(r[2] or 0)
+                band_label = IMPACT_BAND_LABELS_ET[impact_band(score)]
+                out.append(
+                    {
+                        "kind": "report",
+                        "href": f"/drafts/{r[0]}/report",
+                        "title": r[1] or "Pealkirjata eelnõu",
+                        "detail": f"Mõjuaruanne — {band_label}",
+                        "when": r[3],
+                        "_sort": r[3],
+                    }
+                )
+        except Exception:
+            logger.exception("Failed to fetch recent impact reports for org %s", org_id)
+
+    # --- recent drafter sessions (user + org scoped) ------------------------
+    if user_id and org_id:
+        try:
+            with _connect() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT id, current_step, updated_at
+                    FROM drafting_sessions
+                    WHERE user_id = %s AND org_id = %s
+                      AND status IN ('active', 'completed')
+                    ORDER BY updated_at DESC
+                    LIMIT %s
+                    """,
+                    (user_id, org_id, _MAX_RECENT_ANALYSES),
+                ).fetchall()
+            for r in rows:
+                step_num = int(r[1] or 1)
+                out.append(
+                    {
+                        "kind": "session",
+                        "href": f"/drafter/{r[0]}",
+                        "title": "Koostaja eelnõu",
+                        "detail": f"Koostaja — {step_num}. samm: {_step_label(step_num)}",
+                        "when": r[2],
+                        "_sort": r[2],
+                    }
+                )
+        except Exception:
+            logger.exception("Failed to fetch recent drafter sessions for user %s", user_id)
+
+    # Merge newest-first; rows with a missing timestamp sink to the bottom.
+    def _key(item: dict[str, Any]) -> datetime:
+        ts = item.get("_sort")
+        if isinstance(ts, datetime):
+            return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+        return datetime.min.replace(tzinfo=UTC)
+
+    out.sort(key=_key, reverse=True)
+    return out[:_MAX_RECENT_ANALYSES]
+
+
+# ---------------------------------------------------------------------------
+# Directory page (#720)
+# ---------------------------------------------------------------------------
+
+
+def _workflow_card(
+    *,
+    title: str,
+    purpose: str,
+    action: str,
+    input_name: str,
+    input_placeholder: str,
+    input_aria_label: str,
+    examples: str,
+) -> Any:
+    """One compact workflow entry — a card with a one-line purpose + a GET form.
+
+    Not a marketing card: dense, scan-friendly, task-first (per the design
+    doc's "Analüüsikeskus" section). The form does a plain ``GET`` to the
+    workflow route with a single ``sisend`` text input + an "Alusta
+    analüüsi" submit; example inputs sit below in muted text.
+    """
+    return Card(
+        CardHeader(H3(title, cls="card-title")),  # noqa: F405
+        CardBody(
+            P(purpose),  # noqa: F405
+            Form(  # noqa: F405
+                Input(
+                    input_name,
+                    type="text",
+                    placeholder=input_placeholder,
+                    aria_label=input_aria_label,
+                    cls="analyysikeskus-input",
+                ),
+                Button("Alusta analüüsi", type="submit", variant="primary"),
+                method="get",
+                action=action,
+                cls="analyysikeskus-workflow-form",
+            ),
+            Small(examples, cls="muted-text"),  # noqa: F405
+        ),
+    )
+
+
+def _recent_analyses_card(items: list[dict[str, Any]]) -> Any:
+    """The "Hiljutised analüüsid" card — a DataTable of recent activity.
+
+    Empty → a single muted "Veel pole analüüse." row (consistent with how
+    ``app/templates/dashboard.py`` renders its empty section bodies).
+    """
+    if not items:
+        return Card(
+            CardHeader(H3("Hiljutised analüüsid", cls="card-title")),  # noqa: F405
+            CardBody(P("Veel pole analüüse.", cls="muted-text")),  # noqa: F405
+        )
+
+    columns = [
+        Column(
+            key="title",
+            label="Analüüs",
+            sortable=False,
+            render=lambda r: A(r["title"], href=r["href"], cls="table-link"),  # noqa: F405
+        ),
+        Column(key="detail", label="Tüüp", sortable=False),
+        Column(
+            key="when",
+            label="Muudetud",
+            sortable=False,
+            render=lambda r: format_tallinn(r["when"]),
+        ),
+    ]
+    rows = [
+        {"title": it["title"], "href": it["href"], "detail": it["detail"], "when": it["when"]}
+        for it in items
+    ]
+    return Card(
+        CardHeader(H3("Hiljutised analüüsid", cls="card-title")),  # noqa: F405
+        CardBody(DataTable(columns=columns, rows=rows)),
+    )
 
 
 def analyysikeskus_page(req: Request):
-    """GET /analyysikeskus — placeholder for the legal-analysis workflow hub."""
+    """GET /analyysikeskus — the legal-analysis workflow directory."""
     auth = req.scope.get("auth") or None
     theme = get_theme_from_request(req)
-    return PageShell(
+    user_id = auth.get("id") if auth else None
+    org_id = auth.get("org_id") if auth else None
+
+    recent = _get_recent_analyses(user_id, org_id)
+
+    # Compact header — no marketing hero, no InfoBox banner.
+    header = (
         H1("Analüüsikeskus", cls="page-title"),  # noqa: F405
-        InfoBox(
-            P(  # noqa: F405
-                "Analüüsikeskus koondab õigusliku analüüsi töövood — "
-                "normi mõjuahel, EL õiguse ülevõtt ja teised — ühte kohta. "
-                "Tulekul."
-            ),
-            variant="info",
+        P(  # noqa: F405
+            "Õigusliku analüüsi töövood ühes kohas. Vali töövoog, sisesta "
+            "õiguslik viide või küsimus.",
+            cls="page-subtitle",
         ),
+    )
+
+    normi_card = _workflow_card(
+        title="Normi mõjuahel",
+        purpose=(
+            "Vaata, mida muudatus mõjutab — millised sätted viitavad muudetavale "
+            "paragrahvile, millised eelnõud puudutavad sama teemat ja milline "
+            "Riigikohtu praktika on seotud."
+        ),
+        action="/analyysikeskus/normi-mojuahel",
+        input_name="sisend",
+        input_placeholder=(
+            "Nt: AvTS § 35 · CELEX-number · eelnõu pealkiri · või kirjeldage muudatust"
+        ),
+        input_aria_label="Õiguslik viide või kirjeldus",
+        examples=("Näited: «Muudame AvTS § 35.» · «Kontrolli karistusseadustiku § 133 mõju.»"),
+    )
+
+    el_card = _workflow_card(
+        title="EL ülevõtt ja harmoneerimine",
+        purpose=(
+            "Kontrolli, kas Eesti õigus katab EL kohustuse — millised Eesti sätted "
+            "on EL aktiga seotud ja kus on katmata kohad."
+        ),
+        action="/analyysikeskus/el-ulevott",
+        input_name="sisend",
+        input_placeholder="Nt: CELEX-number · EL akti pealkiri · poliitikavaldkond",
+        input_aria_label="CELEX-number, EL akti pealkiri või valdkond",
+        examples="Näited: «Kontrolli AI määruse ülevõttu.» · «32016R0679»",
+    )
+
+    return PageShell(
+        *header,
+        normi_card,
+        el_card,
+        _recent_analyses_card(recent),
         title="Analüüsikeskus",
         user=auth,
         theme=theme,
@@ -35,6 +321,54 @@ def analyysikeskus_page(req: Request):
     )
 
 
+# ---------------------------------------------------------------------------
+# Stub workflow routes (#722 Normi mõjuahel, #723 EL ülevõtt fill these in)
+# ---------------------------------------------------------------------------
+
+
+def _workflow_stub_response(req: Request, *, workflow_title: str):
+    """Shared body for the two stub workflow GET routes.
+
+    Reads the ``sisend`` query param; a blank value redirects back to the
+    directory (303). Otherwise renders :func:`analysis_result_shell` with
+    the echoed input, the "koostamisel" placeholder in ``Tulemused``, a
+    stub ``Tõendid`` line, and the static :data:`_STUB_ACTIONS` set.
+    """
+    sisend = (req.query_params.get("sisend") or "").strip()
+    if not sisend:
+        return RedirectResponse(url="/analyysikeskus", status_code=303)
+
+    auth = req.scope.get("auth") or None
+    theme = get_theme_from_request(req)
+
+    return analysis_result_shell(
+        workflow_title=workflow_title,
+        input_summary=P(f"Sisestasite: «{sisend}»"),  # noqa: F405
+        results_block=Alert(_RESULTS_STUB_TEXT, variant="info"),
+        evidence_block=P(_EVIDENCE_STUB_TEXT, cls="muted-text"),  # noqa: F405
+        actions=_STUB_ACTIONS,
+        user=auth,
+        theme=theme,
+    )
+
+
+def normi_mojuahel_page(req: Request):
+    """GET /analyysikeskus/normi-mojuahel?sisend=<text> — Normi mõjuahel (stub)."""
+    return _workflow_stub_response(req, workflow_title="Normi mõjuahel")
+
+
+def el_ulevott_page(req: Request):
+    """GET /analyysikeskus/el-ulevott?sisend=<text> — EL ülevõtt ja harmoneerimine (stub)."""
+    return _workflow_stub_response(req, workflow_title="EL ülevõtt ja harmoneerimine")
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+
 def register_analyysikeskus_routes(rt) -> None:  # type: ignore[no-untyped-def]
     """Register Analüüsikeskus routes on the FastHTML route decorator *rt*."""
     rt("/analyysikeskus", methods=["GET"])(analyysikeskus_page)
+    rt("/analyysikeskus/normi-mojuahel", methods=["GET"])(normi_mojuahel_page)
+    rt("/analyysikeskus/el-ulevott", methods=["GET"])(el_ulevott_page)

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -150,3 +150,46 @@ def test_el_ulevott_stub_renders(mock_provider: MagicMock, mock_recent: MagicMoc
     for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
         assert heading in body, heading
     assert "32016R0679" in body
+
+
+# ---------------------------------------------------------------------------
+# Result-shell _block_body: empty list → fallback, non-empty list → wrapped
+# ---------------------------------------------------------------------------
+
+
+def test_result_shell_empty_list_block_renders_fallback():
+    from fasthtml.common import P, to_xml
+
+    from app.analyysikeskus.result_shell import analysis_result_shell
+
+    page = analysis_result_shell(
+        workflow_title="Normi mõjuahel",
+        input_summary=P("Sisestasite: «AvTS § 35»"),
+        results_block=[],  # an empty findings list must NOT render as "[]"
+        evidence_block=[],
+        actions=[{"label": "Tagasi", "href": "/analyysikeskus"}],
+        user={"id": "u-1", "email": "u@x.ee", "full_name": "U", "role": "drafter", "org_id": None},
+    )
+    html = to_xml(page)
+    assert "Tulemusi ei leitud." in html
+    assert "Tõendeid ei leitud." in html
+    assert "[]" not in html
+
+
+def test_result_shell_nonempty_list_block_renders_all_items():
+    from fasthtml.common import P, to_xml
+
+    from app.analyysikeskus.result_shell import analysis_result_shell
+
+    page = analysis_result_shell(
+        workflow_title="Normi mõjuahel",
+        input_summary=P("Sisestasite: «AvTS § 35»"),
+        results_block=[P("Leid üks"), P("Leid kaks")],
+        evidence_block=P("Tõend"),
+        actions=[{"label": "Tagasi", "href": "/analyysikeskus"}],
+        user={"id": "u-1", "email": "u@x.ee", "full_name": "U", "role": "drafter", "org_id": None},
+    )
+    html = to_xml(page)
+    assert "Leid üks" in html
+    assert "Leid kaks" in html
+    assert "Tulemusi ei leitud." not in html

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -1,6 +1,9 @@
-"""Tests for the Analüüsikeskus placeholder route (#714, PR-A).
+"""Tests for the Analüüsikeskus routes (#714 — #720 directory, #721 result shell).
 
-Follows the auth-mocking pattern from ``tests/test_chat_routes.py``.
+Follows the auth-mocking pattern from ``tests/test_chat_routes.py``: the
+``app.main.app`` is exercised end-to-end via ``TestClient`` so the
+FastHTML wiring + the ``auth_before`` Beforeware are validated; the
+DB-touching ``_get_recent_analyses`` helper is patched out.
 """
 
 from __future__ import annotations
@@ -36,6 +39,11 @@ def _authed_client():
     return client
 
 
+# ---------------------------------------------------------------------------
+# Unauthenticated requests redirect to login
+# ---------------------------------------------------------------------------
+
+
 def test_analyysikeskus_redirects_unauthenticated():
     from starlette.testclient import TestClient
 
@@ -47,13 +55,98 @@ def test_analyysikeskus_redirects_unauthenticated():
     assert resp.headers["location"] == "/auth/login"
 
 
+def test_workflow_routes_redirect_unauthenticated():
+    from starlette.testclient import TestClient
+
+    from app.main import app
+
+    client = TestClient(app, follow_redirects=False)
+    for path in ("/analyysikeskus/normi-mojuahel", "/analyysikeskus/el-ulevott"):
+        resp = client.get(path)
+        assert resp.status_code == 303, path
+        assert resp.headers["location"] == "/auth/login", path
+
+
+# ---------------------------------------------------------------------------
+# #720 — directory page
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
 @patch("app.auth.middleware._get_provider")
-def test_analyysikeskus_renders_placeholder(mock_provider: MagicMock):
+def test_analyysikeskus_directory_renders(mock_provider: MagicMock, mock_recent: MagicMock):
     mock_provider.return_value = _stub_provider()
     client = _authed_client()
     resp = client.get("/analyysikeskus")
     assert resp.status_code == 200
-    assert "Analüüsikeskus" in resp.text
-    assert "Tulekul" in resp.text
+    body = resp.text
+    assert "Analüüsikeskus" in body
+    # Both in-scope workflow titles.
+    assert "Normi mõjuahel" in body
+    assert "EL ülevõtt" in body
+    # The primary action button on each workflow card.
+    assert "Alusta analüüsi" in body
+    # The recent-analyses section + its empty state.
+    assert "Hiljutised analüüsid" in body
+    assert "Veel pole analüüse." in body
     # Sidebar marks the new nav item active.
-    assert 'aria-current="page"' in resp.text
+    assert 'aria-current="page"' in body
+
+
+# ---------------------------------------------------------------------------
+# #721 / #722 — Normi mõjuahel stub result shell
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_normi_mojuahel_stub_renders_result_shell(
+    mock_provider: MagicMock, mock_recent: MagicMock
+):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    # "AvTS § 35" url-encoded.
+    resp = client.get("/analyysikeskus/normi-mojuahel?sisend=AvTS+%C2%A7+35")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Normi mõjuahel" in body
+    # All five Core-UI-Pattern block headings, in order.
+    for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
+        assert heading in body, heading
+    # The echoed input.
+    assert "AvTS § 35" in body
+    # The "Tulemused" block carries the koostamisel/tulekul placeholder.
+    assert "koostamisel" in body or "tulekul" in body
+    # The static action set.
+    assert "Küsi nõustajalt" in body
+    assert "/chat/new" in body
+    # Back-link near the top.
+    assert "← Analüüsikeskus" in body
+
+
+def test_normi_mojuahel_blank_input_redirects():
+    with patch("app.auth.middleware._get_provider") as mock_provider:
+        mock_provider.return_value = _stub_provider()
+        client = _authed_client()
+        resp = client.get("/analyysikeskus/normi-mojuahel")
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/analyysikeskus"
+
+
+# ---------------------------------------------------------------------------
+# #721 / #723 — EL ülevõtt stub result shell
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_el_ulevott_stub_renders(mock_provider: MagicMock, mock_recent: MagicMock):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/el-ulevott?sisend=32016R0679")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "EL ülevõtt" in body
+    for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
+        assert heading in body, heading
+    assert "32016R0679" in body


### PR DESCRIPTION
Implements **#720** (Analüüsikeskus landing/directory) and **#721** (analysis-result shell) of epic **#714** — the start of Phase B.

## What changed
- **`/analyysikeskus` is now a workflow directory** (replaces the "Tulekul" placeholder): a compact `H1` + one-line intro (no hero), two workflow cards — **`Normi mõjuahel`** and **`EL ülevõtt ja harmoneerimine`** — each with a one-line legal purpose, a single primary text input (`name="sisend"`), example inputs, and an `Alusta analüüsi` button (GET-submits to the workflow route, so the result URL is shareable). Plus a **`Hiljutised analüüsid`** card listing recent impact reports (link to `/drafts/{id}/report`, with the risk band from `scoring.impact_band`) and recent drafter sessions (link to `/drafter/{id}`, with the step label), org-scoped, capped at 10, empty → "Veel pole analüüse." No cards for the deferred workflows 3–8.
- **`app/analyysikeskus/result_shell.py`** — new reusable `analysis_result_shell(...)` building the design doc's 5-block layout: `Sisend → Ulatus → Tulemused → Tõendid → Soovitatud tegevused`, each a `Card`, with a `← Analüüsikeskus` back-link. `Ulatus` renders **legal-language** scope controls (kehtiv õigus ↔ +varasemad redaktsioonid; +EL õigus; +kohtupraktika; kogu org vs minu eelnõud; +KOV regulatsioonid — disabled, "tulekul"; ajavahemik) with an explanatory sentence — **no SPARQL / RDF / named-graph / embedding language anywhere**. `Soovitatud tegevused` renders a **static** `{label, href}` action set — no LLM advice (that's the deferred Phase D).
- **Two stub workflow routes** — `GET /analyysikeskus/normi-mojuahel?sisend=…` and `GET /analyysikeskus/el-ulevott?sisend=…` — render the shell with the input echoed in `Sisend`, the scope controls, and "koostamisel — tulekul" placeholders for `Tulemused`/`Tõendid` (which #722/#723 replace with computed findings). Blank `sisend` → 303 to `/analyysikeskus`. Registered in `register_analyysikeskus_routes`; auth via the global middleware.

## Not in this PR (next in Phase B)
- #722 — `Normi mõjuahel` actual findings. Needs a design note first (the impact analyzer is draft-named-graph-centric — `_SAFE_GRAPH_URI` is locked to `…/estleg/drafts/<uuid>`; pick synthetic-ephemeral-graph vs entity-centered-queries vs persist-the-run; plus a user-input parser, since `reference_resolver` resolves `ExtractedRef`s not raw strings).
- #723 — `EL ülevõtt` act-level transposition table.
- #724 — cross-links (`Ava analüüsikeskuses` from drafts/report; `Küsi nõustajalt selle leiu kohta` via a server-side `pending_chat_seed` token).

## Tests
`tests/test_analyysikeskus_routes.py` — replaced the placeholder test with: directory renders (both workflow titles, `Alusta analüüsi`, `Hiljutised analüüsid`, empty state, active nav); the `Normi mõjuahel` stub renders all five block headings + the echoed input + "koostamisel" + the `Küsi nõustajalt` / back links; blank input → 303; the `EL ülevõtt` stub renders; both workflow routes unauthenticated → 303. Recent-analyses helper mocked.
Full suite: `2202 passed, 23 skipped`. `ruff` + `pyright` clean.

Refs #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)