### PR TITLE
fix: #740 admin temp password off the URL; #742 clamp pagination; #745 serialize version-number allocation

### DIFF
--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -6,8 +6,9 @@ import logging
 import os
 
 from fasthtml.common import *
+from fasthtml.common import to_xml
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import HTMLResponse, RedirectResponse
 
 from app.auth.audit import log_action
 from app.auth.organizations import list_orgs
@@ -765,6 +766,54 @@ def org_user_deactivate(req: Request, user_id: str):
 # Admin password reset — shared helpers and handlers
 # ---------------------------------------------------------------------------
 
+# Session key holding a freshly-set admin temporary password awaiting its
+# one-time reveal on the next ``GET …/reset`` page load. The value is
+# ``{"user_id": <str>, "password": <str>}`` — keyed by user so a reveal can
+# never be shown against the wrong target after a redirect. The credential
+# travels in the signed *session cookie* (server-side state for our
+# purposes), never in the URL, so it can't leak via browser history,
+# proxy/access logs, referrers, or copied links (#740).
+_PW_RESET_REVEAL_KEY = "pw_reset_reveal"
+
+
+def _session_dict(req: Request) -> dict | None:  # type: ignore[type-arg]
+    """Return the Starlette session mapping, or ``None`` if unavailable.
+
+    Mirrors :func:`app.ui.feedback.flash._session` — the session middleware
+    is always installed in production but unit tests that exercise these
+    helpers directly (without the ASGI stack) won't have it.
+    """
+    try:
+        return req.session  # type: ignore[attr-defined,no-any-return]
+    except (AssertionError, AttributeError, KeyError):
+        return None
+
+
+def _stash_temp_password_reveal(req: Request, user_id: str, password: str) -> None:
+    """Stash *password* in the session for a one-time reveal on the reset page."""
+    sess = _session_dict(req)
+    if sess is None:
+        return
+    sess[_PW_RESET_REVEAL_KEY] = {"user_id": str(user_id), "password": password}
+
+
+def _pop_temp_password_reveal(req: Request, user_id: str) -> str | None:
+    """Return and clear the stashed temp password if it matches *user_id*.
+
+    Drains the session key unconditionally so a stale reveal queued for a
+    different user never lingers across navigations.
+    """
+    sess = _session_dict(req)
+    if sess is None:
+        return None
+    raw = sess.pop(_PW_RESET_REVEAL_KEY, None)
+    if not isinstance(raw, dict):
+        return None
+    if str(raw.get("user_id")) != str(user_id):
+        return None
+    pw = raw.get("password")
+    return pw if isinstance(pw, str) and pw else None
+
 
 def _admin_reset_page(req: Request, user_id: str, *, base_path: str, active_nav: str):
     """GET /admin/users/{id}/reset (or /org/users/{id}/reset)."""
@@ -783,18 +832,20 @@ def _admin_reset_page(req: Request, user_id: str, *, base_path: str, active_nav:
                 active_nav,
             )
 
-    flash = req.query_params.get("temp")  # one-time temp-pw reveal
+    # One-time temp-pw reveal — read from the (signed) session, never the URL.
+    revealed_password = _pop_temp_password_reveal(req, user_id)
 
-    return PageShell(
+    page = PageShell(
         H1("Lähtesta parool", cls="page-title"),
         Card(
             CardHeader(P(f"Kasutaja: {user['full_name']} ({user['email']})", cls="card-subtitle")),
             CardBody(
                 Alert(
-                    f"Ajutine parool on määratud. Edasta see kasutajale turvaliselt: {flash}",
+                    "Ajutine parool on määratud. Edasta see kasutajale turvaliselt: "
+                    f"{revealed_password}",
                     variant="success",
                 )
-                if flash
+                if revealed_password
                 else None,
                 AppForm(
                     Button("Saada e-postiga", type="submit", variant="primary"),
@@ -823,6 +874,11 @@ def _admin_reset_page(req: Request, user_id: str, *, base_path: str, active_nav:
         user=auth or None,
         active_nav=active_nav,
     )
+    if revealed_password:
+        # The page body now contains a live credential — keep it out of any
+        # shared/back-button cache.
+        return HTMLResponse(to_xml(page), headers={"Cache-Control": "no-store"})
+    return page
 
 
 def _admin_reset_email(req: Request, user_id: str, *, base_path: str, active_nav: str):
@@ -897,8 +953,12 @@ def _admin_reset_temp(
         {"target_user_id": user_id, "mode": "temp"},
     )
 
+    # Hand the credential to the reveal page via the signed session — NOT
+    # the redirect URL — so it can't leak through history/logs/referrers
+    # (#740). The reset page consumes it exactly once.
+    _stash_temp_password_reveal(req, user_id, new_password)
     return RedirectResponse(
-        url=f"{base_path}/{user_id}/reset?temp={new_password}",
+        url=f"{base_path}/{user_id}/reset",
         status_code=303,
     )
 

--- a/app/docs/upload.py
+++ b/app/docs/upload.py
@@ -39,6 +39,8 @@ import os
 import uuid
 from typing import Any, Protocol
 
+import psycopg
+
 from app.auth.audit import log_action
 from app.auth.provider import UserDict
 from app.db import get_connection as _connect
@@ -53,6 +55,15 @@ from app.jobs import JobQueue
 from app.storage import delete_file, store_file
 
 logger = logging.getLogger(__name__)
+
+# How many times to re-run the v2+ version-creation transaction when it
+# trips the ``UNIQUE(draft_id, version_number)`` constraint (#745).  The
+# advisory lock in :func:`app.docs.version_model.get_next_version_number`
+# should make a collision practically impossible, but a belt-and-braces
+# retry turns any residual race into a transparent second attempt rather
+# than a 500.  A tiny budget is enough — each retry re-reads ``MAX`` after
+# the conflicting transaction has committed, so the next number is free.
+_MAX_VERSION_ALLOC_ATTEMPTS = 3
 
 
 # Allowed extensions and their canonical content types. The tuple order
@@ -273,50 +284,101 @@ async def handle_upload(
 
     # Steps 4-6 live inside a single transaction so we either commit the
     # draft row *and* enqueue the job, or we bail and clean up the file.
+    #
+    # The v2+ branch additionally retries the whole transaction on a
+    # ``UNIQUE(draft_id, version_number)`` violation (#745): the advisory
+    # lock in ``get_next_version_number`` already serialises allocators,
+    # but if one still slips through we re-read ``MAX`` and try again
+    # rather than surface a raw 500.  The new-draft branch never retries.
     factory = conn_factory or _connect
     queue = job_queue or JobQueue()
-    try:
-        with factory() as conn:
-            if parent_draft_id is not None:
-                draft = _create_new_version(
-                    conn,
-                    parent_draft_id=parent_draft_id,
-                    user=user,
-                    file_size=file_size,
-                    filename=filename,
-                    content_type=content_type,
-                    storage_path=stored.storage_path,
+    max_attempts = _MAX_VERSION_ALLOC_ATTEMPTS if parent_draft_id is not None else 1
+    draft: Draft | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with factory() as conn:
+                if parent_draft_id is not None:
+                    draft = _create_new_version(
+                        conn,
+                        parent_draft_id=parent_draft_id,
+                        user=user,
+                        file_size=file_size,
+                        filename=filename,
+                        content_type=content_type,
+                        storage_path=stored.storage_path,
+                    )
+                else:
+                    draft = _create_new_draft(
+                        conn,
+                        user_id=user_id,
+                        org_id=org_id,
+                        title=cleaned_title,
+                        filename=filename,
+                        content_type=content_type,
+                        file_size=file_size,
+                        storage_path=stored.storage_path,
+                        doc_type=doc_type,
+                        parent_vtk_id=parent_vtk_id,
+                    )
+                conn.commit()
+            break
+        except psycopg.errors.UniqueViolation:
+            # Only the v2+ branch knows what a unique violation means here
+            # (the ``UNIQUE(draft_id, version_number)`` race) and how to
+            # recover from it.  Anything else propagates to the generic
+            # handler below — re-raised unchanged after the file cleanup.
+            if parent_draft_id is None:
+                logger.exception(
+                    "Draft insert hit a unique violation — cleaning up path=%s",
+                    stored.storage_path,
                 )
-            else:
-                draft = _create_new_draft(
-                    conn,
-                    user_id=user_id,
-                    org_id=org_id,
-                    title=cleaned_title,
-                    filename=filename,
-                    content_type=content_type,
-                    file_size=file_size,
-                    storage_path=stored.storage_path,
-                    doc_type=doc_type,
-                    parent_vtk_id=parent_vtk_id,
+                delete_file(stored.storage_path)
+                raise
+            # Two uploads raced on the version number despite the advisory
+            # lock.  Roll back is implicit (the ``with`` block aborts the
+            # txn); retry if we still have budget.
+            if attempt < max_attempts:
+                logger.warning(
+                    "Draft version-number collision for parent=%s on attempt %d/%d — retrying",
+                    parent_draft_id,
+                    attempt,
+                    max_attempts,
                 )
-            conn.commit()
-    except DraftUploadError:
-        # User-facing validation failure — clean up the orphan file
-        # before re-raising so the caller can render the error.
-        logger.info(
-            "Draft upload validation failed; cleaning up file path=%s",
-            stored.storage_path,
-        )
+                continue
+            logger.warning(
+                "Draft version-number collision for parent=%s exhausted retries; "
+                "cleaning up file path=%s",
+                parent_draft_id,
+                stored.storage_path,
+            )
+            delete_file(stored.storage_path)
+            raise DraftUploadError(
+                "Uue versiooni loomine ebaõnnestus samaaegse üleslaadimise tõttu. "
+                "Palun proovige uuesti."
+            ) from None
+        except DraftUploadError:
+            # User-facing validation failure — clean up the orphan file
+            # before re-raising so the caller can render the error.
+            logger.info(
+                "Draft upload validation failed; cleaning up file path=%s",
+                stored.storage_path,
+            )
+            delete_file(stored.storage_path)
+            raise
+        except Exception:
+            logger.exception(
+                "Draft insert failed after file was stored — cleaning up path=%s",
+                stored.storage_path,
+            )
+            delete_file(stored.storage_path)
+            raise
+
+    if draft is None:
+        # Unreachable: the loop either assigned ``draft`` and broke, or
+        # raised.  Guard so the type checker (and a future refactor) can't
+        # fall through with a stale file.
         delete_file(stored.storage_path)
-        raise
-    except Exception:
-        logger.exception(
-            "Draft insert failed after file was stored — cleaning up path=%s",
-            stored.storage_path,
-        )
-        delete_file(stored.storage_path)
-        raise
+        raise RuntimeError("Draft upload transaction produced no draft row")
 
     # Step 6 proper: enqueue the async parse pipeline. A failure here is
     # *not* fatal — the DB row already exists, and ops can re-enqueue from

--- a/app/docs/version_model.py
+++ b/app/docs/version_model.py
@@ -305,20 +305,49 @@ def create_draft_version(
     return _row_to_version(row)
 
 
+# Stable 64-bit base for the per-draft advisory-lock key (see
+# :func:`get_next_version_number`).  Postgres advisory locks are namespaced
+# by the *pair* of int4 values passed to ``pg_advisory_xact_lock(int4,
+# int4)``: this constant occupies the first slot so the second slot can
+# carry a hash of the draft id without colliding with unrelated advisory
+# locks elsewhere in the app.  The value is arbitrary — only its
+# uniqueness within our codebase matters.
+_VERSION_ALLOC_LOCK_NAMESPACE = 0x6472_6166  # ASCII "draf"
+
+
 def get_next_version_number(conn: Any, draft_id: uuid.UUID | str) -> int:
-    """Return ``MAX(version_number) + 1`` for *draft_id*.
+    """Return ``MAX(version_number) + 1`` for *draft_id*, serialising callers.
 
     Used by the v2+ upload branch in :mod:`app.docs.upload` to allocate
-    the next version slot under the same lock the caller already holds
-    on the parent draft row.  Returns ``1`` when the parent has no
-    versions yet (cannot happen post migration 030's backfill, but the
-    safe default keeps tests independent).
+    the next version slot.  Returns ``1`` when the parent has no versions
+    yet (cannot happen post migration 030's backfill, but the safe
+    default keeps tests independent).
 
-    Takes an explicit connection so the read can sit inside the same
-    transaction as the subsequent :func:`create_draft_version` call --
-    otherwise two concurrent v2 uploads against the same parent could
-    race on the unique-version-number constraint.
+    **Concurrency (#745):** ``migrations/030_draft_versions.sql`` enforces
+    ``UNIQUE(draft_id, version_number)``, so two uploads that compute the
+    same ``MAX + 1`` would both try to insert the same row and one would
+    fail the constraint.  Before reading ``MAX(version_number)`` this
+    function therefore takes a *transaction-scoped* advisory lock keyed by
+    the draft id (``pg_advisory_xact_lock``).  Concurrent allocators for
+    the *same* parent block here until the holder's transaction
+    commits/rolls back; by then the previous insert is visible (READ
+    COMMITTED), so the next allocator computes a fresh, unused number.
+    Allocators for *different* parents never contend.  The lock is
+    released automatically at transaction end — no explicit unlock, and a
+    rolled-back upload can't leak it.
+
+    Takes an explicit connection so both the lock and the read sit inside
+    the same transaction as the subsequent :func:`create_draft_version`
+    call.  ``conn`` MUST NOT be in autocommit mode or the ``xact`` lock
+    would be released immediately; the upload flow always wraps this in a
+    ``with get_connection() as conn:`` transaction.
     """
+    # int4 range is [-2^31, 2^31-1]; map the draft id into it deterministically.
+    lock_key = uuid.UUID(str(draft_id)).int % 0x8000_0000
+    conn.execute(
+        "SELECT pg_advisory_xact_lock(%s, %s)",
+        (_VERSION_ALLOC_LOCK_NAMESPACE, lock_key),
+    )
     row = conn.execute(
         """
         SELECT COALESCE(MAX(version_number), 0)

--- a/app/ui/data/pagination.py
+++ b/app/ui/data/pagination.py
@@ -92,7 +92,12 @@ def Pagination(
     """Render page controls plus an optional "X kuni Y kokku Z" info line.
 
     Args:
-        current_page: 1-indexed current page.
+        current_page: 1-indexed current page. Clamped into ``[1, total_pages]``
+            (or to ``1`` when there are no pages) so a hand-edited
+            ``?page=999`` URL renders the last real page with a valid
+            "X kuni Y kokku N" range instead of an empty table and an
+            impossible info line (#742). Callers therefore do not need to
+            normalise the page value before passing it in.
         total_pages: Total number of pages (0 when there are no rows).
         base_url: URL to link back to; the ``page`` query param is overwritten.
         page_size: Rows per page — required together with ``total`` to render
@@ -100,8 +105,11 @@ def Pagination(
         total: Grand total row count — required together with ``page_size``.
         cls: Extra classes appended to the wrapper.
     """
-    current = max(1, current_page)
     total_pages = max(0, total_pages)
+    # Clamp the requested page so out-of-range values (negative, zero, or
+    # past the last page) never reach rendering. With no pages at all the
+    # only sensible value is 1; the empty-state info line is handled below.
+    current = min(max(1, current_page), total_pages) if total_pages > 0 else 1
 
     controls: list = []
 

--- a/tests/test_admin_password_reset.py
+++ b/tests/test_admin_password_reset.py
@@ -144,7 +144,11 @@ def test_system_admin_temp_password_sets_must_change(org_with_users):
     )
     assert resp.status_code == 303
     assert "/reset" in resp.headers["location"]
-    assert "temp=Tempnew1Z" in resp.headers["location"]
+    # #740: the live temp credential must NOT travel in the redirect URL
+    # (history / proxy logs / referrers). It is handed to the reveal page
+    # via the signed session cookie instead.
+    assert "Tempnew1Z" not in resp.headers["location"]
+    assert "temp=" not in resp.headers["location"]
 
     with _connect() as conn:
         row = conn.execute(
@@ -155,6 +159,62 @@ def test_system_admin_temp_password_sets_must_change(org_with_users):
     must_change, pw_hash = row
     assert must_change is True
     assert bcrypt.checkpw(b"Tempnew1Z", pw_hash.encode())
+
+
+def test_temp_password_revealed_exactly_once_on_reset_page(org_with_users):
+    """#740 — after setting a temp password the admin sees it once on the
+    reset page (sourced from the session, not the URL), and a second view
+    of the same page no longer shows it. The reveal response is also
+    marked ``Cache-Control: no-store``.
+    """
+    sa = org_with_users["sysadmin_id"]
+    sa_email = f"sa-{sa}@example.com"
+    target = org_with_users["drafter_id"]
+    c = _client_as(sa, sa_email)
+
+    # 1. Set the temp password — the session now holds the one-time reveal.
+    set_resp = c.post(
+        f"/admin/users/{target}/reset_temp",
+        data={"new_password": "Tempnew1Z"},
+        follow_redirects=False,
+    )
+    assert set_resp.status_code == 303
+    reveal_path = set_resp.headers["location"]
+    assert reveal_path.endswith(f"/admin/users/{target}/reset")
+
+    # 2. First load of the reset page reveals the credential exactly once.
+    first = c.get(reveal_path)
+    assert first.status_code == 200
+    assert "Tempnew1Z" in first.text
+    assert first.headers.get("cache-control") == "no-store"
+
+    # 3. Second load no longer reveals it (session value was consumed).
+    second = c.get(reveal_path)
+    assert second.status_code == 200
+    assert "Tempnew1Z" not in second.text
+
+
+def test_org_admin_temp_password_reveal_uses_session_not_url(org_with_users):
+    """#740 — the org-admin variant of the reset flow has the same
+    no-credential-in-URL guarantee.
+    """
+    oa = org_with_users["orgadmin_id"]
+    oa_email = f"oa-{oa}@example.com"
+    target = org_with_users["drafter_id"]
+    c = _client_as(oa, oa_email)
+    resp = c.post(
+        f"/org/users/{target}/reset_temp",
+        data={"new_password": "Tempnew1Z"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith(f"/org/users/{target}/reset")
+    assert "Tempnew1Z" not in resp.headers["location"]
+
+    page = c.get(resp.headers["location"])
+    assert page.status_code == 200
+    assert "Tempnew1Z" in page.text
+    assert page.headers.get("cache-control") == "no-store"
 
 
 def test_org_admin_cannot_temp_password_org_admin(org_with_users):

--- a/tests/test_ui_data.py
+++ b/tests/test_ui_data.py
@@ -142,3 +142,63 @@ def test_pagination_links_have_no_hx_attrs():
     html = to_xml(Pagination(current_page=2, total_pages=5, base_url="/x"))
     assert "hx-get" not in html
     assert "hx-target" not in html
+
+
+def test_pagination_clamps_page_above_total_pages():
+    """#742 — ``?page=999`` on a 5-page table must render the LAST real
+    page and a valid "X kuni Y kokku N" range, not "24951 kuni 100".
+    """
+    # 100 rows / 20 per page = 5 pages; page 999 must clamp to 5.
+    html = to_xml(
+        Pagination(
+            current_page=999,
+            total_pages=5,
+            base_url="/drafts",
+            page_size=20,
+            total=100,
+        )
+    )
+    # The last page is the active one.
+    assert 'aria-current="page"' in html
+    # Active link wraps the number "5", and the nonsense start (24951) is gone.
+    assert ">5</a>" in html
+    assert "81 kuni 100 kokku 100" in html
+    assert "24951" not in html
+    # On the last page the "next" control is disabled.
+    assert "pagination-disabled" in html
+
+
+def test_pagination_clamps_zero_and_negative_pages_to_one():
+    """Pages at or below 1 still normalise to the first page."""
+    for bad in (0, -3):
+        html = to_xml(
+            Pagination(
+                current_page=bad,
+                total_pages=4,
+                base_url="/x",
+                page_size=10,
+                total=35,
+            )
+        )
+        assert "1 kuni 10 kokku 35" in html
+        # First page → prev disabled.
+        assert "pagination-disabled" in html
+
+
+def test_pagination_out_of_range_with_zero_total_pages_renders_empty_state():
+    """When there are no pages at all, a high ``page`` collapses to the
+    empty state rather than an impossible range.
+    """
+    html = to_xml(
+        Pagination(
+            current_page=42,
+            total_pages=0,
+            base_url="/x",
+            page_size=10,
+            total=0,
+        )
+    )
+    assert "0 kirjet" in html
+    # Both controls disabled, no page-number anchors rendered.
+    assert html.count("pagination-disabled") >= 2
+    assert 'aria-current="page"' not in html

--- a/tests/test_upload_new_version.py
+++ b/tests/test_upload_new_version.py
@@ -35,11 +35,12 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import psycopg
 import pytest
 
 from app.auth.provider import UserDict
 from app.docs.draft_model import Draft
-from app.docs.upload import DraftUploadError, handle_upload
+from app.docs.upload import _MAX_VERSION_ALLOC_ATTEMPTS, DraftUploadError, handle_upload
 
 # ---------------------------------------------------------------------------
 # Shared identities
@@ -676,3 +677,149 @@ class TestReturnedDraftReflectsNewVersion:
         assert result.storage_path == new_storage_path
         assert result.graph_uri == new_graph_uri
         assert result.status == "uploaded"
+
+
+# ---------------------------------------------------------------------------
+# Concurrent version-number allocation (#745)
+# ---------------------------------------------------------------------------
+
+
+def _wire_version_conn_with_insert_failures(
+    *,
+    fail_first_n: int,
+    exc: BaseException,
+) -> MagicMock:
+    """Like :func:`_wire_version_conn` but the INSERT raises ``exc`` for the
+    first *fail_first_n* calls (across the life of this mock conn), then
+    succeeds.  Used to simulate a unique-violation race on the version
+    number.
+    """
+    base = _wire_version_conn(
+        parent_row=_make_parent_row(status="ready"),
+        next_version_max=1,
+    )
+    original_side_effect = base.execute.side_effect
+    insert_calls = {"n": 0}
+
+    def _execute(sql: str, params: object = None):
+        if "insert into draft_versions" in " ".join(sql.split()).lower():
+            insert_calls["n"] += 1
+            if insert_calls["n"] <= fail_first_n:
+                raise exc
+        return original_side_effect(sql, params)
+
+    base.execute.side_effect = _execute
+    return base
+
+
+def _factory_sequence(conns: list[MagicMock]):
+    """Return a conn-factory that hands out each conn in *conns* in turn.
+
+    The upload retry loop calls ``factory()`` once per attempt; this lets a
+    test give a distinct (or repeated) mock per attempt.
+    """
+    it = iter(conns)
+
+    def factory():
+        return _ConnectCM(next(it))
+
+    return factory
+
+
+class TestConcurrentVersionAllocation:
+    def test_unique_violation_is_retried_then_succeeds(self):
+        """A single version-number collision is transparently retried — the
+        upload still returns a Draft and the parse job still fires.
+        """
+        # Attempt 1: INSERT raises UniqueViolation. Attempt 2: clean conn.
+        attempt1 = _wire_version_conn_with_insert_failures(
+            fail_first_n=1,
+            exc=psycopg.errors.UniqueViolation("duplicate key (draft_id, version_number)"),
+        )
+        attempt2 = _wire_version_conn(
+            parent_row=_make_parent_row(status="ready"),
+            next_version_max=1,
+        )
+        stored = MagicMock(storage_path="/storage/v2.enc", size_bytes=2, filename="v2.docx")
+        mock_queue = MagicMock()
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.delete_file") as mock_delete,
+        ):
+            result = asyncio.run(
+                handle_upload(
+                    _uploader(),
+                    "",
+                    _StubUpload(contents=b"v2"),
+                    parent_draft_id=_PARENT_DRAFT_ID,
+                    job_queue=mock_queue,
+                    conn_factory=_factory_sequence([attempt1, attempt2]),
+                )
+            )
+
+        assert isinstance(result, Draft)
+        # The encrypted file survived the retry — only a final, exhausted
+        # failure should clean it up.
+        mock_delete.assert_not_called()
+        # Parse pipeline still enqueued exactly once for the parent draft.
+        mock_queue.enqueue.assert_called_once()
+        assert mock_queue.enqueue.call_args.args[1] == {"draft_id": str(_PARENT_DRAFT_ID)}
+
+    def test_exhausted_retries_raise_controlled_error_and_clean_up_file(self):
+        """When every attempt collides, the caller gets a user-facing
+        :class:`DraftUploadError` (NOT a raw 500) and the orphaned
+        ciphertext is removed.
+        """
+        conns = [
+            _wire_version_conn_with_insert_failures(
+                fail_first_n=99,  # always fails
+                exc=psycopg.errors.UniqueViolation("duplicate key"),
+            )
+            for _ in range(_MAX_VERSION_ALLOC_ATTEMPTS)
+        ]
+        stored = MagicMock(storage_path="/storage/orphan.enc", size_bytes=1, filename="v.docx")
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.delete_file") as mock_delete,
+        ):
+            with pytest.raises(DraftUploadError, match="samaaegse üleslaadimise"):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(),
+                        "",
+                        _StubUpload(contents=b"v"),
+                        parent_draft_id=_PARENT_DRAFT_ID,
+                        job_queue=MagicMock(),
+                        conn_factory=_factory_sequence(conns),
+                    )
+                )
+
+        mock_delete.assert_called_once_with("/storage/orphan.enc")
+
+    def test_new_draft_branch_does_not_retry_on_unique_violation(self):
+        """The v1/new-draft path must NOT swallow-and-retry a unique
+        violation — only the version branch has the retry budget. A
+        collision there (e.g. a duplicate-something race) propagates as
+        before, with the file cleaned up exactly once.
+        """
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = psycopg.errors.UniqueViolation("dup")
+        stored = MagicMock(storage_path="/tmp/orphan.enc", size_bytes=1, filename="x.docx")
+
+        with (
+            patch("app.docs.upload.store_file", return_value=stored),
+            patch("app.docs.upload.delete_file") as mock_delete,
+        ):
+            with pytest.raises(psycopg.errors.UniqueViolation):
+                asyncio.run(
+                    handle_upload(
+                        _uploader(),
+                        "Uus eelnõu",  # new-draft branch: no parent_draft_id
+                        _StubUpload(contents=b"x"),
+                        job_queue=MagicMock(),
+                        conn_factory=_make_conn_factory(mock_conn),
+                    )
+                )
+        mock_delete.assert_called_once_with("/tmp/orphan.enc")

--- a/tests/test_version_model.py
+++ b/tests/test_version_model.py
@@ -478,6 +478,44 @@ class TestGetNextVersionNumber:
         assert "COALESCE(MAX(version_number), 0)" in sql
         assert "WHERE draft_id = %s" in sql
 
+    def test_takes_transaction_scoped_advisory_lock_before_reading_max(self):
+        """#745 — the allocation must serialise concurrent callers by taking
+        a ``pg_advisory_xact_lock`` keyed by the draft id *before* reading
+        ``MAX(version_number)``, so two uploads can't compute the same next
+        number.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (2,)
+
+        get_next_version_number(conn, _DRAFT_ID)
+
+        # Two execute() calls: (1) the advisory lock, (2) the MAX read.
+        assert conn.execute.call_count == 2
+        lock_call, max_call = conn.execute.call_args_list
+        assert "pg_advisory_xact_lock" in lock_call.args[0]
+        assert "MAX(version_number)" in max_call.args[0]
+        # Lock key is derived from the draft id and stays inside int4 range.
+        lock_params = lock_call.args[1]
+        assert len(lock_params) == 2
+        assert all(isinstance(p, int) for p in lock_params)
+        assert all(-(2**31) <= p < 2**31 for p in lock_params)
+        # Different drafts must hash to different keys (no global contention).
+        other_conn = MagicMock()
+        other_conn.execute.return_value.fetchone.return_value = (0,)
+        get_next_version_number(other_conn, uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"))
+        other_lock_params = other_conn.execute.call_args_list[0].args[1]
+        assert other_lock_params[1] != lock_params[1]
+
+    def test_advisory_lock_key_is_stable_for_a_given_draft(self):
+        """The same draft id always yields the same lock key (idempotent)."""
+        conn1 = MagicMock()
+        conn1.execute.return_value.fetchone.return_value = (0,)
+        get_next_version_number(conn1, _DRAFT_ID)
+        conn2 = MagicMock()
+        conn2.execute.return_value.fetchone.return_value = (0,)
+        get_next_version_number(conn2, str(_DRAFT_ID))
+        assert conn1.execute.call_args_list[0].args[1] == conn2.execute.call_args_list[0].args[1]
+
 
 class TestDraftVersionDataclass:
     def test_is_frozen(self):


### PR DESCRIPTION
Closes #740
Closes #742
Closes #745

Three small, file-disjoint fixes.

## #740 — Admin temporary password no longer leaks via the redirect URL
- `_admin_reset_temp` previously redirected to `…/{user_id}/reset?temp={new_password}`; the live credential could leak via browser history, proxy/access logs, analytics, referrers, or copied links.
- The temp password is now handed to the reveal page through the **signed session cookie** (key `pw_reset_reveal`, keyed by user id so it can't be shown against the wrong target), consumed **exactly once** on the next `GET …/reset`. Nothing sensitive is in the URL anymore.
- The reveal response carries `Cache-Control: no-store` so the rendered credential stays out of shared/back-button caches.
- Applies to both the system-admin (`/admin/users/...`) and org-admin (`/org/users/...`) variants.

## #742 — Pagination clamps out-of-range pages
- `Pagination` did `current = max(1, current_page)` but never clamped above `total_pages`, so `?page=999` rendered an empty table with text like `24951 kuni 100 kokku 100`.
- Now `current = min(max(1, current_page), total_pages)` when `total_pages > 0`, and `1` (empty state) when there are no pages. The info-line `start`/`end` are derived from the clamped `current`, so "X kuni Y kokku N" is always valid.
- Fixed **inside the component** — callers (`_list.py`, `chat/routes.py`, `drafter/routes.py`, `admin/audit.py`) are untouched; route-level redirect-to-canonical-URL is out of scope.

## #745 — Concurrent draft-version uploads no longer race on the version number
- `get_next_version_number()` was `SELECT COALESCE(MAX(version_number),0)+1 …` with no lock; two concurrent v2+ uploads against the same parent could compute the same number and one would fail the `UNIQUE(draft_id, version_number)` constraint (possibly as a generic 500).
- It now takes a **transaction-scoped `pg_advisory_xact_lock`** keyed by the parent draft id before reading `MAX(version_number)`, so allocators for the same parent serialise; allocators for different parents never contend; the lock auto-releases at transaction end.
- Belt-and-braces: the upload transaction retries on a `UNIQUE` violation (small budget) and, if exhausted, raises a controlled `DraftUploadError` ("…samaaegse üleslaadimise tõttu. Palun proovige uuesti.") instead of a raw 500. The encrypted temp file is cleaned up on the final failed attempt. The new-draft (v1) branch deliberately does **not** retry.

## Tests
- `tests/test_admin_password_reset.py` — assert the redirect `Location` contains neither the temp password nor `temp=`; assert the admin sees the password once on the reset page (from the session), that a second view no longer shows it, and that the reveal response is `Cache-Control: no-store` (system + org variants). (These are `DATABASE_URL`-gated integration tests.)
- `tests/test_ui_data.py` — `Pagination(current_page=999, total_pages=5, page_size=20, total=100)` renders the last page active with `81 kuni 100 kokku 100` (no `24951`); negative/zero pages clamp to 1; out-of-range with 0 pages renders the empty state.
- `tests/test_version_model.py` — `get_next_version_number` issues a `pg_advisory_xact_lock` keyed by the draft id before the `MAX` read; the key is stable per draft, distinct per draft, and inside int4 range.
- `tests/test_upload_new_version.py` — a single `UniqueViolation` is transparently retried (Draft still returned, parse job still enqueued, temp file kept); exhausted retries raise `DraftUploadError` and clean up the file exactly once; the new-draft branch re-raises a `UniqueViolation` unchanged.

## Test status
- `uv run ruff format app/ tests/` — clean
- `uv run ruff check app/ tests/` — All checks passed
- `uv run pyright` (repo-wide) — 0 errors, 0 warnings
- `uv run pytest -q` — 2298 passed, 25 skipped (the skips are the `DATABASE_URL`-gated integration tests; no live Postgres in this environment)

## Files touched
`app/auth/users.py`, `app/ui/data/pagination.py`, `app/docs/version_model.py`, `app/docs/upload.py`, `tests/test_admin_password_reset.py`, `tests/test_ui_data.py`, `tests/test_version_model.py`, `tests/test_upload_new_version.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)