### PR TITLE
fix(explorer): #743 — bookmark button distinguishes a saved row from an expired session

### DIFF
--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -1467,23 +1467,28 @@ async function addBookmark() {
   var label = node ? node.label : '';
 
   try {
+    // #743: ask /api/bookmarks for a JSON response (X-Requested-With) instead
+    // of following its 303 — a `redirect: 'manual'` fetch can't tell a save
+    // (303 → /dashboard) from an expired session (303 → /auth/login), so the
+    // old code marked the button "bookmarked" even when nothing was saved.
     var resp = await fetch('/api/bookmarks', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
       body: 'entity_uri=' + encodeURIComponent(entityUri) + '&label=' + encodeURIComponent(label),
-      redirect: 'manual',
     });
 
-    if (resp.status === 303 || resp.status === 200) {
+    if (resp.ok) {
       showToast('Lisatud j\u00e4rjehoidjatesse: ' + (label || entityUri), 'success');
-
       var btn = document.getElementById('panel-bookmark-btn');
       if (btn) {
         btn.textContent = 'J\u00e4rjehoidjas \u2713';
         btn.classList.add('bookmarked');
       }
-    } else if (resp.status === 303 && resp.headers.get('location') === '/auth/login') {
-      showToast('Logi sisse, et lisada j\u00e4rjehoidjaid', 'warning');
+    } else if (resp.status === 401 || resp.status === 403) {
+      showToast('Sessioon on aegunud \u2014 logige uuesti sisse, et lisada j\u00e4rjehoidjaid.', 'warning');
     } else {
       showToast('J\u00e4rjehoidja lisamine eba\u00f5nnestus', 'warning');
     }

--- a/app/templates/dashboard.py
+++ b/app/templates/dashboard.py
@@ -25,7 +25,7 @@ from typing import Any
 
 from fasthtml.common import *
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import JSONResponse, RedirectResponse
 
 from app.auth.audit import log_action
 from app.db import get_connection as _connect
@@ -917,30 +917,63 @@ def dashboard_page(req: Request):
     )
 
 
+def _wants_json(req: Request) -> bool:
+    """True when the caller is an XHR/fetch (``X-Requested-With: XMLHttpRequest``).
+
+    The bookmark endpoints serve two callers: a plain HTML ``<form>`` on the
+    dashboard (which wants a 303 redirect so the page re-renders) and the
+    Õiguskaart bookmark button (a ``fetch()`` that needs a real JSON response
+    — a 303 to ``/dashboard`` vs a 303 to ``/auth/login`` are indistinguishable
+    to a ``redirect: "manual"`` fetch, so an expired session looked like a
+    successful save — #743).
+    """
+    return req.headers.get("x-requested-with", "").lower() == "xmlhttprequest"
+
+
 def add_bookmark(req: Request, entity_uri: str, label: str = ""):
-    """POST /api/bookmarks — add a bookmark for the current user."""
+    """POST /api/bookmarks — add a bookmark for the current user.
+
+    XHR callers get JSON (``200 {"ok": true, ...}`` / ``401 {"ok": false,
+    "error": "auth"}``); plain-form callers get the 303 redirects.
+    """
+    wants_json = _wants_json(req)
     auth = req.scope.get("auth", {})
     user_id = auth.get("id")
     if not user_id:
+        if wants_json:
+            return JSONResponse({"ok": False, "error": "auth"}, status_code=401)
         return RedirectResponse(url="/auth/login", status_code=303)
 
     actual_label = label.strip() if label else None
     bookmark = _add_bookmark(user_id, entity_uri.strip(), actual_label)
     if bookmark:
         log_action(user_id, "bookmark.add", {"entity_uri": entity_uri, "label": actual_label})
+    if wants_json:
+        # ``bookmark`` is None when the row already existed (ON CONFLICT DO
+        # NOTHING) — still "ok" from the caller's point of view.
+        return JSONResponse({"ok": True, "id": bookmark["id"] if bookmark else None})
     return RedirectResponse(url="/dashboard", status_code=303)
 
 
 def remove_bookmark(req: Request, bookmark_id: str):
-    """POST /api/bookmarks/{bookmark_id}/delete — remove a bookmark."""
+    """POST /api/bookmarks/{bookmark_id}/delete — remove a bookmark.
+
+    XHR callers get JSON (``200 {"ok": <bool>}`` / ``401 {"ok": false,
+    "error": "auth"}``); plain-form callers get the 303 redirects.
+    """
+    wants_json = _wants_json(req)
     auth = req.scope.get("auth", {})
     user_id = auth.get("id")
     if not user_id:
+        if wants_json:
+            return JSONResponse({"ok": False, "error": "auth"}, status_code=401)
         return RedirectResponse(url="/auth/login", status_code=303)
 
     success = _remove_bookmark(bookmark_id, user_id)
     if success:
         log_action(user_id, "bookmark.remove", {"bookmark_id": bookmark_id})
+    if wants_json:
+        return JSONResponse({"ok": bool(success)})
     return RedirectResponse(url="/dashboard", status_code=303)
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -889,3 +889,102 @@ class TestUserStats:
         assert result["total_users"] == 0
         assert result["users_per_org"] == []
         assert result["active_sessions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Bookmark route handlers — #743: XHR callers get JSON, plain forms get a 303
+# ---------------------------------------------------------------------------
+
+
+class TestBookmarkRoute:
+    _AUTH = {"id": "u-1", "email": "u@x.ee", "full_name": "U", "role": "drafter", "org_id": None}
+
+    def _req(self, *, auth: dict | None, xhr: bool):  # type: ignore[type-arg]
+        from starlette.requests import Request
+
+        headers: list[tuple[bytes, bytes]] = []
+        if xhr:
+            headers.append((b"x-requested-with", b"XMLHttpRequest"))
+        scope: dict = {  # type: ignore[type-arg]
+            "type": "http",
+            "method": "POST",
+            "path": "/api/bookmarks",
+            "query_string": b"",
+            "headers": headers,
+        }
+        if auth is not None:
+            scope["auth"] = auth
+        return Request(scope)
+
+    @patch("app.templates.dashboard.log_action")
+    @patch(
+        "app.templates.dashboard._add_bookmark",
+        return_value={"id": "bm-1", "entity_uri": "http://x/1", "label": "L"},
+    )
+    def test_add_xhr_returns_json_ok(self, mock_add: MagicMock, mock_log: MagicMock):
+        import json as _json
+
+        from starlette.responses import JSONResponse
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(auth=self._AUTH, xhr=True), "http://x/1", "L")
+        assert isinstance(resp, JSONResponse)
+        assert resp.status_code == 200
+        assert _json.loads(bytes(resp.body)) == {"ok": True, "id": "bm-1"}
+
+    @patch("app.templates.dashboard.log_action")
+    @patch("app.templates.dashboard._add_bookmark", return_value=None)  # ON CONFLICT DO NOTHING
+    def test_add_xhr_already_exists_still_ok(self, mock_add: MagicMock, mock_log: MagicMock):
+        import json as _json
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(auth=self._AUTH, xhr=True), "http://x/1", "")
+        assert resp.status_code == 200
+        assert _json.loads(bytes(resp.body)) == {"ok": True, "id": None}
+
+    def test_add_xhr_unauthenticated_returns_401_json(self):
+        import json as _json
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(auth=None, xhr=True), "http://x/1", "")
+        assert resp.status_code == 401
+        assert _json.loads(bytes(resp.body)) == {"ok": False, "error": "auth"}
+
+    @patch("app.templates.dashboard.log_action")
+    @patch(
+        "app.templates.dashboard._add_bookmark",
+        return_value={"id": "bm-1", "entity_uri": "http://x/1", "label": "L"},
+    )
+    def test_add_plain_form_still_redirects(self, mock_add: MagicMock, mock_log: MagicMock):
+        from starlette.responses import RedirectResponse
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(auth=self._AUTH, xhr=False), "http://x/1", "L")
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/dashboard"
+
+    def test_add_plain_form_unauthenticated_redirects_to_login(self):
+        from starlette.responses import RedirectResponse
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(auth=None, xhr=False), "http://x/1", "")
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/auth/login"
+
+    @patch("app.templates.dashboard.log_action")
+    @patch("app.templates.dashboard._remove_bookmark", return_value=True)
+    def test_remove_xhr_returns_json(self, mock_rm: MagicMock, mock_log: MagicMock):
+        import json as _json
+
+        from app.templates.dashboard import remove_bookmark
+
+        resp = remove_bookmark(self._req(auth=self._AUTH, xhr=True), "bm-1")
+        assert resp.status_code == 200
+        assert _json.loads(bytes(resp.body)) == {"ok": True}


### PR DESCRIPTION
## What

The Õiguskaart detail-panel bookmark button POSTed to `/api/bookmarks` with `redirect: 'manual'` and treated **any** 303 (or 200) response as success. But `/api/bookmarks` 303s to `/dashboard` on success and to `/auth/login` when the session has expired — and a `redirect: 'manual'` fetch can't read the `Location` header, so an expired session silently rendered the button as "Järjehoidjas ✓" without anything being saved (#743).

## Changes

- **`app/templates/dashboard.py`** — `add_bookmark` / `remove_bookmark` now detect XHR callers (`X-Requested-With: XMLHttpRequest`) and answer with JSON: `200 {"ok": true, "id": …}` on success (`id` is `null` when the row already existed — `ON CONFLICT DO NOTHING`), `401 {"ok": false, "error": "auth"}` when unauthenticated. Plain HTML `<form>` callers (the dashboard bookmarks list) keep the existing 303 redirects (`/dashboard` / `/auth/login`). New `_wants_json()` helper.
- **`app/static/js/explorer.js`** — `addBookmark()` sends `X-Requested-With: XMLHttpRequest`, drops `redirect: 'manual'`, and branches on `resp.ok` (success + mark bookmarked) vs `401/403` (→ *"Sessioon on aegunud — logige uuesti sisse, et lisada järjehoidjaid."*) vs anything else (→ generic failure toast).
- **`tests/test_dashboard.py`** — `TestBookmarkRoute`: XHR add returns `200 {"ok": true, "id": …}`; XHR add on an already-bookmarked entity still `200 {"ok": true, "id": null}`; XHR add unauthenticated → `401 {"ok": false, "error": "auth"}`; plain-form add still `303 → /dashboard`; plain-form add unauthenticated still `303 → /auth/login`; XHR remove returns `200 {"ok": true}`.

## Checks
- `uv run ruff format app/ tests/` — clean (342 files unchanged)
- `uv run ruff check app/ tests/` — All checks passed
- `uv run pyright` (repo-wide) — 0 errors, 0 warnings, 0 informations
- `node --check app/static/js/explorer.js` — OK
- `uv run pytest tests/test_dashboard.py -q` — 44 passed
- `uv run pytest -q` — 2338 passed, 25 skipped

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)