### PR TITLE
fix(http): #739/#741 — 404/403 status on not-found & forbidden pages; PDF export label

### DIFF
--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -8,10 +8,33 @@ from collections.abc import Callable
 from typing import Any
 
 from fasthtml.common import *
+from fasthtml.common import to_xml
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import HTMLResponse, RedirectResponse
 
 logger = logging.getLogger(__name__)
+
+
+def _forbidden_page(message: str) -> HTMLResponse:
+    """Render the shared 403 page wrapped in an ``HTMLResponse``.
+
+    Returning a bare ``Titled(...)`` FT element here let FastHTML serve
+    it as ``200 OK`` (#739) — API clients and HTMX callers could not
+    distinguish a role/membership denial from success. Wrapping it in an
+    explicit ``HTMLResponse`` with ``status_code=403`` keeps the same
+    rendered body (the Estonian "Ligipääs keelatud" page) but emits the
+    correct status code.
+    """
+    return HTMLResponse(
+        to_xml(
+            Titled(
+                "Ligipääs keelatud",
+                P(message),
+                A("Tagasi avalehele", href="/"),
+            )
+        ),
+        status_code=403,
+    )
 
 
 def _get_auth(req: Request) -> dict | None:  # type: ignore[type-arg]
@@ -48,11 +71,7 @@ def require_role(*roles: str) -> Callable[..., Any]:
 
             user_role = auth.get("role", "")
             if user_role not in roles:
-                return Titled(
-                    "Ligipääs keelatud",
-                    P("Teil puudub õigus selle lehe vaatamiseks."),
-                    A("Tagasi avalehele", href="/"),
-                )
+                return _forbidden_page("Teil puudub õigus selle lehe vaatamiseks.")
 
             return fn(*args, **kwargs)
 
@@ -93,10 +112,8 @@ def require_org_member(org_id_param: str = "org_id") -> Callable[..., Any]:
 
             user_org_id = auth.get("org_id")
             if not user_org_id or str(user_org_id) != str(route_org_id):
-                return Titled(
-                    "Ligipääs keelatud",
-                    P("Teil puudub õigus selle organisatsiooni andmete vaatamiseks."),
-                    A("Tagasi avalehele", href="/"),
+                return _forbidden_page(
+                    "Teil puudub õigus selle organisatsiooni andmete vaatamiseks."
                 )
 
             return fn(*args, **kwargs)

--- a/app/docs/_helpers.py
+++ b/app/docs/_helpers.py
@@ -13,20 +13,16 @@ the function body so this charter is preserved (post-review fix).
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import HTMLResponse, Response
 
 from app.auth.helpers import require_auth
 from app.auth.policy import can_delete_draft, can_edit_draft, can_view_draft
 from app.auth.provider import UserDict
 from app.docs import draft_model as _dm
 from app.docs.draft_model import Draft
-
-if TYPE_CHECKING:
-    from fastcore.xml import FT
-
 
 # Set of valid actions for :func:`resolve_draft`. Using ``Literal`` so a
 # typo at the call site is a pyright error rather than a silent fallback
@@ -40,12 +36,12 @@ class ResolvedDraft(NamedTuple):
     A typed ``NamedTuple`` (rather than a bare ``tuple[Draft, dict]``) so
     call sites can discriminate the success branch from the failure
     branch via ``isinstance(result, ResolvedDraft)``. The failure branch
-    returns an opaque response object (Starlette ``Response`` for auth
-    redirects, FastHTML FT element for the 404 page) and the typed
-    discriminator stays unambiguous regardless of what the failure side
-    returns. Future-proofs against fastcore versions where FT may
-    inherit from ``tuple``, and against ad-hoc ``(error, code)`` tuples
-    returned by any upstream helper.
+    returns an opaque Starlette ``Response`` (a ``RedirectResponse`` for
+    auth misses, an ``HTMLResponse`` with ``status_code=404`` for the
+    not-found page) and the typed discriminator stays unambiguous
+    regardless of what the failure side returns. Future-proofs against
+    fastcore versions where FT may inherit from ``tuple``, and against
+    ad-hoc ``(error, code)`` tuples returned by any upstream helper.
 
     Supports both attribute access (``resolved.draft``) and tuple
     unpacking (``draft, auth = resolved``) — see the test in
@@ -68,7 +64,7 @@ def _parse_uuid(raw: str) -> uuid.UUID | None:
         return None
 
 
-def _not_found_page(req: Request) -> Any:
+def _not_found_page(req: Request) -> HTMLResponse:
     """Render the 404 page used whenever a draft is missing or out of scope.
 
     UI-layer imports are deferred to the function body so the module
@@ -76,13 +72,16 @@ def _not_found_page(req: Request) -> Any:
     lets :mod:`app.docs.retry_handler` and other lean importers load
     without dragging the entire ``app.ui`` subtree).
 
-    Return is typed ``Any`` because :func:`PageShell` returns an FT
-    element whose concrete fastcore type is exposed as a 3-tuple,
-    which conflicts with the narrower ``FT`` annotation on
-    :func:`resolve_draft`'s return. Pragmatically the value is opaque
-    to callers — they just return it from their handler.
+    The rendered :func:`PageShell` is wrapped in an explicit
+    :class:`~starlette.responses.HTMLResponse` with ``status_code=404``
+    (#739). Returning the bare FT element let FastHTML serve it as
+    ``200 OK``, so missing / cross-org drafts could be cached, crawled,
+    or mistaken for a success by API and HTMX callers. Every caller in
+    this module (and the sibling route packages) returns the value
+    verbatim from a Starlette handler, so a ``Response`` is the right
+    shape there.
     """
-    from fasthtml.common import H1, A, P
+    from fasthtml.common import H1, A, P, to_xml
 
     from app.ui.layout import PageShell
     from app.ui.surfaces.alert import Alert
@@ -90,7 +89,7 @@ def _not_found_page(req: Request) -> Any:
 
     auth = req.scope.get("auth")
     theme = get_theme_from_request(req)
-    return PageShell(
+    page = PageShell(
         H1("Eelnõu ei leitud", cls="page-title"),
         Alert(
             "Otsitud eelnõu ei ole olemas või Te ei oma selle vaatamise õigust.",
@@ -103,6 +102,7 @@ def _not_found_page(req: Request) -> Any:
         active_nav="/drafts",
         request=req,
     )
+    return HTMLResponse(to_xml(page), status_code=404)
 
 
 def resolve_draft(
@@ -110,7 +110,7 @@ def resolve_draft(
     draft_id: str,
     *,
     action: DraftAction = "view",
-) -> ResolvedDraft | Response | FT:
+) -> ResolvedDraft | Response:
     """Run the standard auth + parse + load + authorize preamble for a draft route.
 
     The drafts module has ~15 handlers that all open with the same five
@@ -125,8 +125,10 @@ def resolve_draft(
 
     This helper consolidates that preamble (#624). On success it returns
     a :class:`ResolvedDraft` named tuple. On any failure it returns the
-    appropriate response object — either a Starlette ``Response`` (auth
-    redirect) or a FastHTML FT element from :func:`_not_found_page`.
+    appropriate Starlette ``Response`` — a ``RedirectResponse`` to the
+    login page for an auth miss, or the ``status_code=404``
+    ``HTMLResponse`` from :func:`_not_found_page` for a missing /
+    cross-org draft.
 
     Discriminate via ``isinstance(result, ResolvedDraft)`` rather than
     ``isinstance(result, tuple)`` — see :class:`ResolvedDraft` for the

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -25,8 +25,9 @@ from typing import Any
 from urllib.parse import quote
 
 from fasthtml.common import *  # noqa: F403
+from fasthtml.common import to_xml
 from starlette.requests import Request
-from starlette.responses import FileResponse, Response
+from starlette.responses import FileResponse, HTMLResponse, Response
 
 from app.annotations.row_keys import (
     collect_row_specs as _collect_row_specs,
@@ -95,11 +96,19 @@ def _parse_uuid(raw: str) -> uuid.UUID | None:
         return None
 
 
-def _not_found_page(req: Request):
-    """Render the 404 page used whenever a draft/report is missing or out of scope."""
+def _not_found_page(req: Request) -> HTMLResponse:
+    """Render the 404 page used whenever a draft/report is missing or out of scope.
+
+    Wrapped in an explicit ``HTMLResponse`` with ``status_code=404``
+    (#739): returning the bare ``PageShell`` let FastHTML serve it as
+    ``200 OK``, so a missing / cross-org draft or report looked like a
+    success to API and HTMX callers. Every caller in this module returns
+    this verbatim from a Starlette route handler, so a ``Response`` is
+    the right shape.
+    """
     auth = req.scope.get("auth")
     theme = get_theme_from_request(req)
-    return PageShell(
+    page = PageShell(
         H1("Eelnõu ei leitud", cls="page-title"),  # noqa: F405
         Alert(
             "Otsitud eelnõu või mõjuaruanne ei ole olemas või Te ei oma selle vaatamise õigust.",
@@ -111,6 +120,7 @@ def _not_found_page(req: Request):
         theme=theme,
         active_nav="/drafts",
     )
+    return HTMLResponse(to_xml(page), status_code=404)
 
 
 def _format_timestamp(value: Any) -> str:
@@ -1520,8 +1530,23 @@ def export_status_fragment(req: Request, draft_id: str, job_id: str):
         # access; reset the archive clock.
         touch_draft_access_conn(parsed_draft)
         result = job.result or {}
-        docx_path = str(result.get("docx_path") or "")
-        if not docx_path:
+        # #741: the requested format decides the artefact + label. PDF
+        # jobs still write a ``docx_path`` (the .docx is the content
+        # source of truth) plus a ``pdf_path``; the download endpoint
+        # picks the right file from the same ``payload["format"]`` key,
+        # so the success-state label has to match or the user who
+        # requested a PDF sees a ".docx" link. Legacy jobs without a
+        # format key are treated as docx (mirrors the download handler).
+        fmt = str(payload.get("format") or "docx").lower()
+        if fmt not in _VALID_EXPORT_FORMATS:
+            fmt = "docx"
+        if fmt == "pdf":
+            artefact_path = str(result.get("pdf_path") or "")
+            download_label = "Laadi alla .pdf"
+        else:
+            artefact_path = str(result.get("docx_path") or "")
+            download_label = "Laadi alla .docx"
+        if not artefact_path:
             return Div(
                 Alert(
                     "Eksport valmis, kuid faili ei leitud.",
@@ -1533,7 +1558,7 @@ def export_status_fragment(req: Request, draft_id: str, job_id: str):
         return Div(
             Span("Eksport valmis. ", cls="export-status-text"),  # noqa: F405
             LinkButton(
-                "Laadi alla .docx",
+                download_label,
                 href=f"/drafts/{parsed_draft}/export/{parsed_job_id}/download",
                 size="sm",
             ),

--- a/app/drafter/routes.py
+++ b/app/drafter/routes.py
@@ -28,8 +28,9 @@ from typing import Any
 from urllib.parse import quote as url_quote
 
 from fasthtml.common import *  # noqa: F403
+from fasthtml.common import to_xml
 from starlette.requests import Request
-from starlette.responses import FileResponse, RedirectResponse, Response
+from starlette.responses import FileResponse, HTMLResponse, RedirectResponse, Response
 
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
@@ -153,10 +154,17 @@ def _parse_uuid(raw: str) -> uuid.UUID | None:
         return None
 
 
-def _not_found_page(req: Request):
-    """Render the 404 page for missing or cross-org sessions."""
+def _not_found_page(req: Request) -> HTMLResponse:
+    """Render the 404 page for missing or cross-org sessions.
+
+    Wrapped in an explicit ``HTMLResponse`` with ``status_code=404``
+    (#739): returning the bare ``PageShell`` let FastHTML serve it as
+    ``200 OK``, so a missing or cross-org session looked like a success
+    to API and HTMX callers. Every caller returns this verbatim from a
+    Starlette route handler, so a ``Response`` is the right shape.
+    """
     auth = req.scope.get("auth")
-    return PageShell(
+    page = PageShell(
         H1("Koostamissessioon ei leitud", cls="page-title"),  # noqa: F405
         Alert(
             "Otsitud koostamissessioon ei ole olemas või Te ei oma selle vaatamise õigust.",
@@ -167,6 +175,7 @@ def _not_found_page(req: Request):
         user=auth,
         active_nav="/drafter",
     )
+    return HTMLResponse(to_xml(page), status_code=404)
 
 
 def _format_timestamp(value: Any) -> str:

--- a/tests/test_archive_warning.py
+++ b/tests/test_archive_warning.py
@@ -344,9 +344,9 @@ class TestKeepDraftRoute:
         client = _authed_client()
         resp = client.post(f"/drafts/{draft.id}/keep")
 
-        # Route returns the 404 page (never 403) so we don't leak the
-        # existence of another user's draft.
-        assert resp.status_code == 200
+        # Route returns the 404 page (never 403, #739) so we don't leak
+        # the existence of another user's draft.
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         mock_touch.assert_not_called()
 
@@ -366,7 +366,7 @@ class TestKeepDraftRoute:
         client = _authed_client()
         resp = client.post(f"/drafts/{draft.id}/keep")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         mock_touch.assert_not_called()
 
@@ -383,7 +383,7 @@ class TestKeepDraftRoute:
         client = _authed_client()
         resp = client.post("/drafts/99999999-9999-9999-9999-999999999999/keep")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
 

--- a/tests/test_docs_report_routes.py
+++ b/tests/test_docs_report_routes.py
@@ -251,7 +251,7 @@ class TestDraftReportPage:
         client = _authed_client()
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.report_routes._fetch_latest_report")
@@ -270,7 +270,7 @@ class TestDraftReportPage:
         client = _authed_client()
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.report_routes.fetch_draft")
@@ -285,7 +285,7 @@ class TestDraftReportPage:
         client = _authed_client()
         resp = client.get("/drafts/not-a-uuid/report")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         # fetch_draft must NOT be called when UUID parsing fails.
         mock_fetch.assert_not_called()
@@ -382,7 +382,7 @@ class TestExportDraftReportHandler:
 
         client = _authed_client()
         resp = client.post(f"/drafts/{_DRAFT_ID}/export")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
 
@@ -473,6 +473,88 @@ class TestExportStatusFragment:
     @patch("app.docs.report_routes.JobQueue")
     @patch("app.docs.report_routes.fetch_draft")
     @patch("app.auth.middleware._get_provider")
+    def test_status_success_pdf_job_labels_link_as_pdf(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """#741: a completed PDF export must show a ``.pdf`` download
+        label (and not ``.docx``), matching what the download endpoint
+        actually serves from ``payload["format"]``. PDF jobs still write
+        a ``docx_path`` (the .docx is the content source of truth) plus
+        a ``pdf_path`` — the fragment must key on the format, not on the
+        mere presence of ``docx_path``."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        queue_instance = MagicMock()
+        queue_instance.get.return_value = _make_job(
+            status="success",
+            payload={
+                "draft_id": str(_DRAFT_ID),
+                "report_id": str(_REPORT_ID),
+                "format": "pdf",
+            },
+            result={
+                "draft_id": str(_DRAFT_ID),
+                "report_id": str(_REPORT_ID),
+                "format": "pdf",
+                "docx_path": "/tmp/exports/output.docx",
+                "pdf_path": "/tmp/exports/output.pdf",
+            },
+        )
+        mock_queue_cls.return_value = queue_instance
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/export-status/7")
+
+        assert resp.status_code == 200
+        assert "Laadi alla .pdf" in resp.text
+        assert "Laadi alla .docx" not in resp.text
+        assert f"/drafts/{_DRAFT_ID}/export/7/download" in resp.text
+        assert "every 2s" not in resp.text
+
+    @patch("app.docs.report_routes.JobQueue")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_status_success_pdf_job_without_pdf_path_shows_error(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """A PDF job whose ``pdf_path`` is missing surfaces the
+        file-not-found alert rather than silently linking the .docx
+        (#741)."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        queue_instance = MagicMock()
+        queue_instance.get.return_value = _make_job(
+            status="success",
+            payload={
+                "draft_id": str(_DRAFT_ID),
+                "report_id": str(_REPORT_ID),
+                "format": "pdf",
+            },
+            result={
+                "draft_id": str(_DRAFT_ID),
+                "report_id": str(_REPORT_ID),
+                "format": "pdf",
+                "docx_path": "/tmp/exports/output.docx",
+            },
+        )
+        mock_queue_cls.return_value = queue_instance
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/export-status/7")
+
+        assert resp.status_code == 200
+        assert "Eksport valmis, kuid faili ei leitud." in resp.text
+        assert "Laadi alla" not in resp.text
+
+    @patch("app.docs.report_routes.JobQueue")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
     def test_status_failed_shows_error_alert(
         self,
         mock_get_provider: MagicMock,
@@ -558,7 +640,7 @@ class TestDownloadExportHandler:
 
         client = _authed_client()
         resp = client.get(f"/drafts/{_DRAFT_ID}/export/7/download")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.report_routes.JobQueue")
@@ -585,7 +667,7 @@ class TestDownloadExportHandler:
 
         client = _authed_client()
         resp = client.get(f"/drafts/{_DRAFT_ID}/export/7/download")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.report_routes.JobQueue")
@@ -606,7 +688,7 @@ class TestDownloadExportHandler:
 
         client = _authed_client()
         resp = client.get(f"/drafts/{_DRAFT_ID}/export/7/download")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
 
@@ -709,7 +791,7 @@ class TestReportSectionPagination:
 
         client = _authed_client()
         resp = client.get(f"/drafts/{_DRAFT_ID}/report/section/bogus")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
 
@@ -802,7 +884,7 @@ class TestOntologyDriftBanner:
         mock_fetch.return_value = _make_draft(org_id=_OTHER_ORG_ID)
         client = _authed_client()
         resp = client.post(f"/drafts/{_DRAFT_ID}/report/reanalyze")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
 

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -678,10 +678,10 @@ class TestDraftDetailPage:
         client = _authed_client()
         resp = client.get(f"/drafts/{foreign.id}")
 
-        # We return the not-found page (HTTP 200 with 404-style content)
-        # rather than a raw 403 so we never leak the existence of drafts
-        # belonging to other organisations.
-        assert resp.status_code == 200
+        # We return the not-found page (HTTP 404, #739) rather than a raw
+        # 403 so we never leak the existence of drafts belonging to other
+        # organisations.
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         assert "Minu eelnõu" not in resp.text
 
@@ -698,8 +698,27 @@ class TestDraftDetailPage:
         client = _authed_client()
         resp = client.get("/drafts/99999999-9999-9999-9999-999999999999")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
+
+    @patch("app.docs.routes._detail.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_invalid_uuid_draft_detail_returns_404(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """A malformed draft id never reaches the DB and 404s (#739)."""
+        mock_get_provider.return_value = _stub_provider()
+
+        client = _authed_client()
+        resp = client.get("/drafts/not-a-uuid")
+
+        assert resp.status_code == 404
+        # The not-found page is served as a full HTML document.
+        assert resp.headers["content-type"].startswith("text/html")
+        assert "Eelnõu ei leitud" in resp.text
+        mock_fetch.assert_not_called()
 
     @patch("app.docs.routes._detail.fetch_draft")
     @patch("app.auth.middleware._get_provider")
@@ -1088,7 +1107,7 @@ class TestDeleteDraftHandler:
         client = _authed_client()
         resp = client.post("/drafts/44444444-4444-4444-4444-444444444444/delete")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.routes._lifecycle.fetch_draft")
@@ -1108,7 +1127,7 @@ class TestDeleteDraftHandler:
         client = _authed_client()
         resp = client.post("/drafts/44444444-4444-4444-4444-444444444444/delete")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.routes._lifecycle.JobQueue")
@@ -1386,6 +1405,7 @@ class TestFlashMessages:
         assert "Eelnõu üles laaditud, analüüs algas." in detail.text
         assert "toast-success" in detail.text
 
+    @patch("app.docs.routes._detail.fetch_draft")
     @patch("app.docs.routes._lifecycle.touch_draft_access")
     @patch("app.docs.routes._lifecycle._connect")
     @patch("app.docs.routes._detail.log_draft_view")
@@ -1398,10 +1418,16 @@ class TestFlashMessages:
         mock_log_view: MagicMock,
         mock_connect: MagicMock,
         mock_touch: MagicMock,
+        mock_detail_fetch: MagicMock,
     ):
         mock_get_provider.return_value = _stub_provider()
         draft = _make_draft()
         mock_fetch.return_value = draft
+        # The follow-up GET /drafts/{id} resolves the draft through the
+        # detail module's own ``fetch_draft`` binding — patch it too so
+        # the detail page renders the draft (not the 404 page) and the
+        # flash toast is asserted against the real content (#739).
+        mock_detail_fetch.return_value = draft
         mock_conn = MagicMock()
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
@@ -1837,7 +1863,7 @@ class TestLinkVtkHandler:
             data={"parent_vtk_id": _VTK_ID},
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
 
@@ -2234,7 +2260,7 @@ class TestRetryFailedDraft:
         client = _authed_client()
         resp = client.post(f"/drafts/{foreign.id}/retry")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         mock_reset.assert_not_called()
         mock_queue.enqueue.assert_not_called()
@@ -2913,7 +2939,7 @@ class TestDraftDiffPage:
         client = _authed_client()
         resp = client.get(f"/drafts/{foreign.id}/diff?from=1&to=2")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         # The diff table must NOT render for an unauthorised viewer.
         assert "diff-table" not in resp.text
@@ -2940,7 +2966,7 @@ class TestDraftDiffPage:
         client = _authed_client()
         resp = client.get(f"/drafts/{draft.id}/diff?from=1&to=99")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
         assert "diff-table" not in resp.text
 
@@ -2959,7 +2985,7 @@ class TestDraftDiffPage:
         # Neither `from` nor `to` provided.
         resp = client.get(f"/drafts/{draft.id}/diff")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.routes._detail_versions.fetch_draft")
@@ -2977,7 +3003,7 @@ class TestDraftDiffPage:
         # 'one' is not a valid int.
         resp = client.get(f"/drafts/{draft.id}/diff?from=one&to=two")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     @patch("app.docs.routes._detail_versions.list_versions_for_draft")
@@ -3038,7 +3064,7 @@ class TestDraftDiffPage:
         client = _authed_client()
         resp = client.get(f"/drafts/{draft.id}/diff?from=2&to=2")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "Eelnõu ei leitud" in resp.text
 
     def test_diff_route_redirects_unauthenticated(self):

--- a/tests/test_drafter_routes.py
+++ b/tests/test_drafter_routes.py
@@ -395,7 +395,7 @@ class TestStepPage:
         client = _authed_client()
         resp = client.get(f"/drafter/{_SESSION_ID}/step/1")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "ei leitud" in resp.text
 
     @patch("app.drafter.routes.fetch_session")
@@ -415,7 +415,7 @@ class TestStepPage:
         client = _authed_client()
         resp = client.get(f"/drafter/{_SESSION_ID}/step/1")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "ei leitud" in resp.text
 
     @patch("app.drafter.routes.fetch_session")
@@ -433,8 +433,26 @@ class TestStepPage:
         client = _authed_client()
         resp = client.get(f"/drafter/{_SESSION_ID}/step/1")
 
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "ei leitud" in resp.text
+
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_invalid_session_uuid_returns_404(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """A malformed session id never hits the DB and 404s (#739)."""
+        mock_get_provider.return_value = _stub_provider()
+
+        client = _authed_client()
+        resp = client.get("/drafter/not-a-uuid/step/1")
+
+        assert resp.status_code == 404
+        assert resp.headers["content-type"].startswith("text/html")
+        assert "ei leitud" in resp.text
+        mock_fetch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import HTMLResponse, RedirectResponse
 from starlette.testclient import TestClient
 
 
@@ -64,9 +66,11 @@ class TestRequireRole:
 
         req = _make_request(auth={"id": "u1", "role": "drafter", "org_id": None})
         result = handler(req)
-        # Should return a Titled FT object (not a string), containing "Ligipääs keelatud"
-        assert result is not None
-        assert result != "ok"
+        # #739: a role denial returns an HTMLResponse with status 403 —
+        # not a bare FT element (which FastHTML would serve as 200 OK).
+        assert isinstance(result, HTMLResponse)
+        assert result.status_code == 403
+        assert b"Ligip\xc3\xa4\xc3\xa4s keelatud" in result.body
 
     def test_redirects_unauthenticated(self):
         from app.auth.roles import require_role
@@ -139,7 +143,11 @@ class TestRequireOrgMember:
             path_params={"org_id": "org-222"},
         )
         result = handler(req, org_id="org-222")
-        assert result != "ok"
+        # #739: an org-membership denial returns an HTMLResponse with
+        # status 403, not a bare FT element served as 200 OK.
+        assert isinstance(result, HTMLResponse)
+        assert result.status_code == 403
+        assert b"Ligip\xc3\xa4\xc3\xa4s keelatud" in result.body
 
     def test_redirects_unauthenticated(self):
         from app.auth.roles import require_org_member
@@ -159,7 +167,27 @@ class TestRequireOrgMember:
 
 
 class TestRoleViaApp:
-    """Verify that admin routes in the app redirect unauthenticated users."""
+    """Verify the admin-route role gate over the real ``app.main.app``."""
+
+    @staticmethod
+    def _stub_provider(role: str) -> MagicMock:
+        provider = MagicMock()
+        provider.get_current_user.return_value = {
+            "id": "33333333-3333-3333-3333-333333333333",
+            "email": "u@seadusloome.ee",
+            "full_name": "Test User",
+            "role": role,
+            "org_id": "11111111-1111-1111-1111-111111111111",
+        }
+        return provider
+
+    @staticmethod
+    def _authed_client() -> TestClient:
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        client.cookies.set("access_token", "stub-token")
+        return client
 
     def test_admin_orgs_redirects_unauthenticated(self):
         from app.main import app
@@ -176,3 +204,24 @@ class TestRoleViaApp:
         response = client.get("/admin/users")
         assert response.status_code == 303
         assert response.headers["location"] == "/auth/login"
+
+    @patch("app.auth.middleware._get_provider")
+    def test_admin_orgs_role_denied_returns_403(self, mock_get_provider: MagicMock):
+        """#739: an authenticated non-admin hitting an ``@require_role('admin')``
+        route gets HTTP 403 — not a 200 OK page that could be cached or
+        mistaken for success."""
+        mock_get_provider.return_value = self._stub_provider("drafter")
+        client = self._authed_client()
+        response = client.get("/admin/organizations")
+        assert response.status_code == 403
+        assert response.headers["content-type"].startswith("text/html")
+        assert "Ligipääs keelatud" in response.text
+
+    @patch("app.auth.middleware._get_provider")
+    def test_admin_users_role_denied_returns_403(self, mock_get_provider: MagicMock):
+        """Same gate, second admin route — a non-admin gets 403 (#739)."""
+        mock_get_provider.return_value = self._stub_provider("reviewer")
+        client = self._authed_client()
+        response = client.get("/admin/users")
+        assert response.status_code == 403
+        assert "Ligipääs keelatud" in response.text


### PR DESCRIPTION
Closes #739
Closes #741

## #739 — not-found / forbidden page helpers return 200 OK

Several route helpers rendered bare FastHTML elements (a `PageShell` or `Titled`), which FastHTML serves as `200 OK`. Missing / cross-org resources and role denials could therefore be cached, crawled, or mistaken for success by API and HTMX callers.

Wrapped each helper in an explicit Starlette response with the right status code (same rendered body):

| Helper | File | Status |
|---|---|---|
| `_not_found_page` (drafts) | `app/docs/_helpers.py` — used by `app/docs/routes/*`, `app/docs/retry_handler.py` | 404 |
| `_not_found_page` (drafter wizard) | `app/drafter/routes.py` | 404 |
| `_not_found_page` (impact report + export) | `app/docs/report_routes.py` | 404 |
| `require_role()` role denial → new `_forbidden_page()` | `app/auth/roles.py` | 403 |
| `require_org_member()` org-mismatch denial → `_forbidden_page()` | `app/auth/roles.py` | 403 |

`resolve_draft()`'s return type narrowed from `ResolvedDraft | Response | FT` to `ResolvedDraft | Response` (the failure branch is now always a Starlette `Response`); the now-unused `TYPE_CHECKING` `FT` import was dropped.

**`app/chat/routes.py` is intentionally untouched** — its `_not_found_page` 404 fix is owned by the #737/#738 chat work, to avoid a file conflict.

## #741 — PDF export completion UI labels the download as DOCX

`export_status_fragment` in `app/docs/report_routes.py` checked only `result["docx_path"]` and always rendered `LinkButton("Laadi alla .docx", …)`, even though the download endpoint serves the PDF based on `payload["format"]` (PDF jobs write both `docx_path` and `pdf_path`). The fragment now reads the job's requested format and renders `Laadi alla .pdf` (linking the pdf artefact) for PDF jobs and `Laadi alla .docx` for DOCX jobs; legacy format-less jobs are still treated as docx (mirrors the download handler). A PDF job missing its `pdf_path` now surfaces the existing "Eksport valmis, kuid faili ei leitud." alert instead of silently linking the .docx.

## Tests

- Existing not-found route tests across `tests/test_docs_routes.py`, `tests/test_drafter_routes.py`, `tests/test_docs_report_routes.py`, and `tests/test_archive_warning.py` now assert `status_code == 404` (previously `200`). One HTMX status-fragment placeholder test (`/drafts/{id}/status`) stays at 200 — it uses its own inline not-found `Div`, not `_not_found_page`.
- `test_keep_flashes_toast_on_detail` was patching only the `/keep` handler's `fetch_draft`; it now also patches the detail module's `fetch_draft` so the follow-up `GET /drafts/{id}` renders the draft (not the 404 page) — a latent bug the status-code change surfaced.
- New: invalid-UUID `404` tests for the draft detail route and the drafter step route (also assert `Content-Type: text/html`).
- New: `require_role` / `require_org_member` unit tests assert the denial is an `HTMLResponse` with `status_code == 403` and the "Ligipääs keelatud" body.
- New: integration tests hitting `/admin/organizations` and `/admin/users` as an authenticated non-admin assert `403`.
- New: a completed-PDF-job `export_status_fragment` test asserts the label contains `.pdf` and not `.docx`; a companion test asserts the missing-`pdf_path` error path.

## Checks

- `uv run ruff format app/ tests/` — clean
- `uv run ruff check app/ tests/` — all checks passed
- `uv run pyright` (whole repo) — 0 errors, 0 warnings
- `uv run pytest tests/test_docs_routes.py tests/test_drafter_routes.py tests/test_docs_report_routes.py tests/test_roles.py -q` — 182 passed
- `uv run pytest -q` (full) — 2296 passed, 23 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)