### PR TITLE
feat(deeplinks): #759 PR-F — open Õiguskaart with context from Koostaja, chat & draft detail

### DIFF
--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -52,6 +52,7 @@ from app.chat.pending_seed import (
 )
 from app.chat.sanitize import render_markdown_safe, render_plaintext_safe
 from app.db import get_connection as _connect
+from app.docs.report_routes import explorer_focus_url
 from app.ui.data.data_table import Column, DataTable
 from app.ui.data.pagination import Pagination
 from app.ui.layout import PageShell
@@ -851,7 +852,17 @@ def _message_action_row(
 
 
 def _rag_sources_block(rag_context: list[dict] | None):
-    """Render a ``<details>`` disclosure of RAG source chunks."""
+    """Render a ``<details>`` disclosure of RAG source chunks.
+
+    #759: each source row that carries an ontology URI also gets a small
+    "vaata kaardil \u2192" affordance that deep-links into \u00d5iguskaart centred
+    on that entity (``/explorer?focus=<urlencoded-uri>``, via
+    :func:`app.docs.report_routes.explorer_focus_url`). RAG context is
+    sourced from ontology-derived chunks, so the chunk URIs are exactly
+    the provision / act / court-case entities the assistant grounded its
+    answer on \u2014 making them the "cited URIs" the design doc asks us to
+    surface a map link for.
+    """
     if not rag_context:
         return ""
 
@@ -866,18 +877,27 @@ def _rag_sources_block(rag_context: list[dict] | None):
         snippet = content[:200].strip()
         if len(content) > 200:
             snippet = snippet + "\u2026"
+        link: Any
+        map_link: Any = ""
         if source_uri:
-            link: Any = A(  # noqa: F405
+            link = A(  # noqa: F405
                 title,
                 href=f"/explorer?q={source_uri}",
                 target="_blank",
                 rel="noopener noreferrer",
+            )
+            map_link = A(  # noqa: F405
+                "vaata kaardil \u2192",
+                href=explorer_focus_url(source_uri),
+                cls="chat-source-map-link",
+                title="Ava see allikas \u00d5iguskaardil.",
             )
         else:
             link = Span(title)  # noqa: F405
         items.append(
             Li(  # noqa: F405
                 link,
+                map_link,
                 P(snippet, cls="chat-source-snippet") if snippet else "",  # noqa: F405
             )
         )

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -154,6 +154,20 @@ def explorer_focus_url(uri: str, draft_id: str | None = None) -> str:
     return f"/explorer?{qs}"
 
 
+def explorer_draft_url(draft_id: str) -> str:
+    """Build an ``/explorer?draft=<id>`` link to a draft's impact subgraph (#759).
+
+    Companion to :func:`explorer_focus_url` for the "open the map for this
+    draft" affordance (Koostaja / draft detail / chat). The ``?draft=``
+    handling itself is issue #755 — this helper just mints the URL; the
+    contract (``/explorer?draft=<urlencoded-draft-id>``) is fixed by the
+    ``docs/2026-05-12-oiguskaart-evidence-map.md`` design doc, workstream B.
+    Draft ids are UUIDs so URL-encoding is a no-op in practice, but we
+    encode anyway to stay robust against non-UUID callers.
+    """
+    return f"/explorer?draft={quote(str(draft_id), safe='')}"
+
+
 # ---------------------------------------------------------------------------
 # Annotation side-panel container + per-row trigger button (PR-C)
 # ---------------------------------------------------------------------------
@@ -1020,7 +1034,7 @@ def draft_report_page(req: Request, draft_id: str):
             Div(
                 LinkButton(
                     "Ava õiguskaardil →",
-                    href=f"/explorer?draft={draft.id}",
+                    href=explorer_draft_url(str(draft.id)),
                     variant="secondary",
                     title="Visualiseeri eelnõu ja mõjutatud sätted graafil.",
                 ),

--- a/app/docs/routes/_detail.py
+++ b/app/docs/routes/_detail.py
@@ -68,6 +68,7 @@ from app.docs.draft_model import (
     update_draft_parent_vtk,
 )
 from app.docs.graph_builder import write_doc_lineage
+from app.docs.report_routes import explorer_draft_url
 from app.docs.routes._detail_modals import (
     _DELETE_FORM_ID,
     _DELETE_MODAL_ID,
@@ -361,6 +362,19 @@ def _draft_detail_body(
             LinkButton(
                 "Vaata mõjuaruannet",
                 href=f"/drafts/{draft.id}/report",
+            )
+        )
+        # #759: deep-link into Õiguskaart centred on this draft's impact
+        # subgraph (``/explorer?draft=<id>`` — the ``?draft=`` handling is
+        # issue #755; this just mints the URL via the shared helper). Same
+        # ``ready`` guard as the report CTA — no impact subgraph exists
+        # before the analyse pipeline completes.
+        actions.append(
+            LinkButton(
+                "Vaata mõjukaarti",
+                href=explorer_draft_url(str(draft.id)),
+                variant="secondary",
+                title="Visualiseeri eelnõu ja mõjutatud sätted Õiguskaardil.",
             )
         )
         # #724: cross-link into the Analüüsikeskus "Normi mõjuahel" workflow,

--- a/app/drafter/routes.py
+++ b/app/drafter/routes.py
@@ -37,6 +37,7 @@ from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_access_drafter_session
 from app.auth.provider import UserDict
 from app.db import get_connection as _connect
+from app.docs.report_routes import explorer_focus_url
 from app.drafter.audit import (
     log_drafter_clause_edit,
     log_drafter_export,
@@ -882,7 +883,15 @@ def _step_3_page(session: DraftingSession, auth: UserDict):
 
 
 def _research_category_card(title: str, items: list[dict[str, str]], category: str):
-    """Render a summary card for a research category."""
+    """Render a summary card for a research category.
+
+    #759: every researched entity that carries an ontology URI gets an
+    "Ava õiguskaardil →" deep link (URL-encoded by
+    :func:`app.docs.report_routes.explorer_focus_url`) so the drafter can
+    jump from a found provision / EL act / court decision straight to the
+    legal map centred on it. Items without a URI (e.g. topic clusters)
+    render as plain text, matching how Analüüsikeskus handles the same case.
+    """
     count = len(items)
     if count == 0:
         return Div(  # noqa: F405
@@ -893,8 +902,23 @@ def _research_category_card(title: str, items: list[dict[str, str]], category: s
 
     item_list: list[Any] = []
     for item in items[:10]:
-        label = item.get("label") or item.get("act_label") or item.get("uri", "")
-        item_list.append(Li(label, cls="research-item"))  # noqa: F405
+        uri = str(item.get("uri") or "").strip()
+        label = item.get("label") or item.get("act_label") or uri or "—"
+        if uri:
+            item_list.append(
+                Li(  # noqa: F405
+                    Span(label, cls="research-item-label"),  # noqa: F405
+                    " ",
+                    A(  # noqa: F405
+                        "Ava õiguskaardil →",
+                        href=explorer_focus_url(uri),
+                        cls="data-table-link research-item-link",
+                    ),
+                    cls="research-item",
+                )
+            )
+        else:
+            item_list.append(Li(label, cls="research-item"))  # noqa: F405
 
     return Div(  # noqa: F405
         H4(f"{title}: {count}", cls="research-category-title"),  # noqa: F405

--- a/app/static/css/chat.css
+++ b/app/static/css/chat.css
@@ -1435,6 +1435,15 @@
   gap: var(--space-2);
 }
 
+/* #759: "vaata kaardil →" deep-link beside each cited source — sits
+   inline after the source title, slightly muted so it reads as a
+   secondary affordance rather than the primary source link. */
+.chat-source-map-link {
+  margin-inline-start: var(--space-2);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
 /* ===========================================================================
    Conversation list toolbar + row actions
    =========================================================================== */

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -714,12 +714,23 @@
         a.target = '_blank';
         a.rel = 'noopener';
         a.textContent = title;
+        li.appendChild(a);
+
+        // #759: a "vaata kaardil" affordance that deep-links into
+        // Õiguskaart centred on this cited entity. Mirrors the
+        // server-rendered _rag_sources_block in app/chat/routes.py.
+        if (uri) {
+          const mapLink = document.createElement('a');
+          mapLink.href = '/explorer?focus=' + encodeURIComponent(uri);
+          mapLink.className = 'chat-source-map-link';
+          mapLink.title = 'Ava see allikas Õiguskaardil.';
+          mapLink.textContent = 'vaata kaardil →';
+          li.appendChild(mapLink);
+        }
 
         const p = document.createElement('p');
         // Use textContent to escape snippet — no raw HTML
         p.textContent = snippet;
-
-        li.appendChild(a);
         if (snippet) li.appendChild(p);
         ul.appendChild(li);
       }

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -737,6 +737,59 @@ class TestConversationViewPolish:
 
     @patch("app.chat.routes._connect")
     @patch("app.auth.middleware._get_provider")
+    def test_rag_sources_carry_oiguskaart_deeplink(self, mock_provider, mock_connect):
+        """#759: each cited source with a URI gets a "vaata kaardil →"
+        affordance pointing at ``/explorer?focus=<urlencoded-uri>``."""
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        provision_uri = "https://data.riik.ee/ontology/estleg#KarS_par_113"
+        rag = [
+            {
+                "source_uri": provision_uri,
+                "content": "Karistusseadustiku § 113 kaitseb inimese elu...",
+                "score": 0.9,
+            },
+        ]
+        msg = _make_message("assistant", "Vastus", rag_context=rag)
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "vaata kaardil" in resp.text
+            assert "chat-source-map-link" in resp.text
+            assert "/explorer?focus=" in resp.text
+            # The estleg ``#`` must be percent-encoded so ``focus`` is not
+            # truncated to ".../estleg" by the browser fragment parser.
+            assert "%23KarS_par_113" in resp.text
+
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_rag_sources_without_uri_have_no_map_link(self, mock_provider, mock_connect):
+        """#759: a source chunk with no ``source_uri`` renders as plain
+        text — no "vaata kaardil" affordance to point nowhere."""
+        mock_provider.return_value = _stub_provider()
+        self._setup(mock_connect)
+        conv = _make_conversation()
+        rag = [
+            {"source_uri": "", "content": "Mingi taustateave ilma allika URI-ta.", "score": 0.5},
+        ]
+        msg = _make_message("assistant", "Vastus", rag_context=rag)
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=[msg]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "chat-sources" in resp.text
+            assert "chat-source-map-link" not in resp.text
+
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
     def test_action_row_present_on_assistant_messages(self, mock_provider, mock_connect):
         mock_provider.return_value = _stub_provider()
         self._setup(mock_connect)

--- a/tests/test_docs_report_routes.py
+++ b/tests/test_docs_report_routes.py
@@ -924,3 +924,40 @@ class TestExplorerFocusUrl:
         url = explorer_focus_url("https://data.riik.ee/ontology/estleg#X", draft_id="abc-123")
         assert "&draft=abc-123" in url
         assert url.index("focus=") < url.index("draft=")
+
+
+# ---------------------------------------------------------------------------
+# explorer_draft_url — /explorer?draft=<id> deep-link helper (#759)
+# ---------------------------------------------------------------------------
+
+
+class TestExplorerDraftUrl:
+    def test_builds_explorer_draft_query(self):
+        from app.docs.report_routes import explorer_draft_url
+
+        draft_id = "11111111-2222-3333-4444-555555555555"
+        url = explorer_draft_url(draft_id)
+        assert url == f"/explorer?draft={draft_id}"
+
+    def test_url_encodes_non_uuid_input(self):
+        from urllib.parse import parse_qs, urlsplit
+
+        from app.docs.report_routes import explorer_draft_url
+
+        url = explorer_draft_url("a b/c#d")
+        # The space / slash / hash must be percent-encoded so the whole
+        # value survives the round-trip through the query string.
+        assert " " not in url
+        assert "#" not in url
+        assert url.startswith("/explorer?draft=")
+        q = parse_qs(urlsplit(url).query)
+        assert q["draft"] == ["a b/c#d"]
+
+    def test_accepts_uuid_object(self):
+        import uuid
+
+        from app.docs.report_routes import explorer_draft_url
+
+        u = uuid.uuid4()
+        url = explorer_draft_url(u)  # type: ignore[arg-type]
+        assert url == f"/explorer?draft={u}"

--- a/tests/test_docs_routes.py
+++ b/tests/test_docs_routes.py
@@ -741,6 +741,10 @@ class TestDraftDetailPage:
         # into the Normi mõjuahel workflow (which reuses this draft's report).
         assert "Ava analüüsikeskuses" in resp.text
         assert f"/analyysikeskus/normi-mojuahel?sisend={draft.id}" in resp.text
+        # #759: a ready draft also offers a "Vaata mõjukaarti" CTA that
+        # deep-links into Õiguskaart centred on its impact subgraph.
+        assert "Vaata mõjukaarti" in resp.text
+        assert f"/explorer?draft={draft.id}" in resp.text
         # No polling for terminal statuses.
         assert "every 3s" not in resp.text
 
@@ -752,7 +756,8 @@ class TestDraftDetailPage:
         mock_fetch: MagicMock,
     ):
         """#724: the Analüüsikeskus cross-link is gated on ``status == ready``
-        (same guard as the "Vaata mõjuaruannet" CTA)."""
+        (same guard as the "Vaata mõjuaruannet" CTA). #759: the
+        "Vaata mõjukaarti" CTA is gated the same way."""
         mock_get_provider.return_value = _stub_provider()
         draft = _make_draft(status="parsing")
         mock_fetch.return_value = draft
@@ -763,6 +768,10 @@ class TestDraftDetailPage:
         assert resp.status_code == 200
         assert "Ava analüüsikeskuses" not in resp.text
         assert f"/analyysikeskus/normi-mojuahel?sisend={draft.id}" not in resp.text
+        # #759: no impact subgraph exists before the analyse pipeline
+        # completes, so the map CTA must not render either.
+        assert "Vaata mõjukaarti" not in resp.text
+        assert f"/explorer?draft={draft.id}" not in resp.text
 
     @patch("app.docs.routes._detail.fetch_draft")
     @patch("app.auth.middleware._get_provider")

--- a/tests/test_drafter_routes.py
+++ b/tests/test_drafter_routes.py
@@ -636,6 +636,51 @@ class TestStep3Page:
         assert "TsiviilS" in resp.text
         assert "Jätka struktuuriga" in resp.text
 
+    @patch("app.drafter.routes._find_latest_job")
+    @patch("app.drafter.routes.decrypt_text")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_step_3_research_items_link_to_oiguskaart(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_find_job: MagicMock,
+    ):
+        """#759: each researched entity with an ontology URI gets an
+        "Ava õiguskaardil →" deep link with the URI percent-encoded into
+        ``?focus=``; entities without a URI render as plain text."""
+        import json
+
+        mock_get_provider.return_value = _stub_provider()
+        session = _make_session(current_step=3)
+        session.research_data_encrypted = b"encrypted"
+        mock_fetch.return_value = session
+        provision_uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+        mock_decrypt.return_value = json.dumps(
+            {
+                "provisions": [
+                    {"uri": provision_uri, "label": "KarS § 133", "act_label": "KarS"},
+                ],
+                "eu_directives": [],
+                "court_decisions": [],
+                # Topic clusters carry no URI — they must stay plain text.
+                "topic_clusters": [{"label": "Inimkaubandus"}],
+            }
+        )
+
+        client = _authed_client()
+        resp = client.get(f"/drafter/{_SESSION_ID}/step/3")
+
+        assert resp.status_code == 200
+        assert "Ava õiguskaardil →" in resp.text
+        # The estleg ``#`` must be percent-encoded so ``focus`` is not
+        # truncated to ".../estleg" by the browser fragment parser.
+        assert "/explorer?focus=" in resp.text
+        assert "%23KarS_par_133" in resp.text
+        # The cluster label is shown but gets no map link of its own.
+        assert "Inimkaubandus" in resp.text
+
 
 # ---------------------------------------------------------------------------
 # Step 4: Structure editing


### PR DESCRIPTION
## Summary

Workstream **F** of epic #762 (`docs/2026-05-12-oiguskaart-evidence-map.md`) — deep-links *into* Õiguskaart from the remaining tools. **Touches no `app/explorer/` files** — it only adds "open the map with context" links from Koostaja, the AI chat, and the draft detail page. Depends on workstream A's `?draft=` URL contract (the `?draft=` handler itself is issue #755 — this PR just mints the URL).

## What changed

### 1. Helper — `app/docs/report_routes.py`
- New `explorer_draft_url(draft_id) -> /explorer?draft=<urlencoded-id>`, sibling to the existing `explorer_focus_url`.
- The report-page "Ava õiguskaardil →" CTA now uses `explorer_draft_url(...)` instead of an inline f-string (same output, one source of truth).

### 2. Koostaja (drafter) — `app/drafter/routes.py`
- The ontology-research step cards render an **"Ava õiguskaardil →"** deep link (`explorer_focus_url`) for every researched provision / EL act / court decision that carries a URI. Items without a URI (topic clusters) stay plain text — matching how `app/analyysikeskus/routes.py` already handles the same case.

### 3. AI chat — `app/chat/routes.py` + `app/static/js/chat.js` + `app/static/css/chat.css`
- Each RAG source row (the cited ontology entities the assistant grounded its answer on) gets a small **"vaata kaardil →"** affordance pointing at `/explorer?focus=<urlencoded-uri>` — both in the server-rendered conversation history (`_rag_sources_block`) and in the streaming sources panel (`chat.js::appendSources`). URI-less source chunks render unchanged (no link to point nowhere). A small `.chat-source-map-link` style keeps it inline + slightly muted as a secondary affordance.
- **Scope note (chat = best-effort-but-clean):** the chat already surfaces cited URIs as the RAG `sources`/`rag_context` list — these *are* the provision / act / case URIs the design doc refers to, since RAG context is sourced exclusively from ontology-derived chunks. The minimal-but-clean version wires an "Ava kaardil" link onto those existing source items in both render paths. A fuller version would: (a) parse §-citations in the assistant prose itself (the client-side `citation-link` auto-linker currently points to `/explorer?q=<text>` — a search, not a focus) and resolve those text refs to entity URIs server-side so each inline citation could carry a `focus=` deep link; (b) thread tool-use results (e.g. SPARQL `query_ontology` hits) into a structured "cited entities" payload distinct from RAG context. Neither is needed for the must-haves and both are larger than this workstream's footprint.

### 4. Draft detail page — `app/docs/routes/_detail.py`
- A `ready` draft's action row gets a **"Vaata mõjukaarti"** `LinkButton` → `explorer_draft_url(draft.id)`, placed next to the existing "Vaata mõjuaruannet" / "Ava analüüsikeskuses" CTAs and gated on `status == ready` the same way (no impact subgraph exists before the analyse pipeline completes).

## Tests
- `explorer_draft_url` produces a correctly URL-encoded `/explorer?draft=...` (UUID + non-UUID + `uuid.UUID` input).
- The drafter research step renders an "Ava õiguskaardil →" link with `?focus=<percent-encoded-uri>` for entities with URIs; URI-less clusters stay plain text.
- The draft detail page renders the "Vaata mõjukaarti" CTA with `?draft=<id>` when ready, and does **not** when not ready.
- The chat RAG-sources block renders the "vaata kaardil →" link with `?focus=<percent-encoded-uri>` when a source has a URI, and omits it when it doesn't.

## Toolchain
`uv run ruff format app/ tests/` → 342 files unchanged · `uv run ruff check app/ tests/` → all checks passed · `uv run pyright` (whole repo) → 0 errors · `uv run pytest -q` → **2344 passed, 25 skipped** · `node --check app/static/js/chat.js` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)