### PR TITLE
fix(docs): #736 — delete every version's file + named graph on draft delete

### DIFF
--- a/app/docs/cleanup_handler.py
+++ b/app/docs/cleanup_handler.py
@@ -1,4 +1,4 @@
-"""``draft_cleanup`` job handler — post-delete orphan cleanup (#628).
+"""``draft_cleanup`` job handler — post-delete orphan cleanup (#628, #736).
 
 When a user deletes a draft we do the fast, transactional work inline
 (drop the row, cancel pending background jobs, clear rag_chunks) and
@@ -9,16 +9,29 @@ user or leave the DB in an inconsistent state.
 Responsibilities
 ----------------
 
-1. Delete the encrypted file on disk (idempotent — a missing file
-   counts as success).
-2. Delete the draft's Jena named graph (idempotent — Fuseki 404 is
-   also success).
+1. Delete **every** encrypted file on disk that the draft (and all its
+   versions) referenced (idempotent — a missing file counts as success;
+   one bad path does not abort the rest of the list).
+2. Delete **every** Jena named graph the draft (and all its versions)
+   referenced (idempotent — Fuseki 404 is also success).
 
-The handler is intentionally tolerant of partial-failure: we do each
-step inside its own ``try`` so a failure in step 2 still leaves step
-1 applied, and we only raise when *both* steps fail. The worker's
-retry machinery will then re-run us with the same payload until the
-retry budget is exhausted.
+Why a list (#736)
+-----------------
+
+A draft can carry multiple ``draft_versions`` rows, each with its own
+``storage_path`` and per-version ``graph_uri``. Those rows cascade-delete
+with the parent ``drafts`` row, so unless the lifecycle handler collects
+them *before* deleting the draft and passes them all here, older versions'
+files and named graphs become undiscoverable orphans. The payload now
+carries ``storage_paths`` / ``graph_uris`` arrays; the legacy singular
+``storage_path`` / ``graph_uri`` keys are still honoured so any job
+enqueued by an older app build (in-flight at deploy time) still works.
+
+The handler is intentionally tolerant of partial-failure: each delete
+runs inside its own ``try`` so a failure in one step (or on one path)
+still applies the rest, and we only raise when **everything** failed and
+nothing was cleaned. The worker's retry machinery will then re-run us
+with the same payload until the retry budget is exhausted.
 
 Registration
 ------------
@@ -39,6 +52,31 @@ from app.sync.jena_loader import delete_named_graph
 logger = logging.getLogger(__name__)
 
 
+def _collect(payload: dict[str, Any], plural_key: str, singular_key: str) -> list[str]:
+    """Merge a payload's ``plural_key`` list and legacy ``singular_key`` scalar.
+
+    De-duplicates while preserving first-seen order and drops empties.
+    Accepts the legacy ``{storage_path: ..., graph_uri: ...}`` shape so a
+    ``draft_cleanup`` job enqueued by an older app build still cleans up
+    its single file/graph after a deploy (#736 backward-compat).
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    values = list(payload.get(plural_key) or [])
+    legacy = payload.get(singular_key)
+    if legacy:
+        values.append(legacy)
+    for value in values:
+        if not value:
+            continue
+        text = str(value)
+        if text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
 def draft_cleanup(
     payload: dict[str, Any],
     *,
@@ -46,10 +84,14 @@ def draft_cleanup(
     max_attempts: int = 3,
     job_id: int | None = None,
 ) -> dict[str, Any]:
-    """Delete the encrypted file + Jena named graph for a removed draft.
+    """Delete every encrypted file + Jena named graph for a removed draft.
 
     Args:
-        payload: ``{"draft_id": "<uuid>", "storage_path": "<path or None>",
+        payload: ``{"draft_id": "<uuid>",
+                    "storage_paths": ["<path>", ...],
+                    "graph_uris": ["<uri>", ...],
+                    # legacy singular keys still accepted:
+                    "storage_path": "<path or None>",
                     "graph_uri": "<uri or None>"}``.
         attempt: 1-based retry counter (unused today but accepted so
             the handler signature matches the worker contract).
@@ -57,58 +99,60 @@ def draft_cleanup(
             "mark the draft as orphaned" logic on final attempt).
 
     Returns:
-        ``{"draft_id": ..., "storage_deleted": bool, "graph_deleted": bool}``.
+        ``{"draft_id": ..., "storage_deleted": int, "graph_deleted": int,
+           "storage_total": int, "graph_total": int}``.
     """
     draft_id = str(payload.get("draft_id") or "")
-    storage_path = payload.get("storage_path")
-    graph_uri = payload.get("graph_uri")
+    storage_paths = _collect(payload, "storage_paths", "storage_path")
+    graph_uris = _collect(payload, "graph_uris", "graph_uri")
 
-    storage_deleted = False
-    graph_deleted = False
+    storage_deleted = 0
+    graph_deleted = 0
     errors: list[str] = []
 
-    if storage_path:
+    for storage_path in storage_paths:
         try:
-            delete_encrypted_file(str(storage_path))
-            storage_deleted = True
+            delete_encrypted_file(storage_path)
+            storage_deleted += 1
         except FileNotFoundError:
-            # Already gone — count as success.
-            storage_deleted = True
+            # Already gone — count as success and keep going.
+            storage_deleted += 1
         except Exception as exc:
-            errors.append(f"storage: {exc}")
+            errors.append(f"storage[{storage_path}]: {exc}")
             logger.exception(
                 "draft_cleanup: failed to delete encrypted file draft=%s path=%s",
                 draft_id,
                 storage_path,
             )
-    else:
-        storage_deleted = True
 
-    if graph_uri:
+    for graph_uri in graph_uris:
         try:
-            delete_named_graph(str(graph_uri))
-            graph_deleted = True
+            delete_named_graph(graph_uri)
+            graph_deleted += 1
         except Exception as exc:
-            errors.append(f"jena: {exc}")
+            errors.append(f"jena[{graph_uri}]: {exc}")
             logger.exception(
                 "draft_cleanup: failed to delete named graph draft=%s uri=%s",
                 draft_id,
                 graph_uri,
             )
-    else:
-        graph_deleted = True
 
-    if errors and not (storage_deleted or graph_deleted):
-        # Both steps failed — re-raise so the worker records the job as
-        # failed and consumes a retry attempt. One-of-two partial
-        # failures still report success so we don't loop forever on a
-        # persistently-missing Jena graph when the file is already gone.
+    # Re-raise only when *everything* failed — i.e. there was work to do,
+    # we attempted it, and not a single file or graph was cleaned. A
+    # partial success (some paths/graphs purged) reports success so we
+    # don't loop forever on a persistently-missing Jena graph while the
+    # files are already gone. An empty payload (no work) is also success.
+    attempted = len(storage_paths) + len(graph_uris)
+    cleaned = storage_deleted + graph_deleted
+    if errors and attempted > 0 and cleaned == 0:
         raise RuntimeError("; ".join(errors))
 
     return {
         "draft_id": draft_id,
         "storage_deleted": storage_deleted,
         "graph_deleted": graph_deleted,
+        "storage_total": len(storage_paths),
+        "graph_total": len(graph_uris),
     }
 
 

--- a/app/docs/draft_model.py
+++ b/app/docs/draft_model.py
@@ -234,14 +234,95 @@ def update_draft_parent_vtk(
     return (result.rowcount or 0) > 0
 
 
+def get_draft_artifact_paths(
+    conn: Any,
+    draft_id: uuid.UUID | str,
+) -> tuple[list[str], list[str]]:
+    """Return every encrypted-file path + Jena named-graph URI for *draft_id*.
+
+    A draft can carry **multiple** versions (``draft_versions`` — one row
+    per legislative reading), each with its own ``storage_path`` and
+    per-version ``graph_uri`` (#618 §9.5). Because ``draft_versions`` is
+    ``ON DELETE CASCADE`` from ``drafts``, those rows vanish the instant
+    the parent draft row is deleted — so the caller MUST collect the
+    artifact paths *before* calling :func:`delete_draft`, then hand them
+    to the ``draft_cleanup`` background job so every file on disk and
+    every named graph in Fuseki is purged (#736).
+
+    The legacy ``drafts.storage_path`` / ``drafts.graph_uri`` columns are
+    folded in too: for v1 rows they equal the version row's values, but a
+    draft that somehow predates migration 030's backfill (or a test fake)
+    would otherwise leak its only file. Results are de-duplicated while
+    preserving first-seen order so the cleanup job never deletes the same
+    path twice.
+
+    Returns:
+        ``(storage_paths, graph_uris)`` — two parallel-purpose lists of
+        non-empty strings. Empty lists when the draft does not exist or
+        the query fails (logged) — the caller treats an empty result as
+        "nothing external to clean up".
+    """
+    storage_paths: list[str] = []
+    graph_uris: list[str] = []
+    seen_paths: set[str] = set()
+    seen_graphs: set[str] = set()
+
+    def _add_path(value: Any) -> None:
+        if value and str(value) not in seen_paths:
+            seen_paths.add(str(value))
+            storage_paths.append(str(value))
+
+    def _add_graph(value: Any) -> None:
+        if value and str(value) not in seen_graphs:
+            seen_graphs.add(str(value))
+            graph_uris.append(str(value))
+
+    try:
+        # Legacy per-draft columns first so they take priority in the
+        # de-dup ordering (they are the v1 values in practice).
+        legacy = conn.execute(
+            "select storage_path, graph_uri from drafts where id = %s",
+            (str(draft_id),),
+        ).fetchone()
+        if legacy is not None:
+            _add_path(legacy[0])
+            _add_graph(legacy[1])
+
+        version_rows = conn.execute(
+            """
+            select storage_path, graph_uri
+            from draft_versions
+            where draft_id = %s
+            order by version_number asc
+            """,
+            (str(draft_id),),
+        ).fetchall()
+        for row in version_rows:
+            _add_path(row[0])
+            _add_graph(row[1])
+    except Exception:
+        logger.exception("Failed to collect artifact paths for draft=%s", draft_id)
+        return [], []
+
+    return storage_paths, graph_uris
+
+
 def delete_draft(conn: Any, draft_id: uuid.UUID | str) -> str | None:
     """Delete a draft row and return its ``storage_path`` for file cleanup.
 
-    The ``drafts`` table has ``ON DELETE CASCADE`` into ``draft_entities``
-    and ``impact_reports``, so removing the row here automatically clears
-    related records. The returned ``storage_path`` lets the caller delete
-    the encrypted file *after* the DB row is gone so we never orphan
-    ciphertext while the DB still points at it.
+    The ``drafts`` table has ``ON DELETE CASCADE`` into ``draft_entities``,
+    ``draft_versions`` and ``impact_reports``, so removing the row here
+    automatically clears related records. The returned ``storage_path``
+    lets the caller delete the encrypted file *after* the DB row is gone
+    so we never orphan ciphertext while the DB still points at it.
+
+    .. note::
+        This returns only the *legacy* ``drafts.storage_path``. Callers
+        that need to clean up **every** version's file + named graph must
+        first call :func:`get_draft_artifact_paths` (which also reads
+        ``draft_versions``) — see ``app/docs/routes/_lifecycle.py`` and
+        #736. ``delete_draft``'s single-path return is kept for backward
+        compatibility with callers that only want the row gone.
 
     Returns ``None`` when the draft did not exist.
     """

--- a/app/docs/routes/_lifecycle.py
+++ b/app/docs/routes/_lifecycle.py
@@ -33,6 +33,7 @@ from app.docs.audit import log_draft_delete
 from app.docs.draft_model import (
     delete_draft,
     fetch_draft,
+    get_draft_artifact_paths,
     touch_draft_access,
 )
 from app.jobs.queue import JobQueue
@@ -82,10 +83,20 @@ def delete_draft_handler(req: Request, draft_id: str):
     # every DB mutation into ONE transactional block and hands the
     # slow/flaky external cleanup off to a background ``draft_cleanup``
     # job that can retry independently.
-    storage_path: str | None = None
+    storage_paths: list[str] = []
+    graph_uris: list[str] = []
     try:
         with _connect() as conn:
-            storage_path = delete_draft(conn, parsed)
+            # #736: a draft can carry multiple ``draft_versions`` rows,
+            # each with its own encrypted file + per-version Jena named
+            # graph. Those rows cascade-delete with the parent ``drafts``
+            # row, so we MUST snapshot every artifact path BEFORE the
+            # delete — otherwise older versions' files/graphs become
+            # undiscoverable orphans. ``get_draft_artifact_paths`` reads
+            # ``draft_versions`` + the legacy ``drafts`` columns and
+            # de-dupes.
+            storage_paths, graph_uris = get_draft_artifact_paths(conn, parsed)
+            delete_draft(conn, parsed)
             # #576: polymorphic soft reference — clear any rag_chunks rows
             # tied to this draft inside the same transaction as the row
             # delete so either both land or neither does. Today no private
@@ -121,18 +132,35 @@ def delete_draft_handler(req: Request, draft_id: str):
     # blocks the user flow or leaves the DB inconsistent. Failure to
     # enqueue is logged but non-fatal — the DB is already clean and
     # the operator can always delete the file/graph manually.
+    #
+    # #736: the payload carries arrays — one entry per draft version —
+    # so the handler purges every file + named graph, not just the
+    # latest. ``draft.graph_uri`` (the latest version's URI) is folded
+    # into ``graph_uris`` by ``get_draft_artifact_paths`` already, but
+    # we union it again defensively in case the snapshot raced an edit.
+    # The legacy singular ``storage_path``/``graph_uri`` keys are kept
+    # so the older handler shape (if a worker hasn't redeployed yet)
+    # still cleans up at least the primary artifact.
+    if draft.graph_uri and draft.graph_uri not in graph_uris:
+        graph_uris.append(draft.graph_uri)
+    primary_path = storage_paths[0] if storage_paths else None
+    primary_graph = graph_uris[0] if graph_uris else draft.graph_uri
     cleanup_payload = {
         "draft_id": str(parsed),
-        "storage_path": storage_path,
-        "graph_uri": draft.graph_uri,
+        "storage_paths": storage_paths,
+        "graph_uris": graph_uris,
+        # Backward-compat for an older in-flight handler build:
+        "storage_path": primary_path,
+        "graph_uri": primary_graph,
     }
     try:
         cleanup_job_id = JobQueue().enqueue("draft_cleanup", cleanup_payload, priority=0)
         logger.info(
-            "Orphan cleanup job enqueued draft=%s job_id=%s storage_path=%s",
+            "Orphan cleanup job enqueued draft=%s job_id=%s files=%d graphs=%d",
             parsed,
             cleanup_job_id,
-            storage_path,
+            len(storage_paths),
+            len(graph_uris),
         )
     except Exception:
         logger.exception(

--- a/tests/test_docs_cleanup_handler.py
+++ b/tests/test_docs_cleanup_handler.py
@@ -1,10 +1,15 @@
-"""Tests for the ``draft_cleanup`` background job handler (#628).
+"""Tests for the ``draft_cleanup`` background job handler (#628, #736).
 
 The handler is deliberately tolerant of partial failure: we keep the
 user-visible delete fast by moving external cleanups (encrypted file +
-Jena graph purge) off-line, and we only re-raise when BOTH steps
-fail so a persistently-missing Jena graph doesn't loop us forever on
-an already-deleted file.
+Jena graph purge) off-line, and we only re-raise when EVERYTHING fails
+(work was attempted, nothing was cleaned) so a persistently-missing
+Jena graph doesn't loop us forever once the files are already gone.
+
+#736 widened the payload from a single ``storage_path`` / ``graph_uri``
+to ``storage_paths`` / ``graph_uris`` arrays — one entry per draft
+version — while still honouring the legacy singular keys for any job
+enqueued by an older app build that was in flight at deploy time.
 """
 
 from __future__ import annotations
@@ -17,9 +22,11 @@ from app.docs.cleanup_handler import draft_cleanup
 
 
 class TestDraftCleanupHandler:
+    # -- legacy singular-key payloads (backward compat) --------------------
+
     @patch("app.docs.cleanup_handler.delete_named_graph")
     @patch("app.docs.cleanup_handler.delete_encrypted_file")
-    def test_deletes_file_and_graph(self, mock_file, mock_graph):
+    def test_legacy_singular_payload_deletes_file_and_graph(self, mock_file, mock_graph):
         payload = {
             "draft_id": "d1",
             "storage_path": "/tmp/cipher.enc",
@@ -28,8 +35,8 @@ class TestDraftCleanupHandler:
         result = draft_cleanup(payload)
         mock_file.assert_called_once_with("/tmp/cipher.enc")
         mock_graph.assert_called_once_with("https://example.org/drafts/d1")
-        assert result["storage_deleted"] is True
-        assert result["graph_deleted"] is True
+        assert result["storage_deleted"] == 1
+        assert result["graph_deleted"] == 1
 
     @patch("app.docs.cleanup_handler.delete_named_graph")
     @patch("app.docs.cleanup_handler.delete_encrypted_file")
@@ -41,38 +48,122 @@ class TestDraftCleanupHandler:
             "graph_uri": "https://example.org/drafts/d1",
         }
         result = draft_cleanup(payload)
-        assert result["storage_deleted"] is True
+        assert result["storage_deleted"] == 1
+
+    # -- array payloads (#736) --------------------------------------------
 
     @patch("app.docs.cleanup_handler.delete_named_graph")
     @patch("app.docs.cleanup_handler.delete_encrypted_file")
-    def test_both_failing_raises(self, mock_file, mock_graph):
+    def test_deletes_every_version_file_and_graph(self, mock_file, mock_graph):
+        payload = {
+            "draft_id": "d1",
+            "storage_paths": ["/tmp/v1.enc", "/tmp/v2.enc", "/tmp/v3.enc"],
+            "graph_uris": [
+                "https://example.org/drafts/d1/v1",
+                "https://example.org/drafts/d1/v2",
+                "https://example.org/drafts/d1/v3",
+            ],
+        }
+        result = draft_cleanup(payload)
+        assert {c.args[0] for c in mock_file.call_args_list} == {
+            "/tmp/v1.enc",
+            "/tmp/v2.enc",
+            "/tmp/v3.enc",
+        }
+        assert {c.args[0] for c in mock_graph.call_args_list} == {
+            "https://example.org/drafts/d1/v1",
+            "https://example.org/drafts/d1/v2",
+            "https://example.org/drafts/d1/v3",
+        }
+        assert result["storage_deleted"] == 3
+        assert result["graph_deleted"] == 3
+        assert result["storage_total"] == 3
+        assert result["graph_total"] == 3
+
+    @patch("app.docs.cleanup_handler.delete_named_graph")
+    @patch("app.docs.cleanup_handler.delete_encrypted_file")
+    def test_array_and_legacy_keys_are_merged_and_deduped(self, mock_file, mock_graph):
+        """A transitional payload may carry both shapes — union, no dups."""
+        payload = {
+            "draft_id": "d1",
+            "storage_paths": ["/tmp/v1.enc", "/tmp/v2.enc"],
+            "graph_uris": ["g1", "g2"],
+            # legacy keys repeat the latest version — must not double-delete
+            "storage_path": "/tmp/v2.enc",
+            "graph_uri": "g2",
+        }
+        result = draft_cleanup(payload)
+        assert sorted(c.args[0] for c in mock_file.call_args_list) == [
+            "/tmp/v1.enc",
+            "/tmp/v2.enc",
+        ]
+        assert sorted(c.args[0] for c in mock_graph.call_args_list) == ["g1", "g2"]
+        assert result["storage_deleted"] == 2
+        assert result["graph_deleted"] == 2
+
+    @patch("app.docs.cleanup_handler.delete_named_graph")
+    @patch("app.docs.cleanup_handler.delete_encrypted_file")
+    def test_one_bad_path_does_not_abort_the_rest(self, mock_file, mock_graph):
+        """A missing/erroring file is logged and skipped; siblings still go."""
+
+        def _maybe_boom(path):
+            if path == "/tmp/v2.enc":
+                raise RuntimeError("disk boom")
+
+        mock_file.side_effect = _maybe_boom
+        result = draft_cleanup(
+            {
+                "draft_id": "d1",
+                "storage_paths": ["/tmp/v1.enc", "/tmp/v2.enc", "/tmp/v3.enc"],
+                "graph_uris": [],
+            }
+        )
+        # v1 + v3 succeeded, v2 failed — but no exception bubbled up
+        # because there was *some* progress.
+        assert result["storage_deleted"] == 2
+        assert result["storage_total"] == 3
+
+    # -- failure semantics ------------------------------------------------
+
+    @patch("app.docs.cleanup_handler.delete_named_graph")
+    @patch("app.docs.cleanup_handler.delete_encrypted_file")
+    def test_everything_failing_raises(self, mock_file, mock_graph):
         mock_file.side_effect = RuntimeError("disk boom")
         mock_graph.side_effect = RuntimeError("jena boom")
         with pytest.raises(RuntimeError):
             draft_cleanup(
                 {
                     "draft_id": "d1",
-                    "storage_path": "/tmp/cipher.enc",
-                    "graph_uri": "https://example.org/drafts/d1",
+                    "storage_paths": ["/tmp/v1.enc"],
+                    "graph_uris": ["https://example.org/drafts/d1"],
                 }
             )
 
     @patch("app.docs.cleanup_handler.delete_named_graph")
     @patch("app.docs.cleanup_handler.delete_encrypted_file")
     def test_partial_failure_does_not_raise(self, mock_file, mock_graph):
-        """File deleted but Jena still failing — don't loop forever."""
+        """Files deleted but Jena still failing — don't loop forever."""
         mock_graph.side_effect = RuntimeError("jena boom")
         result = draft_cleanup(
             {
                 "draft_id": "d1",
-                "storage_path": "/tmp/cipher.enc",
-                "graph_uri": "https://example.org/drafts/d1",
+                "storage_paths": ["/tmp/v1.enc"],
+                "graph_uris": ["https://example.org/drafts/d1"],
             }
         )
-        assert result["storage_deleted"] is True
-        assert result["graph_deleted"] is False
+        assert result["storage_deleted"] == 1
+        assert result["graph_deleted"] == 0
 
-    def test_missing_storage_path_is_no_op(self):
-        result = draft_cleanup({"draft_id": "d1", "storage_path": None, "graph_uri": None})
-        assert result["storage_deleted"] is True
-        assert result["graph_deleted"] is True
+    def test_empty_payload_is_a_no_op(self):
+        result = draft_cleanup({"draft_id": "d1"})
+        assert result["storage_deleted"] == 0
+        assert result["graph_deleted"] == 0
+        assert result["storage_total"] == 0
+        assert result["graph_total"] == 0
+
+    def test_explicit_empty_arrays_is_a_no_op(self):
+        result = draft_cleanup(
+            {"draft_id": "d1", "storage_paths": [], "graph_uris": [], "storage_path": None}
+        )
+        assert result["storage_deleted"] == 0
+        assert result["graph_deleted"] == 0

--- a/tests/test_docs_draft_model.py
+++ b/tests/test_docs_draft_model.py
@@ -29,8 +29,10 @@ from app.docs.draft_model import (
     Draft,
     _row_to_draft,
     create_draft,
+    delete_draft,
     fetch_draft,
     get_draft,
+    get_draft_artifact_paths,
     list_drafts_for_org,
     list_eelnous_for_vtk,
     list_versionable_drafts_for_org,
@@ -1108,3 +1110,128 @@ class TestListEelnousForVtk:
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
         assert list_eelnous_for_vtk(_VTK_ID, org_id=_ORG_ID) == []
+
+
+# ---------------------------------------------------------------------------
+# get_draft_artifact_paths -- collect EVERY version's file + named graph (#736)
+# ---------------------------------------------------------------------------
+
+
+def _artifact_conn(*, legacy_row, version_rows):
+    """Build a MagicMock conn whose two ``execute`` calls return the
+    legacy ``drafts`` row then the ``draft_versions`` rows.
+
+    ``get_draft_artifact_paths`` issues exactly two queries: a single-row
+    SELECT against ``drafts`` followed by a multi-row SELECT against
+    ``draft_versions`` ordered by ``version_number ASC``.
+    """
+    conn = MagicMock()
+    legacy_cursor = MagicMock()
+    legacy_cursor.fetchone.return_value = legacy_row
+    versions_cursor = MagicMock()
+    versions_cursor.fetchall.return_value = list(version_rows)
+    conn.execute.side_effect = [legacy_cursor, versions_cursor]
+    return conn
+
+
+class TestGetDraftArtifactPaths:
+    def test_collects_every_version_path_and_graph(self):
+        """A draft with 3 versions yields all 3 files + all 3 graphs.
+
+        The legacy ``drafts`` columns equal v1's values here (the normal
+        post-migration-030 case) so they de-dup away — the result is the
+        ordered union with no repeats.
+        """
+        v1 = ("/storage/v1.enc", "urn:draft:d/v1")
+        v2 = ("/storage/v2.enc", "urn:draft:d/v2")
+        v3 = ("/storage/v3.enc", "urn:draft:d/v3")
+        conn = _artifact_conn(legacy_row=v1, version_rows=[v1, v2, v3])
+
+        storage_paths, graph_uris = get_draft_artifact_paths(conn, _DRAFT_ID)
+
+        assert storage_paths == ["/storage/v1.enc", "/storage/v2.enc", "/storage/v3.enc"]
+        assert graph_uris == ["urn:draft:d/v1", "urn:draft:d/v2", "urn:draft:d/v3"]
+        # First query targets drafts, second targets draft_versions ASC.
+        first_sql = conn.execute.call_args_list[0].args[0].lower()
+        second_sql = conn.execute.call_args_list[1].args[0].lower()
+        assert "from drafts" in first_sql
+        assert "from draft_versions" in second_sql
+        assert "version_number asc" in second_sql
+
+    def test_legacy_columns_differ_from_versions_are_included(self):
+        """If the legacy ``drafts.*`` differs from every version row
+        (a draft predating the 030 backfill), the legacy file/graph is
+        still returned so it cannot orphan.
+        """
+        legacy = ("/storage/legacy.enc", "urn:draft:d/legacy")
+        v1 = ("/storage/v1.enc", "urn:draft:d/v1")
+        conn = _artifact_conn(legacy_row=legacy, version_rows=[v1])
+
+        storage_paths, graph_uris = get_draft_artifact_paths(conn, _DRAFT_ID)
+
+        assert storage_paths == ["/storage/legacy.enc", "/storage/v1.enc"]
+        assert graph_uris == ["urn:draft:d/legacy", "urn:draft:d/v1"]
+
+    def test_no_versions_falls_back_to_legacy_only(self):
+        legacy = ("/storage/only.enc", "urn:draft:d")
+        conn = _artifact_conn(legacy_row=legacy, version_rows=[])
+
+        storage_paths, graph_uris = get_draft_artifact_paths(conn, _DRAFT_ID)
+
+        assert storage_paths == ["/storage/only.enc"]
+        assert graph_uris == ["urn:draft:d"]
+
+    def test_missing_draft_returns_empty_lists(self):
+        conn = _artifact_conn(legacy_row=None, version_rows=[])
+
+        assert get_draft_artifact_paths(conn, _DRAFT_ID) == ([], [])
+
+    def test_nulls_are_skipped(self):
+        """A version row with a NULL/empty path or graph contributes
+        nothing rather than queueing ``""`` for deletion.
+        """
+        conn = _artifact_conn(
+            legacy_row=(None, None),
+            version_rows=[("/storage/v1.enc", None), (None, "urn:draft:d/v2")],
+        )
+
+        storage_paths, graph_uris = get_draft_artifact_paths(conn, _DRAFT_ID)
+
+        assert storage_paths == ["/storage/v1.enc"]
+        assert graph_uris == ["urn:draft:d/v2"]
+
+    def test_db_error_returns_empty_lists(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("db down")
+
+        assert get_draft_artifact_paths(conn, _DRAFT_ID) == ([], [])
+
+
+class TestDeleteDraft:
+    def test_returns_legacy_storage_path_and_deletes_row(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = ("/storage/x.enc",)
+
+        result = delete_draft(conn, _DRAFT_ID)
+
+        assert result == "/storage/x.enc"
+        # A DELETE FROM drafts was issued for the row.
+        delete_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if "delete from drafts" in (c.args[0].lower() if c.args else "")
+        ]
+        assert delete_calls
+        assert delete_calls[0].args[1] == (str(_DRAFT_ID),)
+
+    def test_missing_draft_returns_none_without_delete(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        assert delete_draft(conn, _DRAFT_ID) is None
+        delete_calls = [
+            c
+            for c in conn.execute.call_args_list
+            if "delete from drafts" in (c.args[0].lower() if c.args else "")
+        ]
+        assert not delete_calls

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -1008,6 +1008,7 @@ class TestDraftStatusFragment:
 class TestDeleteDraftHandler:
     @patch("app.docs.routes._lifecycle.JobQueue")
     @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.get_draft_artifact_paths")
     @patch("app.docs.routes._lifecycle.delete_draft")
     @patch("app.docs.routes._lifecycle._connect")
     @patch("app.docs.routes._lifecycle.fetch_draft")
@@ -1018,6 +1019,7 @@ class TestDeleteDraftHandler:
         mock_fetch: MagicMock,
         mock_connect: MagicMock,
         mock_delete: MagicMock,
+        mock_artifacts: MagicMock,
         mock_log: MagicMock,
         mock_queue_cls: MagicMock,
     ):
@@ -1033,6 +1035,7 @@ class TestDeleteDraftHandler:
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
         mock_delete.return_value = "/tmp/ciphertext.enc"
+        mock_artifacts.return_value = (["/tmp/ciphertext.enc"], [draft.graph_uri])
 
         queue_instance = MagicMock()
         queue_instance.enqueue.return_value = 99
@@ -1045,6 +1048,10 @@ class TestDeleteDraftHandler:
         assert resp.headers["location"] == "/drafts"
         mock_delete.assert_called_once()
         mock_log.assert_called_once()
+
+        # #736: artifact paths are snapshotted BEFORE the row delete so
+        # the cascade-deleted draft_versions rows are still readable.
+        mock_artifacts.assert_called_once()
 
         # #628: a single _connect() transaction covers row delete,
         # rag_chunks clearing and job cancellation. The handler opens
@@ -1064,16 +1071,74 @@ class TestDeleteDraftHandler:
         # #478: running jobs must also be in the status filter.
         assert "'running'" in delete_call.args[0]
 
-        # #628: the external cleanup is enqueued as a background job
-        # with the storage_path + graph_uri payload so the worker can
-        # retry independently.
+        # #628/#736: the external cleanup is enqueued as a background job
+        # with ARRAYS of storage_paths + graph_uris (one per version) so
+        # the worker can retry independently and purge every artifact.
         queue_instance.enqueue.assert_called_once()
         args, kwargs = queue_instance.enqueue.call_args
         assert args[0] == "draft_cleanup"
         payload = args[1]
         assert payload["draft_id"] == str(draft.id)
+        assert payload["storage_paths"] == ["/tmp/ciphertext.enc"]
+        assert payload["graph_uris"] == [draft.graph_uri]
+        # legacy singular keys still present for backward compat
         assert payload["storage_path"] == "/tmp/ciphertext.enc"
         assert payload["graph_uri"] == draft.graph_uri
+
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.get_draft_artifact_paths")
+    @patch("app.docs.routes._lifecycle.delete_draft")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_delete_versioned_draft_enqueues_every_version_artifact(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_delete: MagicMock,
+        mock_artifacts: MagicMock,
+        mock_log: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """#736: deleting a draft with >=2 versions must enqueue cleanup
+        for EVERY version's storage path AND named graph URI, not just
+        the latest — older draft_versions rows cascade away on delete,
+        so their files/graphs would otherwise orphan on disk and in Jena.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft()
+        mock_fetch.return_value = draft
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_delete.return_value = "/tmp/v2.enc"
+        v1_path, v2_path = "/tmp/v1.enc", "/tmp/v2.enc"
+        v1_graph = f"{draft.graph_uri}/v1"
+        v2_graph = f"{draft.graph_uri}/v2"
+        mock_artifacts.return_value = ([v1_path, v2_path], [v1_graph, v2_graph])
+
+        queue_instance = MagicMock()
+        queue_instance.enqueue.return_value = 7
+        mock_queue_cls.return_value = queue_instance
+
+        client = _authed_client()
+        resp = client.post(f"/drafts/{draft.id}/delete")
+
+        assert resp.status_code == 303
+        mock_artifacts.assert_called_once()
+        queue_instance.enqueue.assert_called_once()
+        payload = queue_instance.enqueue.call_args.args[1]
+        # BOTH version files queued for deletion.
+        assert payload["storage_paths"] == [v1_path, v2_path]
+        # BOTH named graphs queued for deletion...
+        assert v1_graph in payload["graph_uris"]
+        assert v2_graph in payload["graph_uris"]
+        # ...plus the "current" draft.graph_uri (defensively unioned by
+        # the handler in case it differs from every version row).
+        assert draft.graph_uri in payload["graph_uris"]
 
     @patch("app.docs.routes._lifecycle.fetch_draft")
     @patch("app.auth.middleware._get_provider")
@@ -1113,6 +1178,7 @@ class TestDeleteDraftHandler:
 
     @patch("app.docs.routes._lifecycle.JobQueue")
     @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.get_draft_artifact_paths")
     @patch("app.docs.routes._lifecycle.delete_draft")
     @patch("app.docs.routes._lifecycle._connect")
     @patch("app.docs.routes._lifecycle.fetch_draft")
@@ -1123,6 +1189,7 @@ class TestDeleteDraftHandler:
         mock_fetch: MagicMock,
         mock_connect: MagicMock,
         mock_delete: MagicMock,
+        mock_artifacts: MagicMock,
         mock_log: MagicMock,
         mock_queue_cls: MagicMock,
     ):
@@ -1145,6 +1212,7 @@ class TestDeleteDraftHandler:
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
         mock_delete.return_value = "/tmp/ciphertext.enc"
+        mock_artifacts.return_value = (["/tmp/ciphertext.enc"], [draft.graph_uri])
 
         client = _authed_client()
         resp = client.post(f"/drafts/{draft.id}/delete")
@@ -1155,6 +1223,7 @@ class TestDeleteDraftHandler:
 
     @patch("app.docs.routes._lifecycle.JobQueue")
     @patch("app.docs.routes._lifecycle.log_draft_delete")
+    @patch("app.docs.routes._lifecycle.get_draft_artifact_paths")
     @patch("app.docs.routes._lifecycle.delete_draft")
     @patch("app.docs.routes._lifecycle._connect")
     @patch("app.docs.routes._lifecycle.fetch_draft")
@@ -1165,6 +1234,7 @@ class TestDeleteDraftHandler:
         mock_fetch: MagicMock,
         mock_connect: MagicMock,
         mock_delete: MagicMock,
+        mock_artifacts: MagicMock,
         mock_log: MagicMock,
         mock_queue_cls: MagicMock,
     ):
@@ -1185,6 +1255,7 @@ class TestDeleteDraftHandler:
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
         mock_delete.return_value = "/tmp/ciphertext.enc"
+        mock_artifacts.return_value = (["/tmp/ciphertext.enc"], [draft.graph_uri])
         queue_instance = MagicMock()
         queue_instance.enqueue.return_value = 99
         mock_queue_cls.return_value = queue_instance


### PR DESCRIPTION
Closes #736.

## Problem
Deleting a versioned draft only queued cleanup for the **latest** draft file and the draft's current `graph_uri`. Because `draft_versions` rows are `ON DELETE CASCADE` from `drafts`, prior versions' `storage_path` / `graph_uri` became undiscoverable the instant the parent row was deleted — leaving orphaned encrypted files on disk and orphaned named graphs in Jena. Pre-publication drafts are sensitive (CLAUDE.md §"Draft sensitivity": explicit delete must remove file + named graph + DB rows).

## Fix
- **`app/docs/draft_model.py`** — new `get_draft_artifact_paths(conn, draft_id) -> (storage_paths: list[str], graph_uris: list[str])`: reads every `draft_versions` row (ordered by `version_number ASC`) plus the legacy `drafts.storage_path` / `drafts.graph_uri` columns, de-duplicated and order-preserving. `delete_draft`'s docstring now points callers at it. Both `delete_draft` and the new helper still return sentinels (no raise) on DB error.
- **`app/docs/routes/_lifecycle.py`** — `delete_draft_handler` now snapshots all artifact paths **before** the row delete (while `draft_versions` is still readable), then enqueues `draft_cleanup` with `storage_paths` / `graph_uris` **arrays**. The legacy singular `storage_path` / `graph_uri` keys are still included (= the primary artifact) so a `draft_cleanup` job picked up by an older worker build still cleans up at least one file/graph. `draft.graph_uri` is defensively unioned in case it differs from every version row.
- **`app/docs/cleanup_handler.py`** — `draft_cleanup` payload widened to `{storage_paths, graph_uris, ...legacy singular keys}`. The handler merges the array + legacy keys (deduped), then iterates: best-effort `delete_file` for **every** path (a missing/erroring file is logged and skipped — siblings still get deleted) and `delete_named_graph` for **every** URI. It re-raises (consuming a retry) only when work was attempted and **nothing** was cleaned; partial success and empty payloads report success so we never loop forever on a persistently-missing Jena graph. Return shape: `{draft_id, storage_deleted, graph_deleted, storage_total, graph_total}` (counts, was bools).

## Tests
- `tests/test_docs_draft_model.py` — new `TestGetDraftArtifactPaths` (collects every version's path+graph; legacy-differs-from-versions still included; no-versions falls back to legacy; missing draft → `([], [])`; NULL paths/graphs skipped; DB error → `([], [])`) and `TestDeleteDraft`.
- `tests/test_docs_cleanup_handler.py` — rewritten for the array payload: legacy singular payloads, array payloads (every version deleted), merged-and-deduped transitional payloads, "one bad path doesn't abort the rest", everything-fails-raises, partial-failure-doesn't-raise, empty payload no-op.
- `tests/test_docs_routes.py` — existing delete tests updated to mock `get_draft_artifact_paths`; **new** `test_delete_versioned_draft_enqueues_every_version_artifact` asserts a 2-version draft delete enqueues `draft_cleanup` with **both** storage paths and **both** named graph URIs (Jena `delete_named_graph` + filesystem are mocked via the handler-level mocks; the route test mocks the model helper).

## Checks (run in the worktree)
- `uv run ruff format app/ tests/` — clean
- `uv run ruff check app/ tests/` — All checks passed!
- `uv run pyright` (whole repo) — 0 errors, 0 warnings
- `uv run pytest tests/test_docs_routes.py tests/test_docs_cleanup_handler.py tests/test_docs_draft_model.py -q` — 182 passed
- `uv run pytest -q` (full) — 2303 passed, 23 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)