### PR TITLE
feat(explorer): #754 — Õiguskaart focus-first entry + contextual start panel

### DIFF
--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -10,6 +10,17 @@ the D3 canvas filling the content area. The former control rail becomes a
 thin horizontal **toolbar** across the top of the canvas; the search box
 moves into it. The D3 v7 CDN ``<script>`` (~270 KB) and ``explorer.css`` are
 pushed into ``<head>`` via ``extra_head=`` so they load on this page only.
+
+Issue #754 (epic #762, design doc ``docs/2026-05-12-oiguskaart-evidence-map.md``,
+workstream A): a "cold" open — ``/explorer`` with no ``?focus=`` / ``?draft=`` /
+``?search=`` and not the explicit ``?vaade=koik`` opt-in — no longer auto-loads
+the 90k-entity category overview. It renders a compact **contextual start panel**
+(search box, your bookmarks, recent high-risk reports for your org, recent drafts,
+a ``Normi mõjuahel`` shortcut, "Sirvi liikide kaupa") inside the otherwise-empty
+graph area, and tells ``explorer.js`` *not* to fetch the graph data. Any of
+``?focus=`` / ``?draft=`` / ``?search=`` / ``?vaade=koik`` bypasses the panel and
+loads the graph exactly as before. The org-scoped DB queries that back the panel
+live in :mod:`app.explorer.start_panel`.
 """
 
 from __future__ import annotations
@@ -25,13 +36,22 @@ from fasthtml.common import *
 from starlette.requests import Request
 
 from app.db import get_connection as _connect
+from app.explorer.start_panel import StartPanelData, load_start_panel_data
 
 # Re-import our design-system Button after the wildcard so the symbol does
 # not silently fall back to FastHTML's unstyled Button (#419).
 from app.ui.layout import PageShell
 from app.ui.primitives.button import Button  # noqa: E402
+from app.ui.time import format_tallinn
 
 logger = logging.getLogger(__name__)
+
+# The explicit "show me the whole 90k map" opt-in. The start panel's "Näita
+# kogu kaarti" / "Sirvi liikide kaupa" buttons (and the toolbar's "Näita kogu
+# kaarti" in the Vaate seaded menu) navigate to ``/explorer?vaade=koik``; that
+# URL renders the graph view (no panel) and lets ``explorer.js`` load the
+# overview as it always did.
+_VAADE_KOIK = "koik"
 
 
 # #475: the explorer page previously re-queried ``drafts`` and
@@ -312,6 +332,17 @@ def _explorer_toolbar(*, has_back_context: bool, draft_tip: bool):  # noqa: ANN2
         Details(
             Summary("Vaate seaded ▾", cls="ctrl-btn ctrl-settings-summary"),
             Div(
+                # #754: an explicit way back to the full 90k category overview
+                # from inside the graph view — pairs with the start panel's
+                # "Näita kogu kaarti" button. Loads the overview via JS (no
+                # navigation) so it doesn't disturb the current focus state.
+                Button(
+                    "Näita kogu kaarti",
+                    type="button",
+                    cls="ctrl-btn",
+                    onclick="explorerShowFullMap()",
+                    title="Lae kogu õiguskaardi liikide ülevaade",
+                ),
                 Button(
                     "Lähtesta paigutus",
                     type="button",
@@ -396,6 +427,177 @@ def _explorer_toolbar(*, has_back_context: bool, draft_tip: bool):  # noqa: ANN2
     )
 
 
+# ---------------------------------------------------------------------------
+# #754 — the contextual start panel (shown on a "cold" open)
+# ---------------------------------------------------------------------------
+
+
+# A muted single-line "nothing here yet" row shared by the panel's sections.
+def _panel_empty(text: str):  # noqa: ANN202
+    return P(text, cls="start-panel-empty")
+
+
+def _start_panel_section(title: str, body):  # noqa: ANN202
+    """One ``<section>`` of the start panel — an ``<h3>`` + its body."""
+    return Section(H3(title, cls="start-panel-section-title"), body, cls="start-panel-section")
+
+
+def _start_panel_search():  # noqa: ANN202
+    """The search box at the top of the start panel.
+
+    Submitting navigates to ``/explorer?search=<term>`` — the same ``?search=``
+    plumbing the toolbar's "Otsi" button and the deep-link bridge already use
+    (#746). ``explorer.js`` wires the click/Enter handlers (``startPanelSearch``)
+    so the page can carry a clean ``<input>`` with no inline JS.
+    """
+    return Form(
+        Input(
+            id="start-panel-search-input",
+            name="search",
+            type="search",
+            placeholder="Otsi seadust, §-viidet, CELEX-numbrit, kohtuasja numbrit…",
+            aria_label="Otsi seadusi, §-viiteid, CELEX-numbreid, kohtuasju",
+            autocomplete="off",
+        ),
+        Button(
+            "Otsi",
+            type="submit",
+            id="start-panel-search-btn",
+            cls="start-panel-search-btn",
+        ),
+        # method=GET so a no-JS submit still lands on /explorer?search=… ;
+        # explorer.js intercepts to reuse the in-page search flow.
+        method="get",
+        action="/explorer",
+        id="start-panel-search-form",
+        cls="start-panel-search",
+        role="search",
+    )
+
+
+def _start_panel_bookmarks(bookmarks: list):  # noqa: ANN202
+    if not bookmarks:
+        return _start_panel_section(
+            "Sinu järjehoidjad", _panel_empty("Sul pole veel ühtegi järjehoidjat.")
+        )
+    items = [
+        Li(
+            A(bm["label"], href=bm["explorer_url"], cls="start-panel-link"),
+            cls="start-panel-item",
+        )
+        for bm in bookmarks
+    ]
+    return _start_panel_section("Sinu järjehoidjad", Ul(*items, cls="start-panel-list"))
+
+
+def _start_panel_high_risk(reports: list):  # noqa: ANN202
+    if not reports:
+        return _start_panel_section(
+            "Hiljutised kõrge riskiga leiud",
+            _panel_empty("Kõrge riskiga mõjuaruandeid hetkel pole."),
+        )
+    items = []
+    for r in reports:
+        meta_bits = f"{r['band_label']} · skoor {r['impact_score']}/100"
+        if r["conflict_count"]:
+            meta_bits += f" · {r['conflict_count']} konflikti"
+        when = format_tallinn(r["generated_at"])
+        items.append(
+            Li(
+                A(r["title"], href=r["report_url"], cls="start-panel-link"),
+                Span(meta_bits, cls="start-panel-meta"),
+                Span(when, cls="start-panel-meta start-panel-meta-date"),
+                A(
+                    "Ava mõjukaart",
+                    href=r["explorer_url"],
+                    cls="start-panel-secondary-link",
+                ),
+                cls="start-panel-item start-panel-item--rich",
+            )
+        )
+    return _start_panel_section(
+        "Hiljutised kõrge riskiga leiud", Ul(*items, cls="start-panel-list")
+    )
+
+
+def _start_panel_recent_drafts(drafts: list):  # noqa: ANN202
+    if not drafts:
+        return _start_panel_section(
+            "Sinu hiljutised eelnõud", _panel_empty("Hiljutisi eelnõusid pole.")
+        )
+    items = []
+    for d in drafts:
+        when = format_tallinn(d["updated_at"])
+        items.append(
+            Li(
+                A(d["title"], href=d["detail_url"], cls="start-panel-link"),
+                Span(when, cls="start-panel-meta start-panel-meta-date"),
+                A(
+                    "Ava mõjukaart",
+                    href=d["explorer_url"],
+                    cls="start-panel-secondary-link",
+                ),
+                cls="start-panel-item start-panel-item--rich",
+            )
+        )
+    return _start_panel_section("Sinu hiljutised eelnõud", Ul(*items, cls="start-panel-list"))
+
+
+def _start_panel_shortcuts():  # noqa: ANN202
+    """The two "do something" rows at the foot of the panel.
+
+    "Alusta Normi mõjuahelat" → ``/analyysikeskus/normi-mojuahel`` (a real
+    navigation). "Sirvi liikide kaupa" → loads today's category overview *in
+    place* (``explorer.js`` ``explorerShowFullMap()``), which is now opt-in.
+    """
+    return Section(
+        Div(
+            A(
+                "Alusta Normi mõjuahelat",
+                href="/analyysikeskus/normi-mojuahel",
+                cls="start-panel-action start-panel-action--primary",
+            ),
+            Button(
+                "Sirvi liikide kaupa",
+                type="button",
+                id="start-panel-browse-btn",
+                cls="start-panel-action start-panel-action--secondary",
+                onclick="explorerShowFullMap()",
+                title="Lae kõigi õiguskaardi liikide ülevaade",
+            ),
+            cls="start-panel-actions",
+        ),
+        cls="start-panel-section start-panel-section--actions",
+    )
+
+
+def _start_panel(data: StartPanelData):  # noqa: ANN202
+    """Build the full contextual start panel (#754).
+
+    Sits inside ``#main-content`` (``position: relative; overflow: hidden``)
+    like the other overlays — ``explorer.css`` anchors ``#explorer-start-panel``
+    absolutely below the toolbar.
+    """
+    return Div(
+        Div(
+            H2("Õiguskaart", cls="start-panel-title"),
+            P(
+                "Vali, mida vaadata — otsi õigusakti, ava järjehoidja, vaata "
+                "eelnõu mõjukaarti, või sirvi kogu kaarti liikide kaupa.",
+                cls="start-panel-lead",
+            ),
+            _start_panel_search(),
+            _start_panel_bookmarks(data["bookmarks"]),
+            _start_panel_high_risk(data["high_risk_reports"]),
+            _start_panel_recent_drafts(data["recent_drafts"]),
+            _start_panel_shortcuts(),
+            cls="start-panel-inner",
+        ),
+        id="explorer-start-panel",
+        aria_label="Õiguskaardi avapaneel",
+    )
+
+
 def explorer_page(req: Request):
     """GET /explorer -- the Õiguskaart graph inside the standard app chrome.
 
@@ -415,17 +617,38 @@ def explorer_page(req: Request):
     ``?focus=`` and ``?search=`` are present, ``focus`` wins. The page
     itself requires authentication via the global ``auth_before``
     middleware (see #442).
+
+    #754: a "cold" open — none of ``?focus=`` / ``?draft=`` / ``?search=`` and
+    not the explicit ``?vaade=koik`` opt-in — renders the **contextual start
+    panel** over the (empty) graph area and tells ``explorer.js`` *not* to
+    fetch the 90k overview. ``?vaade=koik`` (set by the start panel's "Näita
+    kogu kaarti" / "Sirvi liikide kaupa" buttons and the toolbar's "Näita kogu
+    kaarti") forces the classic graph view. Unauthenticated requests never
+    reach here — ``auth_before`` redirects to ``/auth/login`` first (#442).
     """
     auth = req.scope.get("auth")
     draft_param = req.query_params.get("draft", "").strip()
     focus_param = req.query_params.get("focus", "").strip()
     search_param = req.query_params.get("search", "").strip()
+    vaade_param = req.query_params.get("vaade", "").strip()
     overlay_uris: list[str] = []
     if draft_param:
         overlay_uris = _fetch_draft_overlay(req, draft_param)
 
-    # ---- Server → JS bridge: ?focus= / ?search= / draft-overlay blobs ----
+    # #754: the start panel shows only when there is nothing to deep-link to
+    # and the user hasn't explicitly asked for the whole map. Any of
+    # ?focus= / ?draft= / ?search= / ?vaade=koik bypasses it and renders the
+    # classic graph view (so existing deep links / overlays never regress).
+    show_start_panel = not (
+        focus_param or search_param or draft_param or vaade_param == _VAADE_KOIK
+    )
+
+    # ---- Server → JS bridge: ?focus= / ?search= / draft-overlay / mode blobs ----
     bridge_tags: list = []
+    if show_start_panel:
+        # The flag explorer.js checks on init() to skip loadOverview() — the
+        # whole point of #754 (don't fetch the cold blob until the user picks).
+        bridge_tags.append(Script("window.__explorerStartPanel=true;"))
     # #719: hand the focus URI to the JS (it's validated server-side at
     # /api/explorer/entity/{uri}; embedding it escaped keeps the contract
     # explicit so the JS need not re-parse location.search).
@@ -449,10 +672,25 @@ def explorer_page(req: Request):
     # report / analysis result (?focus= or ?draft=) — explorer.js detects
     # the same thing from document.referrer for the detail-panel back link.
     has_back_context = bool(focus_param) or bool(overlay_uris) or bool(draft_param)
-    # A "cold" open (no focus / draft / overlay) gets the small ?draft= tip.
-    show_draft_tip = not overlay_uris and not draft_param and not focus_param
+    # The small ?draft= toolbar tip is only useful in the classic graph view
+    # with no focus/draft/overlay — the start panel makes it redundant.
+    show_draft_tip = (
+        not show_start_panel and not overlay_uris and not draft_param and not focus_param
+    )
+
+    # #754: the start panel is an opaque overlay over the (idle) graph chrome.
+    # We still render the full graph DOM so explorer.js' top-level
+    # getElementById() calls don't hit nulls — it just doesn't fetch data.
+    start_panel_tag: list = []
+    if show_start_panel:
+        user_id = (auth or {}).get("id")
+        org_id = (auth or {}).get("org_id")
+        panel_data = load_start_panel_data(user_id, org_id)
+        start_panel_tag.append(_start_panel(panel_data))
 
     content = (
+        # ----- Contextual start panel (#754) — opaque overlay, cold open only -----
+        *start_panel_tag,
         # ----- Graph toolbar (across the top of the canvas) -----
         _explorer_toolbar(has_back_context=has_back_context, draft_tip=show_draft_tip),
         # ----- Breadcrumb -----
@@ -611,14 +849,19 @@ def explorer_page(req: Request):
         ),
         # ----- SVG canvas (fills the content area; sized by explorer.js) -----
         NotStr('<svg id="canvas"></svg>'),
-        # ----- Explorer JS (after the DOM it touches) -----
+        # ----- Server → JS bridge blobs (mode flag, ?focus= / ?search=, draft
+        # overlay) — emitted BEFORE explorer.js so the flags are visible to
+        # init()'s *synchronous* prologue (the start-panel gate in particular
+        # has to be read before loadOverview() is called). #719's ?focus= /
+        # ?search= blobs are only consulted after an `await`, so this ordering
+        # is also safe for them. -----
+        *bridge_tags,
+        # ----- Explorer JS (after the DOM it touches + the bridge blobs) -----
         Script(src="/static/js/explorer.js"),
         # ----- Auto-hide the (dismissed) draft tip -----
         Script(_TIP_AUTOHIDE_SCRIPT),
         # ----- Detail-panel annotation button wiring -----
         Script(_PANEL_ANNOTATION_SCRIPT),
-        # ----- ?focus= / ?search= / draft-overlay bridge blobs -----
-        *bridge_tags,
     )
 
     return PageShell(

--- a/app/explorer/start_panel.py
+++ b/app/explorer/start_panel.py
@@ -1,0 +1,330 @@
+"""Org-scoped data queries for the Õiguskaart **contextual start panel** (#754).
+
+Issue #754 (epic #762, design doc ``docs/2026-05-12-oiguskaart-evidence-map.md``,
+workstream A): ``/explorer`` with no ``?focus=`` / ``?draft=`` / ``?search=`` query
+param no longer renders the cold 90k-entity category overview. Instead it shows a
+small **start panel** inside the (otherwise empty) graph area — your bookmarks,
+recent high-risk impact reports for your org, recent drafts you've touched, a
+``Normi mõjuahel`` shortcut, a search box, and an explicit "Sirvi liikide kaupa"
+(opt-in to today's overview).
+
+This module is the *data* layer: three pure, individually-testable functions —
+:func:`get_user_bookmarks`, :func:`get_high_risk_reports`,
+:func:`get_recent_drafts` — each with a clean signature that can later be wrapped
+as a REST endpoint or an MCP tool (see ``CLAUDE.md`` — "Internal service
+functions"). They mirror the helper pattern in ``app/templates/dashboard.py``
+(``_get_bookmarks`` / ``_get_high_risk_reports``) — every query is **org-scoped
+at the SQL layer** (bookmarks are scoped by ``user_id``), wrapped in
+``try/except`` → log + return ``[]`` so a DB hiccup degrades the panel to "empty"
+rather than 500-ing the explorer.
+
+Each result row carries an ``explorer_url`` (a relative ``/explorer?focus=…`` /
+``/explorer?draft=…`` link) so the page module doesn't have to know the URL
+contract — that keeps the ``?focus=`` / ``?draft=`` plumbing owned by one place.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TypedDict
+from urllib.parse import quote
+
+from app.db import get_connection as _connect
+from app.docs.impact.scoring import IMPACT_BAND_LABELS_ET, impact_band
+
+logger = logging.getLogger(__name__)
+
+# Per-section row caps — kept small so the panel stays a compact "where do I
+# pick up" surface, not another dashboard. Mirrors the dashboard's widget caps.
+_MAX_BOOKMARKS = 8
+_MAX_HIGH_RISK = 6
+_MAX_RECENT_DRAFTS = 6
+
+# Bands considered "kõrge riskiga" for the start-panel section. ``impact_band``
+# (the 51-80 / 81-100 tiers) is the single source of truth for the cut-off; the
+# SQL pre-filter uses ``impact_score > 50`` as a cheap gate before the helper
+# produces the user-facing label.
+_HIGH_RISK_BANDS = frozenset({"high", "critical"})
+
+
+# ---------------------------------------------------------------------------
+# Result row shapes (TypedDicts — documentation + pyright, no runtime cost)
+# ---------------------------------------------------------------------------
+
+
+class BookmarkRow(TypedDict):
+    """A single bookmark row for the start panel."""
+
+    id: str
+    entity_uri: str
+    label: str
+    explorer_url: str
+
+
+class HighRiskReportRow(TypedDict):
+    """A recent high-risk impact report (one row per draft, latest report)."""
+
+    draft_id: str
+    title: str
+    impact_score: int
+    band: str
+    band_label: str
+    conflict_count: int
+    affected_count: int
+    gap_count: int
+    generated_at: object  # datetime | None — formatted by the page layer
+    report_url: str
+    explorer_url: str
+
+
+class RecentDraftRow(TypedDict):
+    """A draft the user has touched recently (org-scoped)."""
+
+    draft_id: str
+    title: str
+    status: str
+    updated_at: object  # datetime | None — formatted by the page layer
+    detail_url: str
+    explorer_url: str
+
+
+# ---------------------------------------------------------------------------
+# URL helpers — keep the ?focus= / ?draft= contract in one place
+# ---------------------------------------------------------------------------
+
+
+def _explorer_focus_url(entity_uri: str) -> str:
+    """Return a ``/explorer?focus=<uri>`` link (URL-encoded URI).
+
+    Mirrors :func:`app.docs.report_routes.explorer_focus_url` but lives here so
+    ``app/explorer/`` does not import from ``app/docs/`` for a one-liner.
+    """
+    return f"/explorer?focus={quote(entity_uri, safe='')}"
+
+
+def _explorer_draft_url(draft_id: str) -> str:
+    """Return a ``/explorer?draft=<id>`` link for a draft's impact overlay."""
+    return f"/explorer?draft={quote(str(draft_id), safe='')}"
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Sinu järjehoidjad
+# ---------------------------------------------------------------------------
+
+
+def get_user_bookmarks(user_id: str | None, *, limit: int = _MAX_BOOKMARKS) -> list[BookmarkRow]:
+    """Return the user's own bookmarks, newest first.
+
+    Scoped by ``user_id`` — bookmarks are personal (the ``bookmarks`` table has
+    no ``org_id`` column; the per-user scope *is* the access control). Returns
+    ``[]`` for a missing ``user_id`` or on any DB error.
+
+    Args:
+        user_id: The current user's id (string UUID). ``None`` → ``[]``.
+        limit: Maximum rows to return.
+
+    Returns:
+        A list of :class:`BookmarkRow`, each with an ``explorer_url`` that
+        focuses the bookmarked entity.
+    """
+    if not user_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, entity_uri, label
+                FROM bookmarks
+                WHERE user_id = %s
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                (user_id, limit),
+            ).fetchall()
+    except Exception:
+        logger.exception("start_panel: failed to fetch bookmarks for user %s", user_id)
+        return []
+    out: list[BookmarkRow] = []
+    for r in rows:
+        entity_uri = str(r[1])
+        out.append(
+            {
+                "id": str(r[0]),
+                "entity_uri": entity_uri,
+                "label": (r[2] or entity_uri),
+                "explorer_url": _explorer_focus_url(entity_uri),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Hiljutised kõrge riskiga leiud
+# ---------------------------------------------------------------------------
+
+
+def get_high_risk_reports(
+    org_id: str | None, *, limit: int = _MAX_HIGH_RISK
+) -> list[HighRiskReportRow]:
+    """Return recent High/Critical impact reports for the org, newest first.
+
+    Org-scoped via ``drafts.org_id`` in the JOIN. Picks the *latest* report per
+    draft first, then filters by ``impact_score > 50`` — so a draft re-analysed
+    from high risk down to medium/low drops off the list instead of clinging to
+    its stale high-risk row (same logic as the dashboard's "Kõrge riskiga leiud"
+    widget). Returns ``[]`` for a missing ``org_id`` or on any DB error.
+
+    Args:
+        org_id: The current user's organisation id. ``None`` → ``[]``.
+        limit: Maximum rows to return.
+
+    Returns:
+        A list of :class:`HighRiskReportRow` (one per draft). Each row has a
+        ``report_url`` (``/drafts/<id>/report``) and an ``explorer_url``
+        (``/explorer?draft=<id>``).
+    """
+    if not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                WITH latest_report AS (
+                    SELECT DISTINCT ON (ir.draft_id)
+                           ir.draft_id, ir.impact_score, ir.conflict_count,
+                           ir.affected_count, ir.gap_count, ir.generated_at
+                    FROM impact_reports ir
+                    JOIN drafts d ON d.id = ir.draft_id
+                    WHERE d.org_id = %s
+                    ORDER BY ir.draft_id, ir.generated_at DESC
+                )
+                SELECT lr.draft_id, d.title, lr.impact_score,
+                       lr.conflict_count, lr.affected_count, lr.gap_count,
+                       lr.generated_at
+                FROM latest_report lr
+                JOIN drafts d ON d.id = lr.draft_id
+                WHERE lr.impact_score > 50
+                ORDER BY lr.generated_at DESC
+                LIMIT %s
+                """,
+                (org_id, limit),
+            ).fetchall()
+    except Exception:
+        logger.exception("start_panel: failed to fetch high-risk reports for org %s", org_id)
+        return []
+    out: list[HighRiskReportRow] = []
+    for r in rows:
+        draft_id = str(r[0])
+        score = int(r[2] or 0)
+        band = impact_band(score)
+        # Belt-and-braces: the SQL ``> 50`` gate already excludes low/medium,
+        # but if the band cut-offs ever move, keep the section honest.
+        if band not in _HIGH_RISK_BANDS:
+            continue
+        out.append(
+            {
+                "draft_id": draft_id,
+                "title": r[1] or "Pealkirjata eelnõu",
+                "impact_score": score,
+                "band": band,
+                "band_label": IMPACT_BAND_LABELS_ET[band],
+                "conflict_count": int(r[3] or 0),
+                "affected_count": int(r[4] or 0),
+                "gap_count": int(r[5] or 0),
+                "generated_at": r[6],
+                "report_url": f"/drafts/{draft_id}/report",
+                "explorer_url": _explorer_draft_url(draft_id),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Sinu hiljutised eelnõud
+# ---------------------------------------------------------------------------
+
+
+def get_recent_drafts(
+    org_id: str | None, *, limit: int = _MAX_RECENT_DRAFTS
+) -> list[RecentDraftRow]:
+    """Return drafts the org has touched recently, most recently updated first.
+
+    Org-scoped via ``drafts.org_id``. Ordered by ``updated_at`` so a draft that
+    was just edited / re-analysed surfaces at the top. The status comes from the
+    ``drafts`` table directly (the simple column — the start panel only needs a
+    human label, not the version-backed pipeline state). Returns ``[]`` for a
+    missing ``org_id`` or on any DB error.
+
+    Args:
+        org_id: The current user's organisation id. ``None`` → ``[]``.
+        limit: Maximum rows to return.
+
+    Returns:
+        A list of :class:`RecentDraftRow`. Each row has a ``detail_url``
+        (``/drafts/<id>``) and an ``explorer_url`` (``/explorer?draft=<id>`` —
+        "Ava mõjukaart").
+    """
+    if not org_id:
+        return []
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, title, status, updated_at
+                FROM drafts
+                WHERE org_id = %s
+                ORDER BY updated_at DESC NULLS LAST
+                LIMIT %s
+                """,
+                (org_id, limit),
+            ).fetchall()
+    except Exception:
+        logger.exception("start_panel: failed to fetch recent drafts for org %s", org_id)
+        return []
+    out: list[RecentDraftRow] = []
+    for r in rows:
+        draft_id = str(r[0])
+        out.append(
+            {
+                "draft_id": draft_id,
+                "title": r[1] or "Pealkirjata eelnõu",
+                "status": str(r[2] or ""),
+                "updated_at": r[3],
+                "detail_url": f"/drafts/{draft_id}",
+                "explorer_url": _explorer_draft_url(draft_id),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Bundle — one call for the page layer
+# ---------------------------------------------------------------------------
+
+
+class StartPanelData(TypedDict):
+    """Everything the start panel renders, fetched in one go."""
+
+    bookmarks: list[BookmarkRow]
+    high_risk_reports: list[HighRiskReportRow]
+    recent_drafts: list[RecentDraftRow]
+
+
+def load_start_panel_data(user_id: str | None, org_id: str | None) -> StartPanelData:
+    """Fetch all three start-panel sections for the given user/org.
+
+    Convenience wrapper so the page handler makes a single call. Each underlying
+    query independently degrades to ``[]`` on error, so this never raises.
+
+    Args:
+        user_id: The current user's id (for personal bookmarks).
+        org_id: The current user's organisation id (for org-scoped reports/drafts).
+
+    Returns:
+        A :class:`StartPanelData` dict.
+    """
+    return {
+        "bookmarks": get_user_bookmarks(user_id),
+        "high_risk_reports": get_high_risk_reports(org_id),
+        "recent_drafts": get_recent_drafts(org_id),
+    }

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -359,6 +359,106 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 .version-label { color: #cbd5e1; }
 .version-empty { color: #64748b; font-size: 12px; font-style: italic; }
 
+/* ------- #754: contextual start panel (cold-open overlay) -------
+ * A "cold" /explorer open (no ?focus / ?draft / ?search / ?vaade=koik)
+ * renders this panel over the (idle) graph chrome instead of auto-loading
+ * the 90k category overview. It's an opaque, scrollable overlay anchored to
+ * the whole content box — so the legend / instructions / timeline behind it
+ * never peek through. "Sirvi liikide kaupa" / "Näita kogu kaarti" hide it
+ * (display:none) and let explorer.js load the overview. */
+#explorer-start-panel {
+  position: absolute; inset: 0; z-index: 25;
+  overflow-y: auto;
+  background: rgba(15, 23, 41, 0.985);
+  -webkit-overflow-scrolling: touch;
+}
+#explorer-start-panel::-webkit-scrollbar { width: 8px; }
+#explorer-start-panel::-webkit-scrollbar-track { background: transparent; }
+#explorer-start-panel::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.3); border-radius: 4px;
+}
+.start-panel-inner {
+  max-width: 720px; margin: 0 auto; padding: 40px 28px 56px;
+}
+.start-panel-title {
+  font-size: 22px; font-weight: 700; color: #f1f5f9; margin: 0 0 6px;
+}
+.start-panel-lead {
+  font-size: 13px; color: #94a3b8; line-height: 1.6; margin: 0 0 24px;
+  max-width: 56ch;
+}
+
+/* --- search box at the top of the panel --- */
+.start-panel-search {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 28px;
+}
+#start-panel-search-input {
+  flex: 1; min-width: 0;
+  background: rgba(30, 41, 59, 0.85); border: 1px solid rgba(100, 116, 139, 0.3);
+  color: #e2e8f0; padding: 9px 14px; border-radius: 8px; font-size: 13px;
+  outline: none; transition: border-color 0.15s;
+}
+#start-panel-search-input:focus { border-color: rgba(56, 189, 248, 0.5); }
+#start-panel-search-input::placeholder { color: #64748b; }
+.start-panel-search-btn {
+  flex-shrink: 0;
+  background: rgba(56, 189, 248, 0.15); border: 1px solid rgba(56, 189, 248, 0.3);
+  color: #38bdf8; padding: 9px 18px; border-radius: 8px; font-size: 13px;
+  cursor: pointer; transition: all 0.15s;
+}
+.start-panel-search-btn:hover { background: rgba(56, 189, 248, 0.25); }
+
+/* --- sections --- */
+.start-panel-section { margin-bottom: 24px; }
+.start-panel-section-title {
+  font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: #64748b; margin: 0 0 10px;
+}
+.start-panel-empty {
+  font-size: 13px; color: #475569; font-style: italic; margin: 0;
+}
+.start-panel-list { list-style: none; padding: 0; margin: 0; }
+.start-panel-item {
+  padding: 8px 0; border-bottom: 1px solid rgba(100, 116, 139, 0.12);
+  font-size: 13px;
+}
+.start-panel-item:last-child { border-bottom: none; }
+.start-panel-item--rich {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px 12px;
+}
+.start-panel-link {
+  color: #e2e8f0; text-decoration: none; font-weight: 500;
+  border-bottom: 1px solid transparent; transition: border-color 0.15s, color 0.15s;
+}
+.start-panel-link:hover { color: #38bdf8; border-bottom-color: rgba(56, 189, 248, 0.4); }
+.start-panel-meta { font-size: 11px; color: #64748b; }
+.start-panel-meta-date { color: #475569; }
+.start-panel-secondary-link {
+  font-size: 11px; color: #6ee7b7; text-decoration: none;
+  margin-left: auto; white-space: nowrap;
+  border-bottom: 1px solid rgba(110, 231, 183, 0.3); transition: color 0.15s, border-color 0.15s;
+}
+.start-panel-secondary-link:hover { color: #a7f3d0; border-bottom-color: rgba(110, 231, 183, 0.6); }
+
+/* --- bottom action row --- */
+.start-panel-section--actions { margin-top: 8px; }
+.start-panel-actions {
+  display: flex; flex-wrap: wrap; gap: 10px;
+}
+.start-panel-action {
+  display: inline-block; padding: 9px 18px; border-radius: 8px;
+  font-size: 13px; cursor: pointer; text-decoration: none;
+  border: 1px solid transparent; transition: all 0.15s; font-family: inherit;
+}
+.start-panel-action--primary {
+  background: rgba(56, 189, 248, 0.15); border-color: rgba(56, 189, 248, 0.3); color: #38bdf8;
+}
+.start-panel-action--primary:hover { background: rgba(56, 189, 248, 0.25); }
+.start-panel-action--secondary {
+  background: rgba(30, 41, 59, 0.85); border-color: rgba(100, 116, 139, 0.3); color: #94a3b8;
+}
+.start-panel-action--secondary:hover { background: rgba(51, 65, 85, 0.9); color: #e2e8f0; }
+
 /* ------- Annotation section in detail panel ------- */
 .annotation-section { margin-top: 12px; }
 .annotation-button-wrapper { display: inline-flex; align-items: center; gap: 8px; }
@@ -396,4 +496,16 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
      small screen; the detail panel goes full content-width. */
   #legend, #instructions { max-width: 60%; }
   #detail-panel { width: 100%; max-width: 100%; }
+
+  /* #754: the start panel goes edge-to-edge with tighter padding, and its
+     search box / action buttons stack so nothing overflows on a phone. */
+  .start-panel-inner { padding: 24px 16px 40px; }
+  .start-panel-title { font-size: 19px; }
+  .start-panel-search { flex-wrap: wrap; }
+  #start-panel-search-input { flex-basis: 100%; }
+  .start-panel-search-btn { flex: 1; }
+  .start-panel-item--rich { gap: 4px 8px; }
+  .start-panel-secondary-link { margin-left: 0; }
+  .start-panel-actions { flex-direction: column; }
+  .start-panel-action { text-align: center; }
 }

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -82,6 +82,12 @@ const state = {
   timelineActive: false,      // whether the timeline filter is applied
   timelineYear: 2026,         // currently selected year on the timeline slider
   selectedEntityData: null,   // full entity detail data (metadata, outgoing, incoming)
+  // #754: when true the page rendered the contextual start panel and we must
+  // NOT auto-fetch the 90k category overview — the user picks what to load.
+  startPanelMode: false,
+  // Whether loadOverview() has run at least once (so explorerShowFullMap()
+  // can no-op back to the existing overview instead of re-fetching it).
+  overviewLoaded: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -1227,6 +1233,23 @@ window.explorerResetTimeline = resetTimeline;
 
 window.explorerBookmark = addBookmark;
 
+// #754: leave the contextual start panel and load today's full category
+// overview in place — wired to the start panel's "Sirvi liikide kaupa" /
+// "Näita kogu kaarti" buttons and the toolbar's "Näita kogu kaarti" item.
+// Idempotent: if the overview is already loaded, just (re)collapses to it.
+window.explorerShowFullMap = function() {
+  _dismissStartPanel();
+  state.startPanelMode = false;
+  if (state.overviewLoaded) {
+    collapseToOverview(true);
+    setTimeout(function() { zoomToFit(500); }, 300);
+    return;
+  }
+  loadFullOverview().then(function() {
+    setTimeout(function() { zoomToFit(600); }, 800);
+  });
+};
+
 // ---------------------------------------------------------------------------
 // Drag handlers
 // ---------------------------------------------------------------------------
@@ -1498,6 +1521,60 @@ async function addBookmark() {
 }
 
 // ---------------------------------------------------------------------------
+// #754 — contextual start panel: gate the 90k-graph load behind a choice
+// ---------------------------------------------------------------------------
+
+// Hide (and stop occupying) the start-panel overlay. Cheap + idempotent.
+function _dismissStartPanel() {
+  var panel = document.getElementById('explorer-start-panel');
+  if (panel) panel.style.display = 'none';
+}
+
+// Load the category overview into state + render it. Does NOT touch the
+// zoom/viewport — callers decide whether to fit-all afterwards (the plain
+// init path does; the ?focus= / ?search= paths re-frame themselves).
+// Factored out of init() so explorerShowFullMap() (the "Näita kogu kaarti" /
+// "Sirvi liikide kaupa" buttons) can call it on demand.
+async function loadFullOverview() {
+  var overview = await loadOverview();
+  state.nodes = overview.nodes;
+  state.links = overview.links;
+  state.view = 'overview';
+  state.overviewLoaded = true;
+  updateBreadcrumb();
+  render();
+}
+
+// Wire the start panel's own search form: intercept submit and reuse the
+// in-page search flow (the same path the toolbar "Otsi" button uses) instead
+// of a full navigation. A no-JS submit still works — the <form> is
+// method=GET action=/explorer, so it lands on /explorer?search=<term>, which
+// the server then renders in graph mode with the search pre-run.
+function _wireStartPanel() {
+  var form = document.getElementById('start-panel-search-form');
+  if (!form) return;
+  form.addEventListener('submit', function(e) {
+    var input = document.getElementById('start-panel-search-input');
+    var term = input ? input.value.trim() : '';
+    if (!term) { e.preventDefault(); return; }
+    e.preventDefault();
+    // Mirror the term into the toolbar search box (kept in sync for when the
+    // user re-opens "Vaate seaded") and run the shared search.
+    var toolbarInput = document.getElementById('search-input');
+    if (toolbarInput) toolbarInput.value = term;
+    _dismissStartPanel();
+    state.startPanelMode = false;
+    // performSearch() collapses to the overview first — make sure it exists.
+    var run = function() { performSearch(); };
+    if (!state.overviewLoaded) {
+      loadFullOverview().then(run);
+    } else {
+      run();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Version history rendering
 // ---------------------------------------------------------------------------
 
@@ -1716,13 +1793,26 @@ async function init() {
   // #746: wire the toolbar-level "← Tagasi" link if the server rendered it
   // (it's present whenever the page carries back-context — ?focus= / ?draft=).
   _wireToolbarBack();
+  // #754: the start panel has its own search form — always wire it (it's a
+  // no-op when the panel isn't on the page).
+  _wireStartPanel();
 
-  const overview = await loadOverview();
-  state.nodes = overview.nodes;
-  state.links = overview.links;
-  state.view = 'overview';
-  updateBreadcrumb();
-  render();
+  // #754: a "cold" open rendered the contextual start panel — the server set
+  // window.__explorerStartPanel. Do NOT fetch the 90k category overview; the
+  // graph chrome is idle behind the panel until the user picks "Sirvi liikide
+  // kaupa" / "Näita kogu kaarti" (→ explorerShowFullMap) or runs a search.
+  if (window.__explorerStartPanel) {
+    state.startPanelMode = true;
+    // The detail panel can still be Escape-closed etc.; just no graph data.
+    // WebSocket sync notifications are still useful — connect once.
+    if (!wsInitialized) {
+      wsInitialized = true;
+      initWebSocket();
+    }
+    return;
+  }
+
+  await loadFullOverview();
 
   // #719: arrived via ?focus=<uri> (e.g. a link from an impact report)?
   // Jump straight to that entity instead of leaving the user on the
@@ -1747,7 +1837,7 @@ async function init() {
     await performSearch();
     setTimeout(function() { zoomToFit(600); }, 800);
   } else {
-    // Center the graph once the simulation settles
+    // Plain overview — centre the graph once the simulation settles.
     setTimeout(function() { zoomToFit(600); }, 800);
   }
 

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -1,16 +1,36 @@
-"""Smoke tests for the Õiguskaart (explorer) page (#714 / #718 / #746).
+"""Smoke tests for the Õiguskaart (explorer) page (#714 / #718 / #746 / #754).
 
 Renders ``explorer_page`` directly via ``to_xml()`` and asserts on the
-markup — no TestClient, no DB. Post-#746 the page is wrapped in the standard
-``PageShell`` (sidebar + topbar + user menu) with the graph controls as a
-horizontal toolbar; these tests pin both "the standard chrome is present"
-and "the bespoke chrome is gone".
+markup — no TestClient. The start-panel DB queries (#754) are stubbed out by
+an autouse fixture so these stay DB-free. Post-#746 the page is wrapped in the
+standard ``PageShell`` (sidebar + topbar + user menu) with the graph controls
+as a horizontal toolbar; post-#754 a "cold" open (no ?focus / ?draft / ?search /
+?vaade=koik) renders a contextual start panel over the idle graph chrome and
+does NOT auto-load the 90k overview.
 """
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
 from fasthtml.common import to_xml
 from starlette.requests import Request
+
+
+@pytest.fixture(autouse=True)
+def _stub_start_panel_data():
+    """#754: keep these markup tests DB-free.
+
+    ``explorer_page`` calls :func:`app.explorer.start_panel.load_start_panel_data`
+    on a cold open; without this stub every cold-open test would attempt three
+    real ``psycopg.connect`` calls. The individual queries already degrade to
+    ``[]`` on a DB error, but stubbing the bundle keeps the tests fast and
+    deterministic. Tests that want populated sections patch it themselves.
+    """
+    empty: dict = {"bookmarks": [], "high_risk_reports": [], "recent_drafts": []}
+    with patch("app.explorer.pages.load_start_panel_data", return_value=empty):
+        yield
 
 
 def _req(query: str = "") -> Request:
@@ -188,18 +208,308 @@ def test_explorer_page_search_param_is_handed_to_js():
     assert "?draft=ID" in html
 
 
-def test_explorer_page_no_focus_keeps_the_draft_tip():
-    html = _html()
-    assert "window.__explorerFocus" not in html
-    assert "window.__explorerSearch" not in html
-    # The cold-open hint about ?draft=ID is rendered in the toolbar.
-    assert "?draft=ID" in html
-    assert 'id="explorer-tip-banner"' in html
-
-
 def test_explorer_page_search_blob_is_escaped():
     # A `</script>` injection attempt in the term must be neutralised in the
     # embedded blob exactly like the ?focus= blob is.
     html = _html("search=</script><b>x")
     assert "</script><b>x" not in html
     assert "window.__explorerSearch" in html
+
+
+# ---------------------------------------------------------------------------
+# #754 — contextual start panel on a "cold" open
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_cold_open_renders_start_panel():
+    """A bare /explorer (no ?focus / ?draft / ?search / ?vaade=koik) shows the
+    contextual start panel — search, bookmarks, high-risk findings, recent
+    drafts, Normi mõjuahel, "Sirvi liikide kaupa" — not the cold 90k graph."""
+    html = _html()
+    assert 'id="explorer-start-panel"' in html
+    assert 'aria-label="Õiguskaardi avapaneel"' in html
+    # The panel's sections (Estonian copy with proper diacritics).
+    assert "Sinu järjehoidjad" in html
+    assert "Hiljutised kõrge riskiga leiud" in html
+    assert "Sinu hiljutised eelnõud" in html
+    assert "Alusta Normi mõjuahelat" in html
+    assert "Sirvi liikide kaupa" in html
+    # The panel's own search box (a real <form method=get action=/explorer>).
+    assert 'id="start-panel-search-form"' in html
+    assert 'id="start-panel-search-input"' in html
+    assert 'action="/explorer"' in html
+    # The Normi mõjuahel shortcut points at the Analüüsikeskus workflow.
+    assert "/analyysikeskus/normi-mojuahel" in html
+    # The old cold-open ?draft= tip / its banner are gone — the panel replaces it.
+    assert "?draft=ID" not in html
+    assert 'id="explorer-tip-banner"' not in html
+
+
+def test_explorer_cold_open_does_not_bootstrap_the_graph():
+    """The whole point of #754: explorer.js must NOT fetch the 90k graph data
+    on a cold open. The server signals that via window.__explorerStartPanel."""
+    html = _html()
+    assert "window.__explorerStartPanel" in html
+    # No deep-link bridge blobs on a cold open.
+    assert "window.__explorerFocus" not in html
+    assert "window.__explorerSearch" not in html
+    # The graph DOM + JS are still on the page (explorer.js needs them once the
+    # user picks "Sirvi liikide kaupa"), and "Näita kogu kaarti" is offered in
+    # the Vaate seaded dropdown too.
+    assert "/static/js/explorer.js" in html
+    assert 'id="canvas"' in html
+    assert "Näita kogu kaarti" in html
+
+
+def test_explorer_focus_param_skips_the_start_panel():
+    uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+    html = _html(f"focus={uri}")
+    # Deep-linked entry → the graph view, no start panel, no start-panel flag.
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+    assert "window.__explorerFocus" in html
+
+
+def test_explorer_draft_param_skips_the_start_panel():
+    # ?draft= (even a malformed/cross-org one whose overlay is dropped) must
+    # bypass the start panel and render the classic graph view (#755 handles
+    # the proper draft subgraph — for #754 the panel just gets skipped).
+    html = _html("draft=not-a-uuid")
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+    # The graph toolbar is the visible chrome here (not hidden behind a panel).
+    assert 'id="explorer-toolbar"' in html
+
+
+def test_explorer_search_param_skips_the_start_panel():
+    html = _html("search=andmekaitse")
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+    assert "window.__explorerSearch" in html
+
+
+def test_explorer_vaade_koik_forces_the_graph_view():
+    """The "Näita kogu kaarti" / "Sirvi liikide kaupa" buttons navigate to
+    /explorer?vaade=koik — that URL renders the classic graph view, not the
+    start panel."""
+    html = _html("vaade=koik")
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+    assert 'id="explorer-toolbar"' in html
+    assert 'id="canvas"' in html
+
+
+def test_explorer_start_panel_lists_bookmarks_reports_and_drafts():
+    """When the org-scoped queries return rows, the panel renders them as
+    links — bookmarks/drafts focus the entity / draft overlay; high-risk
+    rows link to the report (and offer "Ava mõjukaart")."""
+    bm_url = "/explorer?focus=https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23KarS"
+    populated: dict = {
+        "bookmarks": [
+            {
+                "id": "b-1",
+                "entity_uri": "https://data.riik.ee/ontology/estleg#KarS",
+                "label": "Karistusseadustik",
+                "explorer_url": bm_url,
+            }
+        ],
+        "high_risk_reports": [
+            {
+                "draft_id": "d-9",
+                "title": "Andmekaitse seaduse muutmine",
+                "impact_score": 72,
+                "band": "high",
+                "band_label": "Kõrge risk",
+                "conflict_count": 3,
+                "affected_count": 12,
+                "gap_count": 1,
+                "generated_at": None,
+                "report_url": "/drafts/d-9/report",
+                "explorer_url": "/explorer?draft=d-9",
+            }
+        ],
+        "recent_drafts": [
+            {
+                "draft_id": "d-2",
+                "title": "Liiklusseaduse eelnõu",
+                "status": "analyzed",
+                "updated_at": None,
+                "detail_url": "/drafts/d-2",
+                "explorer_url": "/explorer?draft=d-2",
+            }
+        ],
+    }
+    from app.explorer.pages import explorer_page
+
+    with patch("app.explorer.pages.load_start_panel_data", return_value=populated):
+        html = to_xml(explorer_page(_req()))
+    # Bookmark → focuses that entity.
+    assert "Karistusseadustik" in html
+    assert bm_url in html
+    # High-risk report → links to the report page + "Ava mõjukaart" (?draft=).
+    assert "Andmekaitse seaduse muutmine" in html
+    assert "/drafts/d-9/report" in html
+    assert "/explorer?draft=d-9" in html
+    assert "Kõrge risk" in html
+    # Recent draft → detail page + "Ava mõjukaart".
+    assert "Liiklusseaduse eelnõu" in html
+    assert "/drafts/d-2" in html
+    assert "/explorer?draft=d-2" in html
+    assert "Ava mõjukaart" in html
+
+
+# ---------------------------------------------------------------------------
+# #754 — app/explorer/start_panel.py: the org-scoped data queries
+# ---------------------------------------------------------------------------
+
+
+class _Cur:
+    """Tiny cursor stub: records the SQL+params, replays canned rows."""
+
+    def __init__(self, rows: list, log: list):
+        self._rows = rows
+        self._log = log
+
+    def __call__(self, sql: str, params: tuple = ()):  # conn.execute(...)
+        self._log.append((sql, params))
+        return self
+
+    def fetchall(self) -> list:
+        return self._rows
+
+
+class _Conn:
+    """Context-manager connection stub returning a fixed result set."""
+
+    def __init__(self, rows: list, log: list):
+        self.execute = _Cur(rows, log)
+
+    def __enter__(self):  # noqa: ANN204
+        return self
+
+    def __exit__(self, *_):  # noqa: ANN002
+        return False
+
+
+class TestStartPanelBookmarks:
+    def test_scoped_by_user_id_in_sql(self):
+        from app.explorer import start_panel
+
+        log: list = []
+        rows = [("b-1", "urn:x:1", "Esimene"), ("b-2", "urn:x:2", None)]
+        with patch.object(start_panel, "_connect", return_value=_Conn(rows, log)):
+            out = start_panel.get_user_bookmarks("user-42")
+        # The WHERE clause filters on the caller's user_id — never a bare SELECT.
+        assert len(log) == 1
+        sql, params = log[0]
+        assert "where user_id = %s" in sql.lower()
+        assert params[0] == "user-42"
+        # Rows are mapped, with a fallback label and a ?focus= explorer link.
+        assert out[0]["label"] == "Esimene"
+        assert out[1]["label"] == "urn:x:2"  # NULL label → URI
+        assert out[0]["explorer_url"] == "/explorer?focus=urn%3Ax%3A1"
+
+    def test_missing_user_returns_empty_without_db(self):
+        from app.explorer import start_panel
+
+        with patch.object(start_panel, "_connect") as mock_connect:
+            assert start_panel.get_user_bookmarks(None) == []
+            assert start_panel.get_user_bookmarks("") == []
+            mock_connect.assert_not_called()
+
+    def test_db_error_degrades_to_empty(self):
+        from app.explorer import start_panel
+
+        with patch.object(start_panel, "_connect", side_effect=RuntimeError("no db")):
+            assert start_panel.get_user_bookmarks("user-42") == []
+
+
+class TestStartPanelHighRiskReports:
+    def test_scoped_by_org_id_in_sql(self):
+        from app.explorer import start_panel
+
+        log: list = []
+        # (draft_id, title, impact_score, conflict, affected, gap, generated_at)
+        rows = [("d-7", "Suur eelnõu", 84, 2, 9, 1, None)]
+        with patch.object(start_panel, "_connect", return_value=_Conn(rows, log)):
+            out = start_panel.get_high_risk_reports("org-9")
+        assert len(log) == 1
+        sql, params = log[0]
+        # The org filter is on drafts.org_id inside the JOIN.
+        assert "d.org_id = %s" in sql
+        assert params[0] == "org-9"
+        assert out[0]["draft_id"] == "d-7"
+        assert out[0]["band"] == "critical"
+        assert out[0]["report_url"] == "/drafts/d-7/report"
+        assert out[0]["explorer_url"] == "/explorer?draft=d-7"
+
+    def test_low_band_rows_are_filtered_out(self):
+        from app.explorer import start_panel
+
+        # A row that slipped past the SQL ``> 50`` gate (defensive band check).
+        rows = [("d-1", "Väike", 10, 0, 1, 0, None)]
+        with patch.object(start_panel, "_connect", return_value=_Conn(rows, [])):
+            assert start_panel.get_high_risk_reports("org-9") == []
+
+    def test_missing_org_returns_empty_without_db(self):
+        from app.explorer import start_panel
+
+        with patch.object(start_panel, "_connect") as mock_connect:
+            assert start_panel.get_high_risk_reports(None) == []
+            mock_connect.assert_not_called()
+
+    def test_db_error_degrades_to_empty(self):
+        from app.explorer import start_panel
+
+        with patch.object(start_panel, "_connect", side_effect=RuntimeError("no db")):
+            assert start_panel.get_high_risk_reports("org-9") == []
+
+
+class TestStartPanelRecentDrafts:
+    def test_scoped_by_org_id_in_sql(self):
+        from app.explorer import start_panel
+
+        log: list = []
+        rows = [("d-3", "Mõni eelnõu", "analyzed", None)]
+        with patch.object(start_panel, "_connect", return_value=_Conn(rows, log)):
+            out = start_panel.get_recent_drafts("org-5")
+        assert len(log) == 1
+        sql, params = log[0]
+        assert "where org_id = %s" in sql.lower()
+        assert params[0] == "org-5"
+        assert out[0]["draft_id"] == "d-3"
+        assert out[0]["detail_url"] == "/drafts/d-3"
+        assert out[0]["explorer_url"] == "/explorer?draft=d-3"
+
+    def test_missing_org_returns_empty_without_db(self):
+        from app.explorer import start_panel
+
+        with patch.object(start_panel, "_connect") as mock_connect:
+            assert start_panel.get_recent_drafts(None) == []
+            mock_connect.assert_not_called()
+
+    def test_db_error_degrades_to_empty(self):
+        from app.explorer import start_panel
+
+        with patch.object(start_panel, "_connect", side_effect=RuntimeError("no db")):
+            assert start_panel.get_recent_drafts("org-5") == []
+
+
+class TestStartPanelBundle:
+    def test_load_start_panel_data_fans_out(self):
+        from app.explorer import start_panel
+
+        with (
+            patch.object(start_panel, "get_user_bookmarks", return_value=["bm"]) as gb,
+            patch.object(start_panel, "get_high_risk_reports", return_value=["hr"]) as gh,
+            patch.object(start_panel, "get_recent_drafts", return_value=["dr"]) as gd,
+        ):
+            data = start_panel.load_start_panel_data("u-1", "o-1")
+        gb.assert_called_once_with("u-1")
+        gh.assert_called_once_with("o-1")
+        gd.assert_called_once_with("o-1")
+        assert data == {
+            "bookmarks": ["bm"],
+            "high_risk_reports": ["hr"],
+            "recent_drafts": ["dr"],
+        }


### PR DESCRIPTION
Closes #754. Part of epic #762 (workstream A — design doc `docs/2026-05-12-oiguskaart-evidence-map.md`).

## What changed

`/explorer` with no `?focus=` / `?draft=` / `?search=` (and not the explicit `?vaade=koik` opt-in) no longer renders the "cold blob" — the category-overview of the whole ~90k-entity ontology. It now renders a **contextual start panel** over the otherwise-empty graph area:

- **Otsi** — a search box for a law name / §-reference / CELEX number / court case number. Submitting reuses the existing `?search=` plumbing (a no-JS submit lands on `/explorer?search=<term>`; with JS, `explorer.js` intercepts and runs the in-page search flow).
- **Sinu järjehoidjad** — the current user's bookmarks → `?focus=<uri>`.
- **Hiljutised kõrge riskiga leiud** — recent impact reports for the user's org with band ≥ "kõrge" (latest report per draft, `impact_score > 50`, org-scoped) → the report page + an "Ava mõjukaart" link (`?draft=<id>`).
- **Sinu hiljutised eelnõud** — drafts the org touched recently → the draft detail page + "Ava mõjukaart".
- **Alusta *Normi mõjuahelat*** — link to `/analyysikeskus/normi-mojuahel`.
- **Sirvi liikide kaupa** — loads today's category overview *in place* (now opt-in, not the automatic default).

### Behaviour
- `?focus=<uri>` / `?draft=<id>` / `?search=<term>` **bypass the start panel** and load the subgraph directly, exactly as before — the `#draft-overlay-data` mechanism and all existing deep links are untouched (proper `?draft=` subgraph rendering is a separate issue, #755).
- A **"Näita kogu kaarti"** button — in the start panel **and** in the `Vaate seaded ▾` dropdown — loads the full overview.
- Until the user picks something or clicks "Näita kogu kaarti", **`explorer.js` does NOT fetch the 90k graph data** — the server sets `window.__explorerStartPanel` (emitted before `explorer.js` so `init()`'s synchronous prologue sees it) and `init()` returns early without `loadOverview()`. The graph DOM + JS are still on the page so `explorer.js`' top-level `getElementById` calls don't hit nulls.
- The sidebar "Õiguskaart" link is unchanged (`/explorer` → now lands on the start panel).

## Files

- **new `app/explorer/start_panel.py`** — three org-scoped, individually-testable query functions (`get_user_bookmarks`, `get_high_risk_reports`, `get_recent_drafts`) + a `load_start_panel_data` bundle. Clean signatures (REST/MCP-wrappable per CLAUDE.md). Reuses the dashboard's query logic; each query degrades to `[]` on a DB error rather than 500-ing the explorer. Each result row carries an `explorer_url` so the page layer doesn't have to know the `?focus=` / `?draft=` URL contract.
- **`app/explorer/pages.py`** — decides cold-vs-context at request time; builds the start-panel markup (FastHTML `FT`, Estonian copy with diacritics); adds "Näita kogu kaarti" to `Vaate seaded`; moves the bridge `<script>` blobs before `explorer.js`.
- **`app/static/js/explorer.js`** — `init()` gates the graph load behind `window.__explorerStartPanel`; new `explorerShowFullMap()` (wired to both "Näita kogu kaarti" buttons + "Sirvi liikide kaupa"); start-panel search form wiring; `loadFullOverview()` extracted from `init()`.
- **`app/static/css/explorer.css`** — start-panel styling (opaque scrollable overlay anchored to the content box); the `@media (max-width:768px)` block keeps it usable on phones.
- **`tests/test_explorer_pages.py`** — cold open renders the start panel + `window.__explorerStartPanel` (no graph bootstrap); `?focus=` / `?draft=` / `?search=` / `?vaade=koik` skip the panel and render the graph view; the start panel renders bookmark/report/draft rows when the queries return data; `start_panel.py` query functions are org-scoped (assert the SQL filters on `user_id` / `d.org_id` / `org_id`) and degrade to `[]` on error / missing scope. Unauthenticated `/explorer` behaviour unchanged (existing test in `test_explorer_routes.py`).

## Toolchain

- `uv run ruff format app/ tests/` — clean
- `uv run ruff check app/ tests/` — all checks passed
- `uv run pyright` (whole repo) — 0 errors, 0 warnings
- `uv run pytest -q` — 2355 passed, 25 skipped
- `node --check app/static/js/explorer.js` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)