### PR TITLE
feat(ui): #746 — land on Töölaud; Õiguskaart wears the standard chrome (full_bleed PageShell)

### DIFF
--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -1,4 +1,16 @@
-"""Explorer page — serves the full-page D3.js ontology graph explorer."""
+"""Õiguskaart page — the D3.js ontology graph, wearing the standard app chrome.
+
+Issue #746 (design rationale: ``docs/2026-05-12-ui-plan-explorer-home.html``
+and ``docs/2026-05-11-ministry-lawyer-ui-structure.md``): the explorer no
+longer ships its own bespoke ``<html>`` document with a custom topbar and a
+left rail that mixes graph controls with site navigation. It is rendered
+inside :func:`app.ui.layout.PageShell` with ``full_bleed=True`` — the
+standard sidebar (with "Õiguskaart" highlighted) + topbar + user menu, and
+the D3 canvas filling the content area. The former control rail becomes a
+thin horizontal **toolbar** across the top of the canvas; the search box
+moves into it. The D3 v7 CDN ``<script>`` (~270 KB) and ``explorer.css`` are
+pushed into ``<head>`` via ``extra_head=`` so they load on this page only.
+"""
 
 from __future__ import annotations
 
@@ -16,6 +28,7 @@ from app.db import get_connection as _connect
 
 # Re-import our design-system Button after the wildcard so the symbol does
 # not silently fall back to FastHTML's unstyled Button (#419).
+from app.ui.layout import PageShell
 from app.ui.primitives.button import Button  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -159,8 +172,232 @@ def _fetch_draft_overlay(req: Request, draft_id_raw: str) -> list[str]:
     return uris
 
 
+# ---------------------------------------------------------------------------
+# <head> resources — D3 v7 CDN + the explorer stylesheet. Kept off the global
+# ``_HDRS`` in app/main.py: D3 is ~270 KB and only the Õiguskaart page uses
+# it, and explorer.css only styles this page's overlays.
+# ---------------------------------------------------------------------------
+_EXPLORER_HEAD: list = [
+    Script(
+        src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js",
+        integrity=(
+            "sha512-vc58qvvBdrDR4etbxMdlTt4GBQk1qjvyORR2nrsPsFPyrs+/u5c3+1Ct6upOgdZoIl7eq6k3a1UPDSNAQi/32A=="
+        ),
+        crossorigin="anonymous",
+    ),
+    Link(rel="stylesheet", href="/static/css/explorer.css"),
+]
+
+# Auto-hide the (dismissed-once) draft-tip banner — reads the localStorage
+# flag the toolbar's "×" button sets and removes the element on next load.
+_TIP_AUTOHIDE_SCRIPT = (
+    "(function(){"
+    "if(localStorage.getItem('explorer-tip-dismissed')){"
+    "var t=document.getElementById('explorer-tip-banner');"
+    "if(t)t.remove();"
+    "}"
+    "})();"
+)
+
+# Tiny inline init for the ?draft= overlay: read the JSON blob, build a Set
+# of URIs, and apply the highlight class to any node whose datum.uri /
+# datum.id is in the set. Runs every 500ms so nodes that arrive after the
+# first render via lazy-loading still get highlighted (#446 / Phase 2).
+_DRAFT_OVERLAY_INIT_SCRIPT = (
+    "(function(){"
+    "var el=document.getElementById('draft-overlay-data');"
+    "if(!el){return;}"
+    "var data;try{data=JSON.parse(el.textContent||'{}');}catch(e){return;}"
+    "var uris=new Set((data&&data.uris)||[]);"
+    "if(!uris.size){return;}"
+    "function apply(){"
+    "if(typeof d3==='undefined'){return;}"
+    "d3.selectAll('g.node').each(function(d){"
+    "if(!d){return;}"
+    "var key=d.uri||d.id;"
+    "var hit=uris.has(key);"
+    "d3.select(this).classed('d3-node-highlighted',hit);"
+    "d3.select(this).select('circle.outer').classed('d3-node-highlighted',hit);"
+    "});"
+    "}"
+    "var overlayInterval=setInterval(apply,500);"
+    "apply();"
+    "if(typeof htmx!=='undefined'){"
+    "htmx.on('htmx:beforeSwap',function(){clearInterval(overlayInterval);});"
+    "}"
+    "})();"
+)
+
+# Detail-panel annotation button wiring. When explorerShowDetail() sets
+# #panel-title, this MutationObserver injects an AnnotationButton (+ its
+# popover container) into #panel-annotation-btn via HTMX — keeping
+# explorer.js itself untouched. Built with DOM methods (no innerHTML);
+# hx-get defaults its swap to innerHTML so no hx-swap attribute is needed.
+_PANEL_ANNOTATION_SCRIPT = (
+    "(function(){"
+    "var panelBtn=document.getElementById('panel-annotation-btn');"
+    "var panelTitle=document.getElementById('panel-title');"
+    "if(!panelBtn||!panelTitle){return;}"
+    "var obs=new MutationObserver(function(){"
+    "var uri=panelTitle.dataset.entityUri||panelTitle.textContent.trim();"
+    "if(!uri){panelBtn.style.display='none';return;}"
+    "var safeId=encodeURIComponent(uri).replace(/'/g,'%27');"
+    "while(panelBtn.firstChild){panelBtn.removeChild(panelBtn.firstChild);}"
+    "var wrap=document.createElement('div');"
+    "wrap.className='annotation-button-wrapper';"
+    "var btn=document.createElement('button');"
+    "btn.type='button';btn.className='annotation-button';"
+    "btn.setAttribute('hx-get','/api/annotations?target_type=entity&target_id='+safeId);"
+    "btn.setAttribute('hx-target','#annotation-popover-entity-'+safeId);"
+    "btn.setAttribute('aria-label','Markused');"
+    "btn.setAttribute('title','Markused');"
+    "btn.textContent='\\uD83D\\uDCAC';"
+    "var pop=document.createElement('div');"
+    "pop.id='annotation-popover-entity-'+safeId;"
+    "pop.className='annotation-popover-container';"
+    "wrap.appendChild(btn);wrap.appendChild(pop);"
+    "panelBtn.appendChild(wrap);"
+    "panelBtn.style.display='block';"
+    "if(typeof htmx!=='undefined'){htmx.process(panelBtn);}"
+    "});"
+    "obs.observe(panelTitle,{childList:true,characterData:true,subtree:true});"
+    "})();"
+)
+
+
+def _escape_for_script(payload: str) -> str:
+    """Escape a JSON string so it is safe to embed inside a ``<script>``.
+
+    ``</`` would otherwise terminate the script element early; the
+    line-separator characters U+2028 / U+2029 are valid inside JSON strings
+    but break JavaScript string literals in older parsers, so they are
+    rewritten to their ``\\u`` escapes. JSON natively decodes ``<\\/`` back
+    to ``</`` so ``json.loads`` still works on the rendered payload (#464).
+    """
+    return payload.replace("</", "<\\/").replace(" ", "\\u2028").replace(" ", "\\u2029")
+
+
+def _explorer_toolbar(*, has_back_context: bool, draft_tip: bool):  # noqa: ANN202
+    """The thin horizontal graph toolbar across the top of the canvas.
+
+    Holds the legal-work view actions (``Ülevaade`` / ``Lähtesta vaade``),
+    the ``Vaate seaded`` disclosure (technical layout controls), the search
+    input + ``Otsi`` button (moved here from the deleted bespoke topbar),
+    and — when the page was opened from a report/analysis — a "← Tagasi
+    aruandesse" link. explorer.js wires the ``onclick`` handlers and unhides
+    the panel back link based on ``document.referrer``.
+    """
+    items: list = [
+        # A small page-identity label — the highlighted sidebar item and
+        # the browser tab title carry the rest. Compact, per the wireframe.
+        Span("Õiguskaart", cls="toolbar-title"),
+        Button(
+            "Ülevaade",
+            type="button",
+            cls="ctrl-btn",
+            onclick="explorerCollapseToOverview()",
+            title="Näita kõigi liikide ülevaadet",
+        ),
+        Button(
+            "Lähtesta vaade",
+            type="button",
+            cls="ctrl-btn",
+            onclick="explorerResetView()",
+            title="Lähtesta suum ja valik",
+        ),
+        # Technical layout controls behind a disclosure so the toolbar
+        # reads in legal-work language, not force-simulation jargon
+        # (#714 / #718). The menu drops down (position: absolute) so it
+        # doesn't change the toolbar's height.
+        Details(
+            Summary("Vaate seaded ▾", cls="ctrl-btn ctrl-settings-summary"),
+            Div(
+                Button(
+                    "Lähtesta paigutus",
+                    type="button",
+                    cls="ctrl-btn",
+                    onclick="explorerReheat()",
+                    title="Arvuta sõlmpunktide paigutus uuesti",
+                ),
+                Button(
+                    "Näita/peida seosenimed",
+                    type="button",
+                    cls="ctrl-btn",
+                    onclick="explorerToggleLabels()",
+                ),
+                Button(
+                    "Rühmita liigi järgi",
+                    type="button",
+                    cls="ctrl-btn",
+                    onclick="explorerGroupByCategory()",
+                ),
+                cls="ctrl-settings-menu",
+            ),
+            cls="ctrl-settings",
+        ),
+        # Search — moved out of the deleted #topbar into the toolbar.
+        Div(
+            Input(
+                id="search-input",
+                type="text",
+                placeholder="Otsi seadust, eelnõu, lahendit…",
+                aria_label="Otsi seadusi, eelnõusid, lahendeid",
+            ),
+            Button(
+                "Otsi",
+                type="button",
+                id="search-btn",
+                onclick="explorerSearch()",
+            ),
+            id="search-box",
+        ),
+    ]
+    if has_back_context:
+        # explorer.js rewrites the label ("← Tagasi aruandesse" /
+        # "← Tagasi analüüsi") from document.referrer; this toolbar anchor
+        # is the counterpart of the detail panel's #panel-back link.
+        items.append(
+            A(
+                "← Tagasi aruandesse",
+                id="toolbar-back",
+                href="#",
+                cls="toolbar-back",
+            )
+        )
+    if draft_tip:
+        # Surfaced only on a "cold" open (no ?focus / ?draft / overlay) —
+        # a small dismissible hint that ?draft=ID overlays a draft's
+        # affected entities. localStorage remembers the dismissal.
+        items.append(
+            Span(
+                Span(
+                    "Näpunäide: lisage ?draft=ID URL-ile, et näha eelnõu "
+                    "mõjutatud üksusi graafikul.",
+                    cls="toolbar-tip-text",
+                ),
+                Button(
+                    "×",
+                    type="button",
+                    cls="toolbar-tip-dismiss",
+                    aria_label="Sulge",
+                    onclick=(
+                        "localStorage.setItem('explorer-tip-dismissed','1');"
+                        "this.parentElement.remove()"
+                    ),
+                ),
+                id="explorer-tip-banner",
+                cls="toolbar-tip",
+            )
+        )
+    return Nav(
+        *items,
+        id="explorer-toolbar",
+        aria_label="Õiguskaardi tööriistad",
+    )
+
+
 def explorer_page(req: Request):
-    """GET /explorer -- full-screen interactive ontology graph.
+    """GET /explorer -- the Õiguskaart graph inside the standard app chrome.
 
     When called with ``?draft=<uuid>`` and the caller's org owns that
     draft, the affected-entity URIs from its latest impact report are
@@ -173,482 +410,225 @@ def explorer_page(req: Request):
 
     When called with ``?focus=<uri>`` (URL-encoded — see
     :func:`app.docs.report_routes.explorer_focus_url`) the JS loads that
-    entity's neighbourhood and opens the detail panel on it. ``focus``
-    and ``draft`` may be combined. The page itself requires
-    authentication via the global ``auth_before`` middleware (see #442).
+    entity's neighbourhood and opens the detail panel on it. ``?search=``
+    instead pre-runs the existing search flow with the given term; if both
+    ``?focus=`` and ``?search=`` are present, ``focus`` wins. The page
+    itself requires authentication via the global ``auth_before``
+    middleware (see #442).
     """
+    auth = req.scope.get("auth")
     draft_param = req.query_params.get("draft", "").strip()
     focus_param = req.query_params.get("focus", "").strip()
+    search_param = req.query_params.get("search", "").strip()
     overlay_uris: list[str] = []
     if draft_param:
         overlay_uris = _fetch_draft_overlay(req, draft_param)
 
-    overlay_tags: list = []
-    # #719: hand the focus URI to the JS. We don't resolve it here — the
-    # ``/api/explorer/entity/{uri}`` endpoint validates it server-side —
-    # but embedding it (escaped) keeps the contract explicit and lets the
-    # JS read it without re-parsing ``location.search``.
+    # ---- Server → JS bridge: ?focus= / ?search= / draft-overlay blobs ----
+    bridge_tags: list = []
+    # #719: hand the focus URI to the JS (it's validated server-side at
+    # /api/explorer/entity/{uri}; embedding it escaped keeps the contract
+    # explicit so the JS need not re-parse location.search).
     if focus_param.startswith("http"):
-        focus_payload = json.dumps(focus_param).replace("</", "<\\/")
-        overlay_tags.append(Script(f"window.__explorerFocus={focus_payload};"))
+        focus_payload = _escape_for_script(json.dumps(focus_param))
+        bridge_tags.append(Script(f"window.__explorerFocus={focus_payload};"))
+    elif search_param:
+        # ?search= pre-runs the search on load — the same path the "Otsi"
+        # button triggers. Suppressed when ?focus= is present (focus is
+        # the more specific intent). Escaped exactly like the focus blob.
+        search_payload = _escape_for_script(json.dumps(search_param))
+        bridge_tags.append(Script(f"window.__explorerSearch={search_payload};"))
     if overlay_uris:
-        # #464: escape any closing-tag and Unicode line-separator
-        # sequences in the JSON payload before embedding in a
-        # ``<script>`` tag. ``</`` would otherwise terminate the
-        # script element early and let an attacker inject HTML;
-        # U+2028 / U+2029 are valid in JSON strings but not in
-        # JavaScript string literals, so leaving them in causes a
-        # parse error in older browsers and confuses some inline
-        # script parsers. JSON natively decodes ``<\/`` back to
-        # ``</`` so json.loads still works on the rendered payload.
-        payload = json.dumps({"uris": overlay_uris})
-        payload = payload.replace("</", "<\\/").replace(" ", "\\u2028").replace(" ", "\\u2029")
-        overlay_tags.append(
-            Script(
-                payload,
-                id="draft-overlay-data",
-                type="application/json",
-            )
-        )
-        # Tiny inline init: read the JSON blob, build a Set of URIs,
-        # and apply the highlight class to any node whose datum.uri or
-        # datum.id is in the set. Runs every 500ms so we catch nodes
-        # that arrive after the initial render via lazy-loading.
-        overlay_tags.append(
-            Script(
-                "(function(){"
-                "var el=document.getElementById('draft-overlay-data');"
-                "if(!el){return;}"
-                "var data;try{data=JSON.parse(el.textContent||'{}');}catch(e){return;}"
-                "var uris=new Set((data&&data.uris)||[]);"
-                "if(!uris.size){return;}"
-                "function apply(){"
-                "if(typeof d3==='undefined'){return;}"
-                "d3.selectAll('g.node').each(function(d){"
-                "if(!d){return;}"
-                "var key=d.uri||d.id;"
-                "var hit=uris.has(key);"
-                "d3.select(this).classed('d3-node-highlighted',hit);"
-                "d3.select(this).select('circle.outer').classed('d3-node-highlighted',hit);"
-                "});"
-                "}"
-                "var overlayInterval=setInterval(apply,500);"
-                "apply();"
-                "if(typeof htmx!=='undefined'){"
-                "htmx.on('htmx:beforeSwap',function(){clearInterval(overlayInterval);});"
-                "}"
-                "})();"
-            )
-        )
+        # #464: escape closing-tag + Unicode line-separator sequences in
+        # the JSON payload before embedding in a <script>.
+        payload = _escape_for_script(json.dumps({"uris": overlay_uris}))
+        bridge_tags.append(Script(payload, id="draft-overlay-data", type="application/json"))
+        bridge_tags.append(Script(_DRAFT_OVERLAY_INIT_SCRIPT))
 
-    # Build the help banner elements that sit above the top bar.
-    help_banner = Div(
+    # "Back to report/analysis" context: the page was opened from an impact
+    # report / analysis result (?focus= or ?draft=) — explorer.js detects
+    # the same thing from document.referrer for the detail-panel back link.
+    has_back_context = bool(focus_param) or bool(overlay_uris) or bool(draft_param)
+    # A "cold" open (no focus / draft / overlay) gets the small ?draft= tip.
+    show_draft_tip = not overlay_uris and not draft_param and not focus_param
+
+    content = (
+        # ----- Graph toolbar (across the top of the canvas) -----
+        _explorer_toolbar(has_back_context=has_back_context, draft_tip=show_draft_tip),
+        # ----- Breadcrumb -----
+        Div(id="breadcrumb"),
+        # ----- Tooltip -----
         Div(
-            Span(
-                "ℹ️",
-                cls="info-box-icon",
-                aria_hidden="true",
-            ),
-            Div(
-                "See on õiguskaart — Eesti õiguse ontoloogia visuaalne vaade. "
-                "Klõpsake kategooriatele, et uurida seadusi, kohtuotsuseid "
-                "ja EL-i õigusakte. Kasutage otsingut konkreetsete "
-                "sätete leidmiseks.",
-                cls="info-box-content",
-            ),
-            Button(
-                "×",
-                type="button",
-                cls="info-box-dismiss",
-                aria_label="Sulge",
-                onclick=(
-                    "localStorage.setItem('explorer-help-dismissed','1');"
-                    "this.parentElement.parentElement.remove()"
-                ),
-            ),
-            cls="info-box info-box-info",
-            role="note",
+            H3(id="tt-title"),
+            Span(cls="cat", id="tt-cat"),
+            P(id="tt-desc"),
+            Div(id="tt-stat", cls="stat"),
+            id="tooltip",
         ),
-        id="explorer-help-banner",
-        style="padding:0.75rem 1rem 0;",
-    )
-
-    # Optional draft tip
-    draft_tip = None
-    if not overlay_uris and not draft_param and not focus_param:
-        draft_tip = Div(
+        # ----- Legend -----
+        Div(
+            H3("Kategooriad"),
             Div(
-                Span(
-                    "\U0001f4a1",
-                    cls="info-box-icon",
-                    aria_hidden="true",
+                Div(cls="legend-dot", style="background:#38bdf8"),
+                "Kehtiv seadus",
+                cls="legend-item",
+            ),
+            Div(
+                Div(cls="legend-dot", style="background:#a78bfa"),
+                "Eelnõu",
+                cls="legend-item",
+            ),
+            Div(
+                Div(cls="legend-dot", style="background:#fb923c"),
+                "Kohtulahend",
+                cls="legend-item",
+            ),
+            Div(
+                Div(cls="legend-dot", style="background:#34d399"),
+                "EL õigusakt",
+                cls="legend-item",
+            ),
+            Div(
+                Div(cls="legend-dot", style="background:#f472b6"),
+                "EL kohtulahend",
+                cls="legend-item",
+            ),
+            id="legend",
+        ),
+        # ----- Instructions -----
+        Div(
+            "Lohista sõlmpunkte ümber · Kerige suumimiseks "
+            "· Klõpsa ja lohista tausta panoraamimiseks",
+            Br(),
+            "Hõlju sõlmpunktil detailide nägemiseks "
+            "· Klõpsa kategooriat avamiseks "
+            "· Klõpsa olemit kinnitamiseks",
+            id="instructions",
+        ),
+        # ----- Loading overlay -----
+        Div(
+            Div(cls="spinner"),
+            id="loading-overlay",
+        ),
+        # ----- Timeline / "ajaline vaade" slider (bottom of the canvas) -----
+        Div(
+            Div(
+                Span("1990", cls="tl-label"),
+                Input(
+                    id="timeline-slider",
+                    type="range",
+                    min="1990",
+                    max=str(datetime.now().year + 1),
+                    value=str(datetime.now().year + 1),
+                    step="1",
+                    aria_label="Ajaline vaade — aasta valik",
                 ),
-                Div(
-                    "Näpunäide: lisage ?draft=ID URL-ile, "
-                    "et näha eelnõu mõjutatud üksusi graafikul.",
-                    cls="info-box-content",
+                Span(str(datetime.now().year + 1), cls="tl-label"),
+                cls="tl-slider-row",
+            ),
+            Div(
+                Span("Ajaline vaade: ", cls="tl-prefix"),
+                Span("Väljas", id="timeline-value", cls="tl-value"),
+                Button(
+                    "Lähtesta",
+                    type="button",
+                    id="timeline-reset",
+                    cls="tl-reset-btn",
+                    onclick="explorerResetTimeline()",
                 ),
+                cls="tl-info-row",
+            ),
+            id="timeline-bar",
+        ),
+        # ----- Detail panel (slides in from the right edge of the content) -----
+        Div(
+            # #719: shown only when the page was opened via ?focus= (i.e.
+            # from an impact report / analysis) — explorer.js unhides it
+            # and sets the label/target.
+            A(
+                "← Tagasi",
+                id="panel-back",
+                href="#",
+                cls="panel-back",
+                style="display:none;",
+            ),
+            Div(
+                H2(id="panel-title"),
                 Button(
                     "×",
                     type="button",
-                    cls="info-box-dismiss",
-                    aria_label="Sulge",
-                    onclick=(
-                        "localStorage.setItem('explorer-tip-dismissed','1');"
-                        "this.parentElement.parentElement.remove()"
-                    ),
+                    id="detail-close",
+                    onclick="explorerCloseDetail()",
+                    aria_label="Sulge üksikasjade paneel",
                 ),
-                cls="info-box info-box-tip",
-                role="note",
+                cls="panel-header",
             ),
-            id="explorer-tip-banner",
-            style="padding:0 1rem;",
-        )
+            Span(id="panel-category", cls="panel-category"),
+            Div(
+                H4("Metaandmed"),
+                Div(id="panel-meta"),
+                cls="meta-section",
+            ),
+            # ----- Version history section -----
+            Div(
+                H4("Versiooniajalugu"),
+                Div(id="panel-versions"),
+                id="version-history-section",
+                cls="meta-section",
+                style="display:none;",
+            ),
+            Div(
+                H4("Seosed"),
+                Ul(id="panel-neighbors", cls="neighbor-list"),
+                cls="meta-section",
+            ),
+            # ----- Annotation button (entity-level) -----
+            Div(
+                id="panel-annotation-btn",
+                cls="annotation-section",
+                style="display:none;",
+            ),
+            # ----- Bookmark button -----
+            Div(
+                Button(
+                    "Lisa järjehoidjatesse",
+                    type="button",
+                    id="panel-bookmark-btn",
+                    cls="bookmark-btn",
+                    onclick="explorerBookmark()",
+                ),
+                cls="bookmark-section",
+            ),
+            A(
+                "Ava allikas",
+                id="panel-link",
+                cls="external-link",
+                href="#",
+                target="_blank",
+                rel="noopener",
+            ),
+            id="detail-panel",
+        ),
+        # ----- SVG canvas (fills the content area; sized by explorer.js) -----
+        NotStr('<svg id="canvas"></svg>'),
+        # ----- Explorer JS (after the DOM it touches) -----
+        Script(src="/static/js/explorer.js"),
+        # ----- Auto-hide the (dismissed) draft tip -----
+        Script(_TIP_AUTOHIDE_SCRIPT),
+        # ----- Detail-panel annotation button wiring -----
+        Script(_PANEL_ANNOTATION_SCRIPT),
+        # ----- ?focus= / ?search= / draft-overlay bridge blobs -----
+        *bridge_tags,
+    )
 
-    return Html(
-        Head(
-            Meta(charset="UTF-8"),
-            Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
-            Title("Õiguskaart — Eesti õiguse ontoloogia"),
-            # D3.js v7
-            Script(
-                src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js",
-                integrity="sha512-vc58qvvBdrDR4etbxMdlTt4GBQk1qjvyORR2nrsPsFPyrs+/u5c3+1Ct6upOgdZoIl7eq6k3a1UPDSNAQi/32A==",
-                crossorigin="anonymous",
-            ),
-            # Design tokens (CSS custom properties) — required by ui.css
-            Link(rel="stylesheet", href="/static/css/tokens.css"),
-            # Explorer styles
-            Link(rel="stylesheet", href="/static/css/explorer.css"),
-            # Phase 2 additions (#446): the .d3-node-highlighted rule
-            # used by the draft overlay lives in ui.css. Pull the
-            # whole stylesheet in so future Phase 2 additions take
-            # effect on the explorer page without per-rule duplication.
-            Link(rel="stylesheet", href="/static/css/ui.css"),
-        ),
-        Body(
-            # ----- Help banner -----
-            help_banner,
-            draft_tip if draft_tip else "",
-            # ----- Top bar (banner landmark) -----
-            Header(
-                Div(
-                    H1("Õiguskaart"),
-                    Span("Eesti õiguse ontoloogia", cls="explorer-tagline"),
-                    Span("D3.js", cls="badge"),
-                    # Search box
-                    Div(
-                        Input(
-                            id="search-input",
-                            type="text",
-                            placeholder="Otsi seadust, eelnõu, lahendit…",
-                            aria_label="Otsi seadusi, eelnõusid, lahendeid",
-                        ),
-                        Button(
-                            "Otsi",
-                            id="search-btn",
-                            onclick="explorerSearch()",
-                        ),
-                        id="search-box",
-                    ),
-                    id="topbar",
-                ),
-                role="banner",
-            ),
-            # ----- Controls (navigation landmark) -----
-            Nav(
-                Div(
-                    # Primary view actions — legal-work language, not
-                    # force-simulation jargon (#714 / #718).
-                    Button(
-                        "Ülevaade",
-                        cls="ctrl-btn",
-                        onclick="explorerCollapseToOverview()",
-                        title="Näita kõigi liikide ülevaadet",
-                    ),
-                    Button(
-                        "Lähtesta vaade",
-                        cls="ctrl-btn",
-                        onclick="explorerResetView()",
-                        title="Lähtesta suum ja valik",
-                    ),
-                    # Technical layout controls live behind a disclosure so the
-                    # bar isn't cluttered with simulation vocabulary.
-                    Details(
-                        Summary("Vaate seaded ▾", cls="ctrl-btn ctrl-settings-summary"),
-                        Div(
-                            Button(
-                                "Lähtesta paigutus",
-                                cls="ctrl-btn",
-                                onclick="explorerReheat()",
-                                title="Arvuta sõlmpunktide paigutus uuesti",
-                            ),
-                            Button(
-                                "Näita/peida seosenimed",
-                                cls="ctrl-btn",
-                                onclick="explorerToggleLabels()",
-                            ),
-                            Button(
-                                "Rühmita liigi järgi",
-                                cls="ctrl-btn",
-                                onclick="explorerGroupByCategory()",
-                            ),
-                            cls="ctrl-settings-menu",
-                        ),
-                        cls="ctrl-settings",
-                    ),
-                    # ----- Divider -----
-                    Div(cls="ctrl-divider"),
-                    # ----- Navigation links (semantic anchors, not buttons) -----
-                    A(
-                        "Töölaud",
-                        href="/dashboard",
-                        cls="nav-btn",
-                        role="link",
-                    ),
-                    A(
-                        "Analüüsikeskus",
-                        href="/analyysikeskus",
-                        cls="nav-btn",
-                        role="link",
-                    ),
-                    A(
-                        "Eelnõud",
-                        href="/drafts",
-                        cls="nav-btn",
-                        role="link",
-                    ),
-                    A(
-                        "Koostaja",
-                        href="/drafter",
-                        cls="nav-btn",
-                        role="link",
-                    ),
-                    A(
-                        "Nõustaja",
-                        href="/chat",
-                        cls="nav-btn",
-                        role="link",
-                    ),
-                    A(
-                        "Admin",
-                        href="/admin",
-                        cls="nav-btn",
-                        role="link",
-                    ),
-                    id="controls",
-                ),
-                aria_label="Vaate juhtimine",
-            ),
-            # ----- Main content (graph canvas + companion UI) -----
-            Main(
-                # ----- Breadcrumb -----
-                Div(id="breadcrumb"),
-                # ----- Tooltip -----
-                Div(
-                    H3(id="tt-title"),
-                    Span(cls="cat", id="tt-cat"),
-                    P(id="tt-desc"),
-                    Div(id="tt-stat", cls="stat"),
-                    id="tooltip",
-                ),
-                # ----- Legend -----
-                Div(
-                    H3("Kategooriad"),
-                    Div(
-                        Div(cls="legend-dot", style="background:#38bdf8"),
-                        "Kehtiv seadus",
-                        cls="legend-item",
-                    ),
-                    Div(
-                        Div(cls="legend-dot", style="background:#a78bfa"),
-                        "Eelnõu",
-                        cls="legend-item",
-                    ),
-                    Div(
-                        Div(cls="legend-dot", style="background:#fb923c"),
-                        "Kohtulahend",
-                        cls="legend-item",
-                    ),
-                    Div(
-                        Div(cls="legend-dot", style="background:#34d399"),
-                        "EL õigusakt",
-                        cls="legend-item",
-                    ),
-                    Div(
-                        Div(cls="legend-dot", style="background:#f472b6"),
-                        "EL kohtulahend",
-                        cls="legend-item",
-                    ),
-                    id="legend",
-                ),
-                # ----- Instructions -----
-                Div(
-                    "Lohista sõlmpunkte ümber · Kerige suumimiseks "
-                    "· Klõpsa ja lohista tausta panoraamimiseks",
-                    Br(),
-                    "Hõlju sõlmpunktil detailide nägemiseks "
-                    "· Klõpsa kategooriat avamiseks "
-                    "· Klõpsa olemit kinnitamiseks",
-                    id="instructions",
-                ),
-                # ----- Loading overlay -----
-                Div(
-                    Div(cls="spinner"),
-                    id="loading-overlay",
-                ),
-                # ----- Timeline / "ajaline vaade" slider -----
-                Div(
-                    Div(
-                        Span("1990", cls="tl-label"),
-                        Input(
-                            id="timeline-slider",
-                            type="range",
-                            min="1990",
-                            max=str(datetime.now().year + 1),
-                            value=str(datetime.now().year + 1),
-                            step="1",
-                            aria_label="Ajaline vaade — aasta valik",
-                        ),
-                        Span(str(datetime.now().year + 1), cls="tl-label"),
-                        cls="tl-slider-row",
-                    ),
-                    Div(
-                        Span("Ajaline vaade: ", cls="tl-prefix"),
-                        Span("Väljas", id="timeline-value", cls="tl-value"),
-                        Button(
-                            "Lähtesta",
-                            id="timeline-reset",
-                            cls="tl-reset-btn",
-                            onclick="explorerResetTimeline()",
-                        ),
-                        cls="tl-info-row",
-                    ),
-                    id="timeline-bar",
-                ),
-                # ----- Toast container -----
-                Div(id="toast-container"),
-                # ----- Detail panel (right sidebar) -----
-                Div(
-                    # #719: shown only when the page was opened via
-                    # ?focus= (i.e. from an impact report / analysis) —
-                    # explorer.js unhides it and sets the label/target.
-                    A(
-                        "← Tagasi",
-                        id="panel-back",
-                        href="#",
-                        cls="panel-back",
-                        style="display:none;",
-                    ),
-                    Div(
-                        H2(id="panel-title"),
-                        Button(
-                            "×",
-                            id="detail-close",
-                            onclick="explorerCloseDetail()",
-                            aria_label="Sulge üksikasjade paneel",
-                        ),
-                        cls="panel-header",
-                    ),
-                    Span(id="panel-category", cls="panel-category"),
-                    Div(
-                        H4("Metaandmed"),
-                        Div(id="panel-meta"),
-                        cls="meta-section",
-                    ),
-                    # ----- Version history section -----
-                    Div(
-                        H4("Versiooniajalugu"),
-                        Div(id="panel-versions"),
-                        id="version-history-section",
-                        cls="meta-section",
-                        style="display:none;",
-                    ),
-                    Div(
-                        H4("Seosed"),
-                        Ul(id="panel-neighbors", cls="neighbor-list"),
-                        cls="meta-section",
-                    ),
-                    # ----- Annotation button (entity-level) -----
-                    Div(
-                        id="panel-annotation-btn",
-                        cls="annotation-section",
-                        style="display:none;",
-                    ),
-                    # ----- Bookmark button -----
-                    Div(
-                        Button(
-                            "Lisa järjehoidjatesse",
-                            id="panel-bookmark-btn",
-                            cls="bookmark-btn",
-                            onclick="explorerBookmark()",
-                        ),
-                        cls="bookmark-section",
-                    ),
-                    A(
-                        "Ava allikas",
-                        id="panel-link",
-                        cls="external-link",
-                        href="#",
-                        target="_blank",
-                        rel="noopener",
-                    ),
-                    id="detail-panel",
-                ),
-                # ----- SVG canvas -----
-                NotStr('<svg id="canvas"></svg>'),
-            ),
-            # ----- Explorer JS (after DOM) -----
-            Script(src="/static/js/explorer.js"),
-            # ----- Auto-hide banners via localStorage -----
-            Script(
-                "(function(){"
-                "if(localStorage.getItem('explorer-help-dismissed')){"
-                "var h=document.getElementById('explorer-help-banner');"
-                "if(h)h.remove();"
-                "}"
-                "if(localStorage.getItem('explorer-tip-dismissed')){"
-                "var t=document.getElementById('explorer-tip-banner');"
-                "if(t)t.remove();"
-                "}"
-                "})();"
-            ),
-            # ----- Annotation button wiring for detail panel -----
-            # When explorerShowDetail() sets #panel-title, this
-            # observer injects an AnnotationButton via HTMX into
-            # #panel-annotation-btn. The MutationObserver pattern
-            # avoids patching explorer.js directly.
-            Script(
-                "(function(){"
-                "var panelBtn=document.getElementById('panel-annotation-btn');"
-                "var panelTitle=document.getElementById('panel-title');"
-                "if(!panelBtn||!panelTitle){return;}"
-                "var obs=new MutationObserver(function(){"
-                "var uri=panelTitle.dataset.entityUri||panelTitle.textContent.trim();"
-                "if(!uri){panelBtn.style.display='none';return;}"
-                "var safeId=encodeURIComponent(uri).replace(/'/g,'%27');"
-                "panelBtn.innerHTML="
-                '\'<div class="annotation-button-wrapper">'
-                '<button type="button" class="annotation-button"'
-                " hx-get=\"/api/annotations?target_type=entity&target_id='+safeId+'\""
-                " hx-target=\"#annotation-popover-entity-'+safeId+'\""
-                ' hx-swap="innerHTML"'
-                ' aria-label="Markused"'
-                ' title="Markused">&#128172;</button>'
-                "<div id=\"annotation-popover-entity-'+safeId+'\""
-                ' class="annotation-popover-container"></div></div>\';'
-                "panelBtn.style.display='block';"
-                "if(typeof htmx!=='undefined'){htmx.process(panelBtn);}"
-                "});"
-                "obs.observe(panelTitle,{childList:true,characterData:true,subtree:true});"
-                "})();"
-            ),
-            # ----- Optional draft overlay (Phase 2 Batch 4) -----
-            *overlay_tags,
-            cls="explorer-page",
-        ),
-        lang="et",
-        data_theme="dark",
+    return PageShell(
+        *content,
+        title="Õiguskaart",
+        user=auth or None,
+        active_nav="/explorer",
+        request=req,
+        full_bleed=True,
+        extra_head=_EXPLORER_HEAD,
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ from app.docs.routes import register_draft_routes
 from app.docs.websocket import register_draft_ws_routes
 from app.docs.ws_export_progress import register_export_progress_ws_routes
 from app.drafter.routes import register_drafter_routes
-from app.explorer.pages import explorer_page, register_explorer_pages
+from app.explorer.pages import register_explorer_pages
 from app.explorer.routes import register_explorer_routes
 from app.explorer.websocket import register_ws_routes
 from app.notifications.routes import register_notification_routes
@@ -257,10 +257,17 @@ register_notification_routes(rt)
 
 @rt("/")
 def index(req: Request):
+    """GET / — route the visitor to the right landing page.
+
+    Unauthenticated users are sent to the login page; authenticated users
+    land on the operational dashboard (``/dashboard`` — the "Töölaud" work
+    queue), not the Õiguskaart graph. See issue #746 / the design rationale
+    in ``docs/2026-05-12-ui-plan-explorer-home.html``.
+    """
     auth = req.scope.get("auth")
     if auth is None:
         return RedirectResponse(url="/auth/login", status_code=303)
-    return explorer_page(req)
+    return RedirectResponse(url="/dashboard", status_code=303)
 
 
 @rt("/api/ping", methods=["GET"])

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -1,40 +1,75 @@
-/* Estonian Legal Ontology Explorer — D3.js Force Graph Styles */
+/* Õiguskaart — D3.js force-graph styles.
+ *
+ * Issue #746: the graph now lives inside the standard PageShell with
+ * `full_bleed=True`. Every overlay below is a child of `.main-content--full`
+ * (which is `position: relative; overflow: hidden`), so the anchors are
+ * `position: absolute` against that box — NOT `position: fixed` against the
+ * viewport (the way the bespoke full-page explorer used to do it). The
+ * former vertical control rail + bespoke topbar are gone; their actions
+ * (and the search box) moved into `#explorer-toolbar`, a thin horizontal
+ * bar across the top of the canvas area.
+ *
+ * This stylesheet is pulled into <head> only on the Õiguskaart page (via
+ * PageShell `extra_head=`); it must not restyle anything outside the graph.
+ */
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+/* Toolbar height — the inset every other overlay reserves at the top. */
+:root { --explorer-toolbar-h: 52px; }
 
-body.explorer-page {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  background: #0f1729;
-  color: #e2e8f0;
-  overflow: hidden;
-  height: 100vh;
+/* ------- SVG canvas — fills the content area ------- */
+svg#canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
-svg#canvas { width: 100%; height: 100vh; display: block; }
-
-/* ------- Top bar ------- */
-#topbar {
-  position: fixed; top: 0; left: 0; right: 0; z-index: 10;
-  background: linear-gradient(180deg, rgba(15,23,41,0.95) 0%, rgba(15,23,41,0.7) 80%, transparent 100%);
-  padding: 16px 24px 32px;
-  display: flex; align-items: center; gap: 16px;
+/* ------- Graph toolbar (replaces the bespoke #topbar + #controls rail) ------- */
+#explorer-toolbar {
+  position: absolute; top: 0; left: 0; right: 0; z-index: 14;
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  min-height: var(--explorer-toolbar-h);
+  padding: 8px 16px;
+  background: linear-gradient(180deg, rgba(15,23,41,0.95) 0%, rgba(15,23,41,0.82) 100%);
+  border-bottom: 1px solid rgba(100,116,139,0.2);
+  backdrop-filter: blur(12px);
 }
-#topbar h1 { font-size: 16px; font-weight: 600; color: #f1f5f9; white-space: nowrap; }
-/* #714: descriptive subtitle next to the "Õiguskaart" page heading */
-#topbar .explorer-tagline { font-size: 13px; color: #94a3b8; white-space: nowrap; }
-#topbar .badge {
-  font-size: 11px; background: rgba(251,146,60,0.15); color: #fdba74;
-  padding: 3px 10px; border-radius: 99px; border: 1px solid rgba(251,146,60,0.25);
+#explorer-toolbar .toolbar-title {
+  font-size: 14px; font-weight: 600; color: #f1f5f9; white-space: nowrap;
+  margin-right: 4px;
 }
 
-/* ------- Search ------- */
-#search-box {
-  margin-left: auto; display: flex; align-items: center; gap: 8px;
+/* ------- Toolbar control buttons ------- */
+.ctrl-btn {
+  background: rgba(30,41,59,0.85); border: 1px solid rgba(100,116,139,0.3); color: #94a3b8;
+  padding: 6px 14px; border-radius: 8px; font-size: 12px; cursor: pointer;
+  backdrop-filter: blur(8px); transition: all 0.15s; text-align: left;
 }
+.ctrl-btn:hover { background: rgba(51,65,85,0.9); color: #e2e8f0; }
+.ctrl-btn.active { border-color: rgba(56,189,248,0.4); color: #38bdf8; }
+
+/* ------- "Vaate seaded" disclosure — drops DOWN from the toolbar -------
+   In the old vertical rail the menu expanded inline; in a horizontal
+   toolbar it must be an absolutely-positioned dropdown so it doesn't
+   stretch the toolbar's height. */
+.ctrl-settings { position: relative; }
+summary.ctrl-settings-summary { list-style: none; }
+summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
+.ctrl-settings-menu {
+  position: absolute; top: calc(100% + 6px); left: 0; z-index: 16;
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 8px; min-width: 200px;
+  background: rgba(15,23,42,0.97); border: 1px solid rgba(100,116,139,0.3);
+  border-radius: 10px; backdrop-filter: blur(12px);
+}
+
+/* ------- Search box (moved from the deleted #topbar) ------- */
+#search-box { display: flex; align-items: center; gap: 8px; }
 #search-input {
   background: rgba(30,41,59,0.85); border: 1px solid rgba(100,116,139,0.3);
   color: #e2e8f0; padding: 6px 14px; border-radius: 8px; font-size: 13px;
-  width: 260px; outline: none; backdrop-filter: blur(8px);
+  width: 240px; outline: none; backdrop-filter: blur(8px);
   transition: border-color 0.15s;
 }
 #search-input:focus { border-color: rgba(56,189,248,0.5); }
@@ -46,56 +81,43 @@ svg#canvas { width: 100%; height: 100vh; display: block; }
 }
 #search-btn:hover { background: rgba(56,189,248,0.25); }
 
-/* ------- Controls ------- */
-#controls {
-  position: fixed; top: 56px; left: 24px; z-index: 10;
-  display: flex; flex-direction: column; gap: 6px;
-  max-height: calc(100vh - 130px); overflow-y: auto;
-  scrollbar-width: thin; scrollbar-color: rgba(100,116,139,0.3) transparent;
-}
-.ctrl-btn {
-  background: rgba(30,41,59,0.85); border: 1px solid rgba(100,116,139,0.3); color: #94a3b8;
-  padding: 6px 14px; border-radius: 8px; font-size: 12px; cursor: pointer;
-  backdrop-filter: blur(8px); transition: all 0.15s; text-align: left;
-}
-.ctrl-btn:hover { background: rgba(51,65,85,0.9); color: #e2e8f0; }
-.ctrl-btn.active { border-color: rgba(56,189,248,0.4); color: #38bdf8; }
-
-/* ------- Control divider ------- */
-.ctrl-divider {
-  height: 1px; margin: 6px 0;
-  background: rgba(100,116,139,0.25);
-}
-
-/* ------- "Vaate seaded" disclosure (#714 / #718) -------
-   Holds the technical layout controls (reheat, label toggle, grouping)
-   so the main bar reads in legal-work language. Expands inline within
-   the vertical #controls column. */
-.ctrl-settings { display: flex; flex-direction: column; gap: 6px; }
-summary.ctrl-settings-summary { list-style: none; }
-summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
-.ctrl-settings-menu {
-  display: flex; flex-direction: column; gap: 6px;
-  margin-left: 12px; padding-left: 8px;
-  border-left: 2px solid rgba(100,116,139,0.3);
-}
-
-/* ------- Navigation buttons / links (override design-system .btn) ------- */
-/* Match both <button class="nav-btn"> (legacy) and <a class="nav-btn"> (current). */
-#controls a.nav-btn,
-#controls button.nav-btn {
+/* ------- Toolbar "back to report/analysis" link ------- */
+.toolbar-back {
   background: rgba(52,211,153,0.08); border: 1px solid rgba(52,211,153,0.25); color: #6ee7b7;
-  padding: 6px 14px; border-radius: 8px; font-size: 12px; cursor: pointer;
-  backdrop-filter: blur(8px); transition: all 0.15s; text-align: left;
-  font-weight: 500;
-  text-decoration: none; display: block;
+  padding: 6px 14px; border-radius: 8px; font-size: 12px;
+  text-decoration: none; white-space: nowrap; transition: all 0.15s;
 }
-#controls a.nav-btn:hover,
-#controls button.nav-btn:hover { background: rgba(52,211,153,0.18); color: #a7f3d0; border-color: rgba(52,211,153,0.4); }
+.toolbar-back:hover { background: rgba(52,211,153,0.18); color: #a7f3d0; border-color: rgba(52,211,153,0.4); }
+
+/* ------- Toolbar draft-tip (cold-open hint) ------- */
+.toolbar-tip {
+  display: inline-flex; align-items: center; gap: 8px;
+  margin-left: auto;
+  background: rgba(52,211,153,0.08); border: 1px solid rgba(52,211,153,0.2);
+  border-radius: 8px; padding: 4px 6px 4px 12px;
+  font-size: 11px; color: #94a3b8; max-width: 360px;
+}
+.toolbar-tip-text { line-height: 1.4; }
+.toolbar-tip-dismiss {
+  background: none; border: none; color: #475569; font-size: 16px; line-height: 1;
+  padding: 0 4px; cursor: pointer; transition: color 0.15s;
+}
+.toolbar-tip-dismiss:hover { color: #e2e8f0; }
+
+/* ------- Breadcrumb (navigation state) ------- */
+#breadcrumb {
+  position: absolute; top: calc(var(--explorer-toolbar-h) + 8px); left: 24px; z-index: 12;
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px; color: #64748b;
+}
+#breadcrumb span { cursor: pointer; transition: color 0.15s; }
+#breadcrumb span:hover { color: #e2e8f0; }
+#breadcrumb .separator { cursor: default; }
+#breadcrumb .current { color: #94a3b8; cursor: default; }
 
 /* ------- Tooltip ------- */
 #tooltip {
-  position: fixed; z-index: 20; pointer-events: none;
+  position: absolute; z-index: 20; pointer-events: none;
   background: rgba(15,23,42,0.95); border: 1px solid rgba(100,116,139,0.3);
   border-radius: 10px; padding: 14px 18px; max-width: 300px;
   backdrop-filter: blur(12px); opacity: 0; transition: opacity 0.15s;
@@ -111,7 +133,7 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 
 /* ------- Legend ------- */
 #legend {
-  position: fixed; bottom: 24px; left: 24px; z-index: 10;
+  position: absolute; bottom: 80px; left: 24px; z-index: 12;
   background: rgba(15,23,42,0.92); border: 1px solid rgba(100,116,139,0.2);
   border-radius: 12px; padding: 14px 16px; backdrop-filter: blur(12px);
   max-height: 280px; overflow-y: auto;
@@ -128,15 +150,15 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 
 /* ------- Instructions ------- */
 #instructions {
-  position: fixed; bottom: 24px; right: 24px; z-index: 10;
+  position: absolute; bottom: 80px; right: 24px; z-index: 12;
   background: rgba(15,23,42,0.92); border: 1px solid rgba(100,116,139,0.2);
   border-radius: 12px; padding: 14px 18px; backdrop-filter: blur(12px);
-  font-size: 11px; color: #64748b; line-height: 1.6;
+  font-size: 11px; color: #64748b; line-height: 1.6; max-width: 320px;
 }
 
 /* ------- Loading overlay ------- */
 #loading-overlay {
-  position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  position: absolute; inset: 0;
   z-index: 30; background: rgba(15,23,41,0.7);
   display: flex; align-items: center; justify-content: center;
   backdrop-filter: blur(4px); transition: opacity 0.3s;
@@ -153,17 +175,17 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* ------- Detail panel (right sidebar) ------- */
+/* ------- Detail panel (slides in from the content area's right edge) ------- */
 #detail-panel {
-  position: fixed; top: 0; right: 0; bottom: 0; z-index: 15;
-  width: 380px; max-width: 90vw;
+  position: absolute; top: var(--explorer-toolbar-h); right: 0; bottom: 0; z-index: 15;
+  width: 270px; max-width: 90%;
   background: rgba(15,23,42,0.97);
   border-left: 1px solid rgba(100,116,139,0.2);
   backdrop-filter: blur(12px);
   transform: translateX(100%);
   transition: transform 0.3s ease;
   overflow-y: auto;
-  padding: 24px;
+  padding: 20px;
 }
 #detail-panel.open { transform: translateX(0); }
 
@@ -179,7 +201,7 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
   margin-bottom: 20px;
 }
 #detail-panel .panel-header h2 {
-  font-size: 18px; font-weight: 600; color: #f1f5f9;
+  font-size: 17px; font-weight: 600; color: #f1f5f9;
   line-height: 1.3; flex: 1; padding-right: 12px;
 }
 #detail-close {
@@ -228,20 +250,9 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 }
 #detail-panel .external-link:hover { border-color: #38bdf8; }
 
-/* ------- Breadcrumb (navigation state) ------- */
-#breadcrumb {
-  position: fixed; top: 56px; left: 200px; z-index: 10;
-  display: flex; align-items: center; gap: 6px;
-  font-size: 11px; color: #64748b;
-}
-#breadcrumb span { cursor: pointer; transition: color 0.15s; }
-#breadcrumb span:hover { color: #e2e8f0; }
-#breadcrumb .separator { cursor: default; }
-#breadcrumb .current { color: #94a3b8; cursor: default; }
-
-/* ------- Timeline slider bar ------- */
+/* ------- Timeline slider bar (bottom of the content area) ------- */
 #timeline-bar {
-  position: fixed; bottom: 0; left: 0; right: 0; z-index: 12;
+  position: absolute; bottom: 0; left: 0; right: 0; z-index: 13;
   background: rgba(15,23,42,0.95);
   border-top: 1px solid rgba(100,116,139,0.2);
   backdrop-filter: blur(12px);
@@ -289,12 +300,10 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 }
 .tl-reset-btn:hover { background: rgba(100,116,139,0.3); color: #e2e8f0; }
 
-/* ------- Toast notifications ------- */
-#toast-container {
-  position: fixed; top: 80px; right: 24px; z-index: 50;
-  display: flex; flex-direction: column; gap: 8px;
-  pointer-events: none;
-}
+/* ------- Explorer toasts ------- */
+/* The toast *container* is PageShell's (`<div id="toast-container">`, styled
+   by ui.css — fixed top-right of the viewport). explorer.js' showToast()
+   appends `.toast` elements into it; these rules style those. */
 .toast {
   background: rgba(15,23,42,0.95); border: 1px solid rgba(56,189,248,0.3);
   border-radius: 10px; padding: 12px 20px;
@@ -350,42 +359,6 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 .version-label { color: #cbd5e1; }
 .version-empty { color: #64748b; font-size: 12px; font-style: italic; }
 
-/* ------- Adjust legend and instructions for timeline bar ------- */
-#legend { bottom: 80px; }
-#instructions { bottom: 80px; }
-
-/* ------- Help banners (info-box overrides for dark explorer) ------- */
-#explorer-help-banner {
-  position: fixed; top: 48px; left: 240px; right: 24px; z-index: 11;
-  padding: 0;
-}
-
-body.explorer-page .info-box {
-  background: rgba(30, 41, 59, 0.92);
-  border-radius: 8px;
-  padding: 8px 14px;
-  font-size: 12px;
-  color: #94a3b8;
-  backdrop-filter: blur(12px);
-  margin-bottom: 6px;
-}
-body.explorer-page .info-box-info {
-  border: 1px solid rgba(56, 189, 248, 0.2);
-}
-body.explorer-page .info-box-tip {
-  border: 1px solid rgba(52, 211, 153, 0.2);
-}
-body.explorer-page .info-box-dismiss {
-  color: #475569;
-  font-size: 16px;
-  padding: 0 2px;
-  cursor: pointer;
-  transition: color 0.15s;
-}
-body.explorer-page .info-box-dismiss:hover {
-  color: #e2e8f0;
-}
-
 /* ------- Annotation section in detail panel ------- */
 .annotation-section { margin-top: 12px; }
 .annotation-button-wrapper { display: inline-flex; align-items: center; gap: 8px; }
@@ -406,58 +379,21 @@ body.explorer-page .info-box-dismiss:hover {
 
 /* ------- Responsive ------- */
 @media (max-width: 1280px) {
-  #detail-panel { width: 320px; }
+  #detail-panel { width: 240px; }
   #search-input { width: 180px; }
 }
 @media (max-width: 768px) {
-  /* Allow the page to scroll on small viewports so fixed/positioned
-     elements don't collide with the graph. */
-  body.explorer-page { overflow-y: auto; }
-
-  /* Topbar: let the title + badges + search wrap onto multiple lines
-     instead of clipping. */
-  #topbar { padding: 12px 16px 16px; gap: 8px; flex-wrap: wrap; }
-  #topbar h1 { font-size: 14px; }
-
-  /* Compact mobile search: keep the search input visible but slim,
-     full-width on its own row. */
-  #search-box {
-    display: flex;
-    width: 100%;
-    margin-left: 0;
-    margin-top: 0.5rem;
-  }
+  /* Toolbar wraps onto multiple lines on phones; let the content area grow
+     with it (the wrapped toolbar is taller than --explorer-toolbar-h). */
+  #explorer-toolbar { padding: 8px 12px; gap: 6px; }
+  #explorer-toolbar .toolbar-title { font-size: 13px; }
+  #search-box { width: 100%; margin-top: 4px; }
   #search-input { width: 100%; flex: 1; }
-
-  /* Controls bar: cap height so it doesn't dominate the viewport,
-     and shift to a tighter left inset. */
-  #controls {
-    top: 48px;
-    left: 12px;
-    max-height: 40vh;
-  }
   .ctrl-btn { padding: 5px 10px; font-size: 11px; }
+  .toolbar-tip { margin-left: 0; width: 100%; max-width: none; }
 
-  /* Help / tip banners: stop floating over the graph; flow inline
-     beneath the header instead. */
-  #explorer-help-banner {
-    position: static;
-    left: auto;
-    right: auto;
-    padding: 0.5rem 0.75rem 0;
-  }
-  #explorer-tip-banner {
-    padding: 0 0.75rem;
-  }
-
-  /* Legend + instructions: sit below the graph rather than overlapping
-     it on small screens. */
-  #legend,
-  #instructions {
-    position: static;
-    margin: 0.5rem;
-  }
-
-  /* Detail panel takes the full width on phones. */
-  #detail-panel { width: 100vw; max-width: 100vw; }
+  /* Legend + instructions get tighter insets so they don't dominate a
+     small screen; the detail panel goes full content-width. */
+  #legend, #instructions { max-width: 60%; }
+  #detail-panel { width: 100%; max-width: 100%; }
 }

--- a/app/static/css/ui.css
+++ b/app/static/css/ui.css
@@ -39,6 +39,16 @@
   overflow-x: auto;
 }
 
+/* Full-bleed content area — for pages that own their whole canvas (the
+   Õiguskaart D3 graph). `position: relative` makes this the containing
+   block for the page's `position: absolute` overlays (toolbar, legend,
+   detail panel, …); `overflow: hidden` clips the SVG to the box. */
+.main-content--full {
+  padding: 0;
+  overflow: hidden;
+  position: relative;
+}
+
 .container {
   margin: 0 auto;
   width: 100%;

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -97,8 +97,21 @@ const breadcrumb = document.getElementById('breadcrumb');
 // SVG setup
 // ---------------------------------------------------------------------------
 
-let width = window.innerWidth;
-let height = window.innerHeight;
+// #746: the graph now lives inside the standard PageShell content area
+// (`.main-content--full`), not full-viewport. Size everything off that box;
+// fall back to the viewport defensively if the element is missing (e.g. in
+// a stripped-down test DOM).
+const mainEl = document.getElementById('main-content');
+
+function _contentSize() {
+  if (mainEl) {
+    const r = mainEl.getBoundingClientRect();
+    if (r.width > 0 && r.height > 0) return { width: r.width, height: r.height };
+  }
+  return { width: window.innerWidth || 1200, height: window.innerHeight || 800 };
+}
+
+let { width, height } = _contentSize();
 
 const svg = d3.select('#canvas')
   .attr('width', width)
@@ -676,8 +689,11 @@ function onNodeMouseEnter(event, d) {
 }
 
 function onNodeMouseMove(event) {
-  const x = event.clientX + 16;
-  const y = event.clientY - 10;
+  // #746: #tooltip is `position: absolute` inside `.main-content--full`, so
+  // translate the viewport-relative pointer coords into the content box.
+  const rect = mainEl ? mainEl.getBoundingClientRect() : { left: 0, top: 0 };
+  const x = event.clientX - rect.left + 16;
+  const y = event.clientY - rect.top - 10;
   tooltip.style.left = (x + 320 > width ? x - 340 : x) + 'px';
   tooltip.style.top = y + 'px';
 }
@@ -923,19 +939,18 @@ function _fallbackLabel(uri) {
   }
 }
 
-function _showBackLink() {
-  var back = document.getElementById('panel-back');
-  if (!back) return;
+function _backLabel() {
   var ref = document.referrer || '';
-  if (ref.indexOf('/report') !== -1) {
-    back.textContent = '← Tagasi aruandesse';
-  } else if (ref.indexOf('/analyysikeskus') !== -1) {
-    back.textContent = '← Tagasi analüüsi';
-  } else {
-    back.textContent = '← Tagasi';
-  }
-  back.style.display = '';
-  back.onclick = function(e) {
+  if (ref.indexOf('/report') !== -1) return '← Tagasi aruandesse';
+  if (ref.indexOf('/analyysikeskus') !== -1) return '← Tagasi analüüsi';
+  return '← Tagasi';
+}
+
+function _wireBack(el) {
+  if (!el) return;
+  el.textContent = _backLabel();
+  el.style.display = '';
+  el.onclick = function(e) {
     e.preventDefault();
     if (document.referrer) {
       window.location.href = document.referrer;
@@ -943,6 +958,19 @@ function _showBackLink() {
       window.history.back();
     }
   };
+}
+
+// Detail-panel "← Tagasi" link (#719) — unhidden + wired when the page was
+// opened from a report/analysis (via ?focus=).
+function _showBackLink() {
+  _wireBack(document.getElementById('panel-back'));
+}
+
+// #746: the toolbar-level "← Tagasi aruandesse" link is server-rendered
+// (visible) whenever the page carries back-context (?focus= or ?draft=);
+// wire its label + handler on init.
+function _wireToolbarBack() {
+  _wireBack(document.getElementById('toolbar-back'));
 }
 
 // Pan/zoom so *d* sits at the centre of the viewport (#719 — the generic
@@ -1007,8 +1035,8 @@ async function focusOnEntity(uri) {
       count: 0,
       r: 16,
       isCategory: false,
-      x: (window.innerWidth || 1200) / 2,
-      y: (window.innerHeight || 800) / 2,
+      x: width / 2,
+      y: height / 2,
     };
     if (state.nodes.length < MAX_NODES) {
       state.nodes.push(datum);
@@ -1607,14 +1635,29 @@ function zoomToFit(duration) {
 }
 
 // ---------------------------------------------------------------------------
-// Window resize
+// Resize handling — the content area can change size without a window resize
+// (sidebar toggling, devtools docking, etc.), so a ResizeObserver on
+// `.main-content--full` is the right primitive. A `window.resize` listener is
+// kept as a cheap fallback for environments without ResizeObserver.
 // ---------------------------------------------------------------------------
 
-window.addEventListener('resize', () => {
-  width = window.innerWidth;
-  height = window.innerHeight;
+function _handleResize() {
+  const next = _contentSize();
+  if (Math.abs(next.width - width) < 1 && Math.abs(next.height - height) < 1) return;
+  width = next.width;
+  height = next.height;
   svg.attr('width', width).attr('height', height);
-});
+  // Re-frame the graph in the resized box: zoomToFit re-derives a centered
+  // transform from the current node bounding box. (forceCenter stays at the
+  // origin — it's in graph space, independent of the viewport size.)
+  zoomToFit(200);
+}
+
+if (typeof ResizeObserver !== 'undefined' && mainEl) {
+  const _ro = new ResizeObserver(() => { _handleResize(); });
+  _ro.observe(mainEl);
+}
+window.addEventListener('resize', _handleResize);
 
 // ---------------------------------------------------------------------------
 // Keyboard shortcut: Escape closes panel
@@ -1665,6 +1708,10 @@ document.addEventListener('DOMContentLoaded', () => {
 let wsInitialized = false;
 
 async function init() {
+  // #746: wire the toolbar-level "← Tagasi" link if the server rendered it
+  // (it's present whenever the page carries back-context — ?focus= / ?draft=).
+  _wireToolbarBack();
+
   const overview = await loadOverview();
   state.nodes = overview.nodes;
   state.links = overview.links;
@@ -1680,8 +1727,20 @@ async function init() {
     try { focusUri = new URLSearchParams(window.location.search).get('focus'); }
     catch (e) { focusUri = null; }
   }
+  // #746: ?search=<term> deep link — pre-run the search on load. ?focus=
+  // is more specific, so it wins when both are present.
+  var searchTerm = focusUri ? null : window.__explorerSearch;
+  if (!focusUri && !searchTerm) {
+    try { searchTerm = new URLSearchParams(window.location.search).get('search'); }
+    catch (e) { searchTerm = null; }
+  }
   if (focusUri) {
     await focusOnEntity(focusUri);
+  } else if (searchTerm && String(searchTerm).trim()) {
+    var searchInput = document.getElementById('search-input');
+    if (searchInput) searchInput.value = String(searchTerm);
+    await performSearch();
+    setTimeout(function() { zoomToFit(600); }, 800);
   } else {
     // Center the graph once the simulation settles
     setTimeout(function() { zoomToFit(600); }, 800);

--- a/app/ui/layout/page_shell.py
+++ b/app/ui/layout/page_shell.py
@@ -37,17 +37,28 @@ _TOAST_DISMISS_SCRIPT = """
 """
 
 
-def _head_tags(title: str):  # noqa: ANN202
+def _head_tags(title: str, extra_head: list | None = None):  # noqa: ANN202
     """Per-page ``<head>`` tags.
 
-    Only ``<title>`` varies per page — the theme init script, charset,
-    viewport, color-scheme and stylesheet ``<link>`` elements live on
-    ``fast_app(hdrs=...)`` in ``app.main`` so they land inside ``<head>``
-    regardless of which handler runs. Inline ``Script(...)`` / ``Link(...)``
-    returned from a handler end up in ``<body>`` and would defeat the FOUC
-    guard.
+    Only ``<title>`` varies per page in the common case — the theme init
+    script, charset, viewport, color-scheme and stylesheet ``<link>``
+    elements live on ``fast_app(hdrs=...)`` in ``app.main`` so they land
+    inside ``<head>`` regardless of which handler runs. Inline
+    ``Script(...)`` / ``Link(...)`` returned from a handler end up in
+    ``<body>`` and would defeat the FOUC guard.
+
+    ``extra_head`` lets a single page push extra ``<head>`` resources that
+    do not belong in the global ``hdrs`` list — e.g. the Õiguskaart page
+    pulls in the D3 v7 CDN ``<script>`` (~270 KB) and ``explorer.css``,
+    which no other page needs. These elements are appended *after* the
+    standard ``<title>``; FastHTML hoists everything a handler returns at
+    the very top of its response into ``<head>``, so listing them here
+    keeps them out of ``<body>``.
     """
-    return (Title(f"{title} — Seadusloome"),)  # noqa: F405
+    head = [Title(f"{title} — Seadusloome")]  # noqa: F405
+    if extra_head:
+        head.extend(extra_head)
+    return tuple(head)
 
 
 def PageShell(  # noqa: ANN201
@@ -59,6 +70,8 @@ def PageShell(  # noqa: ANN201
     unread_count: int = 0,
     container_size: ContainerSize = "lg",
     request: Request | None = None,
+    full_bleed: bool = False,
+    extra_head: list | None = None,
 ):
     """Wrap page content with topbar, sidebar, and main container.
 
@@ -67,14 +80,37 @@ def PageShell(  # noqa: ANN201
     session-flashed toast messages are drained and rendered into
     ``#toast-container`` (see :mod:`app.ui.feedback.flash`).
 
+    ``full_bleed=True`` is for pages that own their whole content area — the
+    Õiguskaart D3 canvas being the canonical example. In that mode the
+    ``<main>`` element gets the ``main-content--full`` modifier (zero
+    padding, ``overflow: hidden``, ``position: relative`` so the page's own
+    ``position: absolute`` children anchor to it) and the content is dropped
+    straight into ``<main>`` without the centring ``Container`` wrapper.
+
+    ``extra_head`` is a list of FT elements (``Script(...)`` / ``Link(...)``)
+    to append into ``<head>`` after the standard tags — for per-page assets
+    that should not bloat the global ``hdrs`` list (see :func:`_head_tags`).
+
     The ``theme`` parameter is retained for caller back-compat after the
     2026-04-16 dark-only migration but is no longer consumed internally —
     TopBar ignores its ``theme`` kwarg too, so we don't forward it.
     """
     del theme  # dark-only UI; accepted for back-compat with existing callers
     flash_toasts = render_flash_toasts(request) if request is not None else []
+    if full_bleed:
+        main_el = Main(  # noqa: F405
+            *content,
+            cls="main-content main-content--full",
+            id="main-content",
+        )
+    else:
+        main_el = Main(  # noqa: F405
+            Container(*content, size=container_size),
+            cls="main-content",
+            id="main-content",
+        )
     return (
-        *_head_tags(title),
+        *_head_tags(title, extra_head),
         A(  # noqa: F405
             "Mine põhisisu juurde",
             href="#main-content",
@@ -84,11 +120,7 @@ def PageShell(  # noqa: ANN201
             TopBar(user=user, unread_count=unread_count),
             Div(  # noqa: F405
                 Sidebar(user=user, active=active_nav),
-                Main(  # noqa: F405
-                    Container(*content, size=container_size),
-                    cls="main-content",
-                    id="main-content",
-                ),
+                main_el,
                 cls="app-body",
             ),
             Div(  # noqa: F405

--- a/docs/2026-05-12-ui-plan-explorer-home.html
+++ b/docs/2026-05-12-ui-plan-explorer-home.html
@@ -1,0 +1,898 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Seadusloome UI Plan - Home and Õiguskaart</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --panel: #101b2d;
+      --panel-2: #17243a;
+      --line: #2b3c58;
+      --muted: #9fb0c8;
+      --text: #eef5ff;
+      --accent: #22c7ee;
+      --accent-2: #7dd3fc;
+      --green: #34d399;
+      --amber: #fbbf24;
+      --red: #fb7185;
+      --white: #ffffff;
+      --shadow: 0 24px 80px rgba(0, 0, 0, .35);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at 20% 0%, rgba(34, 199, 238, .10), transparent 34rem),
+        linear-gradient(180deg, #081525 0%, var(--bg) 42rem);
+      color: var(--text);
+      line-height: 1.55;
+    }
+
+    a { color: var(--accent-2); }
+
+    .page {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 40px 24px 72px;
+    }
+
+    header.hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 24px;
+      align-items: end;
+      padding: 34px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: rgba(16, 27, 45, .82);
+      box-shadow: var(--shadow);
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      color: var(--accent-2);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      font-size: 12px;
+    }
+
+    h1, h2, h3 { line-height: 1.15; margin: 0; }
+    h1 { font-size: clamp(32px, 5vw, 58px); max-width: 850px; }
+    h2 { font-size: 28px; margin-bottom: 14px; }
+    h3 { font-size: 18px; margin-bottom: 8px; }
+
+    .hero p {
+      max-width: 820px;
+      margin: 18px 0 0;
+      color: var(--muted);
+      font-size: 18px;
+    }
+
+    .stamp {
+      min-width: 180px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      background: #0b1627;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .stamp strong {
+      display: block;
+      color: var(--white);
+      font-size: 18px;
+      margin-bottom: 2px;
+    }
+
+    section {
+      margin-top: 36px;
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: rgba(16, 27, 45, .76);
+    }
+
+    .plain {
+      padding: 0;
+      border: 0;
+      background: transparent;
+    }
+
+    .grid {
+      display: grid;
+      gap: 18px;
+    }
+
+    .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #0d1829;
+      padding: 18px;
+    }
+
+    .card p { margin: 8px 0 0; color: var(--muted); }
+
+    .callout {
+      border-left: 4px solid var(--accent);
+      padding: 16px 18px;
+      background: rgba(34, 199, 238, .08);
+      border-radius: 8px;
+      color: var(--text);
+    }
+
+    .warning { border-left-color: var(--amber); background: rgba(251, 191, 36, .08); }
+    .success { border-left-color: var(--green); background: rgba(52, 211, 153, .08); }
+
+    ul, ol { padding-left: 22px; }
+    li + li { margin-top: 8px; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #0d1829;
+    }
+
+    th, td {
+      padding: 13px 14px;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid var(--line);
+    }
+
+    th {
+      color: var(--white);
+      background: #132036;
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+    td { color: var(--muted); }
+    td strong { color: var(--white); }
+
+    code {
+      padding: 2px 5px;
+      border: 1px solid var(--line);
+      border-radius: 5px;
+      background: #07111f;
+      color: var(--accent-2);
+      font-size: .92em;
+    }
+
+    figure {
+      margin: 0;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: #0b1627;
+    }
+
+    figure img {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+
+    figcaption {
+      padding: 12px 14px;
+      color: var(--muted);
+      font-size: 14px;
+      border-top: 1px solid var(--line);
+    }
+
+    .tag-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 4px 9px;
+      border-radius: 6px;
+      border: 1px solid var(--line);
+      background: #0b1627;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .decision {
+      display: grid;
+      grid-template-columns: 160px 1fr;
+      gap: 18px;
+      align-items: start;
+    }
+
+    .score {
+      display: grid;
+      place-items: center;
+      min-height: 120px;
+      border-radius: 8px;
+      border: 1px solid rgba(52, 211, 153, .45);
+      background: rgba(52, 211, 153, .08);
+      color: var(--green);
+      font-weight: 800;
+      font-size: 28px;
+      text-align: center;
+    }
+
+    .flow {
+      width: 100%;
+      min-height: 290px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #07111f;
+    }
+
+    .wireframe {
+      display: grid;
+      grid-template-columns: 230px 1fr;
+      min-height: 450px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      background: #07111f;
+    }
+
+    .wf-sidebar {
+      border-right: 1px solid var(--line);
+      background: #101b2d;
+      padding: 18px;
+    }
+
+    .wf-sidebar .logo {
+      font-weight: 800;
+      margin-bottom: 22px;
+    }
+
+    .wf-nav {
+      display: grid;
+      gap: 8px;
+    }
+
+    .wf-nav span {
+      padding: 9px 10px;
+      border-radius: 6px;
+      color: var(--muted);
+    }
+
+    .wf-nav .active {
+      background: rgba(34, 199, 238, .12);
+      color: var(--white);
+      border: 1px solid rgba(34, 199, 238, .35);
+    }
+
+    .wf-main {
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+      min-width: 0;
+    }
+
+    .wf-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 16px 18px;
+      border-bottom: 1px solid var(--line);
+      background: #0d1829;
+    }
+
+    .wf-title {
+      font-weight: 800;
+      font-size: 22px;
+    }
+
+    .wf-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 12px 18px;
+      border-bottom: 1px solid var(--line);
+      background: #111d30;
+    }
+
+    .wf-pill {
+      min-height: 32px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--line);
+      color: var(--muted);
+      background: #0b1627;
+      font-size: 13px;
+    }
+
+    .wf-pill.primary {
+      background: var(--accent);
+      color: #06111f;
+      border-color: var(--accent);
+      font-weight: 800;
+    }
+
+    .wf-body {
+      display: grid;
+      grid-template-columns: 1fr 270px;
+      min-height: 330px;
+    }
+
+    .wf-graph {
+      position: relative;
+      min-height: 330px;
+      background:
+        radial-gradient(circle at 44% 45%, rgba(34, 199, 238, .2), transparent 16px),
+        radial-gradient(circle at 58% 35%, rgba(52, 211, 153, .2), transparent 18px),
+        radial-gradient(circle at 55% 62%, rgba(251, 191, 36, .16), transparent 16px),
+        #07111f;
+    }
+
+    .wf-graph::before,
+    .wf-graph::after {
+      content: "";
+      position: absolute;
+      height: 1px;
+      background: #526886;
+      transform-origin: left;
+    }
+
+    .wf-graph::before { width: 190px; left: 42%; top: 45%; transform: rotate(-32deg); }
+    .wf-graph::after { width: 210px; left: 44%; top: 45%; transform: rotate(26deg); }
+
+    .wf-detail {
+      border-left: 1px solid var(--line);
+      padding: 16px;
+      background: #101b2d;
+    }
+
+    .wf-detail .line {
+      height: 12px;
+      margin: 12px 0;
+      border-radius: 3px;
+      background: #263853;
+    }
+
+    .priority-list {
+      display: grid;
+      gap: 14px;
+      counter-reset: item;
+    }
+
+    .priority {
+      display: grid;
+      grid-template-columns: 42px 1fr;
+      gap: 14px;
+      align-items: start;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #0d1829;
+    }
+
+    .priority::before {
+      counter-increment: item;
+      content: counter(item);
+      display: grid;
+      place-items: center;
+      width: 36px;
+      height: 36px;
+      border-radius: 8px;
+      background: rgba(34, 199, 238, .12);
+      color: var(--accent-2);
+      font-weight: 800;
+    }
+
+    .priority p { margin: 6px 0 0; color: var(--muted); }
+
+    footer {
+      margin-top: 36px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    @media (max-width: 860px) {
+      header.hero,
+      .grid.two,
+      .grid.three,
+      .decision,
+      .wireframe,
+      .wf-body {
+        grid-template-columns: 1fr;
+      }
+
+      .wf-sidebar { border-right: 0; border-bottom: 1px solid var(--line); }
+      .wf-detail { border-left: 0; border-top: 1px solid var(--line); }
+      .page { padding: 24px 14px 48px; }
+      section { padding: 20px; }
+      table { display: block; overflow-x: auto; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">UI planning report</p>
+        <h1>Move Seadusloome from graph-first to workbench-first</h1>
+        <p>
+          The current authenticated root sends users directly into Õiguskaart. That makes the product feel like a graph tool, while the higher-value workflows are analysis, draft review, advisory help, and daily legal work triage.
+        </p>
+        <div class="tag-row">
+          <span class="tag">Scope: main view</span>
+          <span class="tag">Scope: explorer navigation</span>
+          <span class="tag">Output: implementation-ready plan</span>
+        </div>
+      </div>
+      <div class="stamp">
+        <strong>2026-05-12</strong>
+        Seadusloome<br>
+        UI logic review
+      </div>
+    </header>
+
+    <section>
+      <h2>Executive Recommendation</h2>
+      <div class="decision">
+        <div class="score">Use<br>Dashboard</div>
+        <div>
+          <p>
+            Change authenticated <code>/</code> from Õiguskaart to <code>/dashboard</code>. Keep Õiguskaart as an evidence and relationship view that opens from a draft, analysis result, search, or advisory answer with context already applied.
+          </p>
+          <p>
+            The Explorer should not be the main product surface. It is useful when the user already knows what legal object they want to inspect. It is weak as a daily starting point because it asks officials to begin with a visualization instead of a legal question, draft, risk, task, or recommendation.
+          </p>
+          <div class="callout success">
+            Recommended root behavior: unauthenticated users still go to <code>/auth/login</code>; authenticated users go to <code>/dashboard</code>. Dashboard then routes them into <code>Analüüsikeskus</code>, <code>Eelnõud</code>, <code>Koostaja</code>, <code>Nõustaja</code>, or <code>Õiguskaart</code> based on the work item.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="plain">
+      <div class="grid two">
+        <figure>
+          <img src="kasutusjuhend/assets/screenshot_explorer.png" alt="Existing Õiguskaart screenshot">
+          <figcaption>
+            Existing authenticated Õiguskaart screenshot in the repository manual assets. It shows the graph-first experience and a custom navigation/control bar.
+          </figcaption>
+        </figure>
+        <figure>
+          <img src="kasutusjuhend/assets/screenshot_dashboard.png" alt="Dashboard screenshot">
+          <figcaption>
+            Dashboard screenshot from the same manual assets. This is closer to the right default landing model: user-specific work queue and next actions.
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section>
+      <h2>What Is Happening Now</h2>
+      <div class="grid three">
+        <div class="card">
+          <h3>Root route is graph-first</h3>
+          <p>
+            In <code>app/main.py</code>, authenticated <code>/</code> currently returns <code>explorer_page(req)</code>. That makes the graph the default product entry point.
+          </p>
+        </div>
+        <div class="card">
+          <h3>Explorer has a separate shell</h3>
+          <p>
+            <code>app/explorer/pages.py</code> builds a custom <code>Html</code>/<code>Body</code> page and local navigation instead of using the standard <code>PageShell</code>.
+          </p>
+        </div>
+        <div class="card">
+          <h3>Global nav already exists</h3>
+          <p>
+            <code>app/ui/layout/sidebar.py</code> already defines the broader workbench nav: <code>Töölaud</code>, <code>Analüüsikeskus</code>, <code>Eelnõud</code>, <code>Õiguskaart</code>, <code>Koostaja</code>, <code>Nõustaja</code>, and admin items.
+          </p>
+        </div>
+      </div>
+      <p class="callout warning">
+        Note: the live URL was login-gated during this review, so the authenticated screenshots come from the repository's existing user-manual assets and the UI logic is verified from local source.
+      </p>
+    </section>
+
+    <section>
+      <h2>Why Explorer Is Weak As Home</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Problem</th>
+            <th>User impact</th>
+            <th>Better behavior</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>It starts with the data structure</strong></td>
+            <td>Officials have to translate a legal task into graph exploration.</td>
+            <td>Start from daily legal work: drafts, risks, analyses, review tasks, and recent work.</td>
+          </tr>
+          <tr>
+            <td><strong>It lacks a clear next action</strong></td>
+            <td>A graph can show relationships, but it does not tell the user what needs attention.</td>
+            <td>Dashboard cards should show "continue drafting", "review high-risk finding", "analysis changed", and "ask advisor".</td>
+          </tr>
+          <tr>
+            <td><strong>Graph usefulness depends on context</strong></td>
+            <td>The graph is useful after selecting a provision, draft, EU act, or court decision; it is less useful cold.</td>
+            <td>Open Õiguskaart with <code>?focus=</code>, <code>?draft=</code>, or <code>?search=</code> from other workflows.</td>
+          </tr>
+          <tr>
+            <td><strong>Custom navigation creates inconsistency</strong></td>
+            <td>Explorer feels like a separate app and users lose the stable sidebar/topbar model.</td>
+            <td>Use the shared app shell or recreate it exactly, with Õiguskaart active in the same sidebar.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Current Flow</h2>
+      <svg class="flow" viewBox="0 0 1080 300" role="img" aria-label="Current user flow from login to explorer">
+        <defs>
+          <marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+            <path d="M0,0 L10,4 L0,8 z" fill="#7dd3fc"></path>
+          </marker>
+          <style>
+            .box { fill:#101b2d; stroke:#2b3c58; stroke-width:2; rx:8; }
+            .box-warn { fill:#241c12; stroke:#b98718; stroke-width:2; rx:8; }
+            .txt { fill:#eef5ff; font: 700 16px Inter, sans-serif; }
+            .sub { fill:#9fb0c8; font: 13px Inter, sans-serif; }
+            .arr { stroke:#7dd3fc; stroke-width:2.5; marker-end:url(#arrow); fill:none; }
+          </style>
+        </defs>
+        <rect class="box" x="30" y="95" width="170" height="92"></rect>
+        <text class="txt" x="56" y="132">Login</text>
+        <text class="sub" x="56" y="158">/auth/login</text>
+        <path class="arr" d="M205 141 H300"></path>
+        <rect class="box-warn" x="310" y="75" width="210" height="132"></rect>
+        <text class="txt" x="338" y="116">Authenticated /</text>
+        <text class="sub" x="338" y="142">returns explorer_page(req)</text>
+        <text class="sub" x="338" y="166">user lands in graph</text>
+        <path class="arr" d="M525 141 H620"></path>
+        <rect class="box" x="630" y="75" width="190" height="132"></rect>
+        <text class="txt" x="658" y="116">Õiguskaart</text>
+        <text class="sub" x="658" y="142">search / nodes / timeline</text>
+        <text class="sub" x="658" y="166">custom nav controls</text>
+        <path class="arr" d="M825 141 H920"></path>
+        <rect class="box" x="930" y="75" width="120" height="132"></rect>
+        <text class="txt" x="956" y="116">Manual</text>
+        <text class="sub" x="956" y="142">find route,</text>
+        <text class="sub" x="956" y="164">task, or</text>
+        <text class="sub" x="956" y="186">entity</text>
+      </svg>
+    </section>
+
+    <section>
+      <h2>Proposed Flow</h2>
+      <svg class="flow" viewBox="0 0 1080 330" role="img" aria-label="Proposed user flow from login to dashboard and contextual explorer">
+        <defs>
+          <marker id="arrow2" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+            <path d="M0,0 L10,4 L0,8 z" fill="#34d399"></path>
+          </marker>
+          <style>
+            .box2 { fill:#101b2d; stroke:#2b3c58; stroke-width:2; rx:8; }
+            .box-good { fill:#102318; stroke:#2f8d63; stroke-width:2; rx:8; }
+            .txt2 { fill:#eef5ff; font: 700 16px Inter, sans-serif; }
+            .sub2 { fill:#9fb0c8; font: 13px Inter, sans-serif; }
+            .arr2 { stroke:#34d399; stroke-width:2.5; marker-end:url(#arrow2); fill:none; }
+          </style>
+        </defs>
+        <rect class="box2" x="30" y="119" width="150" height="92"></rect>
+        <text class="txt2" x="56" y="156">Login</text>
+        <text class="sub2" x="56" y="181">/auth/login</text>
+        <path class="arr2" d="M185 165 H270"></path>
+        <rect class="box-good" x="280" y="95" width="190" height="140"></rect>
+        <text class="txt2" x="310" y="132">Dashboard</text>
+        <text class="sub2" x="310" y="158">/dashboard</text>
+        <text class="sub2" x="310" y="181">next actions, risks,</text>
+        <text class="sub2" x="310" y="202">stale analyses</text>
+        <path class="arr2" d="M475 165 H560"></path>
+        <rect class="box2" x="570" y="28" width="190" height="94"></rect>
+        <text class="txt2" x="600" y="64">Analüüsikeskus</text>
+        <text class="sub2" x="600" y="90">legal workflows</text>
+        <rect class="box2" x="570" y="136" width="190" height="94"></rect>
+        <text class="txt2" x="600" y="172">Eelnõud</text>
+        <text class="sub2" x="600" y="198">draft workspace</text>
+        <rect class="box2" x="570" y="244" width="190" height="64"></rect>
+        <text class="txt2" x="600" y="282">Koostaja / Nõustaja</text>
+        <path class="arr2" d="M765 75 C840 75 840 150 910 150"></path>
+        <path class="arr2" d="M765 183 H910"></path>
+        <path class="arr2" d="M765 276 C840 276 840 216 910 216"></path>
+        <rect class="box-good" x="920" y="116" width="130" height="132"></rect>
+        <text class="txt2" x="944" y="154">Õiguskaart</text>
+        <text class="sub2" x="944" y="181">opened with</text>
+        <text class="sub2" x="944" y="203">context:</text>
+        <text class="sub2" x="944" y="225">focus/draft/search</text>
+      </svg>
+    </section>
+
+    <section>
+      <h2>Recommended Navigation Model</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Area</th>
+            <th>Role in product</th>
+            <th>Home priority</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Töölaud</strong></td>
+            <td>Daily queue: next actions, high-risk findings, stale analyses, active drafts, recent exports, bookmarks.</td>
+            <td>Default authenticated root.</td>
+          </tr>
+          <tr>
+            <td><strong>Analüüsikeskus</strong></td>
+            <td>Main place to start legal questions such as norm impact chains and EU transposition checks.</td>
+            <td>Primary dashboard CTA and top-level nav item.</td>
+          </tr>
+          <tr>
+            <td><strong>Eelnõud</strong></td>
+            <td>Document workspace for uploads, versions, impact reports, retention, export, and deletion.</td>
+            <td>Primary dashboard CTA when draft work exists.</td>
+          </tr>
+          <tr>
+            <td><strong>Õiguskaart</strong></td>
+            <td>Evidence map for relationships, provenance, timeline, and graph inspection.</td>
+            <td>Secondary: opened from context or direct search.</td>
+          </tr>
+          <tr>
+            <td><strong>Koostaja</strong></td>
+            <td>Drafting workflow, preferably seeded from an analysis or uploaded draft.</td>
+            <td>Primary when a user has active drafting sessions.</td>
+          </tr>
+          <tr>
+            <td><strong>Nõustaja</strong></td>
+            <td>Legal advisory conversation, also available from report rows and findings.</td>
+            <td>Contextual and top-level fallback.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Explorer Menu Fix</h2>
+      <p>
+        The Explorer should use one of two implementation paths. The first is preferable because it removes duplicated navigation logic.
+      </p>
+      <div class="grid two">
+        <div class="card">
+          <h3>Preferred: PageShell-based Õiguskaart</h3>
+          <p>
+            Render Õiguskaart inside the shared <code>PageShell</code> with <code>active_nav="/explorer"</code>. The sidebar and topbar come from the same components as the rest of the app. The graph canvas becomes the page content area.
+          </p>
+          <ul>
+            <li>One source of truth for nav labels and role filtering.</li>
+            <li>Consistent active state, user menu, notifications, skip link, and layout landmarks.</li>
+            <li>Explorer-specific controls become a toolbar, not global navigation.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Fallback: Visual parity shell</h3>
+          <p>
+            If the full PageShell constrains the D3 canvas too much, keep a custom body but import the same navigation data and match the same sidebar/topbar dimensions, colors, icons, and active states.
+          </p>
+          <ul>
+            <li>No hard-coded Explorer nav list.</li>
+            <li>Use real anchors for app navigation.</li>
+            <li>Use <code>aria-label="Õiguskaardi tööriistad"</code> for graph controls.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout">
+        Separate the concepts: app navigation belongs in the app shell; graph actions belong in the Õiguskaart toolbar. Users should never have to learn a different menu model just because the page contains D3.
+      </div>
+    </section>
+
+    <section>
+      <h2>Target Õiguskaart Layout</h2>
+      <div class="wireframe" aria-label="Wireframe of proposed Õiguskaart with consistent left navigation and graph toolbar">
+        <aside class="wf-sidebar">
+          <div class="logo">Seadusloome</div>
+          <nav class="wf-nav">
+            <span>Töölaud</span>
+            <span>Analüüsikeskus</span>
+            <span>Eelnõud</span>
+            <span class="active">Õiguskaart</span>
+            <span>Koostaja</span>
+            <span>Nõustaja</span>
+            <span>Administraator</span>
+          </nav>
+        </aside>
+        <div class="wf-main">
+          <div class="wf-top">
+            <div>
+              <div class="wf-title">Õiguskaart</div>
+              <div style="color:var(--muted);font-size:13px;">Eesti õiguse seosed ja tõendid</div>
+            </div>
+            <div class="wf-pill">User menu</div>
+          </div>
+          <div class="wf-toolbar">
+            <span class="wf-pill primary">Otsi</span>
+            <span class="wf-pill">Sisend: AvTS § 35</span>
+            <span class="wf-pill">Ajaline vaade</span>
+            <span class="wf-pill">Vaate seaded</span>
+            <span class="wf-pill">Tagasi aruandesse</span>
+          </div>
+          <div class="wf-body">
+            <div class="wf-graph"></div>
+            <aside class="wf-detail">
+              <strong>Detailpaneel</strong>
+              <div class="line" style="width:72%;"></div>
+              <div class="line" style="width:94%;"></div>
+              <div class="line" style="width:88%;"></div>
+              <div class="line" style="width:52%;"></div>
+              <div class="wf-pill primary" style="margin-top:24px;display:inline-flex;">Küsi nõustajalt</div>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Make Õiguskaart More Useful</h2>
+      <div class="priority-list">
+        <div class="priority">
+          <div>
+            <h3>Open with context by default</h3>
+            <p>
+              Treat direct, blank graph entry as the exception. Most links into Õiguskaart should include <code>?focus=</code>, <code>?draft=</code>, <code>?search=</code>, or an analysis id so the user sees a relevant subgraph immediately.
+            </p>
+          </div>
+        </div>
+        <div class="priority">
+          <div>
+            <h3>Replace cold graph start with legal starting points</h3>
+            <p>
+              If there is no context, show a compact start panel: search a law/provision, open recent bookmarks, inspect recent high-risk findings, or start <code>Normi mõjuahel</code> in Analüüsikeskus. Load the broad graph only after a choice.
+            </p>
+          </div>
+        </div>
+        <div class="priority">
+          <div>
+            <h3>Turn graph detail into evidence and actions</h3>
+            <p>
+              The detail panel should show source, date/version, relation type in legal language, why it matters, and actions: <code>Küsi nõustajalt</code>, <code>Ava analüüsikeskuses</code>, <code>Lisa märkus</code>, <code>Lisa järjehoidja</code>.
+            </p>
+          </div>
+        </div>
+        <div class="priority">
+          <div>
+            <h3>Use presets instead of graph jargon</h3>
+            <p>
+              Prefer legal view presets such as "Kehtiv õigus", "Eelnõu mõjud", "EL seosed", "Kohtupraktika", and "Ajalugu". Keep simulation controls under <code>Vaate seaded</code>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Implementation Plan</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th>Change</th>
+            <th>Files likely touched</th>
+            <th>Validation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>1</strong></td>
+            <td>Change authenticated root from Explorer to Dashboard.</td>
+            <td><code>app/main.py</code>, dashboard auth tests.</td>
+            <td><code>GET /</code> unauthenticated still redirects to login; authenticated user lands on <code>/dashboard</code> or receives a 303 to it.</td>
+          </tr>
+          <tr>
+            <td><strong>2</strong></td>
+            <td>Unify Explorer navigation with shared app shell.</td>
+            <td><code>app/explorer/pages.py</code>, <code>app/static/css/explorer.css</code>, possibly <code>app/ui/layout/page_shell.py</code>.</td>
+            <td>Õiguskaart shows same sidebar/topbar model, active nav state, user menu, and landmarks as other pages.</td>
+          </tr>
+          <tr>
+            <td><strong>3</strong></td>
+            <td>Move graph actions into an Explorer toolbar.</td>
+            <td><code>app/explorer/pages.py</code>, <code>app/static/js/explorer.js</code>, explorer CSS.</td>
+            <td>Toolbar contains search, timeline, view presets, and settings; no duplicated global nav in the graph toolbar.</td>
+          </tr>
+          <tr>
+            <td><strong>4</strong></td>
+            <td>Add contextual empty state and stronger deep links.</td>
+            <td>Explorer page, analysis result links, draft detail/report links, chat seed links.</td>
+            <td>Opening from a report focuses the entity or draft; opening blank shows useful legal starting points.</td>
+          </tr>
+          <tr>
+            <td><strong>5</strong></td>
+            <td>Responsive QA and accessibility pass.</td>
+            <td>Explorer CSS/tests.</td>
+            <td>Desktop and mobile screenshots show no overlap; keyboard can reach search, toolbar, graph controls, and detail panel.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Acceptance Criteria</h2>
+      <div class="grid two">
+        <div class="card">
+          <h3>Navigation</h3>
+          <ul>
+            <li>Authenticated root no longer opens a blank graph as the first screen.</li>
+            <li>All primary sections use the same labels and ordering in topbar/sidebar.</li>
+            <li>Õiguskaart has the same active nav treatment as other pages.</li>
+            <li>App navigation links are anchors with real <code>href</code> values.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Explorer usefulness</h3>
+          <ul>
+            <li>Blank Õiguskaart has a useful search/start state.</li>
+            <li>Analysis and draft pages can open Õiguskaart with context already applied.</li>
+            <li>The detail panel explains why a relation matters and offers next actions.</li>
+            <li>Mobile layout keeps search, controls, graph, and detail panel usable without overlap.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Decision Summary</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Decision</th>
+            <th>Recommendation</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Main view</strong></td>
+            <td>Use <code>Töölaud</code> / <code>/dashboard</code>.</td>
+            <td>It can represent daily legal work and route users to the right tool.</td>
+          </tr>
+          <tr>
+            <td><strong>Explorer role</strong></td>
+            <td>Reframe as <code>Õiguskaart</code>, a supporting evidence map.</td>
+            <td>The graph is valuable after context is known, not as the first decision surface.</td>
+          </tr>
+          <tr>
+            <td><strong>Explorer menu</strong></td>
+            <td>Use the shared app shell or an exact visual/navigation equivalent.</td>
+            <td>One navigation system lowers cognitive load and maintenance cost.</td>
+          </tr>
+          <tr>
+            <td><strong>Graph controls</strong></td>
+            <td>Keep them in a local toolbar with legal-language presets.</td>
+            <td>Users need legal scope controls, not simulation vocabulary.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <footer>
+      Sources reviewed: <code>app/main.py</code>, <code>app/ui/layout/sidebar.py</code>, <code>app/ui/layout/page_shell.py</code>, <code>app/explorer/pages.py</code>, existing manual screenshots under <code>docs/kasutusjuhend/assets/</code>, and the product structure note <code>docs/2026-05-11-ministry-lawyer-ui-structure.md</code>.
+    </footer>
+  </main>
+</body>
+</html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -32,6 +32,28 @@ class TestDashboardAuth:
         assert response.status_code == 303
         assert response.headers["location"] == "/auth/login"
 
+    @patch("app.auth.middleware._get_provider")
+    def test_index_redirects_authenticated_to_dashboard(self, mock_get_provider: MagicMock):
+        """#746: authenticated ``GET /`` lands on ``/dashboard`` (Töölaud),
+        not the Õiguskaart graph."""
+        from app.main import app
+
+        provider = MagicMock()
+        provider.get_current_user.return_value = {
+            "id": "u-1",
+            "email": "u@seadusloome.ee",
+            "full_name": "Test Kasutaja",
+            "role": "drafter",
+            "org_id": "11111111-1111-1111-1111-111111111111",
+        }
+        mock_get_provider.return_value = provider
+
+        client = TestClient(app, follow_redirects=False)
+        client.cookies.set("access_token", "stub-token")
+        response = client.get("/")
+        assert response.status_code == 303
+        assert response.headers["location"] == "/dashboard"
+
 
 # ---------------------------------------------------------------------------
 # /api/health returns JSON without auth

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -1,7 +1,10 @@
-"""Smoke tests for the Õiguskaart (explorer) page shell (#714 / #718).
+"""Smoke tests for the Õiguskaart (explorer) page (#714 / #718 / #746).
 
 Renders ``explorer_page`` directly via ``to_xml()`` and asserts on the
-control-bar copy — no TestClient, no DB.
+markup — no TestClient, no DB. Post-#746 the page is wrapped in the standard
+``PageShell`` (sidebar + topbar + user menu) with the graph controls as a
+horizontal toolbar; these tests pin both "the standard chrome is present"
+and "the bespoke chrome is gone".
 """
 
 from __future__ import annotations
@@ -32,60 +35,171 @@ def _req(query: str = "") -> Request:
     )
 
 
-def test_explorer_page_uses_legal_language_controls():
+def _html(query: str = "") -> str:
     from app.explorer.pages import explorer_page
 
-    html = to_xml(explorer_page(_req()))
+    return to_xml(explorer_page(_req(query)))
 
-    # New, plain-language / legal-work control labels (#714 / #718).
+
+# ---------------------------------------------------------------------------
+# Standard chrome present (PageShell sidebar + topbar)
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_page_renders_standard_sidebar():
+    html = _html()
+    # Standard nav labels from app.ui.layout.sidebar.NAV_ITEMS.
+    for label in ("Töölaud", "Analüüsikeskus", "Eelnõud", "Õiguskaart", "Koostaja", "Nõustaja"):
+        assert label in html, label
+    assert "sidebar" in html
+    # active_nav="/explorer" → the Õiguskaart item is marked current.
+    assert 'aria-current="page"' in html
+    assert "sidebar-link active" in html
+
+
+def test_explorer_page_renders_standard_topbar():
+    html = _html()
+    # The "Seadusloome" logo + the user menu (with the test user's name).
+    assert "Seadusloome" in html
+    assert "user-menu" in html
+    assert "Test User" in html
+    # Logout form posts to /auth/logout (part of the standard TopBar).
+    assert 'action="/auth/logout"' in html
+
+
+def test_explorer_page_pulls_d3_and_explorer_css_into_head():
+    html = _html()
+    # D3 v7 from the CDN — only the Õiguskaart page loads it (extra_head=).
+    assert "d3/7.9.0/d3.min.js" in html
+    assert 'integrity="sha512-' in html
+    assert 'crossorigin="anonymous"' in html
+    # The explorer stylesheet, also page-scoped.
+    assert "/static/css/explorer.css" in html
+    # The page's own JS bundle is still loaded.
+    assert "/static/js/explorer.js" in html
+
+
+# ---------------------------------------------------------------------------
+# Bespoke chrome removed
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_page_drops_bespoke_topbar_and_nav_buttons():
+    html = _html()  # a "cold" open — no ?focus / ?draft, so no toolbar-back link
+    # The old bespoke top bar block + its tagline / "D3.js" badge are gone.
+    assert 'id="topbar"' not in html
+    assert "explorer-tagline" not in html
+    # The bespoke left rail mixed graph controls with site-nav `.nav-btn`
+    # anchors and a `.ctrl-divider`. The real Sidebar replaces the site nav;
+    # the only `.nav-btn` left is the (conditional) toolbar back link, which
+    # is absent on a cold open.
+    assert "nav-btn" not in html
+    assert "ctrl-divider" not in html
+    # The old vertical control rail id is gone (replaced by #explorer-toolbar).
+    assert 'id="controls"' not in html
+    # Old site-nav anchors that lived in #controls (e.g. an <a href="/dashboard">
+    # styled as a button) are not in the explorer's own markup — those are now
+    # the Sidebar's sidebar-link anchors instead.
+    assert 'class="nav-btn"' not in html
+
+
+# ---------------------------------------------------------------------------
+# The graph toolbar
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_page_has_graph_toolbar_with_search_and_view_settings():
+    html = _html()
+    assert 'id="explorer-toolbar"' in html
+    assert 'aria-label="Õiguskaardi tööriistad"' in html
+    # The search box moved out of the deleted #topbar into the toolbar.
+    assert 'id="search-box"' in html
+    assert 'id="search-input"' in html
+    assert 'id="search-btn"' in html
+    # Legal-work view actions + the "Vaate seaded" disclosure.
+    assert "Ülevaade" in html
+    assert "Lähtesta vaade" in html
     assert "Vaate seaded" in html
     assert "Lähtesta paigutus" in html
     assert "Näita/peida seosenimed" in html
     assert "Rühmita liigi järgi" in html
-    assert "Lähtesta vaade" in html
-
-    # Old force-simulation vocabulary is gone from the control bar.
+    # Old force-simulation vocabulary stays gone from the control surface.
     assert "Taaskäivita simulatsioon" not in html
     assert "Lülita silte" not in html
     assert "Rühm. kategooria järgi" not in html
 
 
-def test_explorer_page_is_branded_oiguskaart():
-    from app.explorer.pages import explorer_page
-
-    html = to_xml(explorer_page(_req()))
-    assert "Õiguskaart" in html
-    assert "Uurija" not in html
-
-
 def test_explorer_page_timeline_is_clearly_labelled():
-    from app.explorer.pages import explorer_page
-
-    html = to_xml(explorer_page(_req()))
+    html = _html()
     assert "Ajaline vaade" in html
     assert "timeline-slider" in html
     # "Keelatud" was a confusing label for "no time filter active".
     assert "Keelatud" not in html
 
 
-def test_explorer_page_focus_param_is_handed_to_js():
-    from app.explorer.pages import explorer_page
+# ---------------------------------------------------------------------------
+# Branding
+# ---------------------------------------------------------------------------
 
+
+def test_explorer_page_is_branded_oiguskaart():
+    html = _html()
+    assert "Õiguskaart" in html
+    # The old "Uurija" name is gone everywhere on the page.
+    assert "Uurija" not in html
+
+
+def test_explorer_page_title_is_oiguskaart():
+    html = _html()
+    # PageShell renders "<title>Õiguskaart — Seadusloome</title>".
+    assert "Õiguskaart — Seadusloome" in html
+
+
+# ---------------------------------------------------------------------------
+# Deep links: ?focus= / ?search= / cold-open draft tip
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_page_focus_param_is_handed_to_js():
     uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
     # ``focus`` arrives already URL-decoded in req.query_params.
-    html = to_xml(explorer_page(_req(f"focus={uri}")))
+    html = _html(f"focus={uri}")
     assert "window.__explorerFocus" in html
     assert uri in html
-    # The "?draft=ID …" tip is suppressed when the user came here to
-    # look at a specific entity.
+    # The "?draft=ID …" tip is suppressed when the user came to look at a
+    # specific entity.
     assert "?draft=ID" not in html
-    # The back-link element is in the DOM (explorer.js unhides it).
+    # The detail-panel back link element is in the DOM (explorer.js unhides it),
+    # and the toolbar-level back link is rendered too.
     assert 'id="panel-back"' in html
+    assert 'id="toolbar-back"' in html
+    # ?focus= wins over ?search= when both are present.
+    html2 = _html(f"focus={uri}&search=karistus")
+    assert "window.__explorerFocus" in html2
+    assert "window.__explorerSearch" not in html2
+
+
+def test_explorer_page_search_param_is_handed_to_js():
+    html = _html("search=andmekaitse")
+    assert "window.__explorerSearch" in html
+    assert "andmekaitse" in html
+    # A bare ?search= is still a "cold" open as far as the back link goes —
+    # but the draft tip is still shown (no draft/focus/overlay).
+    assert "?draft=ID" in html
 
 
 def test_explorer_page_no_focus_keeps_the_draft_tip():
-    from app.explorer.pages import explorer_page
-
-    html = to_xml(explorer_page(_req()))
+    html = _html()
     assert "window.__explorerFocus" not in html
+    assert "window.__explorerSearch" not in html
+    # The cold-open hint about ?draft=ID is rendered in the toolbar.
     assert "?draft=ID" in html
+    assert 'id="explorer-tip-banner"' in html
+
+
+def test_explorer_page_search_blob_is_escaped():
+    # A `</script>` injection attempt in the term must be neutralised in the
+    # embedded blob exactly like the ?focus= blob is.
+    html = _html("search=</script><b>x")
+    assert "</script><b>x" not in html
+    assert "window.__explorerSearch" in html

--- a/tests/test_ui_layout.py
+++ b/tests/test_ui_layout.py
@@ -8,10 +8,11 @@ TestClient so they remain fast and isolated from the rest of the app.
 from typing import cast, get_args
 
 import pytest
-from fasthtml.common import to_xml
+from fasthtml.common import Link, Script, to_xml
 
 from app.auth.provider import UserDict
 from app.ui.layout.container import Container, ContainerSize
+from app.ui.layout.page_shell import PageShell
 from app.ui.layout.sidebar import NAV_ITEMS, Sidebar
 from app.ui.layout.top_bar import TopBar
 
@@ -228,3 +229,61 @@ def test_head_contains_theme_init_script_and_stylesheets():
 
     # And the per-page <title> must still be present.
     assert head.find("title") is not None
+
+
+# ---------------------------------------------------------------------------
+# PageShell — default container wrapping vs full_bleed; extra_head (#746)
+# ---------------------------------------------------------------------------
+
+
+def test_page_shell_default_wraps_content_in_container():
+    html = to_xml(PageShell("hello", title="Test"))
+    # The standard shell centres content in a .container (size-lg by default).
+    assert "container container-lg" in html
+    assert "main-content" in html
+    # Default mode is NOT full-bleed.
+    assert "main-content--full" not in html
+    assert "hello" in html
+
+
+def test_page_shell_full_bleed_skips_container_and_marks_main():
+    html = to_xml(PageShell("canvas-goes-here", title="Õiguskaart", full_bleed=True))
+    # full_bleed=True: the <main> carries the modifier class…
+    assert "main-content main-content--full" in html
+    # …and the content is NOT wrapped in a centring .container.
+    assert "container container-lg" not in html
+    assert "canvas-goes-here" in html
+
+
+def test_page_shell_extra_head_elements_appended_after_title():
+    """``extra_head=`` FT elements are appended into the head fragment, after
+    the standard ``<title>`` — FastHTML hoists everything a handler returns
+    that belongs in ``<head>`` (``Script``/``Link``/``Title``) at response
+    time, so emitting them here keeps them out of ``<body>``."""
+    html = to_xml(
+        PageShell(
+            "body",
+            title="WithExtra",
+            extra_head=[
+                Script(src="https://example.test/x.js"),
+                Link(rel="stylesheet", href="/x.css"),
+            ],
+        )
+    )
+    # The standard <title> is still present…
+    assert "WithExtra — Seadusloome" in html
+    # …and the extra head resources are emitted (before the body landmarks).
+    assert "https://example.test/x.js" in html
+    assert "/x.css" in html
+    title_pos = html.index("WithExtra — Seadusloome")
+    skip_pos = html.index("skip-to-content")
+    assert title_pos < html.index("https://example.test/x.js") < skip_pos
+    assert title_pos < html.index("/x.css") < skip_pos
+
+
+def test_page_shell_no_extra_head_is_back_compat():
+    """Default ``PageShell(...)`` (no ``extra_head``) still emits just the
+    standard <title> at the top — the explorer is the only caller passing
+    ``extra_head=``."""
+    html = to_xml(PageShell("body", title="Plain"))
+    assert "Plain — Seadusloome" in html


### PR DESCRIPTION
Closes **#746**. Two UI-logic fixes (planned in `docs/2026-05-12-ui-plan-explorer-home.html`, validated against source).

## Part 1 — authenticated `GET /` → `/dashboard`
Was rendering `explorer_page(req)` (the home page = a full-screen D3 graph). Now 303s to `/dashboard` — the "Töölaud" work queue ("what needs my attention today", from #717). Unauthenticated `/` → `/auth/login` unchanged. The Explorer is reached via the sidebar or via "Ava õiguskaardil" links from reports/analyses — not as the app's front door (the #714 doc explicitly de-framed it from "the primary Explorer" to "a supporting evidence view opened from analyses").

## Part 2 — Õiguskaart on the standard chrome (Option C)
- **`PageShell`** gains `full_bleed: bool` (no `Container` wrapper; `<main>` gets `main-content--full` → `padding:0; overflow:hidden; position:relative`) and `extra_head: list` (page-only `<head>` resources — the D3 v7 CDN script + `explorer.css` now load on Õiguskaart **only**, not in the global `_HDRS`).
- **`explorer_page`** returns `PageShell(<canvas + #explorer-toolbar + legend + instructions + #timeline-bar + #detail-panel + ?focus=/?search=/overlay blobs + explorer.js>, title="Õiguskaart", active_nav="/explorer", request=req, full_bleed=True, extra_head=...)`. Deleted: the bespoke `<header id="topbar">` (search box moved into the toolbar), the `#controls` `.nav-btn` site-nav links + `ctrl-divider` (the **real `Sidebar`** replaces them, with Õiguskaart highlighted — same nav labels/order/icons/role-filtering as every other page), and the verbose help banner (the small `?draft=ID` tip moved into the toolbar).
- **`#explorer-toolbar`** (`aria-label="Õiguskaardi tööriistad"`) — a thin horizontal bar across the top of the canvas: `Õiguskaart` label · `Ülevaade` · `Lähtesta vaade` · `Vaate seaded ▾` (dropdown) · search box · `← Tagasi aruandesse` (when opened via `?focus=`/`?draft=`) · the cold-open tip. Timeline bar stays at the bottom.
- **`explorer.css`** — every `position:fixed` → `position:absolute` (children of `.main-content--full`); deleted the global `*` reset / `body.explorer-page` rules / `#topbar` / `.nav-btn` / `.ctrl-divider` / the duplicate `#toast-container` (explorer.js' `showToast` now uses PageShell's container — avoids two elements with `id="toast-container"`); added the toolbar/dropdown/back-link/tip styling + a `@media (max-width:768px)` block.
- **`explorer.js`** — viewport size from `#main-content`'s bounding rect (not `window.innerWidth/innerHeight`); a `ResizeObserver` on it (+ a `window.resize` fallback); synthetic-node + tooltip coords adjusted to the content box; reads the new `window.__explorerSearch` (server-set when `?search=<term>` is in the URL) to pre-run the search on load (`?focus=` wins over `?search=`).

## Tests
`test_index_redirects_authenticated_to_dashboard` (303 → `/dashboard`); the unauthenticated one still green. PageShell `full_bleed` / `extra_head` cases (`tests/test_ui_layout.py`). `tests/test_explorer_pages.py` rewritten — standard `Sidebar`/`TopBar` markup + `aria-current="page"` on Õiguskaart + the toolbar with the moved search box + `?search=` `</script>`-injection escaping + the bespoke chrome (`#topbar`, `.nav-btn`, `explorer-tagline`, dup toast container) gone; the `?focus=`/timeline assertions preserved. Full suite: `2290 passed, 23 skipped`. `ruff` + `pyright` (repo-wide) + `node --check explorer.js` clean.

Also commits the planning doc `docs/2026-05-12-ui-plan-explorer-home.html`.

**Out of scope (next):** `#736`–`#745` review-finding fixes (incl. `#743`, which touches `explorer.js` — done after this merges to avoid the conflict), then the "make Õiguskaart a useful contextual evidence view" overhaul (focused-subgraph + presets + start-panel + detail-panel-as-evidence-with-actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)