### PR TITLE
fix(chat): #737/#738 — regenerate resolves to the preceding user turn; edit re-generates

### DIFF
--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -68,6 +68,7 @@ from app.chat.models import (
     Conversation,
     Message,
     delete_messages_after,
+    delete_messages_from,
     fork_conversation,
     get_conversation,
     list_conversations_for_user,
@@ -219,6 +220,56 @@ def _delete_messages_after_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Messa
     ``created_at`` and delegate.
     """
     return int(delete_messages_after(conn, conv_id, pivot_msg.created_at) or 0)
+
+
+def _delete_messages_from_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Message) -> int:
+    """Drop the pivot row *and* every row newer than it in *conv_id*.
+
+    Used by the regenerate flow's degenerate fallback (assistant bubble
+    with no preceding user turn): we cannot anchor the replay on a user
+    message, so the orphan assistant reply itself must be removed before
+    the next turn — otherwise it survives a reload (issue #737).
+    """
+    return int(delete_messages_from(conn, conv_id, pivot_msg.created_at) or 0)
+
+
+def _resolve_regenerate_pivot(
+    conn: Any, conv_id: uuid.UUID, clicked: Message
+) -> tuple[Message, bool] | None:
+    """Resolve the clicked message to the user-turn boundary for a regenerate.
+
+    The regenerate affordance lives on assistant bubbles, but the assistant
+    reply is *itself* a persisted row — so "delete everything after the
+    clicked message" leaves the stale reply behind (issue #737). The fix is
+    to anchor the replay on the **preceding user message**: delete the
+    assistant reply + everything downstream, keep the user turn, and
+    re-run generation from the existing history up to and including that
+    user message.
+
+    Returns a ``(boundary_message, inclusive)`` tuple:
+
+    * the clicked message *is* a ``user`` message → ``(clicked, False)``
+      (delete strictly after it; this is the edit-style anchor).
+    * the clicked message is an ``assistant`` / ``tool`` reply with a
+      preceding ``user`` message → ``(that_user_message, False)``.
+    * the clicked message is an ``assistant`` / ``tool`` reply with **no**
+      preceding ``user`` message (pathological) → ``(clicked, True)`` so
+      the caller drops the orphan reply too.
+
+    Returns ``None`` when the message id is not in the conversation.
+    """
+    messages = list_messages(conn, conv_id)
+    idx = next((i for i, m in enumerate(messages) if m.id == clicked.id), None)
+    if idx is None:
+        return None
+    if messages[idx].role == "user":
+        return messages[idx], False
+    # Walk backwards for the nearest preceding user message.
+    for j in range(idx - 1, -1, -1):
+        if messages[j].role == "user":
+            return messages[j], False
+    # No user turn before this reply — drop the orphan reply itself.
+    return messages[idx], True
 
 
 def _update_message_content(conn: Any, msg_id: uuid.UUID, new_content: str) -> None:
@@ -698,13 +749,25 @@ async def feedback_handler(req: Request, conv_id: str, msg_id: str):
 async def regenerate_handler(req: Request, conv_id: str, msg_id: str):
     """POST /chat/{conv_id}/messages/{msg_id}/regenerate.
 
-    Discards every message *after* the pivot and returns 204. The actual
-    replay is driven by the client: after this call succeeds the page
-    re-sends the preceding user message through the existing chat
-    WebSocket, which re-enters :mod:`app.chat.orchestrator` and streams a
-    fresh assistant turn. Keeping the regenerate trigger out of the WS
-    protocol means the HTTP transaction — delete + audit — cannot race
+    Resolves the clicked message to its **preceding user turn** (the
+    regenerate affordance lives on assistant bubbles; the assistant reply
+    is itself a persisted row), deletes that reply + everything downstream
+    *before* re-generating, and returns JSON describing the user-turn
+    pivot::
+
+        {"conversation_id": "<uuid>", "pivot_message_id": "<uuid>"}
+
+    The actual replay is driven by the client over the chat WebSocket via
+    a distinct ``{"type": "regenerate", ...}`` action that carries the
+    conversation id (and the pivot message id): the orchestrator re-runs
+    generation from the existing history *up to and including* that user
+    message and does **not** insert a new user message (issue #737).
+    Keeping the delete in this HTTP transaction means it cannot race
     against an in-flight stream.
+
+    ``pivot_message_id`` is ``None`` in the degenerate case where the
+    clicked reply has no preceding user turn — the orphan reply is dropped
+    outright and the client just reloads.
     """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
@@ -722,10 +785,22 @@ async def regenerate_handler(req: Request, conv_id: str, msg_id: str):
 
     try:
         with _connect() as conn:
-            pivot = _load_message_in_conversation(conn, parsed_conv, parsed_msg)
-            if pivot is None:
+            clicked = _load_message_in_conversation(conn, parsed_conv, parsed_msg)
+            if clicked is None:
                 return _not_found_response()
-            deleted = _delete_messages_after_pivot(conn, parsed_conv, pivot)
+            resolved = _resolve_regenerate_pivot(conn, parsed_conv, clicked)
+            if resolved is None:
+                return _not_found_response()
+            pivot_msg, inclusive = resolved
+            if inclusive:
+                # Orphan assistant reply (no preceding user turn): drop the
+                # reply itself + downstream. There is nothing to replay from.
+                deleted = _delete_messages_from_pivot(conn, parsed_conv, pivot_msg)
+                pivot_for_replay: uuid.UUID | None = None
+            else:
+                # Keep the user turn; drop its reply + everything after it.
+                deleted = _delete_messages_after_pivot(conn, parsed_conv, pivot_msg)
+                pivot_for_replay = pivot_msg.id
             conn.commit()
     except Exception:
         logger.exception("Failed to regenerate from message %s", msg_id)
@@ -736,19 +811,34 @@ async def regenerate_handler(req: Request, conv_id: str, msg_id: str):
         "chat.message.regenerate",
         {
             "conversation_id": str(parsed_conv),
-            "pivot_message_id": str(parsed_msg),
+            "clicked_message_id": str(parsed_msg),
+            "pivot_message_id": str(pivot_for_replay) if pivot_for_replay else None,
             "deleted_count": deleted,
         },
     )
-    return _hx_trigger_response("chat:message-regenerate")
+    return JSONResponse(
+        {
+            "conversation_id": str(parsed_conv),
+            "pivot_message_id": str(pivot_for_replay) if pivot_for_replay else None,
+        }
+    )
 
 
 async def edit_message_handler(req: Request, conv_id: str, msg_id: str):
     """POST /chat/{conv_id}/messages/{msg_id}/edit.
 
     Only ``role='user'`` messages can be edited. Downstream messages
-    (every message strictly after the edited one) are dropped so the
-    assistant can regenerate a response to the new prompt.
+    (every message strictly after the edited one) are dropped, then a
+    fresh assistant turn is generated for the rewritten prompt. The
+    response is JSON describing the user-turn pivot::
+
+        {"conversation_id": "<uuid>", "pivot_message_id": "<uuid>"}
+
+    The client persists the edit via this endpoint and then fires the
+    same WebSocket ``{"type": "regenerate", ...}`` action used by the
+    regenerate affordance (issue #737 / #738) — #737 and #738 share one
+    primitive: "persist the rewind → run the standard WS generation path
+    from that user message", with no duplicate user row inserted.
     """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
@@ -795,7 +885,12 @@ async def edit_message_handler(req: Request, conv_id: str, msg_id: str):
             "message_id": str(parsed_msg),
         },
     )
-    return _hx_trigger_response("chat:message-edited")
+    return JSONResponse(
+        {
+            "conversation_id": str(parsed_conv),
+            "pivot_message_id": str(parsed_msg),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -756,6 +756,41 @@ def delete_messages_after(
     return int(getattr(cursor, "rowcount", 0) or 0)
 
 
+def delete_messages_from(
+    conn: Any,
+    conv_id: uuid.UUID | str,
+    from_created_at: datetime,
+) -> int:
+    """Delete every message at or after *from_created_at* (inclusive).
+
+    The companion of :func:`delete_messages_after`. Where the latter keeps
+    the boundary message (used by the edit / regenerate-from-a-user-turn
+    flow), this one *removes* the boundary too. Used by the regenerate
+    flow's degenerate fallback: when an assistant bubble has no preceding
+    user turn we cannot regenerate "from the user message", so we drop the
+    orphan assistant reply (and anything after it) outright before the
+    next turn replays — otherwise the stale reply would survive a reload
+    (issue #737). Returns the number of rows deleted; returns ``0`` on DB
+    error (logged) so callers can treat the operation as a no-op.
+    """
+    try:
+        cursor = conn.execute(
+            """
+            DELETE FROM messages
+            WHERE conversation_id = %s AND created_at >= %s
+            """,
+            (str(conv_id), from_created_at),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to delete messages from %s for conversation=%s",
+            from_created_at,
+            conv_id,
+        )
+        return 0
+    return int(getattr(cursor, "rowcount", 0) or 0)
+
+
 # ---------------------------------------------------------------------------
 # Fork a conversation (migration 017)
 # ---------------------------------------------------------------------------

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -600,6 +600,8 @@ class ChatOrchestrator:
         user_message: str,
         auth: dict[str, Any],
         send: Callable[[dict[str, Any]], Awaitable[None]],
+        *,
+        regenerate_pivot_message_id: uuid.UUID | None = None,
     ) -> None:
         """Process a user message and stream the assistant response.
 
@@ -618,15 +620,31 @@ class ChatOrchestrator:
         conversation_id:
             UUID of the conversation this message belongs to.
         user_message:
-            The text the user typed.
+            The text the user typed. The sentinel empty string ``""`` is
+            the marker for **regenerate mode** (issues #737 / #738) — the
+            WS ``regenerate`` action passes it; the prompt is then taken
+            from the persisted history rather than from this argument.
         auth:
             Auth dict from request scope (must have ``id``, ``org_id``).
         send:
             Async callback for pushing events to the client. Wrapped in
             :func:`_safe_send` with a 5-second timeout.
+        regenerate_pivot_message_id:
+            Only meaningful in regenerate mode. The user message to
+            regenerate from; the HTTP regenerate/edit endpoints resolve
+            the clicked assistant bubble to that boundary and have
+            already deleted the stale reply + downstream. When the id
+            resolves to an assistant / tool reply we walk back to the
+            nearest preceding user turn; when it is ``None`` the
+            conversation's last user message is used. Outside regenerate
+            mode (``user_message`` non-empty) this argument is ignored.
         """
         user_id = auth.get("id")
         org_id = auth.get("org_id")
+        # Regenerate mode is signalled by the WS ``regenerate`` action
+        # passing an empty ``user_message``; a normal ``send_message`` turn
+        # always carries non-empty content (the WS handler rejects blanks).
+        regenerating = not (user_message or "").strip()
 
         # Post-review fix to #684: track pre-stream wall-clock so each
         # awaited DB step is capped by ``min(per_step_ceiling,
@@ -751,6 +769,42 @@ class ChatOrchestrator:
 
         history_length_before = len(history)
 
+        # Regenerate mode (issues #737 / #738): the prompt is the persisted
+        # user turn, not a freshly-typed message. Resolve the pivot, strip
+        # it (and anything after — though the HTTP endpoint already trimmed)
+        # from ``history`` so :func:`_build_llm_messages` re-adds it exactly
+        # once at the tail, and use its content as the effective
+        # ``user_message``. We do NOT persist a new user row — re-inserting
+        # the pivot is exactly the duplicate-turn bug #737 set out to fix.
+        # ``history_length_before`` keeps the *pre-trim* count so the
+        # first-exchange-only auto-title job (:func:`_maybe_generate_title`,
+        # gated on ``history_length_before == 0``) never fires when the
+        # conversation's opening turn is regenerated.
+        if regenerating:
+            pivot_index = _find_regenerate_pivot_index(history, regenerate_pivot_message_id)
+            if pivot_index is None:
+                logger.info(
+                    "Regenerate requested for conv=%s but no user turn found "
+                    "(pivot=%s) — nothing to replay",
+                    conversation_id,
+                    regenerate_pivot_message_id,
+                )
+                try:
+                    await _safe_send(
+                        send,
+                        {"type": "error", "message": "Pole midagi uuesti genereerida."},
+                    )
+                except WebSocketSendTimeout:
+                    pass
+                return
+            user_message = history[pivot_index].content or ""
+            history = history[:pivot_index]
+            logger.info(
+                "chat.handle_message step=regenerate conv=%s pivot_index=%s",
+                conversation_id,
+                pivot_index,
+            )
+
         # 3a. Persist the user message FIRST in its own transaction (#658).
         # Decoupled from the budget check so a stuck pg_advisory_xact_lock
         # or any downstream failure cannot lose user input. Bounded by an
@@ -764,42 +818,46 @@ class ChatOrchestrator:
         # path would silently re-introduce the data-loss bug. Persist is
         # now unconditionally the first DB write of the turn after the
         # read-only setup steps.
-        logger.info(
-            "chat.handle_message step=3a-persist-user conv=%s user=%s",
-            conversation_id,
-            user_id,
-        )
-        try:
-            await asyncio.wait_for(
-                asyncio.to_thread(_persist_user_message, conversation_id, user_message),
-                timeout=_step_deadline(pre_stream_start),
-            )
-        except TimeoutError:
-            logger.warning(
-                "User-message persist timed out after %.1fs of pre-stream budget for conv=%s",
-                time.monotonic() - pre_stream_start,
+        #
+        # Skipped in regenerate mode: the user message already lives in the
+        # DB (it is the pivot), so re-inserting it would duplicate the turn.
+        if not regenerating:
+            logger.info(
+                "chat.handle_message step=3a-persist-user conv=%s user=%s",
                 conversation_id,
+                user_id,
             )
             try:
-                await _safe_send(
-                    send,
-                    {
-                        "type": "error",
-                        "message": "Andmebaas vastab aeglaselt. Palun proovi uuesti.",
-                    },
+                await asyncio.wait_for(
+                    asyncio.to_thread(_persist_user_message, conversation_id, user_message),
+                    timeout=_step_deadline(pre_stream_start),
                 )
-            except WebSocketSendTimeout:
-                pass
-            return
-        except Exception:
-            logger.exception("Failed to persist user message for conv=%s", conversation_id)
-            try:
-                await _safe_send(
-                    send, {"type": "error", "message": "Sõnumi salvestamine ebaõnnestus."}
+            except TimeoutError:
+                logger.warning(
+                    "User-message persist timed out after %.1fs of pre-stream budget for conv=%s",
+                    time.monotonic() - pre_stream_start,
+                    conversation_id,
                 )
-            except WebSocketSendTimeout:
-                pass
-            return
+                try:
+                    await _safe_send(
+                        send,
+                        {
+                            "type": "error",
+                            "message": "Andmebaas vastab aeglaselt. Palun proovi uuesti.",
+                        },
+                    )
+                except WebSocketSendTimeout:
+                    pass
+                return
+            except Exception:
+                logger.exception("Failed to persist user message for conv=%s", conversation_id)
+                try:
+                    await _safe_send(
+                        send, {"type": "error", "message": "Sõnumi salvestamine ebaõnnestus."}
+                    )
+                except WebSocketSendTimeout:
+                    pass
+                return
 
         # 3b. Budget check in a separate transaction. The user message is
         # already safely persisted; if the budget is over the user simply
@@ -1387,6 +1445,45 @@ class ChatOrchestrator:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _find_regenerate_pivot_index(
+    history: list[Any], pivot_message_id: uuid.UUID | None
+) -> int | None:
+    """Return the index in *history* of the user turn to regenerate from.
+
+    Resolution mirrors :func:`app.chat.handlers._resolve_regenerate_pivot`
+    so the orchestrator is robust even if it loads a slightly different
+    view of the conversation than the HTTP endpoint did:
+
+    * *pivot_message_id* points at a ``user`` message → that index.
+    * *pivot_message_id* points at an ``assistant`` / ``tool`` reply →
+      walk back to the nearest preceding ``user`` message.
+    * *pivot_message_id* is ``None``, unknown, or has no preceding user
+      turn → fall back to the conversation's **last** ``user`` message.
+
+    Returns ``None`` when the conversation contains no ``user`` message at
+    all (nothing to regenerate).
+    """
+
+    def _last_user_index() -> int | None:
+        for i in range(len(history) - 1, -1, -1):
+            if getattr(history[i], "role", None) == "user":
+                return i
+        return None
+
+    if pivot_message_id is not None:
+        idx = next(
+            (i for i, m in enumerate(history) if getattr(m, "id", None) == pivot_message_id),
+            None,
+        )
+        if idx is not None:
+            if getattr(history[idx], "role", None) == "user":
+                return idx
+            for j in range(idx - 1, -1, -1):
+                if getattr(history[j], "role", None) == "user":
+                    return j
+    return _last_user_index()
 
 
 def _tool_result_count(result: Any) -> int:

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -29,7 +29,7 @@ from typing import Any
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import ClientDisconnect, Request
-from starlette.responses import RedirectResponse, Response
+from starlette.responses import HTMLResponse, RedirectResponse, Response
 
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_access_conversation
@@ -92,11 +92,22 @@ def _format_timestamp(value: Any) -> str:
     return format_tallinn(value)
 
 
-def _not_found_page(req: Request):
-    """Render the 404 page for missing or cross-org conversations."""
+def _not_found_page(req: Request) -> HTMLResponse:
+    """Render the themed 404 page for missing or cross-org conversations.
+
+    Returns a ``starlette`` :class:`HTMLResponse` with an explicit
+    ``404`` status (issue #739): the module's security model treats
+    missing / cross-org conversations as not-found, and a bare FT element
+    rendered through FastHTML's default path answers ``200 OK`` — which
+    lets these pages be cached, crawled, or mistaken for success by HTMX /
+    API callers. Wrapping the ``PageShell`` in an explicit response keeps
+    the themed body *and* the correct status code.
+    """
+    from fasthtml.common import to_xml
+
     auth = req.scope.get("auth")
     theme = get_theme_from_request(req)
-    return PageShell(
+    page = PageShell(
         H1("Vestlust ei leitud", cls="page-title"),  # noqa: F405
         Alert(
             "Otsitud vestlust ei ole olemas või Teil puudub selle vaatamise õigus.",
@@ -107,7 +118,9 @@ def _not_found_page(req: Request):
         user=auth,
         theme=theme,
         active_nav="/chat",
+        request=req,
     )
+    return HTMLResponse(to_xml(page), status_code=404)
 
 
 def _get_message_count(conv_id: uuid.UUID) -> int:

--- a/app/chat/websocket.py
+++ b/app/chat/websocket.py
@@ -17,6 +17,15 @@ Phase UX polish additions (issue #594):
   cancels the currently-running orchestrator task for the connection.
   The orchestrator catches ``CancelledError`` and persists the partial
   assistant turn with ``is_truncated=True``.
+- **Regenerate**: a ``{"type": "regenerate", "conversation_id": "<uuid>",
+  "pivot_message_id": "<uuid>"?}`` message re-runs generation from the
+  existing conversation history *up to and including* the pivot user
+  message — **no new user message is inserted** (issues #737 / #738). The
+  HTTP regenerate/edit endpoints (``app.chat.handlers``) own the prior
+  rewind (delete the stale assistant reply + downstream) so it cannot
+  race against an in-flight stream; this WS action only drives the
+  replay. It reuses the same active-task registry as ``send_message`` so
+  ``stop_generation`` can cancel a regenerate too.
 """
 
 from __future__ import annotations
@@ -113,7 +122,8 @@ async def ws_chat(
 
     Expected message formats::
 
-        {"type": "send_message", "conversation_id": "<uuid>", "content": "..."}
+        {"type": "send_message",    "conversation_id": "<uuid>", "content": "..."}
+        {"type": "regenerate",      "conversation_id": "<uuid>", "pivot_message_id": "<uuid>"?}
         {"type": "stop_generation", "conversation_id": "<uuid>"}
 
     All other message types are silently ignored.
@@ -129,8 +139,9 @@ async def ws_chat(
         test harness or passed from the WS handler wrapper).
     active_tasks:
         Optional per-connection mapping of ``conversation_id -> Task``
-        so that ``stop_generation`` can cancel an in-flight stream.
-        When omitted the stop handler is a no-op.
+        so that ``stop_generation`` can cancel an in-flight stream
+        (both ``send_message`` and ``regenerate`` register here). When
+        omitted the stop handler is a no-op.
     """
     # Parse JSON
     try:
@@ -148,6 +159,11 @@ async def ws_chat(
     # --- stop_generation -------------------------------------------------
     if msg_type == "stop_generation":
         await _handle_stop_generation(data, send, active_tasks)
+        return
+
+    # --- regenerate ------------------------------------------------------
+    if msg_type == "regenerate":
+        await _handle_regenerate(data, send, scope, active_tasks)
         return
 
     if msg_type != "send_message":
@@ -190,15 +206,55 @@ async def ws_chat(
         return
 
     # Extract auth from scope
-    auth: dict[str, Any] = {}
-    if scope is not None:
-        auth = scope.get("auth") or {}
-
-    if not auth or not auth.get("id"):
+    auth = _auth_from_scope(scope)
+    if not auth:
         await send(json.dumps({"type": "error", "message": "Autentimine nõutav."}))
         return
 
-    # Create orchestrator and handle message
+    await _drive_orchestrator(
+        conversation_id,
+        auth,
+        send,
+        active_tasks,
+        user_message=content,
+    )
+
+
+def _auth_from_scope(scope: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return the auth dict from the ASGI *scope*, or ``None`` if absent."""
+    auth: dict[str, Any] = {}
+    if scope is not None:
+        auth = scope.get("auth") or {}
+    if not auth or not auth.get("id"):
+        return None
+    return auth
+
+
+async def _drive_orchestrator(
+    conversation_id: uuid.UUID,
+    auth: dict[str, Any],
+    send: Any,
+    active_tasks: dict[str, asyncio.Task[Any]] | None,
+    *,
+    user_message: str | None = None,
+    regenerate: bool = False,
+    regenerate_pivot_message_id: uuid.UUID | None = None,
+) -> None:
+    """Run one orchestrator turn (new message *or* regenerate) for a socket.
+
+    Shared by the ``send_message`` and ``regenerate`` paths.
+
+    * ``send_message`` → pass *user_message* (non-empty) and
+      ``regenerate=False``; the orchestrator is invoked with the classic
+      4-arg signature so existing callers/tests are unaffected.
+    * ``regenerate`` → pass ``regenerate=True`` and optionally
+      *regenerate_pivot_message_id*; the orchestrator re-runs generation
+      from the existing history up to and including that user message and
+      persists no new user row (issues #737 / #738).
+
+    Both paths register the task in *active_tasks* so ``stop_generation``
+    can cancel an in-flight turn.
+    """
     orchestrator = ChatOrchestrator(get_default_provider())
 
     async def send_event(event: dict[str, Any]) -> None:
@@ -207,14 +263,33 @@ async def ws_chat(
 
     conv_key = str(conversation_id)
 
-    async def _run() -> None:
-        try:
-            await orchestrator.handle_message(conversation_id, content, auth, send_event)
-        finally:
-            if active_tasks is not None:
-                active_tasks.pop(conv_key, None)
+    async def _invoke() -> None:
+        if regenerate:
+            # Empty ``user_message`` is the orchestrator's regenerate-mode
+            # sentinel; the prompt is the persisted pivot turn.
+            await orchestrator.handle_message(
+                conversation_id,
+                "",
+                auth,
+                send_event,
+                regenerate_pivot_message_id=regenerate_pivot_message_id,
+            )
+        else:
+            await orchestrator.handle_message(
+                conversation_id,
+                user_message or "",
+                auth,
+                send_event,
+            )
 
     if active_tasks is not None:
+
+        async def _run() -> None:
+            try:
+                await _invoke()
+            finally:
+                active_tasks.pop(conv_key, None)
+
         task = asyncio.create_task(_run())
         active_tasks[conv_key] = task
         try:
@@ -226,7 +301,7 @@ async def ws_chat(
             logger.info("Chat stream cancelled for conversation %s", conv_key)
     else:
         # No task registry (test path) — run inline.
-        await orchestrator.handle_message(conversation_id, content, auth, send_event)
+        await _invoke()
 
 
 async def _handle_stop_generation(
@@ -276,6 +351,57 @@ async def _handle_stop_generation(
         # CancelledError is expected; any other exception has already
         # been logged inside the orchestrator.
         pass
+
+
+async def _handle_regenerate(
+    data: dict[str, Any],
+    send: Any,
+    scope: dict[str, Any] | None,
+    active_tasks: dict[str, asyncio.Task[Any]] | None,
+) -> None:
+    """Re-run generation from an existing user turn (issues #737 / #738).
+
+    Carries ``conversation_id`` and an optional ``pivot_message_id`` (the
+    user message to regenerate from; the HTTP regenerate/edit endpoints
+    resolve the clicked assistant bubble to that boundary and have
+    already deleted the stale reply + downstream). When ``pivot_message_id``
+    is omitted the orchestrator regenerates from the conversation's last
+    user message. **No new user message is inserted** — the existing
+    history *is* the prompt.
+    """
+    raw_conv_id = data.get("conversation_id")
+    if not raw_conv_id:
+        await send(json.dumps({"type": "error", "message": "Puudub conversation_id."}))
+        return
+
+    try:
+        conversation_id = uuid.UUID(str(raw_conv_id))
+    except (ValueError, TypeError):
+        await send(json.dumps({"type": "error", "message": "Vigane conversation_id."}))
+        return
+
+    raw_pivot = data.get("pivot_message_id")
+    pivot_message_id: uuid.UUID | None = None
+    if raw_pivot:
+        try:
+            pivot_message_id = uuid.UUID(str(raw_pivot))
+        except (ValueError, TypeError):
+            await send(json.dumps({"type": "error", "message": "Vigane pivot_message_id."}))
+            return
+
+    auth = _auth_from_scope(scope)
+    if not auth:
+        await send(json.dumps({"type": "error", "message": "Autentimine nõutav."}))
+        return
+
+    await _drive_orchestrator(
+        conversation_id,
+        auth,
+        send,
+        active_tasks,
+        regenerate=True,
+        regenerate_pivot_message_id=pivot_message_id,
+    )
 
 
 def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) -> str | None:

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -12,7 +12,15 @@
  * CLIENT → SERVER  (JSON objects)
  * --------------------------------
  *   {type: "send_message",    conversation_id, content}
+ *   {type: "regenerate",      conversation_id, pivot_message_id?}
  *   {type: "stop_generation", conversation_id}
+ *
+ * `regenerate` re-runs generation from the conversation's persisted history
+ * up to and including the pivot *user* message — NO text is re-sent and NO
+ * new user turn is inserted (issues #737 / #738). The HTTP regenerate/edit
+ * endpoints own the prior rewind (delete the stale assistant reply +
+ * downstream rows) and return the pivot id; this client then fires the WS
+ * `regenerate` action and updates the DOM optimistically.
  *
  * SERVER → CLIENT  (JSON objects, all have `type`)
  * --------------------------------
@@ -1298,33 +1306,72 @@
         showToast('Taasgenereerimine ebaõnnestus', 'error');
         return;
       }
-      // Locate the preceding user message text and replay it via WS
-      const msgEl = messagesEl
-        ? messagesEl.querySelector('[data-message-id="' + msgId + '"]')
-        : null;
-      let userText = '';
-      if (msgEl) {
-        // Walk backwards through siblings to find the previous user bubble
-        let prev = msgEl.previousElementSibling;
-        while (prev) {
-          if (prev.classList.contains('chat-message-user')) {
-            const t = prev.querySelector('.chat-message-text');
-            if (t) userText = t.innerText || t.textContent || '';
-            break;
-          }
-          prev = prev.previousElementSibling;
-        }
-        // Remove the assistant bubble we just asked to regenerate
-        if (msgEl.parentNode) msgEl.parentNode.removeChild(msgEl);
+      return res.json().catch(function () { return null; });
+    }).then(function (data) {
+      if (data === undefined) return; // !res.ok branch already handled
+      // The server has resolved the clicked assistant bubble to its
+      // preceding user turn and already deleted the stale reply +
+      // everything downstream. ``pivot_message_id`` is the user turn to
+      // replay from (issue #737); ``null`` is the degenerate "orphan
+      // reply, nothing to replay" case — fall back to a reload so the
+      // authoritative (trimmed) history is rendered.
+      const pivotId = data && data.pivot_message_id;
+      if (!pivotId) {
+        location.reload();
+        return;
       }
-
-      if (userText && inputEl) {
-        inputEl.value = userText;
-        sendMessage();
-      }
+      replayFromPivot(pivotId, null);
     }).catch(function () {
       showToast('Taasgenereerimine ebaõnnestus', 'error');
     });
+  }
+
+  /**
+   * Optimistically rewind the transcript to the pivot user bubble and
+   * kick off a fresh generation over the WebSocket.
+   *
+   * @param {string} pivotMsgId  message id of the user turn to replay from
+   * @param {?string} newUserText  when set, re-render the pivot bubble's
+   *   text with this string (the edit flow); when null, leave it as-is
+   *   (the regenerate flow).
+   */
+  function replayFromPivot(pivotMsgId, newUserText) {
+    const pivotEl = messagesEl
+      ? messagesEl.querySelector('[data-message-id="' + pivotMsgId + '"]')
+      : null;
+
+    if (pivotEl) {
+      // Drop every bubble / tool-activity / sources block after the pivot
+      // — they belong to the turn(s) the server just deleted.
+      let sib = pivotEl.nextElementSibling;
+      while (sib) {
+        const next = sib.nextElementSibling;
+        if (sib.parentNode) sib.parentNode.removeChild(sib);
+        sib = next;
+      }
+      if (typeof newUserText === 'string') {
+        const textEl = pivotEl.querySelector('.chat-message-text');
+        if (textEl) textEl.textContent = newUserText;
+      }
+    }
+
+    // Clear any transient streaming state from a prior turn before we open
+    // a new thinking bubble for the regenerated reply.
+    for (const k in msgBubbles) delete msgBubbles[k];
+    for (const k in msgBuffers) delete msgBuffers[k];
+    pendingBubble = null;
+    pendingMsgId = null;
+
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      showToast('Ühendus puudub — palun oodake...', 'warning');
+      return;
+    }
+
+    hideEmptyState();
+    wsSend({ type: 'regenerate', conversation_id: convId, pivot_message_id: pivotMsgId });
+    disableInput();
+    startThinking();
+    if (inputEl) inputEl.focus();
   }
 
   function handleEdit(msgId, msgEl, btn) {
@@ -1367,6 +1414,18 @@
       bubble.innerHTML = originalHtml;
     });
 
+    // Replace the inline edit form with a plain rendered user bubble
+    // (a <p class="chat-message-text"> child, exactly like the server
+    // renders user turns). Uses textContent — never innerHTML — so the
+    // rewritten text cannot inject markup.
+    function restorePivotBubble(text) {
+      while (bubble.firstChild) bubble.removeChild(bubble.firstChild);
+      const p = document.createElement('p');
+      p.className = 'chat-message-text';
+      p.textContent = text;
+      bubble.appendChild(p);
+    }
+
     saveBtn.addEventListener('click', function () {
       const newContent = textarea.value.trim();
       if (!newContent) return;
@@ -1379,17 +1438,26 @@
         body: formData,
         credentials: 'same-origin',
       }).then(function (res) {
-        if (res.ok) {
-          // Simplest correct approach: reload the page so server-rendered
-          // history is authoritative (per spec).
-          location.reload();
-        } else {
+        if (!res.ok) {
           showToast('Muutmine ebaõnnestus', 'error');
-          bubble.innerHTML = originalHtml;
+          restorePivotBubble(originalText);
+          return undefined; // signal: the !res.ok branch already handled it
         }
+        // The edit persisted. The body names the replay pivot, but even
+        // if it fails to parse we still regenerate (the edit is committed).
+        return res.json().catch(function () { return {}; });
+      }).then(function (data) {
+        if (data === undefined) return; // !res.ok branch already handled
+        // Render the edited prompt in place, then rewind + regenerate via
+        // the SAME WS primitive the regenerate button uses (issue #738):
+        // #737 and #738 share one path — "persist the edit, re-generate
+        // from that user message", no duplicate user row inserted.
+        restorePivotBubble(newContent);
+        const pivotId = (data && data.pivot_message_id) || msgId;
+        replayFromPivot(pivotId, newContent);
       }).catch(function () {
         showToast('Muutmine ebaõnnestus', 'error');
-        bubble.innerHTML = originalHtml;
+        restorePivotBubble(originalText);
       });
     });
   }

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -574,25 +574,154 @@ class TestFeedback:
 
 
 class TestRegenerate:
-    def test_regenerate_deletes_and_returns_204(self, provider_patch, mock_conn):
+    def test_regenerate_from_user_message_keeps_pivot(self, provider_patch, mock_conn):
+        """Clicking regenerate on a user bubble (defensive path): the
+        pivot resolves to that user message itself, only downstream rows
+        are deleted, and the JSON body names that user message as the
+        replay pivot (#737)."""
         conv = _make_conversation()
         msg = _make_message(role="user")
         with (
             patch("app.chat.handlers.get_conversation", return_value=conv),
             patch("app.chat.handlers.list_messages", return_value=[msg]),
             patch("app.chat.handlers._delete_messages_after_pivot", return_value=2) as mock_del,
+            patch("app.chat.handlers._delete_messages_from_pivot") as mock_del_from,
         ):
             client = _authed_client()
             resp = client.post(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/regenerate")
-            assert resp.status_code == 204
-            assert resp.headers.get("HX-Trigger") == "chat:message-regenerate"
+            assert resp.status_code == 200
+            assert resp.json() == {
+                "conversation_id": str(_CONV_ID),
+                "pivot_message_id": str(_MSG_ID),
+            }
             mock_del.assert_called_once()
+            mock_del_from.assert_not_called()
+
+    def test_regenerate_from_assistant_resolves_to_preceding_user(self, provider_patch, mock_conn):
+        """#737: the regenerate affordance lives on assistant bubbles. The
+        server resolves the clicked assistant row to its preceding *user*
+        message, deletes the assistant reply + downstream (keeping the
+        user turn), and returns that user turn as the replay pivot — so
+        the old assistant reply is gone and no duplicate user turn is
+        re-sent."""
+        user_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        asst_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        # created_at must differ so "delete strictly after the user turn"
+        # actually removes the assistant reply.
+        user_msg = Message(
+            id=user_id,
+            conversation_id=_CONV_ID,
+            role="user",
+            content="Mis on TsÜS?",
+            tool_name=None,
+            tool_input=None,
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=datetime(2026, 4, 14, 9, 30, tzinfo=UTC),
+        )
+        asst_msg = Message(
+            id=asst_id,
+            conversation_id=_CONV_ID,
+            role="assistant",
+            content="TsÜS on tsiviilseadustiku üldosa seadus.",
+            tool_name=None,
+            tool_input=None,
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=datetime(2026, 4, 14, 9, 31, tzinfo=UTC),
+        )
+
+        captured: dict[str, Any] = {}
+
+        def _fake_delete_after(conn, conv_id, pivot_msg):
+            captured["after_pivot_id"] = pivot_msg.id
+            return 1
+
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=_make_conversation()),
+            patch(
+                "app.chat.handlers.list_messages",
+                return_value=[user_msg, asst_msg],
+            ),
+            patch(
+                "app.chat.handlers._delete_messages_after_pivot",
+                side_effect=_fake_delete_after,
+            ),
+            patch("app.chat.handlers._delete_messages_from_pivot") as mock_del_from,
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{asst_id}/regenerate")
+            assert resp.status_code == 200
+            # The replay pivot is the preceding USER message, not the
+            # clicked assistant row.
+            assert resp.json() == {
+                "conversation_id": str(_CONV_ID),
+                "pivot_message_id": str(user_id),
+            }
+            # And the delete was anchored on the user turn (so the
+            # assistant reply, which is strictly after it, is removed).
+            assert captured["after_pivot_id"] == user_id
+            mock_del_from.assert_not_called()
+
+    def test_regenerate_orphan_assistant_drops_reply(self, provider_patch, mock_conn):
+        """Degenerate case: an assistant reply with no preceding user turn
+        cannot be regenerated *from* a user message — so the orphan reply
+        itself (and anything after it) is deleted and the JSON pivot is
+        ``None`` (the client then just reloads)."""
+        asst_id = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+        asst_msg = Message(
+            id=asst_id,
+            conversation_id=_CONV_ID,
+            role="assistant",
+            content="orphan",
+            tool_name=None,
+            tool_input=None,
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=datetime(2026, 4, 14, 9, 30, tzinfo=UTC),
+        )
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=_make_conversation()),
+            patch("app.chat.handlers.list_messages", return_value=[asst_msg]),
+            patch("app.chat.handlers._delete_messages_after_pivot") as mock_del_after,
+            patch(
+                "app.chat.handlers._delete_messages_from_pivot", return_value=1
+            ) as mock_del_from,
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{asst_id}/regenerate")
+            assert resp.status_code == 200
+            assert resp.json() == {
+                "conversation_id": str(_CONV_ID),
+                "pivot_message_id": None,
+            }
+            mock_del_from.assert_called_once()
+            mock_del_after.assert_not_called()
 
     def test_regenerate_bad_msg_id_404(self, provider_patch, mock_conn):
         conv = _make_conversation()
         with patch("app.chat.handlers.get_conversation", return_value=conv):
             client = _authed_client()
             resp = client.post(f"/chat/{_CONV_ID}/messages/not-a-uuid/regenerate")
+            assert resp.status_code == 404
+
+    def test_regenerate_unknown_msg_404(self, provider_patch, mock_conn):
+        conv = _make_conversation()
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[]),
+        ):
+            client = _authed_client()
+            resp = client.post(f"/chat/{_CONV_ID}/messages/{_MSG_ID}/regenerate")
             assert resp.status_code == 404
 
     def test_regenerate_cross_org_404(self, provider_patch, mock_conn):
@@ -609,23 +738,32 @@ class TestRegenerate:
 
 
 class TestEditMessage:
-    def test_edit_user_message_success(self, provider_patch, mock_conn):
+    def test_edit_user_message_returns_replay_pivot(self, provider_patch, mock_conn):
+        """#738: a successful edit persists the rewrite, drops downstream
+        rows, and returns JSON naming the edited user message as the
+        replay pivot — the client then fires the same WS ``regenerate``
+        action used by the regenerate button, so a fresh answer is
+        generated for the rewritten prompt (no duplicate user row)."""
         conv = _make_conversation()
         msg = _make_message(role="user", content="vana")
         with (
             patch("app.chat.handlers.get_conversation", return_value=conv),
             patch("app.chat.handlers.list_messages", return_value=[msg]),
             patch("app.chat.handlers._update_message_content") as mock_update,
-            patch("app.chat.handlers._delete_messages_after_pivot", return_value=0),
+            patch("app.chat.handlers._delete_messages_after_pivot", return_value=0) as mock_del,
         ):
             client = _authed_client()
             resp = client.post(
                 f"/chat/{_CONV_ID}/messages/{_MSG_ID}/edit",
                 data={"content": "uus sisu"},
             )
-            assert resp.status_code == 204
-            assert resp.headers.get("HX-Trigger") == "chat:message-edited"
+            assert resp.status_code == 200
+            assert resp.json() == {
+                "conversation_id": str(_CONV_ID),
+                "pivot_message_id": str(_MSG_ID),
+            }
             mock_update.assert_called_once()
+            mock_del.assert_called_once()
 
     def test_edit_rejects_assistant_message(self, provider_patch, mock_conn):
         conv = _make_conversation()

--- a/tests/test_chat_models.py
+++ b/tests/test_chat_models.py
@@ -21,6 +21,7 @@ from app.chat.models import (
     create_message,
     delete_conversation,
     delete_messages_after,
+    delete_messages_from,
     fork_conversation,
     get_conversation,
     list_conversations_for_user,
@@ -628,6 +629,37 @@ class TestDeleteMessagesAfter:
         conn.execute.side_effect = RuntimeError("boom")
 
         result = delete_messages_after(conn, uuid.uuid4(), datetime.now(UTC))
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_messages_from (#737 — drop the boundary too)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMessagesFrom:
+    def test_delete_uses_inclusive_greater_or_equal(self):
+        """Unlike :func:`delete_messages_after`, the boundary row IS deleted —
+        used by the regenerate flow's orphan-assistant fallback (#737)."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.rowcount = 4
+        conn.execute.return_value = cursor
+        boundary = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+
+        result = delete_messages_from(conn, uuid.uuid4(), boundary)
+
+        assert result == 4
+        sql, params = conn.execute.call_args.args
+        assert "DELETE" in sql
+        assert "created_at >= %s" in sql
+        assert params[1] == boundary
+
+    def test_returns_zero_on_db_error(self):
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("boom")
+
+        result = delete_messages_from(conn, uuid.uuid4(), datetime.now(UTC))
         assert result == 0
 
 

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -2262,3 +2262,194 @@ class TestTurnDeadline:
         # No stopped event — only error.
         assert not any(e.get("type") == "stopped" for e in collector.events)
         assert any(e.get("type") == "error" for e in collector.events)
+
+
+# ---------------------------------------------------------------------------
+# #737 / #738: regenerate mode
+# ---------------------------------------------------------------------------
+
+
+class _RegenConn:
+    """Minimal conn whose ``fetchone`` always yields a valid message row.
+
+    Used by the regenerate-mode tests where ``_load_conversation`` /
+    ``_load_history`` are patched out, so the only DB traffic is the
+    fresh assistant-message INSERT ... RETURNING + the conversation
+    ``updated_at`` bump.
+    """
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self._result = MagicMock()
+        self._result.fetchone.side_effect = lambda: _make_message_row(role="assistant")
+        self._result.fetchall.return_value = []
+
+    def execute(self, sql: str, params: Any = None) -> Any:  # noqa: ANN401
+        if isinstance(sql, str):
+            self.executed.append(sql)
+        return self._result
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+    def __enter__(self) -> _RegenConn:
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+
+class TestRegenerateMode:
+    """The WS ``regenerate`` action re-runs generation from the persisted
+    user turn — it must NOT insert a new user message (issue #737, the
+    duplicate-turn bug) and is the shared primitive behind the edit flow
+    (issue #738)."""
+
+    @patch("app.chat.orchestrator._persist_user_message")
+    @patch("app.chat.orchestrator._load_history")
+    @patch("app.chat.orchestrator._load_conversation")
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_regenerate_skips_user_persist_and_replays_pivot(
+        self,
+        mock_get_conn,
+        mock_rate,
+        mock_cost,
+        mock_load_conv,
+        mock_load_hist,
+        mock_persist,
+    ):
+        conn = _RegenConn()
+        mock_get_conn.return_value = conn
+        mock_load_conv.return_value = _make_conversation()
+        # The HTTP regenerate endpoint already deleted the stale assistant
+        # reply + downstream, so handle_message sees a history that ends at
+        # the user turn we are regenerating from.
+        user_msg = _make_message("user", "Mis on TsÜS?")
+        mock_load_hist.return_value = [user_msg]
+
+        captured: dict[str, str] = {}
+
+        class _RecordingLLM(FakeLLM):
+            async def astream(self, prompt: str, **kwargs: Any):  # type: ignore[override]
+                captured["prompt"] = prompt
+                async for ev in super().astream(prompt, **kwargs):
+                    yield ev
+
+        collector = _Collector()
+        orch = ChatOrchestrator(_RecordingLLM(), FakeSparql())
+        asyncio.run(
+            orch.handle_message(
+                _CONV_ID,
+                "",  # empty content == regenerate-mode sentinel
+                _auth(),
+                collector,
+                regenerate_pivot_message_id=user_msg.id,
+            )
+        )
+
+        # #737: the user message was NOT re-persisted — it already exists
+        # as the pivot, so a fresh INSERT would be the duplicate turn.
+        mock_persist.assert_not_called()
+        # A regenerated assistant turn streamed to completion.
+        assert any(e.get("type") == "content_delta" for e in collector.events)
+        assert any(e.get("type") == "done" for e in collector.events)
+        # The prompt the LLM saw contains the pivot user message exactly
+        # once (it is re-appended by ``_build_llm_messages``, not doubled).
+        assert captured["prompt"].count("Mis on TsÜS?") == 1
+        # And the fresh assistant reply was persisted.
+        assert any("INSERT INTO messages" in sql for sql in conn.executed)
+
+    @patch("app.chat.orchestrator._persist_user_message")
+    @patch("app.chat.orchestrator._load_history")
+    @patch("app.chat.orchestrator._load_conversation")
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_regenerate_resolves_assistant_pivot_to_preceding_user(
+        self,
+        mock_get_conn,
+        mock_rate,
+        mock_cost,
+        mock_load_conv,
+        mock_load_hist,
+        mock_persist,
+    ):
+        """Defence in depth: even if a stale assistant id reaches the
+        orchestrator (e.g. the history view differs slightly from what the
+        HTTP endpoint trimmed), it resolves to the preceding user turn and
+        the trailing assistant content is not fed back into the prompt."""
+        conn = _RegenConn()
+        mock_get_conn.return_value = conn
+        mock_load_conv.return_value = _make_conversation()
+        user_msg = _make_message("user", "Selgita lepingu tühisust")
+        asst_msg = _make_message("assistant", "Leping on tühine kui ...")
+        mock_load_hist.return_value = [user_msg, asst_msg]
+
+        captured: dict[str, str] = {}
+
+        class _RecordingLLM(FakeLLM):
+            async def astream(self, prompt: str, **kwargs: Any):  # type: ignore[override]
+                captured["prompt"] = prompt
+                async for ev in super().astream(prompt, **kwargs):
+                    yield ev
+
+        collector = _Collector()
+        orch = ChatOrchestrator(_RecordingLLM(), FakeSparql())
+        asyncio.run(
+            orch.handle_message(
+                _CONV_ID,
+                "",
+                _auth(),
+                collector,
+                regenerate_pivot_message_id=asst_msg.id,
+            )
+        )
+
+        mock_persist.assert_not_called()
+        assert any(e.get("type") == "done" for e in collector.events)
+        # The pivot user message is present once; the stale assistant reply
+        # is NOT re-sent into the prompt (it was after the pivot).
+        assert captured["prompt"].count("Selgita lepingu tühisust") == 1
+        assert "Leping on tühine kui" not in captured["prompt"]
+
+    @patch("app.chat.orchestrator._persist_user_message")
+    @patch("app.chat.orchestrator._load_history")
+    @patch("app.chat.orchestrator._load_conversation")
+    @patch("app.chat.orchestrator.check_org_cost_budget")
+    @patch("app.chat.orchestrator.check_message_rate")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_regenerate_with_no_user_turn_errors(
+        self,
+        mock_get_conn,
+        mock_rate,
+        mock_cost,
+        mock_load_conv,
+        mock_load_hist,
+        mock_persist,
+    ):
+        conn = _RegenConn()
+        mock_get_conn.return_value = conn
+        mock_load_conv.return_value = _make_conversation()
+        mock_load_hist.return_value = []  # nothing to replay
+
+        collector = _Collector()
+        orch = ChatOrchestrator(FakeLLM(), FakeSparql())
+        asyncio.run(
+            orch.handle_message(
+                _CONV_ID,
+                "",
+                _auth(),
+                collector,
+                regenerate_pivot_message_id=_MSG_ID,
+            )
+        )
+
+        mock_persist.assert_not_called()
+        # No generation happened; the user gets a friendly error event.
+        assert any(e.get("type") == "error" for e in collector.events)
+        assert not any(e.get("type") == "content_delta" for e in collector.events)

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -369,7 +369,8 @@ class TestChatView:
         with patch("app.chat.routes.get_conversation", return_value=conv):
             client = _authed_client()
             resp = client.get(f"/chat/{_CONV_ID}")
-            assert resp.status_code == 200
+            # #739: the not-found page now answers an explicit 404.
+            assert resp.status_code == 404
             assert "ei leitud" in resp.text.lower() or "puudub" in resp.text.lower()
 
     @patch("app.chat.routes._connect")
@@ -387,7 +388,7 @@ class TestChatView:
         with patch("app.chat.routes.get_conversation", return_value=conv):
             client = _authed_client()
             resp = client.get(f"/chat/{_CONV_ID}")
-            assert resp.status_code == 200
+            assert resp.status_code == 404
             assert "ei leitud" in resp.text.lower() or "puudub" in resp.text.lower()
 
     @patch("app.chat.routes._connect")
@@ -396,7 +397,7 @@ class TestChatView:
         mock_provider.return_value = _stub_provider()
         client = _authed_client()
         resp = client.get("/chat/not-a-uuid")
-        assert resp.status_code == 200
+        assert resp.status_code == 404
         assert "ei leitud" in resp.text.lower()
 
     @patch("app.chat.routes._connect")
@@ -410,7 +411,7 @@ class TestChatView:
         with patch("app.chat.routes.get_conversation", return_value=None):
             client = _authed_client()
             resp = client.get(f"/chat/{_CONV_ID}")
-            assert resp.status_code == 200
+            assert resp.status_code == 404
             assert "ei leitud" in resp.text.lower()
 
     @patch("app.chat.routes._get_draft_title", return_value="TestEelnou")
@@ -540,7 +541,8 @@ class TestChatDelete:
         with patch("app.chat.routes.get_conversation", return_value=conv):
             client = _authed_client()
             resp = client.post(f"/chat/{_CONV_ID}/delete")
-            assert resp.status_code == 200
+            # #739: the not-found page now answers an explicit 404.
+            assert resp.status_code == 404
             assert "ei leitud" in resp.text.lower()
 
     @patch("app.chat.routes._connect")
@@ -556,7 +558,7 @@ class TestChatDelete:
         with patch("app.chat.routes.get_conversation", return_value=conv):
             client = _authed_client()
             resp = client.post(f"/chat/{_CONV_ID}/delete")
-            assert resp.status_code == 200
+            assert resp.status_code == 404
             assert "ei leitud" in resp.text.lower()
 
 

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -519,6 +519,137 @@ class TestWsChatStopGeneration:
         assert parsed["type"] == "stopped"
 
 
+# ---------------------------------------------------------------------------
+# #737 / #738: regenerate action
+# ---------------------------------------------------------------------------
+
+
+class TestWsChatRegenerate:
+    """The ``regenerate`` action re-runs generation from the persisted
+    history (no re-sent text, no new user message) — issues #737 / #738."""
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    def test_regenerate_calls_orchestrator_in_regenerate_mode(self, mock_provider, mock_orch_cls):
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_instance
+
+        pivot_id = "44444444-4444-4444-4444-444444444444"
+        collector = _Collector()
+        msg = json.dumps(
+            {
+                "type": "regenerate",
+                "conversation_id": _CONV_ID,
+                "pivot_message_id": pivot_id,
+            }
+        )
+        asyncio.run(ws_chat(msg, collector, _auth_scope()))
+
+        mock_instance.handle_message.assert_called_once()
+        call = mock_instance.handle_message.call_args
+        # conversation_id, then the empty-string regenerate sentinel.
+        assert str(call[0][0]) == _CONV_ID
+        assert call[0][1] == ""
+        assert call[0][2]["id"] == _USER_ID
+        # The pivot is forwarded as a UUID keyword arg.
+        assert str(call.kwargs["regenerate_pivot_message_id"]) == pivot_id
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    def test_regenerate_without_pivot_passes_none(self, mock_provider, mock_orch_cls):
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_instance
+
+        collector = _Collector()
+        msg = json.dumps({"type": "regenerate", "conversation_id": _CONV_ID})
+        asyncio.run(ws_chat(msg, collector, _auth_scope()))
+
+        mock_instance.handle_message.assert_called_once()
+        call = mock_instance.handle_message.call_args
+        assert call[0][1] == ""
+        assert call.kwargs["regenerate_pivot_message_id"] is None
+
+    @patch("app.chat.websocket.ChatOrchestrator")
+    @patch("app.chat.websocket.get_default_provider")
+    def test_regenerate_bad_pivot_id_sends_error(self, mock_provider, mock_orch_cls):
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock()
+        mock_orch_cls.return_value = mock_instance
+
+        collector = _Collector()
+        msg = json.dumps(
+            {
+                "type": "regenerate",
+                "conversation_id": _CONV_ID,
+                "pivot_message_id": "not-a-uuid",
+            }
+        )
+        asyncio.run(ws_chat(msg, collector, _auth_scope()))
+
+        mock_instance.handle_message.assert_not_called()
+        assert len(collector.sent) == 1
+        assert json.loads(collector.sent[0])["type"] == "error"
+
+    def test_regenerate_missing_conversation_id_sends_error(self):
+        collector = _Collector()
+        asyncio.run(ws_chat(json.dumps({"type": "regenerate"}), collector, _auth_scope()))
+        assert len(collector.sent) == 1
+        parsed = json.loads(collector.sent[0])
+        assert parsed["type"] == "error"
+        assert "conversation_id" in parsed["message"].lower()
+
+    def test_regenerate_unauthenticated_sends_error(self):
+        collector = _Collector()
+        msg = json.dumps({"type": "regenerate", "conversation_id": _CONV_ID})
+        asyncio.run(ws_chat(msg, collector, scope={}))
+        assert len(collector.sent) == 1
+        parsed = json.loads(collector.sent[0])
+        assert parsed["type"] == "error"
+        assert "autentimine" in parsed["message"].lower()
+
+    def test_regenerate_stop_can_cancel_it(self):
+        """``stop_generation`` cancels an in-flight ``regenerate`` too —
+        both paths share the active-task registry."""
+        cancel_observed: dict[str, bool] = {"called": False}
+
+        async def slow_handle(conv_id, content, auth, send_event, **kwargs):
+            try:
+                await send_event({"type": "content_delta", "delta": "partial"})
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                cancel_observed["called"] = True
+                await send_event({"type": "stopped", "message_id": None})
+                raise
+
+        mock_instance = MagicMock()
+        mock_instance.handle_message = AsyncMock(side_effect=slow_handle)
+
+        collector = _Collector()
+
+        async def scenario():
+            with (
+                patch("app.chat.websocket.ChatOrchestrator", return_value=mock_instance),
+                patch("app.chat.websocket.get_default_provider"),
+            ):
+                tasks: dict[str, Any] = {}
+                regen_msg = json.dumps({"type": "regenerate", "conversation_id": _CONV_ID})
+                stop_msg = json.dumps({"type": "stop_generation", "conversation_id": _CONV_ID})
+
+                regen_task = asyncio.create_task(
+                    ws_chat(regen_msg, collector, _auth_scope(), active_tasks=tasks)
+                )
+                await asyncio.sleep(0.05)
+                await ws_chat(stop_msg, collector, _auth_scope(), active_tasks=tasks)
+                await regen_task
+
+        asyncio.run(scenario())
+
+        assert cancel_observed["called"] is True
+        assert any(json.loads(s).get("type") == "stopped" for s in collector.sent)
+
+
 class TestWsHandlerDisconnectCleanup:
     """Disconnect mid-stream must cancel pending tasks and drop the registry key."""
 


### PR DESCRIPTION
## Summary

Two coupled chat-action bugs, fixed with one shared primitive.

### #737 — Regenerate left a stale assistant reply *and* duplicated the user turn
The regenerate affordance lives on assistant bubbles, but the assistant reply is itself a persisted row. The old server deleted only rows *after* the clicked assistant row (so the clicked row survived in the DB), and `chat.js` walked back to the previous user bubble and re-sent that text as a **new** `send_message` over the WS. On reload you saw the old reply + a duplicated user turn + a new reply.

Now:
- The server (`regenerate_handler`) **resolves the clicked assistant row to its preceding *user* message**, deletes that reply + everything downstream *before* re-generating, and returns JSON `{conversation_id, pivot_message_id}` (the user-turn pivot).
- A distinct WebSocket action `{"type": "regenerate", "conversation_id", "pivot_message_id"?}` re-runs generation **from the existing history up to and including that user message** — it does **not** insert a new user message. `ChatOrchestrator.handle_message` gains `regenerate_pivot_message_id`; an empty `user_message` is the regenerate-mode sentinel (skips the user-message persist, derives the prompt from the persisted pivot turn, trims history so `_build_llm_messages` re-appends it exactly once, keeps the pre-trim `history_length_before` so the first-exchange auto-title never fires on a regenerate).
- `chat.js`'s `handleRegenerate` POSTs, then fires the WS `regenerate` event (no re-sent text) and optimistically rewinds the transcript to the pivot bubble.
- Degenerate case (orphan assistant reply with no preceding user turn): the orphan reply is dropped outright via the new inclusive `delete_messages_from(conn, conv_id, created_at)`, the endpoint returns `pivot_message_id: null`, and the client reloads.

### #738 — Edit deleted later replies but never re-generated
"Muuda ja saada uuesti" updated the message + deleted downstream rows, and `chat.js` just `location.reload()`'d — no new generation. You landed on a conversation with the edited prompt and no answer.

Now `edit_message_handler` returns the edited user message as the replay pivot, and `chat.js` fires the **same** `regenerate` WS event — #737 and #738 share one path: "persist the rewind → run the standard WS generation path from that user message", no duplicate user row.

### #739 (chat/routes.py slice only)
`_not_found_page` now returns `HTMLResponse(to_xml(PageShell(...)), status_code=404)` instead of a bare 200 OK. (The rest of #739 is owned by another change.)

## WebSocket protocol addition
```
CLIENT → SERVER:  {type: "regenerate", conversation_id, pivot_message_id?}
```
Reuses the per-connection active-task registry, so `stop_generation` cancels a `regenerate` too.

## Tests
- `test_chat_handlers.py`: regenerate via the assistant path (server resolves to the preceding user turn; the delete is anchored on that user turn so the assistant reply is removed; JSON pivot is the user message); orphan-assistant fallback (reply dropped, pivot `null`); edit-save returns the replay pivot.
- `test_chat_orchestrator.py`: `TestRegenerateMode` — regenerate skips the user-message persist (the #737 duplicate-turn bug), the LLM prompt carries the pivot content exactly once, a fresh assistant turn streams + persists; stale-assistant id resolves to the preceding user turn (the trailing reply is not fed back into the prompt); no-user-turn → friendly error, no generation.
- `test_chat_websocket.py`: `TestWsChatRegenerate` — `regenerate` dispatches to the orchestrator in regenerate mode (empty content + UUID pivot kwarg); no pivot → `None`; bad pivot/missing conv id/unauthenticated → error; `stop_generation` cancels an in-flight `regenerate`.
- `test_chat_models.py`: `delete_messages_from` uses `created_at >= %s` (inclusive) and is fault-tolerant.
- `test_chat_routes.py`: not-found chat route tests flipped to assert `404`.

## Status
- `uv run ruff format app/ tests/` ✓
- `uv run ruff check app/ tests/` ✓
- `uv run pyright` (repo-wide) ✓ — 0 errors, 0 warnings
- `node --check app/static/js/chat.js` ✓
- `uv run pytest tests/test_chat_handlers.py tests/test_chat_routes.py -q` ✓
- `uv run pytest -q` ✓ — 2304 passed, 23 skipped

Closes #737
Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)