### PR TITLE
fix(a11y): #744 — tabs roving tabindex follows arrow-key focus

### DIFF
--- a/app/static/js/tabs.js
+++ b/app/static/js/tabs.js
@@ -26,9 +26,22 @@
     const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight";
     const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft";
 
+    // Roving tabindex follows *focus*: when arrow keys move focus to another
+    // tab, that tab becomes the single tab-stop (tabindex="0") and the rest
+    // drop to tabindex="-1". This is intentionally separate from selection —
+    // `aria-selected` and the panels' `hidden` state only change on actual
+    // activation (Enter/Space/click) via `activateTab`. WAI-ARIA APG: "tabs
+    // with manual activation". See issue #744.
+    function setRovingTabindex(focusedIndex) {
+      tabs.forEach(function (t, i) {
+        t.setAttribute("tabindex", i === focusedIndex ? "0" : "-1");
+      });
+    }
+
     function focusTab(index) {
-      const target = tabs[(index + tabs.length) % tabs.length];
-      target.focus();
+      const targetIndex = (index + tabs.length) % tabs.length;
+      setRovingTabindex(targetIndex);
+      tabs[targetIndex].focus();
     }
 
     function activateTab(tab) {

--- a/tests/test_ui_navigation.py
+++ b/tests/test_ui_navigation.py
@@ -1,5 +1,7 @@
 """Smoke tests for Breadcrumb, Tabs, and TabPanel navigation components."""
 
+import re
+
 from fasthtml.common import to_xml
 
 from app.ui.navigation import Breadcrumb, TabPanel, Tabs
@@ -54,6 +56,33 @@ def test_tabs_explicit_active_selects_given_tab():
     assert 'data-tab-id="b"' in html
     assert html.count('aria-selected="true"') == 1
     assert html.count('aria-selected="false"') == 2
+
+
+def test_tabs_initial_roving_tabindex_invariant():
+    """Server render must seed the roving tabindex correctly: exactly one
+    tab is the tab-stop (``tabindex="0"``) and it is the selected tab — the
+    rest are ``tabindex="-1"``. This is the invariant ``tabs.js``'s
+    ``setRovingTabindex`` maintains as arrow keys move focus (issue #744:
+    roving tabindex must follow focus, not only activation). ``aria-selected``
+    stays pinned to the *selected* tab regardless of where focus roams.
+    """
+    html = to_xml(
+        Tabs(
+            [("a", "Alpha"), ("b", "Beta"), ("c", "Gamma")],
+            active="b",
+        )
+    )
+    assert html.count('tabindex="0"') == 1
+    assert html.count('tabindex="-1"') == 2
+    # The single tab-stop is the selected tab: both attributes land on tab-b.
+    tab_tags = re.findall(r"<button[^>]*\brole=\"tab\"[^>]*>", html)
+    assert len(tab_tags) == 3
+    selected_tag = next(t for t in tab_tags if 'id="tab-b"' in t)
+    assert 'aria-selected="true"' in selected_tag
+    assert 'tabindex="0"' in selected_tag
+    for other in (t for t in tab_tags if 'id="tab-b"' not in t):
+        assert 'aria-selected="false"' in other
+        assert 'tabindex="-1"' in other
 
 
 def test_tabs_vertical_orientation_sets_classes():


### PR DESCRIPTION
Closes #744

## Problem
`app/static/js/tabs.js` advertises the WAI-ARIA APG "tabs with manual activation" pattern (roving tabindex), but `focusTab(index)` only called `.focus()` — it never moved the `tabindex="0"` marker. `activateTab` updates `tabindex`, but that runs only on click / Enter / Space. So after arrowing to an inactive tab in manual-activation mode, focus sat on a `tabindex="-1"` element and subsequent Tab key behaviour jumped inconsistently instead of continuing from the visibly focused tab.

## Fix
- New `setRovingTabindex(focusedIndex)` helper, called from `focusTab`: on arrow-key focus movement (Arrow keys / Home / End) every tab is updated so the focused tab gets `tabindex="0"` and the rest get `tabindex="-1"`.
- `aria-selected` and the panels' `hidden` state are **left unchanged** until actual activation (Enter / Space / click) — "roving focus" (tabindex follows focus) and "selection" (aria-selected + panel visibility follows activation) are now cleanly separated. The behaviour and its rationale are documented in a comment block referencing this issue.
- `app/ui/navigation/tabs.py` — **no change needed**. The `Tabs` FT component already seeds the initial render correctly (selected tab `tabindex="0"`, others `-1`), which is exactly the invariant `setRovingTabindex` maintains at runtime. Verified.

## Tests / checks
- `tests/test_ui_navigation.py` — added `test_tabs_initial_roving_tabindex_invariant`: asserts the server render seeds exactly one `tabindex="0"` and it lands on the selected tab (the others `tabindex="-1"`, `aria-selected="false"`) — the invariant the JS mirrors. There is no JS DOM test harness in the repo, so the runtime arrow-nav behaviour is captured in a comment + `node --check`.
- `node --check app/static/js/tabs.js` — clean
- `uv run ruff format app/ tests/` — no changes
- `uv run ruff check app/ tests/` — All checks passed
- `uv run pyright` (whole repo) — 0 errors, 0 warnings
- `uv run pytest tests/test_ui_navigation.py -q` — 8 passed (was 7)
- `uv run pytest -q` (full) — 2291 passed, 23 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)