### PR TITLE
feat(analyysikeskus): #714 PR-G — Normi mõjuahel workflow (#722) + fix CI (pyright)

### DIFF
--- a/app/analyysikeskus/adhoc_analysis.py
+++ b/app/analyysikeskus/adhoc_analysis.py
@@ -1,0 +1,173 @@
+"""Run the impact analyser against an ephemeral synthetic named graph (#722).
+
+Epic #714 design note — *mechanism: synthetic ephemeral named graph,
+reusing the existing impact queries*. The "Normi mõjuahel" workflow
+resolves the user's input to one ontology entity URI, then:
+
+    1. Mints a fresh graph URI ``…/estleg/adhoc/<uuid4>`` (the
+       ``adhoc/`` arm of the :data:`app.sync.jena_loader._SAFE_GRAPH_URI`
+       allowlist — see #722 widening).
+    2. Writes **one triple** into Jena via Graph Store Protocol PUT —
+       ``<that-graph> { <adhoc-subject> estleg:references <entityUri> }``
+       — mirroring the single ``estleg:references`` edge a draft's named
+       graph carries (the analyzer's SPARQL queries pivot off exactly
+       that predicate; see :mod:`app.docs.graph_builder` +
+       :mod:`app.docs.impact.queries`).
+    3. Runs :meth:`app.docs.impact.analyzer.ImpactAnalyzer.analyze` and
+       :func:`app.docs.impact.scoring.calculate_impact_score` against
+       the graph — exactly as the draft analyze pipeline does.
+    4. **Always** ``delete_named_graph``-s the graph in a ``finally`` —
+       including on a PUT failure or an analyzer exception — so no
+       ephemeral graph ever lingers in Fuseki.
+
+Nothing is persisted: ad-hoc analyses are recomputed on each GET of
+``/analyysikeskus/normi-mojuahel`` (C-lite — no ``analysis_runs`` table,
+no migration).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from uuid import uuid4
+
+from rdflib import Graph, Namespace, URIRef
+from rdflib.namespace import RDF
+
+from app.docs.impact import ImpactAnalyzer, ImpactFindings, calculate_impact_score
+from app.sync.jena_loader import delete_named_graph, put_named_graph
+
+logger = logging.getLogger(__name__)
+
+# Same namespace the draft graph builder uses, so the synthetic graph's
+# ``estleg:references`` predicate is byte-identical to a real draft's.
+_ESTLEG = Namespace("https://data.riik.ee/ontology/estleg#")
+
+# Host + path prefix for the ephemeral graphs. The trailing ``<uuid4>``
+# segment is appended per request; the result must match the ``adhoc/``
+# arm of ``app.sync.jena_loader._SAFE_GRAPH_URI``.
+_ADHOC_GRAPH_PREFIX = "https://data.riik.ee/ontology/estleg/adhoc/"
+
+
+@dataclass(frozen=True)
+class AdhocAnalysisResult:
+    """Bundle of an ad-hoc impact analysis run.
+
+    Attributes:
+        findings: The :class:`ImpactFindings` the analyzer produced
+            (empty lists / zero counts if Jena was unreachable or the
+            PUT failed — the route still renders a graceful "nothing
+            found" page in that case).
+        score: The 0-100 impact score from
+            :func:`calculate_impact_score`.
+        graph_uri: The ephemeral graph URI that was minted (and, by the
+            time this result is returned, already deleted). Surfaced
+            only for logging/debugging — the UI never shows it.
+    """
+
+    findings: ImpactFindings
+    score: int
+    graph_uri: str
+
+
+def _mint_adhoc_graph_uri() -> str:
+    """Return a fresh ``…/estleg/adhoc/<uuid4>`` graph URI.
+
+    ``uuid4()`` renders as a 36-char lowercase hyphenated string, which
+    is exactly what the allowlist regex's ``[0-9a-f-]{36}`` arm
+    expects.
+    """
+    return f"{_ADHOC_GRAPH_PREFIX}{uuid4()}"
+
+
+def _build_adhoc_turtle(graph_uri: str, entity_uri: str) -> str:
+    """Serialise the one-triple synthetic graph as Turtle.
+
+    The subject is ``<graph_uri>#self`` — the same fragment-IRI trick
+    :func:`app.docs.graph_builder.build_draft_graph` uses to keep the
+    graph's subject distinct from the graph name. We also assert the
+    subject's ``rdf:type`` as ``estleg:DraftLegislation`` so the
+    conflict pass's ``?otherDraft a estleg:DraftLegislation`` filter
+    treats neighbouring real drafts (not this synthetic node) as the
+    "other draft" side — exactly as it does for a real draft graph.
+    """
+    g = Graph()
+    g.bind("estleg", _ESTLEG)
+    subject = URIRef(f"{graph_uri}#self")
+    g.add((subject, RDF.type, _ESTLEG.DraftLegislation))
+    g.add((subject, _ESTLEG.references, URIRef(entity_uri)))
+    serialised = g.serialize(format="turtle")
+    if isinstance(serialised, bytes):
+        return serialised.decode("utf-8")
+    return serialised
+
+
+def run_adhoc_impact_analysis(
+    entity_uri: str,
+    *,
+    analyzer: ImpactAnalyzer | None = None,
+) -> AdhocAnalysisResult:
+    """Run the impact analyser against a fresh synthetic graph for *entity_uri*.
+
+    Args:
+        entity_uri: The resolved ontology entity URI to analyse the
+            impact of (a provision, EU act, court decision …). Must be
+            a non-empty string; an empty value short-circuits to an
+            empty result without touching Jena.
+        analyzer: Optional :class:`ImpactAnalyzer` override (tests inject
+            one whose ``analyze`` is patched). Defaults to a fresh
+            :class:`ImpactAnalyzer`.
+
+    Returns:
+        An :class:`AdhocAnalysisResult`. On a Jena PUT failure or an
+        analyzer exception the result carries empty findings + score 0
+        (the route degrades to "nothing found" rather than 500). The
+        ephemeral graph is **always** deleted before this returns,
+        including on the failure paths.
+    """
+    if not entity_uri or not entity_uri.strip():
+        return AdhocAnalysisResult(findings=ImpactFindings(), score=0, graph_uri="")
+
+    graph_uri = _mint_adhoc_graph_uri()
+    runner = analyzer if analyzer is not None else ImpactAnalyzer()
+
+    try:
+        turtle = _build_adhoc_turtle(graph_uri, entity_uri)
+        loaded = put_named_graph(graph_uri, turtle)
+        if not loaded:
+            logger.warning(
+                "run_adhoc_impact_analysis: Jena PUT failed for graph=%s entity=%s",
+                graph_uri,
+                entity_uri,
+            )
+            return AdhocAnalysisResult(findings=ImpactFindings(), score=0, graph_uri=graph_uri)
+
+        findings = runner.analyze(graph_uri)
+        score = calculate_impact_score(findings)
+        logger.info(
+            "run_adhoc_impact_analysis: entity=%s affected=%d conflicts=%d score=%d",
+            entity_uri,
+            findings.affected_count,
+            findings.conflict_count,
+            score,
+        )
+        return AdhocAnalysisResult(findings=findings, score=score, graph_uri=graph_uri)
+    except Exception:
+        logger.exception(
+            "run_adhoc_impact_analysis: analysis failed for entity=%s graph=%s",
+            entity_uri,
+            graph_uri,
+        )
+        return AdhocAnalysisResult(findings=ImpactFindings(), score=0, graph_uri=graph_uri)
+    finally:
+        # Always tear down the ephemeral graph — even on a PUT failure
+        # (delete is idempotent: a 404 counts as success) or a render
+        # error upstream. Best-effort: a delete failure is logged inside
+        # ``delete_named_graph`` and must not mask the analysis result.
+        try:
+            delete_named_graph(graph_uri)
+        except Exception:
+            logger.exception(
+                "run_adhoc_impact_analysis: failed to delete ephemeral graph %s",
+                graph_uri,
+            )

--- a/app/analyysikeskus/input_parser.py
+++ b/app/analyysikeskus/input_parser.py
@@ -1,0 +1,178 @@
+"""Parse a free-text Analüüsikeskus input into structured legal references (#722).
+
+The "Normi mõjuahel" workflow lets a ministry lawyer type a single line
+into a search box — ``"AvTS § 35"``, a CELEX number like ``32016R0679``,
+a Supreme Court case number like ``3-1-1-63-15``, a CJEU case like
+``C-131/12``, or free prose. :func:`parse_user_reference` turns that
+line into the ``list[ExtractedRef]`` that
+:class:`app.docs.reference_resolver.ReferenceResolver` consumes — the
+resolver only speaks :class:`~app.docs.entity_extractor.ExtractedRef`,
+not raw strings, so this module is the adapter between the search box
+and the resolver.
+
+Recognition is **deliberately rule-based and conservative** — the same
+spirit as the Estonian-legal-NLP note in ``CLAUDE.md`` ("Start with
+rule-based regex for §-references and law names; layer ML later"):
+
+* **CELEX** (``32016R0679``, ``32019L0790`` …) → one ``eu_act`` ref.
+* **Court case number** — Estonian ``3-1-1-63-15`` style or CJEU
+  ``C-131/12`` / ``T-99/04`` / ``F-1/05`` → one ``court_decision`` ref.
+* **§-reference** — ``<LawShortName> § <n>`` optionally followed by
+  ``lg <n>`` and/or ``p <n>`` → a ``provision`` ref carrying the full
+  matched text *plus* a ``law`` ref carrying just the short name (the
+  resolver tries the precise provision first and the law as a fallback).
+* **Anything else** → ``[]``. The route surfaces a friendly "no
+  structured reference recognised" message + (optionally) RAG
+  candidates; this function never guesses.
+
+All regexes are module-level constants so they're cheap to reuse and
+trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.docs.entity_extractor import ExtractedRef
+
+# CELEX numbers: 1-digit sector + 4-digit year + single descriptor
+# letter + 1-4 digit running number, e.g. ``32016R0679``. Mirrors the
+# pattern already used in :mod:`app.docs.reference_resolver` so the
+# two stay in lockstep. ``fullmatch`` semantics are enforced by the
+# caller anchoring on ``\b`` boundaries below.
+_CELEX_RE = re.compile(r"^\d{5}[A-Z]\d{1,4}$", re.IGNORECASE)
+_CELEX_SCAN_RE = re.compile(r"\b\d{5}[A-Z]\d{1,4}\b", re.IGNORECASE)
+
+# Estonian court case numbers: ``3-1-1-63-15``, ``3-2-1-4-13``, ``5-19-1-2``…
+# A run of digit groups joined by hyphens, at least three groups, last
+# group typically a 2-digit year but we don't enforce that.
+_EE_CASE_RE = re.compile(r"^\d+-\d+-\d+(?:-\d+)*$")
+
+# CJEU / EU General Court case numbers: ``C-131/12``, ``T-99/04``,
+# ``F-1/05``, ``C-362/14`` … letter + dash + digits + slash + digits.
+_EU_CASE_RE = re.compile(r"^[CTF]-\d+/\d+$", re.IGNORECASE)
+
+# §-reference: a law short name (a token of letters incl. Estonian
+# diacritics, possibly with internal digits like ``KOKS``), then ``§``,
+# then a section number that may carry a literal index suffix (``§
+# 35^1``-style data uses a caret; we keep it permissive), optionally
+# followed by ``lg N`` and/or ``p N``. The short name is captured so we
+# can emit it as a standalone ``law`` ref. Case-insensitive on the
+# ``lg`` / ``p`` keywords; the law name itself keeps its original case
+# because Estonian law abbreviations are case-significant (``AvTS`` vs
+# ``avts``).
+_SECTION_RE = re.compile(
+    r"""
+    ^\s*
+    (?P<law>[A-Za-zÕÄÖÜŠŽõäöüšž][\wÕÄÖÜŠŽõäöüšž]*)   # law short name, e.g. AvTS / KarS / KOKS
+    \s+§\s*
+    (?P<section>\d+(?:[.\^]\d+)?)                       # section number, optional .N / ^N suffix
+    (?:\s+lg\s*(?P<lg>\d+))?                            # optional 'lg N'
+    (?:\s+p\s*(?P<p>\d+))?                              # optional 'p N'
+    \s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def parse_user_reference(sisend: str) -> list[ExtractedRef]:
+    """Turn a free-text Analüüsikeskus input into structured references.
+
+    Args:
+        sisend: The raw search-box string. Leading/trailing whitespace
+            is stripped; an empty/whitespace-only value yields ``[]``.
+
+    Returns:
+        A list of :class:`ExtractedRef` ready to hand to
+        :meth:`app.docs.reference_resolver.ReferenceResolver.resolve`.
+        Empty when nothing structured is recognised (the route handles
+        that case with a friendly message + optional RAG candidates).
+        For a §-reference the list has two entries — the precise
+        ``provision`` ref first, then the ``law`` short-name ref — so
+        the resolver can fall back to the law if the exact provision
+        literal doesn't match. ``confidence`` is a flat ``1.0`` because
+        a regex match is a deterministic recognition, not a probability.
+    """
+    text = (sisend or "").strip()
+    if not text:
+        return []
+
+    # 1. CELEX — exact token, or a CELEX embedded in a short phrase
+    #    (people paste "GDPR (32016R0679)"). The exact-match branch wins
+    #    first so a bare "32016R0679" doesn't fall through to the scan.
+    if _CELEX_RE.fullmatch(text):
+        return [_ref(text, "eu_act")]
+    celex_scan = _CELEX_SCAN_RE.search(text)
+    if celex_scan is not None:
+        return [_ref(celex_scan.group(0), "eu_act")]
+
+    # 2. Court case numbers — Estonian (``3-1-1-63-15``) or CJEU
+    #    (``C-131/12``). Exact-match only: we don't want a stray number
+    #    range inside prose to be misread as a case number.
+    if _EE_CASE_RE.fullmatch(text) or _EU_CASE_RE.fullmatch(text):
+        return [_ref(text, "court_decision")]
+
+    # 3. §-reference — ``AvTS § 35``, ``KarS § 133 lg 2 p 1`` … The
+    #    matched text becomes a ``provision`` ref; the law short name
+    #    also gets emitted as a ``law`` ref so the resolver has a
+    #    fallback when the provision literal doesn't resolve exactly.
+    sec = _SECTION_RE.match(text)
+    if sec is not None:
+        law_short = sec.group("law")
+        # Normalise the provision ref text to a canonical "Law § N[ lg N][ p N]"
+        # spelling so it matches the literals the ontology stores
+        # regardless of how the user spaced/cased "lg"/"p".
+        provision_text = _canonical_provision_text(
+            law_short,
+            sec.group("section"),
+            sec.group("lg"),
+            sec.group("p"),
+        )
+        return [
+            _ref(provision_text, "provision"),
+            _ref(law_short, "law"),
+        ]
+
+    # 4. Nothing structured recognised.
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ref(ref_text: str, ref_type: str) -> ExtractedRef:
+    """Build a flat-confidence :class:`ExtractedRef` from a recognised token.
+
+    ``location`` records that the ref came from the Analüüsikeskus
+    search box rather than a parsed document — handy for debugging and
+    harmless to the resolver, which only reads ``ref_text`` / ``ref_type``.
+    """
+    return ExtractedRef(
+        ref_text=ref_text,
+        ref_type=ref_type,
+        confidence=1.0,
+        location={"source": "analyysikeskus_input"},
+    )
+
+
+def _canonical_provision_text(
+    law_short: str,
+    section: str,
+    lg: str | None,
+    p: str | None,
+) -> str:
+    """Render a canonical ``"Law § N[ lg N][ p N]"`` provision string.
+
+    The ontology stores provision literals in a consistent shape; the
+    user's typing may differ in spacing ("§35", "lg2"). Re-spelling
+    here gives the resolver its best shot at an exact literal match
+    before it falls back to the law short-name lookup.
+    """
+    out = f"{law_short} § {section}"
+    if lg:
+        out += f" lg {lg}"
+    if p:
+        out += f" p {p}"
+    return out

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -5,7 +5,7 @@ rationale lives in ``docs/2026-05-11-ministry-lawyer-ui-structure.md``.
 This module hosts:
 
     GET  /analyysikeskus                         — workflow directory (#720)
-    GET  /analyysikeskus/normi-mojuahel          — Normi mõjuahel stub (#722 fills it in)
+    GET  /analyysikeskus/normi-mojuahel          — Normi mõjuahel (#722)
     GET  /analyysikeskus/el-ulevott              — EL ülevõtt stub (#723 fills it in)
 
 Only the two workflows with backing ontology data today (``Normi
@@ -16,11 +16,24 @@ no placeholder cards in the meantime.
 Auth is handled by the global ``auth_before`` middleware — none of these
 paths are in ``SKIP_PATHS`` so an unauthenticated request is redirected
 to ``/auth/login`` before any handler runs.
+
+**#722 — Normi mõjuahel.** The workflow resolves the user's free-text
+input to one ontology entity URI, runs the existing impact analyser
+against an *ephemeral synthetic named graph* (see
+:mod:`app.analyysikeskus.adhoc_analysis`), and renders the findings
+through :func:`app.analyysikeskus.result_shell.analysis_result_shell`.
+A UUID matching a draft the caller's org owns short-circuits to that
+draft's persisted ``impact_reports`` row instead. Ad-hoc analyses are
+ephemeral — recomputed on every GET, never persisted (C-lite). Nothing
+on the page uses SPARQL / RDF / named-graph / "graph URI" language —
+the ``Ulatus`` controls read purely as legal/policy scope.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import uuid
 from datetime import UTC, datetime
 from typing import Any
 
@@ -28,14 +41,22 @@ from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
+from app.analyysikeskus.adhoc_analysis import run_adhoc_impact_analysis
+from app.analyysikeskus.input_parser import parse_user_reference
 from app.analyysikeskus.result_shell import analysis_result_shell
 from app.db import get_connection as _connect
-from app.docs.impact.scoring import IMPACT_BAND_LABELS_ET, impact_band
+from app.docs.entity_extractor import ExtractedRef
+from app.docs.impact.analyzer import ImpactFindings
+from app.docs.impact.scoring import IMPACT_BAND_LABELS_ET, ImpactBand, impact_band
+from app.docs.labels import TYPE_LABELS_ET as _TYPE_LABELS_ET
+from app.docs.reference_resolver import ReferenceResolver
+from app.docs.report_routes import explorer_focus_url
 from app.drafter.state_machine import STEP_LABELS_ET, Step
 from app.ui.data.data_table import Column, DataTable
 from app.ui.layout import PageShell
+from app.ui.primitives.badge import Badge, BadgeVariant  # noqa: E402  (re-import after wildcard)
 from app.ui.primitives.button import Button  # noqa: E402  (re-import after wildcard)
-from app.ui.primitives.input import Input
+from app.ui.primitives.input import Checkbox, Input, Select
 from app.ui.surfaces.alert import Alert
 from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.theme import get_theme_from_request
@@ -48,20 +69,36 @@ logger = logging.getLogger(__name__)
 # page stays dense-but-calm.
 _MAX_RECENT_ANALYSES = 10
 
-# Stub copy reused by both workflow result pages until #722 / #723 land
-# the real computation.
-_RESULTS_STUB_TEXT = "Selle töövoo tulemuste arvutus on koostamisel — tulekul."
-_EVIDENCE_STUB_TEXT = (
-    "Tõendid (allikad, seosed, kuupäevad, lingid) kuvatakse siin, kui tulemused on arvutatud."
-)
+# How many RAG candidates to surface when no structured ref is recognised.
+_MAX_RAG_CANDIDATES = 5
 
-# Static action set every stub workflow ends with — no LLM-generated
-# recommendations (that's Phase D). ``{label, href}`` dicts.
-_STUB_ACTIONS: list[dict[str, str]] = [
-    {"label": "Küsi nõustajalt", "href": "/chat/new"},
-    {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
-]
+# Cap how many rows we render inline in each result sub-section — purely
+# page-weight control (the underlying findings can be 100s of rows).
+_MAX_RESULT_ROWS = 30
 
+# Entity types we treat as "drafts" / "court practice" when partitioning
+# the affected + conflicting entity sets into the result sub-sections.
+_DRAFT_TYPE_LOCALNAMES = frozenset({"DraftLegislation", "DraftingIntent"})
+_COURT_TYPE_LOCALNAMES = frozenset({"CourtDecision", "EUCourtDecision"})
+
+# Map the four impact bands to the legal-language risk labels the design
+# note asks for on the result page. ``high`` / ``critical`` already read
+# as risk in ``IMPACT_BAND_LABELS_ET`` ("Kõrge risk" / "Kriitiline");
+# ``low`` / ``medium`` get re-labelled here so the result page speaks the
+# "Väike mõju" / "Vajab kontrolli" / "Taustateave" / "Kõrge risk" vocabulary.
+_RISK_BAND_LABELS_ET: dict[ImpactBand, str] = {
+    "low": "Väike mõju",
+    "medium": "Vajab kontrolli",
+    "high": "Kõrge risk",
+    "critical": "Kõrge risk",
+}
+
+_RISK_BAND_BADGE_VARIANT: dict[ImpactBand, BadgeVariant] = {
+    "low": "success",
+    "medium": "warning",
+    "high": "danger",
+    "critical": "danger",
+}
 
 # ---------------------------------------------------------------------------
 # DB helper — "Hiljutised analüüsid"
@@ -322,27 +359,31 @@ def analyysikeskus_page(req: Request):
 
 
 # ---------------------------------------------------------------------------
-# Stub workflow routes (#722 Normi mõjuahel, #723 EL ülevõtt fill these in)
+# EL ülevõtt — still a stub (#723 fills it in)
 # ---------------------------------------------------------------------------
 
+# Stub copy reused by the EL ülevõtt result page until #723 lands the
+# real computation.
+_RESULTS_STUB_TEXT = "Selle töövoo tulemuste arvutus on koostamisel — tulekul."
+_EVIDENCE_STUB_TEXT = (
+    "Tõendid (allikad, seosed, kuupäevad, lingid) kuvatakse siin, kui tulemused on arvutatud."
+)
+_STUB_ACTIONS: list[dict[str, str]] = [
+    {"label": "Küsi nõustajalt", "href": "/chat/new"},
+    {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
+]
 
-def _workflow_stub_response(req: Request, *, workflow_title: str):
-    """Shared body for the two stub workflow GET routes.
 
-    Reads the ``sisend`` query param; a blank value redirects back to the
-    directory (303). Otherwise renders :func:`analysis_result_shell` with
-    the echoed input, the "koostamisel" placeholder in ``Tulemused``, a
-    stub ``Tõendid`` line, and the static :data:`_STUB_ACTIONS` set.
-    """
+def el_ulevott_page(req: Request):
+    """GET /analyysikeskus/el-ulevott?sisend=<text> — EL ülevõtt ja harmoneerimine (stub)."""
     sisend = (req.query_params.get("sisend") or "").strip()
     if not sisend:
         return RedirectResponse(url="/analyysikeskus", status_code=303)
 
     auth = req.scope.get("auth") or None
     theme = get_theme_from_request(req)
-
     return analysis_result_shell(
-        workflow_title=workflow_title,
+        workflow_title="EL ülevõtt ja harmoneerimine",
         input_summary=P(f"Sisestasite: «{sisend}»"),  # noqa: F405
         results_block=Alert(_RESULTS_STUB_TEXT, variant="info"),
         evidence_block=P(_EVIDENCE_STUB_TEXT, cls="muted-text"),  # noqa: F405
@@ -352,14 +393,1085 @@ def _workflow_stub_response(req: Request, *, workflow_title: str):
     )
 
 
+# ---------------------------------------------------------------------------
+# Normi mõjuahel (#722) — helpers
+# ---------------------------------------------------------------------------
+
+
+# Scope state read off the query string. Booleans default per the design
+# note: EU + court practice on, org-wide drafts off.
+class _Scope:
+    """Parsed ``Ulatus`` scope from the GET query params.
+
+    ``oigus`` is informational only (temporal redactions aren't wired —
+    the second select option is disabled). ``include_eu`` /
+    ``include_court`` actually filter the analysis output;
+    ``org_wide_drafts`` only changes the ``Seotud eelnõud`` framing
+    (the underlying query returns what it returns).
+    """
+
+    def __init__(self, params: Any) -> None:
+        # Checkboxes: present in the query string ⇒ checked. The default
+        # form has EU + court checked, so on a *first* GET (no scope
+        # params at all) we want both ON; we detect "the form was
+        # submitted" by the presence of the marker hidden input
+        # ``ulatus_submitted``.
+        submitted = params.get("ulatus_submitted") == "1"
+        if submitted:
+            self.include_eu = params.get("kaasa_el") is not None
+            self.include_court = params.get("kaasa_kohtupraktika") is not None
+            self.org_wide_drafts = params.get("kogu_organisatsioon") is not None
+        else:
+            self.include_eu = True
+            self.include_court = True
+            self.org_wide_drafts = False
+        self.oigus = params.get("oigus") or "current"
+        self.ajavahemik_algus = params.get("ajavahemik_algus") or ""
+        self.ajavahemik_lopp = params.get("ajavahemik_lopp") or ""
+
+    def query_pairs(self, sisend: str) -> list[tuple[str, str]]:
+        """Return the ``(key, value)`` pairs to carry the scope through links."""
+        pairs: list[tuple[str, str]] = [("sisend", sisend), ("ulatus_submitted", "1")]
+        if self.include_eu:
+            pairs.append(("kaasa_el", "1"))
+        if self.include_court:
+            pairs.append(("kaasa_kohtupraktika", "1"))
+        if self.org_wide_drafts:
+            pairs.append(("kogu_organisatsioon", "1"))
+        if self.oigus and self.oigus != "current":
+            pairs.append(("oigus", self.oigus))
+        if self.ajavahemik_algus:
+            pairs.append(("ajavahemik_algus", self.ajavahemik_algus))
+        if self.ajavahemik_lopp:
+            pairs.append(("ajavahemik_lopp", self.ajavahemik_lopp))
+        return pairs
+
+
+def _type_localname(uri: str) -> str:
+    """Return the local name of a type URI (after ``#`` or last ``/``)."""
+    if not uri:
+        return ""
+    return uri.rsplit("#", 1)[-1] if "#" in uri else uri.rsplit("/", 1)[-1]
+
+
+def _type_label(uri: str) -> str:
+    """Estonian label for a type URI, falling back to the bare local name."""
+    if not uri:
+        return "—"
+    return _TYPE_LABELS_ET.get(_type_localname(uri), _type_localname(uri))
+
+
+def _entity_display_label(row: dict[str, Any]) -> str:
+    """Best human label for an entity row — its ``label`` or the URI tail."""
+    label = str(row.get("label") or "").strip()
+    if label:
+        return label
+    uri = str(row.get("uri") or "").strip()
+    return _type_localname(uri) or uri or "—"
+
+
+def _split_link_query(pairs: list[tuple[str, str]]) -> str:
+    """URL-encode ``(key, value)`` pairs into an ``a=b&c=d`` query string."""
+    from urllib.parse import urlencode
+
+    return urlencode(pairs)
+
+
+def _normi_link(sisend: str, *, scope: _Scope | None = None) -> str:
+    """Build a ``/analyysikeskus/normi-mojuahel?sisend=…`` link (scope-carrying)."""
+    pairs: list[tuple[str, str]] = (
+        scope.query_pairs(sisend) if scope is not None else [("sisend", sisend)]
+    )
+    return f"/analyysikeskus/normi-mojuahel?{_split_link_query(pairs)}"
+
+
+# ---------------------------------------------------------------------------
+# Normi mõjuahel — scope form (the design note overrides result_shell's stub)
+# ---------------------------------------------------------------------------
+
+_LAW_SCOPE_OPTIONS: list[tuple[str, str]] = [
+    ("current", "Kehtiv õigus"),
+    ("current_plus_history", "Kehtiv + varasemad redaktsioonid (tulekul)"),
+]
+
+
+def _normi_scope_block(sisend: str, scope: _Scope) -> Any:
+    """The enabled ``Ulatus`` scope form for Normi mõjuahel.
+
+    A ``GET`` form back to ``/analyysikeskus/normi-mojuahel`` carrying
+    ``sisend`` as a hidden input + the legal-language scope controls.
+    Submitting re-runs the analysis with the chosen scope. All copy is
+    legal/policy language — there is no SPARQL / RDF / named-graph
+    vocabulary anywhere (these are *scope* words).
+    """
+    return Form(  # noqa: F405
+        P(  # noqa: F405
+            "Analüüsin vaikimisi kehtivat õigust, seotud eelnõusid, Riigikohtu "
+            "praktikat ja EL õigusakte. Võite ulatust muuta ja analüüsi uuesti käivitada.",
+            cls="muted-text",
+        ),
+        # Carry the analysed input through unchanged.
+        Hidden(name="sisend", value=sisend),  # noqa: F405
+        # Marker so the handler can tell "form submitted" from "first GET".
+        Hidden(name="ulatus_submitted", value="1"),  # noqa: F405
+        # "Õigus" — which redactions of the law count. Second option is
+        # disabled ("tulekul") because temporal versions aren't wired.
+        Div(  # noqa: F405
+            Label("Õigus", fr="analyysikeskus-scope-law"),  # noqa: F405
+            Select(
+                "oigus",
+                _LAW_SCOPE_OPTIONS,
+                # Reflect the chosen value, but the second ("varasemad
+                # redaktsioonid") option is "tulekul" — temporal versions
+                # aren't wired, so we always fall back to "current".
+                value="current",
+                id="analyysikeskus-scope-law",
+            ),
+            cls="form-field",
+        ),
+        # Toggles that actually affect the analysis output.
+        Checkbox("kaasa_el", checked=scope.include_eu, label="Kaasa EL õigus"),
+        Checkbox(
+            "kaasa_kohtupraktika",
+            checked=scope.include_court,
+            label="Kaasa kohtupraktika",
+        ),
+        Checkbox(
+            "kogu_organisatsioon",
+            checked=scope.org_wide_drafts,
+            label="Kaasa kogu organisatsiooni eelnõud",
+        ),
+        Small(  # noqa: F405
+            "Vaikimisi näitan otseseid eelnõuseoseid; märkige see, et "
+            "kaasata kogu organisatsiooni eelnõud.",
+            cls="muted-text",
+        ),
+        # KOV regulations — not wired yet; disabled with a "Tulekul" tooltip.
+        Checkbox(
+            "kaasa_kov",
+            checked=False,
+            label="Kaasa KOV regulatsioonid",
+            disabled=True,
+            title="Tulekul",
+        ),
+        # Optional time range — disabled ("tulekul"); temporal scoping
+        # isn't backed by data yet.
+        Div(  # noqa: F405
+            Label("Ajavahemik (tulekul)"),  # noqa: F405
+            Span(  # noqa: F405
+                Input(
+                    "ajavahemik_algus",
+                    type="date",
+                    aria_label="Alguskuupäev",
+                    disabled=True,
+                ),
+                Span(" – ", cls="muted-text"),  # noqa: F405
+                Input(
+                    "ajavahemik_lopp",
+                    type="date",
+                    aria_label="Lõppkuupäev",
+                    disabled=True,
+                ),
+                cls="analyysikeskus-date-range",
+            ),
+            cls="form-field",
+        ),
+        Button("Uuenda ulatust", type="submit", variant="secondary", size="sm"),
+        method="get",
+        action="/analyysikeskus/normi-mojuahel",
+        cls="analyysikeskus-scope-form",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normi mõjuahel — Tulemused sub-sections
+# ---------------------------------------------------------------------------
+
+
+def _sub_section(heading: str, *content: Any) -> Any:
+    """One ``Tulemused`` sub-section: a small ``H4`` + its content."""
+    return Div(H4(heading, cls="analyysikeskus-subsection-title"), *content)  # noqa: F405
+
+
+def _missing_row(text: str) -> Any:
+    """A one-line muted "…ei leitud" row standing in for an empty sub-section body."""
+    return P(text, cls="muted-text")  # noqa: F405
+
+
+def _entity_link(row: dict[str, Any]) -> Any:
+    """Render an entity row's label as an "open on the legal map" link.
+
+    Affected/conflicting entities are clickable: clicking opens the
+    entity on the legal map (``/explorer?focus=…``, URL-encoded by
+    :func:`explorer_focus_url`) — the "drill into this" affordance the
+    design note asks for. Rows without a URI render as plain text.
+    """
+    uri = str(row.get("uri") or row.get("conflicting_entity") or "").strip()
+    label = _entity_display_label(row)
+    if not uri:
+        return Span(label)  # noqa: F405
+    return A(label, href=explorer_focus_url(uri), cls="data-table-link")  # noqa: F405
+
+
+def _peamised_mojud_section(
+    affected: list[dict[str, Any]],
+    *,
+    n_provisions: int,
+    n_drafts: int,
+    n_courts: int,
+) -> Any:
+    """``Peamised mõjud`` — the top affected entities + a one-line lead."""
+    lead = P(  # noqa: F405
+        f"Kavandatav muudatus mõjutab vähemalt {n_provisions} sätet, "
+        f"{n_drafts} eelnõu ja {n_courts} Riigikohtu lahendit.",
+        cls="muted-text",
+    )
+    if not affected:
+        return _sub_section("Peamised mõjud", lead, _missing_row("Otseseid mõjusid ei leitud."))
+    rows = affected[:_MAX_RESULT_ROWS]
+    columns = [
+        Column(key="label", label="Üksus", sortable=False, render=lambda r: _entity_link(r)),
+        Column(
+            key="type",
+            label="Tüüp",
+            sortable=False,
+            render=lambda r: _type_label(str(r.get("type") or "")),
+        ),
+    ]
+    return _sub_section(
+        "Peamised mõjud",
+        lead,
+        DataTable(columns=columns, rows=rows, empty_message="Otseseid mõjusid ei leitud."),
+    )
+
+
+def _korge_riskiga_section(conflicts: list[dict[str, Any]]) -> Any:
+    """``Kõrge riskiga seosed`` — the conflict rows with a legal-language reason."""
+    if not conflicts:
+        return _sub_section(
+            "Kõrge riskiga seosed", _missing_row("Kõrge riskiga seoseid ei leitud.")
+        )
+    rows = conflicts[:_MAX_RESULT_ROWS]
+    columns = [
+        Column(
+            key="conflicting_label",
+            label="Konflikti üksus",
+            sortable=False,
+            render=lambda r: _entity_link(
+                {"uri": r.get("conflicting_entity"), "label": r.get("conflicting_label")}
+            ),
+        ),
+        Column(
+            key="reason",
+            label="Põhjus",
+            sortable=False,
+            render=lambda r: str(r.get("reason") or "—"),
+        ),
+    ]
+    return _sub_section(
+        "Kõrge riskiga seosed",
+        DataTable(columns=columns, rows=rows, empty_message="Kõrge riskiga seoseid ei leitud."),
+    )
+
+
+def _seotud_eelnoud_section(draft_rows: list[dict[str, Any]], *, org_wide: bool) -> Any:
+    """``Seotud eelnõud`` — affected entities that are drafts."""
+    framing = P(  # noqa: F405
+        "Näitan kõiki seotud eelnõusid." if org_wide else "Näitan otseselt seotud eelnõusid.",
+        cls="muted-text",
+    )
+    if not draft_rows:
+        return _sub_section("Seotud eelnõud", framing, _missing_row("Seotud eelnõusid ei leitud."))
+    rows = draft_rows[:_MAX_RESULT_ROWS]
+    columns = [
+        Column(key="label", label="Eelnõu", sortable=False, render=lambda r: _entity_link(r)),
+    ]
+    return _sub_section(
+        "Seotud eelnõud",
+        framing,
+        DataTable(columns=columns, rows=rows, empty_message="Seotud eelnõusid ei leitud."),
+    )
+
+
+def _riigikohtu_section(court_rows: list[dict[str, Any]]) -> Any:
+    """``Riigikohtu praktika`` — affected/conflicting entities that are court decisions."""
+    if not court_rows:
+        return _sub_section(
+            "Riigikohtu praktika", _missing_row("Seotud kohtulahendeid ei leitud.")
+        )
+    rows = court_rows[:_MAX_RESULT_ROWS]
+    columns = [
+        Column(key="label", label="Lahend", sortable=False, render=lambda r: _entity_link(r)),
+        Column(
+            key="type",
+            label="Tüüp",
+            sortable=False,
+            render=lambda r: _type_label(str(r.get("type") or "")),
+        ),
+    ]
+    return _sub_section(
+        "Riigikohtu praktika",
+        DataTable(columns=columns, rows=rows, empty_message="Seotud kohtulahendeid ei leitud."),
+    )
+
+
+def _el_seosed_section(eu_rows: list[dict[str, Any]], *, included: bool) -> Any:
+    """``EL seosed`` — the EU-compliance rows (EU act ↔ linking Estonian provision)."""
+    if not included:
+        return _sub_section("EL seosed", _missing_row("EL õigus on ulatusest välja jäetud."))
+    if not eu_rows:
+        return _sub_section("EL seosed", _missing_row("EL õiguse seoseid ei leitud."))
+    rows = eu_rows[:_MAX_RESULT_ROWS]
+    columns = [
+        Column(
+            key="eu_label",
+            label="EL õigusakt",
+            sortable=False,
+            render=lambda r: _entity_link({"uri": r.get("eu_act"), "label": r.get("eu_label")}),
+        ),
+        Column(
+            key="provision_label",
+            label="Seotud Eesti säte",
+            sortable=False,
+            render=lambda r: str(r.get("provision_label") or r.get("estonian_provision") or "—"),
+        ),
+    ]
+    return _sub_section(
+        "EL seosed",
+        DataTable(columns=columns, rows=rows, empty_message="EL õiguse seoseid ei leitud."),
+    )
+
+
+def _risk_and_recommendation(
+    score: int,
+    *,
+    n_conflicts: int,
+    n_provisions: int,
+    n_eu: int,
+) -> Any:
+    """The risk-band Badge + a templated recommended-next-action sentence."""
+    band = impact_band(score)
+    label = _RISK_BAND_LABELS_ET[band]
+    variant = _RISK_BAND_BADGE_VARIANT[band]
+
+    # Template the recommendation from the counts/conflicts — no LLM.
+    if n_conflicts > 0:
+        recommendation = (
+            "Soovitus: vaadata üle vastuolud teiste eelnõude / kohtupraktikaga "
+            "ja kaaluda üleminekusätet."
+        )
+    elif n_eu > 0:
+        recommendation = (
+            "Soovitus: kontrollida, kas muudatus mõjutab EL õiguse ülevõtmist, "
+            "ja vajadusel kooskõlastada."
+        )
+    elif n_provisions > 0:
+        recommendation = (
+            "Soovitus: vaadata üle viidatud sätted ja veenduda, et muudatus on nendega kooskõlas."
+        )
+    else:
+        recommendation = "Soovitus: täiendavat tegevust ei tuvastatud — kasuta seda taustateabena."
+
+    return _sub_section(
+        "Riskihinnang ja soovitus",
+        P(Span("Riskitase: ", cls="muted-text"), Badge(label, variant=variant)),  # noqa: F405
+        P(recommendation),  # noqa: F405
+    )
+
+
+def _is_court_conflict(row: dict[str, Any]) -> bool:
+    """True when a conflict row is a case-law conflict (the analyzer's reason phrasing)."""
+    reason = str(row.get("reason") or "").lower()
+    return "tõlgendab" in reason or "kohtulahend" in reason
+
+
+def _build_results_block(findings: ImpactFindings, score: int, scope: _Scope) -> list[Any]:
+    """Assemble the ``Tulemused`` sub-sections from the (scope-filtered) findings.
+
+    Scope wiring (only what has backing data):
+
+    * ``Kaasa kohtupraktika`` off → ``CourtDecision`` / ``EUCourtDecision``
+      rows are filtered out of the affected set, and case-law conflict
+      rows out of the conflict set, *before* rendering.
+    * ``Kaasa EL õigus`` off → the EU-compliance rows are dropped.
+    * ``Kaasa kogu organisatsiooni eelnõud`` only re-frames the
+      ``Seotud eelnõud`` block ("näitan kõiki" vs "näitan otseseid
+      seoseid") — the underlying query returns what it returns, so we
+      don't pretend to filter what we can't.
+    """
+    affected = list(findings.affected_entities or [])
+    conflicts = list(findings.conflicts or [])
+    eu_rows = list(findings.eu_compliance or [])
+
+    if not scope.include_court:
+        affected = [
+            r
+            for r in affected
+            if _type_localname(str(r.get("type") or "")) not in _COURT_TYPE_LOCALNAMES
+        ]
+        conflicts = [r for r in conflicts if not _is_court_conflict(r)]
+    if not scope.include_eu:
+        eu_rows = []
+
+    draft_rows = [
+        r for r in affected if _type_localname(str(r.get("type") or "")) in _DRAFT_TYPE_LOCALNAMES
+    ]
+    court_rows = [
+        r for r in affected if _type_localname(str(r.get("type") or "")) in _COURT_TYPE_LOCALNAMES
+    ]
+    provision_rows = [
+        r
+        for r in affected
+        if _type_localname(str(r.get("type") or "")) not in _DRAFT_TYPE_LOCALNAMES
+        and _type_localname(str(r.get("type") or "")) not in _COURT_TYPE_LOCALNAMES
+    ]
+
+    return [
+        _peamised_mojud_section(
+            affected,
+            n_provisions=len(provision_rows),
+            n_drafts=len(draft_rows),
+            n_courts=len(court_rows),
+        ),
+        _korge_riskiga_section(conflicts),
+        _seotud_eelnoud_section(draft_rows, org_wide=scope.org_wide_drafts),
+        _riigikohtu_section(court_rows),
+        _el_seosed_section(eu_rows, included=scope.include_eu),
+        _risk_and_recommendation(
+            score,
+            n_conflicts=len(conflicts),
+            n_provisions=len(provision_rows),
+            n_eu=len(eu_rows),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Normi mõjuahel — Tõendid block
+# ---------------------------------------------------------------------------
+
+
+def _evidence_row(
+    *,
+    source_label: str,
+    relation: str,
+    target_label: str,
+    uri: str,
+    why: str,
+    snippet: str = "",
+    when: str = "",
+) -> Any:
+    """One row in the ``Tõendid`` card.
+
+    Carries the source label, the relation **in legal language**, an
+    optional snippet/date, an "Ava allikas" link, a "miks see on oluline"
+    line, and an "Ava õiguskaardil →" deep link (URL-encoded by
+    :func:`explorer_focus_url`).
+    """
+    bits: list[Any] = [
+        P(  # noqa: F405
+            Strong(source_label),  # noqa: F405
+            f" {relation} ",
+            Strong(target_label) if target_label else "",  # noqa: F405
+        ),
+    ]
+    if snippet:
+        bits.append(P(snippet, cls="muted-text"))  # noqa: F405
+    if when:
+        bits.append(P(f"Kuupäev / redaktsioon: {when}", cls="muted-text"))  # noqa: F405
+    if why:
+        bits.append(P(why, cls="muted-text"))  # noqa: F405
+    link_bits: list[Any] = []
+    if uri:
+        link_bits.append(A("Ava allikas", href=uri, cls="data-table-link"))  # noqa: F405
+        link_bits.append(Span(" · ", cls="muted-text"))  # noqa: F405
+        link_bits.append(
+            A("Ava õiguskaardil →", href=explorer_focus_url(uri), cls="data-table-link")  # noqa: F405
+        )
+    if link_bits:
+        bits.append(P(*link_bits))  # noqa: F405
+    return Div(*bits, cls="analyysikeskus-evidence-row")  # noqa: F405
+
+
+def _build_evidence_block(
+    findings: ImpactFindings,
+    *,
+    analysed_label: str,
+    scope: _Scope,
+) -> list[Any]:
+    """Assemble the ``Tõendid`` rows from the findings.
+
+    One row per affected entity (the affected-entities pass doesn't
+    return the linking predicate, so the relation reads as the neutral
+    "on seotud üksusega"), plus one row per conflict (relation = the
+    analyzer's reason string, which is already legal language) and one
+    row per EU link ("võtab üle direktiivi"). Court rows are filtered
+    out when ``Kaasa kohtupraktika`` is off; EU rows when ``Kaasa EL
+    õigus`` is off — same scope wiring as :func:`_build_results_block`.
+    """
+    rows: list[Any] = []
+
+    for r in list(findings.affected_entities or []):
+        type_ln = _type_localname(str(r.get("type") or ""))
+        if not scope.include_court and type_ln in _COURT_TYPE_LOCALNAMES:
+            continue
+        uri = str(r.get("uri") or "").strip()
+        if not uri:
+            continue
+        type_word = _type_label(str(r.get("type") or "")).lower()
+        rows.append(
+            _evidence_row(
+                source_label=analysed_label,
+                relation="on seotud üksusega",
+                target_label=_entity_display_label(r),
+                uri=uri,
+                why=(
+                    f"See {type_word} on analüüsitava üksusega otseses seoses, "
+                    "seega võib muudatus seda mõjutada."
+                ),
+            )
+        )
+
+    for r in list(findings.conflicts or []):
+        if not scope.include_court and _is_court_conflict(r):
+            continue
+        uri = str(r.get("conflicting_entity") or "").strip()
+        label = str(r.get("conflicting_label") or uri or "—")
+        rows.append(
+            _evidence_row(
+                source_label=label,
+                relation="—",
+                target_label="",
+                uri=uri,
+                why=str(r.get("reason") or "Seotud üksus, mis võib põhjustada vastuolu."),
+            )
+        )
+
+    if scope.include_eu:
+        for r in list(findings.eu_compliance or []):
+            uri = str(r.get("eu_act") or "").strip()
+            label = str(r.get("eu_label") or uri or "EL õigusakt")
+            provision = str(r.get("provision_label") or r.get("estonian_provision") or "")
+            rows.append(
+                _evidence_row(
+                    source_label=provision or "Eesti säte",
+                    relation="võtab üle direktiivi",
+                    target_label=label,
+                    uri=uri,
+                    why=(
+                        "Muudatus võib mõjutada EL õiguse ülevõtmist — kontrolli "
+                        "vastavust enne menetlust."
+                    ),
+                )
+            )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Normi mõjuahel — draft-backed path
+# ---------------------------------------------------------------------------
+
+
+def _load_owned_draft_report(draft_uuid: uuid.UUID, org_id: str | None) -> tuple | None:
+    """Return ``(draft_id, draft_title, draft_version_id, report_data, impact_score)``.
+
+    Only when *draft_uuid* is a draft the caller's org owns **and** that
+    draft has an ``impact_reports`` row. ``None`` (→ fall through to the
+    parse path) when the UUID doesn't resolve to an owned draft or there
+    is no report yet. Best-effort: any DB error also returns ``None``.
+    """
+    if not org_id:
+        return None
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                """
+                SELECT d.id, d.title, ir.draft_version_id, ir.report_data, ir.impact_score
+                FROM drafts d
+                JOIN impact_reports ir ON ir.draft_id = d.id
+                WHERE d.id = %s AND d.org_id = %s
+                ORDER BY ir.generated_at DESC
+                LIMIT 1
+                """,
+                (str(draft_uuid), str(org_id)),
+            ).fetchone()
+    except Exception:
+        logger.warning("Failed to load owned-draft report for draft=%s", draft_uuid, exc_info=True)
+        return None
+    return row
+
+
+def _parse_report_data(raw: Any) -> dict[str, Any]:
+    """Normalise a JSONB ``report_data`` value into a dict (mirrors report_routes)."""
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            return json.loads(raw.decode())
+        except (TypeError, ValueError, UnicodeDecodeError):
+            return {}
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+    return {}
+
+
+def _findings_from_report_data(data: dict[str, Any]) -> ImpactFindings:
+    """Rebuild an :class:`ImpactFindings` from a persisted ``report_data`` dict."""
+    affected = list(data.get("affected_entities") or [])
+    conflicts = list(data.get("conflicts") or [])
+    gaps = list(data.get("gaps") or [])
+    eu = list(data.get("eu_compliance") or [])
+    return ImpactFindings(
+        affected_entities=affected,
+        conflicts=conflicts,
+        gaps=gaps,
+        eu_compliance=eu,
+        affected_count=int(data.get("affected_count") or len(affected)),
+        conflict_count=int(data.get("conflict_count") or len(conflicts)),
+        gap_count=int(data.get("gap_count") or len(gaps)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normi mõjuahel — resolution / RAG helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_refs(refs: list[ExtractedRef]) -> list[Any]:
+    """Resolve parsed refs to ontology URIs; an unreachable Jena yields ``[]``.
+
+    Wrapped so a dead Jena (or any resolver crash) degrades to "nothing
+    resolved" rather than 500 — the route then shows the "no structured
+    ref" branch, which is the right fallback.
+    """
+    if not refs:
+        return []
+    try:
+        return ReferenceResolver().resolve(refs)
+    except Exception:
+        logger.warning("Normi mõjuahel: reference resolution failed", exc_info=True)
+        return []
+
+
+def _rag_candidates(sisend: str, org_id: str | None) -> list[dict[str, str]]:
+    """Light RAG fallback: top provision-ish chunks for *sisend*.
+
+    Returns a list of ``{"label": str, "ref": str}`` dicts — ``ref`` is
+    the search-box text a click should re-submit. Best-effort: if the
+    RAG retriever isn't wired / errors / returns nothing, returns ``[]``
+    and the route simply omits the candidates (no crash). ``ref`` is
+    derived from the chunk metadata's provision/law fields when present,
+    else the first line of the chunk content trimmed.
+    """
+    try:
+        from app.rag.retriever import Retriever
+    except Exception:
+        return []
+    try:
+        import asyncio
+
+        retriever = Retriever()
+
+        async def _run() -> list[Any]:
+            return await retriever.retrieve(
+                sisend,
+                k=_MAX_RAG_CANDIDATES,
+                org_id=org_id,
+            )
+
+        try:
+            chunks = asyncio.run(_run())
+        except RuntimeError:
+            # Already inside an event loop (shouldn't happen in a sync
+            # route, but be defensive) — skip the RAG fallback.
+            return []
+    except Exception:
+        logger.debug("Normi mõjuahel: RAG candidate lookup failed", exc_info=True)
+        return []
+
+    out: list[dict[str, str]] = []
+    for ch in chunks or []:
+        meta = getattr(ch, "metadata", None) or {}
+        ref_text = ""
+        for key in ("provision_ref", "provision", "section_ref", "law_short", "law"):
+            val = meta.get(key) if isinstance(meta, dict) else None
+            if val:
+                ref_text = str(val).strip()
+                break
+        label = ref_text or (str(getattr(ch, "content", "") or "").strip().splitlines() or [""])[0]
+        label = label[:120].strip()
+        if not label:
+            continue
+        out.append({"label": label, "ref": ref_text or label})
+        if len(out) >= _MAX_RAG_CANDIDATES:
+            break
+    return out
+
+
+def _candidate_links(candidates: list[dict[str, str]], *, scope: _Scope | None = None) -> Any:
+    """Render RAG / disambiguation candidates as clickable workflow links.
+
+    Each candidate becomes ``A(label, href="/analyysikeskus/normi-mojuahel?sisend=<ref>")``
+    so a click re-runs the workflow with that candidate's reference text;
+    when *scope* is supplied the chosen scope params ride along so a
+    disambiguation pick keeps the user's scope selection. Empty /
+    ref-less candidates are skipped; an empty list renders nothing.
+    """
+    if not candidates:
+        return ""
+    items = []
+    for c in candidates:
+        ref = (c.get("ref") or c.get("label") or "").strip()
+        if not ref:
+            continue
+        items.append(Li(A(c.get("label") or ref, href=_normi_link(ref, scope=scope))))  # noqa: F405
+    if not items:
+        return ""
+    return Ul(*items, cls="analyysikeskus-candidates")  # noqa: F405
+
+
+# ---------------------------------------------------------------------------
+# GET /analyysikeskus/normi-mojuahel
+# ---------------------------------------------------------------------------
+
+
 def normi_mojuahel_page(req: Request):
-    """GET /analyysikeskus/normi-mojuahel?sisend=<text> — Normi mõjuahel (stub)."""
-    return _workflow_stub_response(req, workflow_title="Normi mõjuahel")
+    """GET /analyysikeskus/normi-mojuahel?sisend=<text> — the Normi mõjuahel workflow.
+
+    Flow (per the epic #714 design note):
+
+    1. Blank ``sisend`` → 303 back to ``/analyysikeskus``.
+    2. ``sisend`` is a UUID of a draft the caller's org owns *and* that
+       draft has an ``impact_reports`` row → render that persisted report
+       through the result shell (no synthetic graph). ``Lisa märkus`` is
+       enabled here (links to ``/drafts/{id}/report`` where the row-
+       annotation flow lives).
+    3. Else parse ``sisend`` → resolve via :class:`ReferenceResolver`:
+       * exactly one resolved entity → run the ephemeral-graph impact
+         analysis (:func:`run_adhoc_impact_analysis`), score it, render
+         the result;
+       * nothing resolved → render a friendly "no structured reference"
+         warning + (optionally) RAG candidate links;
+       * multiple plausible resolutions → render them as clickable
+         disambiguation links.
+    """
+    auth = req.scope.get("auth") or None
+    theme = get_theme_from_request(req)
+    org_id = auth.get("org_id") if auth else None
+
+    sisend = (req.query_params.get("sisend") or "").strip()
+    if not sisend:
+        return RedirectResponse(url="/analyysikeskus", status_code=303)
+
+    scope = _Scope(req.query_params)
+
+    # --- 2. UUID → owned-draft report short-circuit -------------------------
+    maybe_uuid = _try_parse_uuid(sisend)
+    if maybe_uuid is not None:
+        report_row = _load_owned_draft_report(maybe_uuid, org_id)
+        if report_row is not None:
+            return _render_draft_backed_result(
+                req,
+                auth=auth,
+                theme=theme,
+                draft_id=str(report_row[0]),
+                draft_title=str(report_row[1] or "Pealkirjata eelnõu"),
+                report_data=_parse_report_data(report_row[3]),
+                impact_score=int(report_row[4] or 0),
+                sisend=sisend,
+                scope=scope,
+            )
+        # UUID that isn't an owned draft with a report → fall through to
+        # the parse path (it may still be a recognisable reference).
+
+    # --- 3. parse + resolve -------------------------------------------------
+    parsed_refs = parse_user_reference(sisend)
+    resolved = _resolve_refs(parsed_refs)
+    resolved_with_uri = [
+        r for r in resolved if getattr(r, "entity_uri", None) and str(r.entity_uri).strip()
+    ]
+    # Dedupe by entity URI so "AvTS § 35" + the "AvTS" law ref both
+    # resolving don't count as two distinct entities.
+    seen: set[str] = set()
+    unique_resolved: list[Any] = []
+    for r in resolved_with_uri:
+        uri = str(r.entity_uri)
+        if uri in seen:
+            continue
+        seen.add(uri)
+        unique_resolved.append(r)
+
+    if len(unique_resolved) == 1:
+        return _render_adhoc_result(
+            req,
+            auth=auth,
+            theme=theme,
+            resolved=unique_resolved[0],
+            sisend=sisend,
+            scope=scope,
+        )
+
+    if len(unique_resolved) > 1:
+        return _render_disambiguation(
+            req,
+            auth=auth,
+            theme=theme,
+            resolved=unique_resolved,
+            sisend=sisend,
+            scope=scope,
+        )
+
+    # Nothing resolved.
+    return _render_unresolved(
+        req,
+        auth=auth,
+        theme=theme,
+        sisend=sisend,
+        scope=scope,
+        org_id=org_id,
+    )
 
 
-def el_ulevott_page(req: Request):
-    """GET /analyysikeskus/el-ulevott?sisend=<text> — EL ülevõtt ja harmoneerimine (stub)."""
-    return _workflow_stub_response(req, workflow_title="EL ülevõtt ja harmoneerimine")
+# ---------------------------------------------------------------------------
+# Render branches
+# ---------------------------------------------------------------------------
+
+
+def _try_parse_uuid(value: str) -> uuid.UUID | None:
+    try:
+        return uuid.UUID(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _resolved_label(resolved: Any, fallback: str) -> str:
+    """Best human label for a resolved ref."""
+    label = getattr(resolved, "matched_label", None)
+    if label and str(label).strip():
+        return str(label).strip()
+    extracted = getattr(resolved, "extracted", None)
+    if extracted is not None and getattr(extracted, "ref_text", None):
+        return str(extracted.ref_text).strip()
+    return fallback
+
+
+def _resolved_type_label(resolved: Any) -> str:
+    """Estonian type label for a resolved ref's ref_type, or "" if unknown."""
+    extracted = getattr(resolved, "extracted", None)
+    ref_type = getattr(extracted, "ref_type", "") if extracted is not None else ""
+    return {
+        "law": "seadus",
+        "provision": "säte",
+        "eu_act": "EL õigusakt",
+        "court_decision": "kohtulahend",
+        "concept": "õigusmõiste",
+    }.get(str(ref_type), "")
+
+
+def _result_actions(
+    *,
+    focus_uri: str | None,
+    draft_id: str | None = None,
+    adhoc: bool,
+) -> list[dict[str, str]]:
+    """Build the ``Soovitatud tegevused`` action set.
+
+    ``Lisa märkus`` only on the draft-backed path (links to the row-
+    annotation flow at ``/drafts/{id}/report``); it is *omitted* on an
+    ad-hoc result, which has no ``draft_version_id`` + no row-annotation
+    flow. ``Ekspordi memo`` is omitted for ad-hoc (no export machinery
+    yet) — on the draft-backed path the user can export from the report
+    page itself, so we don't duplicate it here either; the design note
+    allows omitting it.
+    """
+    actions: list[dict[str, str]] = []
+    if focus_uri:
+        actions.append({"label": "Ava õiguskaardil", "href": explorer_focus_url(focus_uri)})
+    actions.append({"label": "Küsi nõustajalt", "href": "/chat/new"})
+    if draft_id and not adhoc:
+        actions.append({"label": "Lisa märkus", "href": f"/drafts/{draft_id}/report"})
+    actions.append({"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"})
+    return actions
+
+
+def _render_adhoc_result(
+    req: Request,
+    *,
+    auth: Any,
+    theme: str,
+    resolved: Any,
+    sisend: str,
+    scope: _Scope,
+) -> Any:
+    """Render the result page for a single resolved entity (ephemeral-graph path).
+
+    Runs :func:`run_adhoc_impact_analysis` (which mints + PUTs + analyses
+    + **always deletes** an ephemeral named graph), scores the findings,
+    and lays them out through :func:`analysis_result_shell`. Because the
+    synthetic graph is already torn down by the time control returns
+    here, a render error below cannot leave a graph behind.
+    """
+    entity_uri = str(resolved.entity_uri)
+    label = _resolved_label(resolved, sisend)
+    type_label = _resolved_type_label(resolved)
+
+    result = run_adhoc_impact_analysis(entity_uri)
+    findings = result.findings
+    score = result.score
+
+    input_summary = P(  # noqa: F405
+        "Analüüsisin: ",
+        Strong(label),
+        (f" — {type_label}" if type_label else ""),
+    )
+
+    results_block = _build_results_block(findings, score, scope)
+    evidence_block = _build_evidence_block(findings, analysed_label=label, scope=scope)
+    actions = _result_actions(focus_uri=entity_uri, adhoc=True)
+
+    return analysis_result_shell(
+        workflow_title="Normi mõjuahel",
+        input_summary=input_summary,
+        results_block=results_block,
+        evidence_block=evidence_block if evidence_block else _missing_row("Tõendeid ei leitud."),
+        actions=actions,
+        user=auth,
+        theme=theme,
+        scope_block=_normi_scope_block(sisend, scope),
+    )
+
+
+def _render_draft_backed_result(
+    req: Request,
+    *,
+    auth: Any,
+    theme: str,
+    draft_id: str,
+    draft_title: str,
+    report_data: dict[str, Any],
+    impact_score: int,
+    sisend: str,
+    scope: _Scope,
+) -> Any:
+    """Render the result page from a draft's persisted ``impact_reports`` row.
+
+    No synthetic graph here — the findings come straight from the
+    ``impact_reports`` row. ``Lisa märkus`` is enabled (links to
+    ``/drafts/{id}/report`` where the row-annotation flow lives).
+    """
+    findings = _findings_from_report_data(report_data)
+
+    input_summary = Div(  # noqa: F405
+        P("Analüüsisin eelnõu: ", Strong(draft_title)),  # noqa: F405
+        P(  # noqa: F405
+            A(
+                "Ava eelnõu mõjuaruanne →",
+                href=f"/drafts/{draft_id}/report",
+                cls="data-table-link",
+            ),
+            cls="muted-text",
+        ),
+    )
+
+    results_block = _build_results_block(findings, impact_score, scope)
+    evidence_block = _build_evidence_block(findings, analysed_label=draft_title, scope=scope)
+    actions = _result_actions(focus_uri=None, draft_id=draft_id, adhoc=False)
+    # Draft-backed: also offer the explorer view of the whole draft.
+    actions.insert(0, {"label": "Ava õiguskaardil", "href": f"/explorer?draft={draft_id}"})
+
+    return analysis_result_shell(
+        workflow_title="Normi mõjuahel",
+        input_summary=input_summary,
+        results_block=results_block,
+        evidence_block=evidence_block if evidence_block else _missing_row("Tõendeid ei leitud."),
+        actions=actions,
+        user=auth,
+        theme=theme,
+        scope_block=_normi_scope_block(sisend, scope),
+    )
+
+
+def _render_disambiguation(
+    req: Request,
+    *,
+    auth: Any,
+    theme: str,
+    resolved: list[Any],
+    sisend: str,
+    scope: _Scope,
+) -> Any:
+    """Render a disambiguation page listing the plausible resolutions as links."""
+    candidates: list[dict[str, str]] = []
+    for r in resolved:
+        label = _resolved_label(r, sisend)
+        extracted = getattr(r, "extracted", None)
+        ref_text = str(getattr(extracted, "ref_text", "") or label)
+        candidates.append({"label": label, "ref": ref_text})
+
+    results_block = [
+        Alert(
+            "Sisend võib viidata mitmele üksusele. Vali, millist analüüsida:",
+            variant="info",
+        ),
+        _candidate_links(candidates, scope=scope),
+    ]
+    return analysis_result_shell(
+        workflow_title="Normi mõjuahel",
+        input_summary=P(f"Sisestasite: «{sisend}»"),  # noqa: F405
+        results_block=results_block,
+        evidence_block=_missing_row("—"),
+        actions=[
+            {"label": "Küsi nõustajalt", "href": "/chat/new"},
+            {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
+        ],
+        user=auth,
+        theme=theme,
+        scope_block=_normi_scope_block(sisend, scope),
+    )
+
+
+def _render_unresolved(
+    req: Request,
+    *,
+    auth: Any,
+    theme: str,
+    sisend: str,
+    scope: _Scope,
+    org_id: str | None,
+) -> Any:
+    """Render the "no structured reference recognised" page (+ optional RAG candidates)."""
+    warning = Alert(
+        "Ei tuvastanud õiguslikku viidet. Proovige nt «AvTS § 35», CELEX-numbrit "
+        "(32016R0679) või kohtulahendi numbrit.",
+        variant="warning",
+    )
+    candidates = _rag_candidates(sisend, org_id)
+    results_children: list[Any] = [warning]
+    if candidates:
+        results_children.append(
+            P("Võimalikud sätted, mida võisite mõelda:", cls="muted-text")  # noqa: F405
+        )
+        results_children.append(_candidate_links(candidates, scope=scope))
+
+    return analysis_result_shell(
+        workflow_title="Normi mõjuahel",
+        input_summary=P(f"Sisestasite: «{sisend}»"),  # noqa: F405
+        results_block=results_children,
+        evidence_block=_missing_row("—"),
+        actions=[
+            {"label": "Küsi nõustajalt", "href": "/chat/new"},
+            {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
+        ],
+        user=auth,
+        theme=theme,
+        scope_block=_normi_scope_block(sisend, scope),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/docs/impact/queries.py
+++ b/app/docs/impact/queries.py
@@ -46,10 +46,12 @@ from __future__ import annotations
 # #465/#476: every ``graph_uri`` value interpolated into a SPARQL
 # template must match the allowlist. The format mirrors the URIs we
 # generate server-side: ``https://data.riik.ee/ontology/estleg/drafts/
-# <uuid>``. #476 tightened this from a generic ``https?://...`` shape
-# to the exact production host + path so any future code path handing
-# us a user-supplied URI is rejected loudly rather than slipping
-# through on a lexical match.
+# <uuid>`` (and, since #722, the ephemeral ``…/estleg/adhoc/<uuid>``
+# graphs the Analüüsikeskus "Normi mõjuahel" workflow mints + deletes
+# per request). #476 tightened this from a generic ``https?://...``
+# shape to the exact production host + path so any future code path
+# handing us a user-supplied URI is rejected loudly rather than
+# slipping through on a lexical match.
 #
 # #479: the regex is deliberately strict about the characters we allow
 # in the path. We do NOT permit ``#`` (fragment) or ``?`` (query)

--- a/app/sync/jena_loader.py
+++ b/app/sync/jena_loader.py
@@ -39,12 +39,25 @@ JENA_ADMIN_PASSWORD = os.environ.get("FUSEKI_ADMIN_PASSWORD", "localdev")
 # #480: the same allowlist that ``app.docs.impact.queries`` uses for
 # SPARQL interpolation applies at the Graph Store Protocol layer too —
 # ``put_named_graph`` / ``delete_named_graph`` must reject any URI that
-# isn't one of our generated ``drafts/<uuid>`` shapes before the HTTP
-# request even goes out. Keeping the canonical definition here (and
-# re-exporting from ``app.docs.impact.queries``) means the validator
-# lives next to the GSP transport, which is conceptually where the
-# named-graph contract is enforced.
-_SAFE_GRAPH_URI = re.compile(r"^https://data\.riik\.ee/ontology/estleg/drafts/[0-9a-f-]{36}$")
+# isn't one of our generated ``drafts/<uuid>`` / ``adhoc/<uuid>`` shapes
+# before the HTTP request even goes out. Keeping the canonical definition
+# here (and re-exporting from ``app.docs.impact.queries``) means the
+# validator lives next to the GSP transport, which is conceptually where
+# the named-graph contract is enforced.
+#
+# #722 (epic #714): the Analüüsikeskus "Normi mõjuahel" workflow runs
+# the impact analyser against an *ephemeral* synthetic named graph it
+# mints per request (``…/estleg/adhoc/<uuid4>``) holding a single
+# ``estleg:references`` triple, then ``delete_named_graph``-s it in a
+# ``finally``. That graph URI must pass the same allowlist as a draft
+# graph, so the regex carries a ``(?:drafts|adhoc)`` alternation. Both
+# arms still require a literal 36-char UUID — user input never reaches
+# this regex (the UUID is server-generated), but the allowlist stays a
+# defence-in-depth guard against any future code path assembling a URI
+# from user-supplied data.
+_SAFE_GRAPH_URI = re.compile(
+    r"^https://data\.riik\.ee/ontology/estleg/(?:drafts|adhoc)/[0-9a-f-]{36}$"
+)
 
 
 def _validate_graph_uri(uri: str) -> str:

--- a/tests/test_analyysikeskus_input_parser.py
+++ b/tests/test_analyysikeskus_input_parser.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``app.analyysikeskus.input_parser`` (#722).
+
+``parse_user_reference`` is the adapter between the Analüüsikeskus
+"Normi mõjuahel" search box and :class:`ReferenceResolver`: it turns a
+free-text line into ``list[ExtractedRef]``. These tests pin the
+recognition rules — CELEX, §-references (with/without ``lg`` / ``p``),
+court case numbers, and "plain prose → empty".
+"""
+
+from __future__ import annotations
+
+from app.analyysikeskus.input_parser import parse_user_reference
+from app.docs.entity_extractor import ExtractedRef
+
+
+def _types(refs: list[ExtractedRef]) -> list[str]:
+    return [r.ref_type for r in refs]
+
+
+def _by_type(refs: list[ExtractedRef], ref_type: str) -> ExtractedRef:
+    matches = [r for r in refs if r.ref_type == ref_type]
+    assert matches, f"no {ref_type!r} ref in {refs!r}"
+    return matches[0]
+
+
+class TestCelex:
+    def test_bare_celex_regulation(self):
+        refs = parse_user_reference("32016R0679")
+        assert _types(refs) == ["eu_act"]
+        assert refs[0].ref_text == "32016R0679"
+        assert refs[0].confidence == 1.0
+
+    def test_bare_celex_directive(self):
+        refs = parse_user_reference("32019L0790")
+        assert _types(refs) == ["eu_act"]
+        assert refs[0].ref_text == "32019L0790"
+
+    def test_celex_embedded_in_phrase(self):
+        refs = parse_user_reference("GDPR (32016R0679)")
+        assert _types(refs) == ["eu_act"]
+        assert refs[0].ref_text == "32016R0679"
+
+    def test_celex_is_case_insensitive(self):
+        refs = parse_user_reference("32016r0679")
+        assert _types(refs) == ["eu_act"]
+
+
+class TestSectionReference:
+    def test_simple_section(self):
+        refs = parse_user_reference("AvTS § 35")
+        # provision first, then the law short name.
+        assert _types(refs) == ["provision", "law"]
+        prov = _by_type(refs, "provision")
+        assert "AvTS" in prov.ref_text and "§ 35" in prov.ref_text
+        law = _by_type(refs, "law")
+        assert law.ref_text == "AvTS"
+
+    def test_section_with_lg_and_p(self):
+        refs = parse_user_reference("KarS § 133 lg 2 p 1")
+        assert _types(refs) == ["provision", "law"]
+        prov = _by_type(refs, "provision")
+        assert prov.ref_text == "KarS § 133 lg 2 p 1"
+        assert _by_type(refs, "law").ref_text == "KarS"
+
+    def test_section_with_only_lg(self):
+        refs = parse_user_reference("TsÜS § 12 lg 3")
+        prov = _by_type(refs, "provision")
+        assert prov.ref_text == "TsÜS § 12 lg 3"
+        assert _by_type(refs, "law").ref_text == "TsÜS"
+
+    def test_section_tight_spacing_is_normalised(self):
+        refs = parse_user_reference("AvTS §35 lg2 p1")
+        prov = _by_type(refs, "provision")
+        # Re-spelled to the canonical "Law § N lg N p N" form.
+        assert prov.ref_text == "AvTS § 35 lg 2 p 1"
+
+    def test_section_keyword_case_insensitive(self):
+        refs = parse_user_reference("KOKS § 6 LG 1 P 2")
+        prov = _by_type(refs, "provision")
+        assert prov.ref_text == "KOKS § 6 lg 1 p 2"
+        assert _by_type(refs, "law").ref_text == "KOKS"
+
+
+class TestCourtCaseNumber:
+    def test_estonian_supreme_court_number(self):
+        refs = parse_user_reference("3-1-1-63-15")
+        assert _types(refs) == ["court_decision"]
+        assert refs[0].ref_text == "3-1-1-63-15"
+
+    def test_estonian_three_group_number(self):
+        refs = parse_user_reference("5-19-1-2")
+        assert _types(refs) == ["court_decision"]
+
+    def test_cjeu_case_number(self):
+        refs = parse_user_reference("C-131/12")
+        assert _types(refs) == ["court_decision"]
+        assert refs[0].ref_text == "C-131/12"
+
+    def test_general_court_case_number(self):
+        refs = parse_user_reference("T-99/04")
+        assert _types(refs) == ["court_decision"]
+
+
+class TestPlainProse:
+    def test_plain_prose_returns_empty(self):
+        assert parse_user_reference("mingi suvaline jutt") == []
+
+    def test_descriptive_intent_returns_empty(self):
+        assert parse_user_reference("Soovin muuta avaliku teabe kättesaadavust") == []
+
+    def test_blank_input_returns_empty(self):
+        assert parse_user_reference("") == []
+        assert parse_user_reference("   ") == []
+        assert parse_user_reference("\t\n") == []
+
+    def test_law_name_alone_without_section_returns_empty(self):
+        # A bare law abbreviation with no "§" is too ambiguous — the
+        # parser is conservative and returns nothing (the route then
+        # surfaces the "no structured ref" branch).
+        assert parse_user_reference("karistusseadustik") == []

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -1,9 +1,17 @@
-"""Tests for the Analüüsikeskus routes (#714 — #720 directory, #721 result shell).
+"""Tests for the Analüüsikeskus routes (#714 — #720 directory, #721 result shell,
+#722 Normi mõjuahel).
 
 Follows the auth-mocking pattern from ``tests/test_chat_routes.py``: the
 ``app.main.app`` is exercised end-to-end via ``TestClient`` so the
 FastHTML wiring + the ``auth_before`` Beforeware are validated; the
 DB-touching ``_get_recent_analyses`` helper is patched out.
+
+The #722 tests mock the SPARQL/Jena layer entirely: ``put_named_graph`` /
+``delete_named_graph`` (the ephemeral-graph transport),
+``ImpactAnalyzer.analyze`` (canned :class:`ImpactFindings`),
+``ReferenceResolver.resolve`` (canned :class:`ResolvedRef`), the
+owned-draft-report lookup, and the RAG retriever — all patched
+*where used* (the patch-path contract).
 """
 
 from __future__ import annotations
@@ -28,15 +36,96 @@ def _stub_provider() -> MagicMock:
     return provider
 
 
-def _authed_client():
+def _authed_client(*, raise_server_exceptions: bool = True):
     from starlette.testclient import TestClient
 
     client = TestClient(
         __import__("app.main", fromlist=["app"]).app,
         follow_redirects=False,
+        raise_server_exceptions=raise_server_exceptions,
     )
     client.cookies.set("access_token", "stub-token")
     return client
+
+
+# ---------------------------------------------------------------------------
+# #722 — shared fixtures: canned ImpactFindings + ResolvedRef
+# ---------------------------------------------------------------------------
+
+# The ``estleg:`` URI deliberately contains a ``#`` so the test can
+# assert ``explorer_focus_url`` percent-encodes it to ``%23`` in the
+# result-page links.
+_AVTS_URI = "https://data.riik.ee/ontology/estleg#AvTS-p35"
+_OTHER_DRAFT_URI = (
+    "https://data.riik.ee/ontology/estleg/drafts/abcdef01-2345-6789-abcd-ef0123456789"
+)
+_COURT_URI = "https://data.riik.ee/ontology/estleg#RKHKo-3-1-1-63-15"
+_EU_ACT_URI = "https://data.riik.ee/ontology/estleg#EU-32016R0679"
+
+
+def _canned_findings():
+    from app.docs.impact.analyzer import ImpactFindings
+
+    affected = [
+        {
+            "uri": _AVTS_URI,
+            "label": "AvTS § 35",
+            "type": "https://data.riik.ee/ontology/estleg#Provision",
+        },
+        {
+            "uri": _OTHER_DRAFT_URI,
+            "label": "Teine eelnõu",
+            "type": "https://data.riik.ee/ontology/estleg#DraftLegislation",
+        },
+        {
+            "uri": _COURT_URI,
+            "label": "RKHKo 3-1-1-63-15",
+            "type": "https://data.riik.ee/ontology/estleg#CourtDecision",
+        },
+    ]
+    conflicts = [
+        {
+            "draft_ref": _AVTS_URI,
+            "conflicting_entity": _OTHER_DRAFT_URI,
+            "conflicting_label": "Teine eelnõu",
+            "reason": "Teine eelnõu viitab juba sellele sättele",
+        },
+    ]
+    eu_compliance = [
+        {
+            "eu_act": _EU_ACT_URI,
+            "eu_label": "GDPR",
+            "estonian_provision": _AVTS_URI,
+            "provision_label": "AvTS § 35",
+            "transposition_status": "linked",
+        },
+    ]
+    return ImpactFindings(
+        affected_entities=affected,
+        conflicts=conflicts,
+        gaps=[],
+        eu_compliance=eu_compliance,
+        affected_count=len(affected),
+        conflict_count=len(conflicts),
+        gap_count=0,
+    )
+
+
+def _canned_resolved_ref(entity_uri: str = _AVTS_URI):
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    return ResolvedRef(
+        extracted=ExtractedRef(
+            ref_text="AvTS § 35",
+            ref_type="provision",
+            confidence=1.0,
+            location={"source": "analyysikeskus_input"},
+        ),
+        entity_uri=entity_uri,
+        matched_label="AvTS § 35 — Avaliku teabe seadus",
+        match_score=1.0,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -94,34 +183,205 @@ def test_analyysikeskus_directory_renders(mock_provider: MagicMock, mock_recent:
 
 
 # ---------------------------------------------------------------------------
-# #721 / #722 — Normi mõjuahel stub result shell
+# #722 — Normi mõjuahel: resolved-reference happy path
 # ---------------------------------------------------------------------------
 
 
 @patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.adhoc_analysis.delete_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.ImpactAnalyzer")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
 @patch("app.auth.middleware._get_provider")
-def test_normi_mojuahel_stub_renders_result_shell(
-    mock_provider: MagicMock, mock_recent: MagicMock
+def test_normi_mojuahel_resolved_renders_full_result(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_analyzer_cls: MagicMock,
+    mock_put: MagicMock,
+    mock_delete: MagicMock,
+    mock_recent: MagicMock,
 ):
     mock_provider.return_value = _stub_provider()
+    mock_resolve.return_value = [_canned_resolved_ref()]
+    mock_analyzer_cls.return_value.analyze.return_value = _canned_findings()
+
     client = _authed_client()
     # "AvTS § 35" url-encoded.
     resp = client.get("/analyysikeskus/normi-mojuahel?sisend=AvTS+%C2%A7+35")
     assert resp.status_code == 200
     body = resp.text
+
     assert "Normi mõjuahel" in body
-    # All five Core-UI-Pattern block headings, in order.
+    # All five Core-UI-Pattern block headings (the result shell).
     for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
         assert heading in body, heading
-    # The echoed input.
-    assert "AvTS § 35" in body
-    # The "Tulemused" block carries the koostamisel/tulekul placeholder.
-    assert "koostamisel" in body or "tulekul" in body
-    # The static action set.
+    # All five Tulemused sub-headings.
+    for sub in (
+        "Peamised mõjud",
+        "Kõrge riskiga seosed",
+        "Seotud eelnõud",
+        "Riigikohtu praktika",
+        "EL seosed",
+    ):
+        assert sub in body, sub
+    # The resolved entity's label in the Sisend block.
+    assert "AvTS § 35 — Avaliku teabe seadus" in body
+    # A Tõendid row references the analysed entity.
+    assert "Tõendid" in body
+    assert "on seotud üksusega" in body
+    # "Ava õiguskaardil" link with the focus param %23-encoded (the
+    # estleg: URI's "#" must survive into the query string).
+    assert "/explorer?focus=" in body
+    assert "%23" in body
+    # "Küsi nõustajalt" → /chat/new.
     assert "Küsi nõustajalt" in body
     assert "/chat/new" in body
-    # Back-link near the top.
-    assert "← Analüüsikeskus" in body
+    # The enabled scope form — its submit must NOT be disabled (the
+    # result shell's default disabled "Tulekul" stub button is replaced
+    # here by the workflow's own enabled scope form).
+    assert 'class="btn btn-secondary btn-sm">Uuenda ulatust</button>' in body
+    # The synthetic graph was minted and torn down.
+    mock_put.assert_called_once()
+    mock_delete.assert_called_once()
+    # The PUT and DELETE target the SAME ephemeral adhoc graph URI.
+    put_uri = mock_put.call_args.args[0]
+    del_uri = mock_delete.call_args.args[0]
+    assert put_uri == del_uri
+    assert "/estleg/adhoc/" in put_uri
+    # An ad-hoc result must NOT offer "Lisa märkus" (no draft-version flow).
+    assert "Lisa märkus" not in body
+
+
+# ---------------------------------------------------------------------------
+# #722 — the ephemeral graph is deleted even when rendering raises mid-way
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.adhoc_analysis.delete_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.ImpactAnalyzer")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_normi_mojuahel_deletes_graph_even_on_render_error(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_analyzer_cls: MagicMock,
+    mock_put: MagicMock,
+    mock_delete: MagicMock,
+    mock_recent: MagicMock,
+):
+    mock_provider.return_value = _stub_provider()
+    mock_resolve.return_value = [_canned_resolved_ref()]
+    mock_analyzer_cls.return_value.analyze.return_value = _canned_findings()
+
+    # Make the result-page assembly blow up *after* the analysis (and
+    # thus after run_adhoc_impact_analysis's finally deleted the graph).
+    with patch(
+        "app.analyysikeskus.routes._build_results_block",
+        side_effect=RuntimeError("boom while rendering"),
+    ):
+        client = _authed_client(raise_server_exceptions=False)
+        resp = client.get("/analyysikeskus/normi-mojuahel?sisend=AvTS+%C2%A7+35")
+        assert resp.status_code == 500
+
+    # The ephemeral graph must still have been deleted.
+    mock_delete.assert_called_once()
+    put_uri = mock_put.call_args.args[0]
+    del_uri = mock_delete.call_args.args[0]
+    assert put_uri == del_uri
+    assert "/estleg/adhoc/" in del_uri
+
+
+# ---------------------------------------------------------------------------
+# #722 — no structured reference recognised
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.routes._rag_candidates", return_value=[])
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=True)
+@patch("app.auth.middleware._get_provider")
+def test_normi_mojuahel_unresolved_input_shows_warning(
+    mock_provider: MagicMock,
+    mock_put: MagicMock,
+    mock_rag: MagicMock,
+    mock_recent: MagicMock,
+):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/normi-mojuahel?sisend=mingi+suvaline+jutt")
+    assert resp.status_code == 200
+    body = resp.text
+    # The friendly "no structured reference" warning.
+    assert "Ei tuvastanud õiguslikku viidet" in body
+    # Still a full result shell.
+    for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
+        assert heading in body, heading
+    # No synthetic graph was minted for an unrecognised input.
+    mock_put.assert_not_called()
+    # The scope form is still rendered (enabled).
+    assert "Uuenda ulatust" in body
+
+
+# ---------------------------------------------------------------------------
+# #722 — owned-draft UUID short-circuits to the persisted impact_reports row
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=True)
+@patch("app.analyysikeskus.routes._load_owned_draft_report")
+@patch("app.auth.middleware._get_provider")
+def test_normi_mojuahel_draft_uuid_reuses_impact_report(
+    mock_provider: MagicMock,
+    mock_load_report: MagicMock,
+    mock_put: MagicMock,
+    mock_recent: MagicMock,
+):
+    import json
+
+    mock_provider.return_value = _stub_provider()
+    draft_id = "11111111-2222-3333-4444-555555555555"
+    findings = _canned_findings()
+    report_data = {
+        "affected_entities": findings.affected_entities,
+        "conflicts": findings.conflicts,
+        "gaps": [],
+        "eu_compliance": findings.eu_compliance,
+        "affected_count": findings.affected_count,
+        "conflict_count": findings.conflict_count,
+        "gap_count": 0,
+    }
+    # (draft_id, draft_title, draft_version_id, report_data, impact_score)
+    mock_load_report.return_value = (
+        draft_id,
+        "Minu eelnõu pealkiri",
+        "ver-1",
+        json.dumps(report_data),
+        42,
+    )
+
+    client = _authed_client()
+    resp = client.get(f"/analyysikeskus/normi-mojuahel?sisend={draft_id}")
+    assert resp.status_code == 200
+    body = resp.text
+    # The draft title shows in the Sisend block.
+    assert "Minu eelnõu pealkiri" in body
+    # The draft-backed path enables "Lisa märkus" → /drafts/{id}/report.
+    assert "Lisa märkus" in body
+    assert f"/drafts/{draft_id}/report" in body
+    # All five Tulemused sub-headings still render.
+    for sub in (
+        "Peamised mõjud",
+        "Kõrge riskiga seosed",
+        "Seotud eelnõud",
+        "Riigikohtu praktika",
+        "EL seosed",
+    ):
+        assert sub in body, sub
+    # No ephemeral synthetic graph for the draft-backed path.
+    mock_put.assert_not_called()
 
 
 def test_normi_mojuahel_blank_input_redirects():
@@ -131,6 +391,84 @@ def test_normi_mojuahel_blank_input_redirects():
         resp = client.get("/analyysikeskus/normi-mojuahel")
         assert resp.status_code == 303
         assert resp.headers["location"] == "/analyysikeskus"
+
+
+# ---------------------------------------------------------------------------
+# #722 — run_adhoc_impact_analysis: lifecycle of the ephemeral graph
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.adhoc_analysis.delete_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.ImpactAnalyzer")
+def test_run_adhoc_impact_analysis_happy_path(
+    mock_analyzer_cls: MagicMock, mock_put: MagicMock, mock_delete: MagicMock
+):
+    from app.analyysikeskus.adhoc_analysis import run_adhoc_impact_analysis
+
+    mock_analyzer_cls.return_value.analyze.return_value = _canned_findings()
+    result = run_adhoc_impact_analysis(_AVTS_URI)
+
+    # Findings + a score came back.
+    assert result.findings.affected_count == 3
+    assert result.score > 0
+    # The graph was minted, PUT, analysed, and deleted — same URI throughout.
+    mock_put.assert_called_once()
+    mock_delete.assert_called_once()
+    put_uri = mock_put.call_args.args[0]
+    assert put_uri == result.graph_uri == mock_delete.call_args.args[0]
+    assert "/estleg/adhoc/" in put_uri
+    # The analyzer ran against the minted graph.
+    mock_analyzer_cls.return_value.analyze.assert_called_once_with(put_uri)
+
+
+@patch("app.analyysikeskus.adhoc_analysis.delete_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.ImpactAnalyzer")
+def test_run_adhoc_impact_analysis_deletes_graph_when_analyze_raises(
+    mock_analyzer_cls: MagicMock, mock_put: MagicMock, mock_delete: MagicMock
+):
+    from app.analyysikeskus.adhoc_analysis import run_adhoc_impact_analysis
+
+    mock_analyzer_cls.return_value.analyze.side_effect = RuntimeError("jena exploded")
+    result = run_adhoc_impact_analysis(_AVTS_URI)
+
+    # Degrades to empty findings (no 500), and the graph is still deleted.
+    assert result.findings.affected_count == 0
+    assert result.score == 0
+    mock_delete.assert_called_once()
+    assert mock_delete.call_args.args[0] == mock_put.call_args.args[0]
+
+
+@patch("app.analyysikeskus.adhoc_analysis.delete_named_graph", return_value=True)
+@patch("app.analyysikeskus.adhoc_analysis.put_named_graph", return_value=False)
+@patch("app.analyysikeskus.adhoc_analysis.ImpactAnalyzer")
+def test_run_adhoc_impact_analysis_deletes_graph_when_put_fails(
+    mock_analyzer_cls: MagicMock, mock_put: MagicMock, mock_delete: MagicMock
+):
+    from app.analyysikeskus.adhoc_analysis import run_adhoc_impact_analysis
+
+    result = run_adhoc_impact_analysis(_AVTS_URI)
+
+    # PUT failed → empty findings, analyzer never ran, graph still deleted.
+    assert result.findings.affected_count == 0
+    mock_analyzer_cls.return_value.analyze.assert_not_called()
+    mock_delete.assert_called_once()
+
+
+def test_run_adhoc_impact_analysis_blank_uri_short_circuits():
+    from app.analyysikeskus.adhoc_analysis import run_adhoc_impact_analysis
+
+    # An empty entity URI must not touch Jena at all.
+    with (
+        patch("app.analyysikeskus.adhoc_analysis.put_named_graph") as mock_put,
+        patch("app.analyysikeskus.adhoc_analysis.delete_named_graph") as mock_delete,
+    ):
+        result = run_adhoc_impact_analysis("")
+        assert result.findings.affected_count == 0
+        assert result.graph_uri == ""
+        mock_put.assert_not_called()
+        mock_delete.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +506,7 @@ def test_result_shell_empty_list_block_renders_fallback():
         results_block=[],  # an empty findings list must NOT render as "[]"
         evidence_block=[],
         actions=[{"label": "Tagasi", "href": "/analyysikeskus"}],
-        user={"id": "u-1", "email": "u@x.ee", "full_name": "U", "role": "drafter", "org_id": None},
+        user=None,
     )
     html = to_xml(page)
     assert "Tulemusi ei leitud." in html
@@ -187,7 +525,7 @@ def test_result_shell_nonempty_list_block_renders_all_items():
         results_block=[P("Leid üks"), P("Leid kaks")],
         evidence_block=P("Tõend"),
         actions=[{"label": "Tagasi", "href": "/analyysikeskus"}],
-        user={"id": "u-1", "email": "u@x.ee", "full_name": "U", "role": "drafter", "org_id": None},
+        user=None,
     )
     html = to_xml(page)
     assert "Leid üks" in html

--- a/tests/test_sync_jena_loader_named_graphs.py
+++ b/tests/test_sync_jena_loader_named_graphs.py
@@ -133,6 +133,59 @@ class TestGraphUriValidation:
             jena_loader.delete_named_graph("not a uri at all")
         mock_delete.assert_not_called()
 
+    # --- #722 (epic #714): the allowlist widening to ``adhoc/<uuid>`` -------
+    #
+    # The Analüüsikeskus "Normi mõjuahel" workflow mints an ephemeral
+    # ``…/estleg/adhoc/<uuid4>`` graph, PUTs one ``estleg:references``
+    # triple into it, runs the impact analyser, then deletes it. That
+    # graph URI must pass ``_validate_graph_uri`` — but a ``urn:…`` /
+    # arbitrary URI must still raise.
+
+    _ADHOC_URI = "https://data.riik.ee/ontology/estleg/adhoc/22222222-2222-2222-2222-222222222222"
+
+    def test_validate_accepts_adhoc_uri(self):
+        """An ``adhoc/<uuid>`` URI must pass ``_validate_graph_uri`` unchanged."""
+        assert jena_loader._validate_graph_uri(self._ADHOC_URI) == self._ADHOC_URI
+        # And the regex itself fullmatches it.
+        assert jena_loader._SAFE_GRAPH_URI.fullmatch(self._ADHOC_URI)
+
+    def test_validate_still_accepts_drafts_uri(self):
+        """The pre-existing ``drafts/<uuid>`` arm must keep working."""
+        assert jena_loader._validate_graph_uri(_GRAPH_URI) == _GRAPH_URI
+
+    def test_validate_rejects_urn_uri(self):
+        """A ``urn:…`` URI is outside both arms and must raise ``ValueError``."""
+        with pytest.raises(ValueError, match="Unsafe graph URI"):
+            jena_loader._validate_graph_uri("urn:estleg:adhoc:not-a-uuid")
+
+    def test_validate_rejects_arbitrary_uri(self):
+        """An arbitrary HTTPS URI that isn't a drafts/adhoc graph must raise."""
+        with pytest.raises(ValueError, match="Unsafe graph URI"):
+            jena_loader._validate_graph_uri("https://example.com/whatever/123")
+        # A near-miss (right host + path prefix, but a non-UUID tail) too.
+        with pytest.raises(ValueError, match="Unsafe graph URI"):
+            jena_loader._validate_graph_uri(
+                "https://data.riik.ee/ontology/estleg/adhoc/not-a-uuid"
+            )
+
+    @patch("app.sync.jena_loader.httpx.put")
+    def test_put_accepts_adhoc_uri(self, mock_put: MagicMock):
+        """``put_named_graph`` must accept an ``adhoc/<uuid>`` graph (it reaches httpx)."""
+        response = MagicMock()
+        response.status_code = 204
+        mock_put.return_value = response
+        assert jena_loader.put_named_graph(self._ADHOC_URI, "# turtle") is True
+        mock_put.assert_called_once()
+
+    @patch("app.sync.jena_loader.httpx.delete")
+    def test_delete_accepts_adhoc_uri(self, mock_delete: MagicMock):
+        """``delete_named_graph`` must accept an ``adhoc/<uuid>`` graph."""
+        response = MagicMock()
+        response.status_code = 204
+        mock_delete.return_value = response
+        assert jena_loader.delete_named_graph(self._ADHOC_URI) is True
+        mock_delete.assert_called_once()
+
     def test_validator_re_exported_from_queries(self):
         """#480: ``app.docs.impact.queries`` must re-export the validator.
 


### PR DESCRIPTION
Implements **#722** — the `Normi mõjuahel` impact-chain workflow — per the design note ([#722 comment](https://github.com/henrikaavik/Seadusloome/issues/722#issuecomment-4422232001)). **Also fixes `main`'s red CI** (a pyright error introduced by #731's `test_result_shell_*` helpers).

## #722 — `Normi mõjuahel`
- **Input parser** (`app/analyysikeskus/input_parser.py`) — `parse_user_reference(sisend)` recognises CELEX numbers, `<LawShortName> § N [lg N] [p N]` references, and Estonian/CJEU court case numbers from the free-text box → `list[ExtractedRef]` for `ReferenceResolver`; plain prose → empty list.
- **Synthetic ephemeral graph** (`app/analyysikeskus/adhoc_analysis.py`) — `run_adhoc_impact_analysis(entity_uri)` mints a `…/estleg/adhoc/<uuid4>` graph, writes one `estleg:references` triple, runs `ImpactAnalyzer.analyze` + `calculate_impact_score`, and **always `delete_named_graph()`s in a `finally`** (covered by a test where rendering raises mid-way).
- **Allowlist** — `_SAFE_GRAPH_URI` in `app/sync/jena_loader.py` widened to `^…/estleg/(?:drafts|adhoc)/[0-9a-f-]{36}$` (re-exported by `queries.py`, so the SPARQL builders pick it up). New tests: `adhoc/<uuid>` accepted, `urn:…`/arbitrary/near-miss rejected, PUT/DELETE accept `adhoc`.
- **Route** — `GET /analyysikeskus/normi-mojuahel?sisend=…`: a UUID → reuse the draft's `impact_reports` row (`Lisa märkus` enabled, `Ava õiguskaardil` → `/explorer?draft=…`); a structured ref → resolve + run the ad-hoc analysis → render the `analysis_result_shell` with `Tulemused` = `Peamised mõjud` / `Kõrge riskiga seosed` / `Seotud eelnõud` / `Riigikohtu praktika` / `EL seosed` + a risk-band `Badge` (`Väike mõju` / `Vajab kontrolli` / `Kõrge risk` via `scoring.impact_band`) + a templated recommendation, and `Tõendid` = a row per finding (relation in legal language, `Ava allikas` / `Ava õiguskaardil →` via `explorer_focus_url`, a "miks see on oluline" line); no structured ref → a friendly "Ei tuvastanud õiguslikku viidet…" `Alert` + (if RAG is wired) up to 5 clickable candidate suggestions. Blank input → 303 to `/analyysikeskus`.
- **Scope controls** wired to what has data: "Kaasa EL õigus" off → drop the EU-compliance rows; "Kaasa kohtupraktika" off → filter court-decision rows; "Kogu org eelnõud" → reframes the `Seotud eelnõud` block; temporal-redactions + KOV stay disabled/"tulekul". Scope params carried through the result-page links. No SPARQL/RDF/named-graph language anywhere; `Soovitatud tegevused` is a static action set (no LLM — that's the deferred Phase D).

## CI fix
#731 added two `test_result_shell_*` helpers that pass a plain dict where `analysis_result_shell`'s `user: UserDict | None` is expected — pyright (CI's "Type check" step) flags this, so `main` went red on the #731 merge. Fixed: those two helpers now pass `user=None` (the result-shell content they assert on doesn't depend on the sidebar). `uv run pyright` is clean repo-wide again.

## Tests
`tests/test_analyysikeskus_input_parser.py` (17 unit tests); additions to `tests/test_analyysikeskus_routes.py` (resolved path → full result page; render-error still deletes the graph; unresolved input → warning; draft-UUID → reuses `impact_reports` + `Lisa märkus`; + `run_adhoc_impact_analysis` unit tests); 6 new `_SAFE_GRAPH_URI` tests in `tests/test_sync_jena_loader_named_graphs.py`. Full suite: `2234 passed, 23 skipped`. `ruff` + `pyright` clean.

> Note: `app/analyysikeskus/routes.py` is now ~1.5k lines; once #723 lands it should be split into a `routes/` package (like `app/docs/routes/`). Tracked as a follow-up.

Refs #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)