### PR TITLE
feat(explorer): #756 legal-view presets in the Õiguskaart toolbar

### DIFF
--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -21,6 +21,16 @@ graph area, and tells ``explorer.js`` *not* to fetch the graph data. Any of
 ``?focus=`` / ``?draft=`` / ``?search=`` / ``?vaade=koik`` bypasses the panel and
 loads the graph exactly as before. The org-scoped DB queries that back the panel
 live in :mod:`app.explorer.start_panel`.
+
+Issue #756 (epic #762, same design doc, workstream C): the toolbar grows
+**legal-view preset chips** — ``Kehtiv õigus`` · ``Eelnõu mõjud`` · ``EL
+seosed`` · ``Kohtupraktika`` · ``Ajalugu``. Each preset is a named bundle of
+the knobs the explorer already has (which entity types / relation types to keep
+on screen + whether the timeline is on); the raw simulation knobs stay under
+``Vaate seaded ▾``. Presets are URL-addressable — ``/explorer?vaade=<slug>``
+applies one on load (and, like ``?vaade=koik``, skips the start panel);
+``explorer.js`` mirrors a clicked preset into the URL. See
+:data:`_LEGAL_VIEW_PRESETS`.
 """
 
 from __future__ import annotations
@@ -52,6 +62,114 @@ logger = logging.getLogger(__name__)
 # URL renders the graph view (no panel) and lets ``explorer.js`` load the
 # overview as it always did.
 _VAADE_KOIK = "koik"
+
+# #756 (epic #762, design doc ``docs/2026-05-12-oiguskaart-evidence-map.md``,
+# workstream C): legal-view presets in the toolbar. Each preset is a *named
+# bundle* of the knobs the explorer already has — which entity types (graph
+# categories) to keep on screen, which relation types to keep (matched on the
+# edge labels explorer.js already renders, i.e. the predicate names), and
+# whether the timeline ("ajaline vaade") is on. The raw simulation knobs
+# (``Lähtesta paigutus`` / ``Näita-peida seosenimed`` / ``Rühmita liigi
+# järgi`` / the timeline slider) stay under the existing ``Vaate seaded ▾``
+# disclosure — presets are the *legal-work* surface.
+#
+# Presets are URL-addressable: ``/explorer?vaade=<slug>`` applies the preset on
+# load (and, like ``?vaade=koik``, forces the graph view past the #754 start
+# panel — a preset is meaningless without the graph). explorer.js mirrors a
+# clicked preset back into the URL via ``history.replaceState``. An unknown
+# ``?vaade=`` value is ignored gracefully (the page renders as if no ``vaade``
+# param were present).
+#
+# The mapping is best-effort against the ontology's actual predicates
+# (``estleg:references`` / ``interpretsProvision`` / ``transposesDirective`` /
+# ``amendsProvision`` / ``transposedBy`` / ``harmonisedWith`` — see
+# ``app/docs/impact/queries.py`` / ``app/analyysikeskus/eu_lookup.py``); where a
+# clean relation-type grouping doesn't exist the keyword list errs on the side
+# of "show a bit more". Category keys match ``CATEGORY_COLORS`` in
+# ``app/static/js/explorer.js``.
+#
+# Each entry: ``slug -> {"label", "title", "categories", "rel_keywords",
+# "timeline"}``. ``categories`` / ``rel_keywords`` empty ⇒ "no filter on that
+# axis" (used by ``ajalugu``, which keeps every type and just turns the
+# timeline on).
+_LEGAL_VIEW_PRESETS: dict[str, dict] = {
+    "kehtiv-oigus": {
+        "label": "Kehtiv õigus",
+        "title": "Kehtivad seadused ja õigusnormid ning nende struktuursed seosed",
+        "categories": [
+            "EnactedLaw",
+            "LegalProvision",
+            "Section",
+            "Division",
+            "Chapter",
+            "Subdivision",
+            "LegalPart",
+        ],
+        # Structural containment relations between an act and its provisions —
+        # no impact/EU/case predicates. ``hasInstance`` is the synthetic
+        # category→entity edge explorer.js draws on drill-down.
+        "rel_keywords": ["contains", "haspart", "ispartof", "hasprovision", "hasinstance"],
+        "timeline": False,
+    },
+    "eelnou-mojud": {
+        "label": "Eelnõu mõjud",
+        "title": "Eelnõud ja nende mõjuseosed (mõjutab / on vastuolus / muudab)",
+        "categories": ["DraftLegislation", "LegalProvision", "EnactedLaw"],
+        "rel_keywords": [
+            "reference",
+            "viit",
+            "affect",
+            "mojut",
+            "conflict",
+            "vastuolu",
+            "amend",
+            "muut",
+        ],
+        "timeline": False,
+    },
+    "el-seosed": {
+        "label": "EL seosed",
+        "title": "EL õigusaktid ja ülevõtmisseosed (võtab üle direktiivi / on harmoneeritud)",
+        "categories": ["EULegislation", "LegalProvision", "EnactedLaw"],
+        "rel_keywords": [
+            "transpos",
+            "ulevot",
+            "directive",
+            "direktiiv",
+            "harmonis",
+            "harmonee",
+            "implement",
+        ],
+        "timeline": False,
+    },
+    "kohtupraktika": {
+        "label": "Kohtupraktika",
+        "title": "Kohtulahendid ja nende tõlgendus-/kohaldamisseosed",
+        "categories": ["CourtDecision", "EUCourtDecision", "LegalProvision"],
+        "rel_keywords": ["interpret", "tolgenda", "appl", "kohalda", "cite", "viit"],
+        "timeline": False,
+    },
+    "ajalugu": {
+        "label": "Ajalugu",
+        "title": "Versioonid ja muudatused — ajaline vaade sees",
+        # No category filter — versions/amendments span every entity type.
+        "categories": [],
+        "rel_keywords": ["amend", "muut", "version", "versioon", "supersede", "asend", "replace"],
+        "timeline": True,
+    },
+}
+
+
+def _legal_view_presets_for_js() -> dict[str, dict]:
+    """Trim the preset table to the keys ``explorer.js`` needs (no labels)."""
+    return {
+        slug: {
+            "categories": p["categories"],
+            "relKeywords": p["rel_keywords"],
+            "timeline": p["timeline"],
+        }
+        for slug, p in _LEGAL_VIEW_PRESETS.items()
+    }
 
 
 # #475: the explorer page previously re-queried ``drafts`` and
@@ -297,15 +415,57 @@ def _escape_for_script(payload: str) -> str:
     return payload.replace("</", "<\\/").replace(" ", "\\u2028").replace(" ", "\\u2029")
 
 
-def _explorer_toolbar(*, has_back_context: bool, draft_tip: bool):  # noqa: ANN202
+# #756: the legal-view preset chips, rendered as one group in the toolbar.
+def _legal_view_preset_chips(active_preset: str | None):  # noqa: ANN202
+    """Build the ``Õigusvaated`` chip row for the toolbar.
+
+    One ``.preset-chip`` button per entry in :data:`_LEGAL_VIEW_PRESETS`; the
+    chip matching *active_preset* (the resolved ``?vaade=`` slug, if it names a
+    real preset) carries the ``active`` class so the page reflects which view is
+    on without waiting for JS. explorer.js wires the ``onclick`` (it calls
+    ``explorerApplyPreset(slug)``), re-paints the active chip when a preset is
+    clicked, and mirrors the slug into the URL.
+    """
+    chips: list = [Span("Õigusvaated:", cls="preset-group-label")]
+    for slug, preset in _LEGAL_VIEW_PRESETS.items():
+        is_active = slug == active_preset
+        chips.append(
+            Button(
+                preset["label"],
+                type="button",
+                cls="ctrl-btn preset-chip active" if is_active else "ctrl-btn preset-chip",
+                # explorer.js reads this to find the button when reflecting the
+                # URL / re-painting the active state.
+                data_vaade=slug,
+                onclick=f"explorerApplyPreset('{slug}')",
+                title=preset["title"],
+                aria_pressed="true" if is_active else "false",
+            )
+        )
+    return Div(
+        *chips,
+        id="explorer-presets",
+        cls="preset-group",
+        role="group",
+        aria_label="Õiguskaardi vaated",
+        data_active_vaade=active_preset or "",
+    )
+
+
+def _explorer_toolbar(
+    *, has_back_context: bool, draft_tip: bool, active_preset: str | None = None
+):  # noqa: ANN202
     """The thin horizontal graph toolbar across the top of the canvas.
 
-    Holds the legal-work view actions (``Ülevaade`` / ``Lähtesta vaade``),
-    the ``Vaate seaded`` disclosure (technical layout controls), the search
-    input + ``Otsi`` button (moved here from the deleted bespoke topbar),
-    and — when the page was opened from a report/analysis — a "← Tagasi
-    aruandesse" link. explorer.js wires the ``onclick`` handlers and unhides
-    the panel back link based on ``document.referrer``.
+    Holds the legal-work view actions (``Ülevaade`` / ``Lähtesta vaade``), the
+    legal-view preset chips (#756 — ``Kehtiv õigus`` · ``Eelnõu mõjud`` · ``EL
+    seosed`` · ``Kohtupraktika`` · ``Ajalugu``), the ``Vaate seaded``
+    disclosure (technical layout controls), the search input + ``Otsi`` button
+    (moved here from the deleted bespoke topbar), and — when the page was
+    opened from a report/analysis — a "← Tagasi aruandesse" link. explorer.js
+    wires the ``onclick`` handlers and unhides the panel back link based on
+    ``document.referrer``. *active_preset* is the resolved ``?vaade=`` slug when
+    it names a real preset (else ``None``); the matching chip renders active.
     """
     items: list = [
         # A small page-identity label — the highlighted sidebar item and
@@ -325,6 +485,9 @@ def _explorer_toolbar(*, has_back_context: bool, draft_tip: bool):  # noqa: ANN2
             onclick="explorerResetView()",
             title="Lähtesta suum ja valik",
         ),
+        # #756: legal-view presets — the legal-work surface; the raw graph
+        # knobs stay under "Vaate seaded ▾" below.
+        _legal_view_preset_chips(active_preset),
         # Technical layout controls behind a disclosure so the toolbar
         # reads in legal-work language, not force-simulation jargon
         # (#714 / #718). The menu drops down (position: absolute) so it
@@ -625,30 +788,59 @@ def explorer_page(req: Request):
     kogu kaarti" / "Sirvi liikide kaupa" buttons and the toolbar's "Näita kogu
     kaarti") forces the classic graph view. Unauthenticated requests never
     reach here — ``auth_before`` redirects to ``/auth/login`` first (#442).
+
+    #756: ``?vaade=<slug>`` where ``<slug>`` names a legal-view preset (see
+    :data:`_LEGAL_VIEW_PRESETS`) renders the graph view with that preset's chip
+    active and hands the preset config to ``explorer.js`` (``window.__explorerVaade``)
+    so the filter combo (entity types + relation types + timeline) is applied on
+    load. Like ``?vaade=koik`` a preset slug bypasses the start panel. An unknown
+    ``?vaade=`` value is ignored (treated as if absent).
     """
     auth = req.scope.get("auth")
     draft_param = req.query_params.get("draft", "").strip()
     focus_param = req.query_params.get("focus", "").strip()
     search_param = req.query_params.get("search", "").strip()
     vaade_param = req.query_params.get("vaade", "").strip()
+    # #756: resolve ?vaade= once. ``active_preset`` is set only when the slug
+    # names a real legal-view preset; ``?vaade=koik`` (the #754 "show me
+    # everything" opt-in) and unknown values both leave it ``None``. ``?focus=``
+    # / ``?search=`` are more specific intents (a particular entity / query) —
+    # when present, ``?vaade=`` is ignored entirely so the chip state and the
+    # JS init path don't fight the focus/search deep link.
+    active_preset: str | None = None
+    if not focus_param and not search_param:
+        active_preset = vaade_param if vaade_param in _LEGAL_VIEW_PRESETS else None
     overlay_uris: list[str] = []
     if draft_param:
         overlay_uris = _fetch_draft_overlay(req, draft_param)
 
-    # #754: the start panel shows only when there is nothing to deep-link to
-    # and the user hasn't explicitly asked for the whole map. Any of
-    # ?focus= / ?draft= / ?search= / ?vaade=koik bypasses it and renders the
-    # classic graph view (so existing deep links / overlays never regress).
+    # #754 / #756: the start panel shows only when there is nothing to deep-link
+    # to and the user hasn't explicitly asked for a full/preset view. Any of
+    # ?focus= / ?draft= / ?search= / ?vaade=koik / ?vaade=<preset> bypasses it
+    # and renders the classic graph view (so existing deep links / overlays
+    # never regress, and a preset has the graph to filter).
     show_start_panel = not (
-        focus_param or search_param or draft_param or vaade_param == _VAADE_KOIK
+        focus_param
+        or search_param
+        or draft_param
+        or vaade_param == _VAADE_KOIK
+        or active_preset is not None
     )
 
-    # ---- Server → JS bridge: ?focus= / ?search= / draft-overlay / mode blobs ----
+    # ---- Server → JS bridge: ?focus= / ?search= / ?vaade= / draft-overlay / mode blobs ----
     bridge_tags: list = []
     if show_start_panel:
         # The flag explorer.js checks on init() to skip loadOverview() — the
         # whole point of #754 (don't fetch the cold blob until the user picks).
         bridge_tags.append(Script("window.__explorerStartPanel=true;"))
+    # #756: hand the full preset table + the active slug to explorer.js. The
+    # table is small static config (no user data) so plain json.dumps is fine;
+    # _escape_for_script keeps it safe inside the <script> regardless.
+    presets_payload = _escape_for_script(json.dumps(_legal_view_presets_for_js()))
+    bridge_tags.append(Script(f"window.__explorerPresets={presets_payload};"))
+    if active_preset is not None:
+        vaade_payload = _escape_for_script(json.dumps(active_preset))
+        bridge_tags.append(Script(f"window.__explorerVaade={vaade_payload};"))
     # #719: hand the focus URI to the JS (it's validated server-side at
     # /api/explorer/entity/{uri}; embedding it escaped keeps the contract
     # explicit so the JS need not re-parse location.search).
@@ -692,7 +884,11 @@ def explorer_page(req: Request):
         # ----- Contextual start panel (#754) — opaque overlay, cold open only -----
         *start_panel_tag,
         # ----- Graph toolbar (across the top of the canvas) -----
-        _explorer_toolbar(has_back_context=has_back_context, draft_tip=show_draft_tip),
+        _explorer_toolbar(
+            has_back_context=has_back_context,
+            draft_tip=show_draft_tip,
+            active_preset=active_preset,
+        ),
         # ----- Breadcrumb -----
         Div(id="breadcrumb"),
         # ----- Tooltip -----

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -49,6 +49,26 @@ svg#canvas {
 .ctrl-btn:hover { background: rgba(51,65,85,0.9); color: #e2e8f0; }
 .ctrl-btn.active { border-color: rgba(56,189,248,0.4); color: #38bdf8; }
 
+/* #756 — legal-view preset chips. A pill row in the toolbar; each chip is a
+   `.ctrl-btn` so it inherits the base look, with a tighter shape + a clear
+   active state (the chip for the resolved ?vaade= slug). */
+.preset-group {
+  display: inline-flex; align-items: center; flex-wrap: wrap; gap: 6px;
+  padding-left: 8px; margin-left: 2px;
+  border-left: 1px solid rgba(100,116,139,0.25);
+}
+.preset-group-label {
+  font-size: 11px; color: #64748b; white-space: nowrap; letter-spacing: 0.02em;
+}
+.ctrl-btn.preset-chip {
+  border-radius: 999px; padding: 5px 12px; font-size: 11.5px;
+}
+.ctrl-btn.preset-chip:hover { background: rgba(56,189,248,0.12); color: #cbd5e1; }
+.ctrl-btn.preset-chip.active {
+  background: rgba(56,189,248,0.18); border-color: rgba(56,189,248,0.55); color: #7dd3fc;
+}
+.ctrl-btn.preset-chip.active:hover { background: rgba(56,189,248,0.24); color: #bae6fd; }
+
 /* ------- "Vaate seaded" disclosure — drops DOWN from the toolbar -------
    In the old vertical rail the menu expanded inline; in a horizontal
    toolbar it must be an absolutely-positioned dropdown so it doesn't
@@ -491,6 +511,13 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
   #search-input { width: 100%; flex: 1; }
   .ctrl-btn { padding: 5px 10px; font-size: 11px; }
   .toolbar-tip { margin-left: 0; width: 100%; max-width: none; }
+  /* #756: the preset chips wrap onto their own full-width line on a phone
+     rather than fighting the search box for horizontal space. */
+  .preset-group {
+    width: 100%; margin-left: 0; padding-left: 0; border-left: none;
+    border-top: 1px solid rgba(100,116,139,0.2); padding-top: 6px;
+  }
+  .ctrl-btn.preset-chip { padding: 5px 10px; font-size: 11px; }
 
   /* Legend + instructions get tighter insets so they don't dominate a
      small screen; the detail panel goes full content-width. */

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -88,6 +88,10 @@ const state = {
   // Whether loadOverview() has run at least once (so explorerShowFullMap()
   // can no-op back to the existing overview instead of re-fetching it).
   overviewLoaded: false,
+  // #756: the slug of the active legal-view preset, or null. Set by
+  // explorerApplyPreset(); reflected into the URL (?vaade=<slug>) and the
+  // active toolbar chip.
+  activePreset: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -1251,6 +1255,187 @@ window.explorerShowFullMap = function() {
 };
 
 // ---------------------------------------------------------------------------
+// #756 — legal-view presets: a named bundle of the knobs the explorer already
+// has (which graph categories / relation types to keep, plus the timeline
+// mode). The server hands the table (and the resolved ?vaade= slug) via
+// window.__explorerPresets / window.__explorerVaade; the constant below is a
+// fallback so the file is self-contained in a stripped test DOM.
+// ---------------------------------------------------------------------------
+
+const LEGAL_VIEW_PRESETS_FALLBACK = {
+  'kehtiv-oigus': {
+    categories: ['EnactedLaw', 'LegalProvision', 'Section', 'Division', 'Chapter', 'Subdivision', 'LegalPart'],
+    relKeywords: ['contains', 'haspart', 'ispartof', 'hasprovision', 'hasinstance'],
+    timeline: false,
+  },
+  'eelnou-mojud': {
+    categories: ['DraftLegislation', 'LegalProvision', 'EnactedLaw'],
+    relKeywords: ['reference', 'viit', 'affect', 'mojut', 'conflict', 'vastuolu', 'amend', 'muut'],
+    timeline: false,
+  },
+  'el-seosed': {
+    categories: ['EULegislation', 'LegalProvision', 'EnactedLaw'],
+    relKeywords: ['transpos', 'ulevot', 'directive', 'direktiiv', 'harmonis', 'harmonee', 'implement'],
+    timeline: false,
+  },
+  'kohtupraktika': {
+    categories: ['CourtDecision', 'EUCourtDecision', 'LegalProvision'],
+    relKeywords: ['interpret', 'tolgenda', 'appl', 'kohalda', 'cite', 'viit'],
+    timeline: false,
+  },
+  'ajalugu': {
+    categories: [],
+    relKeywords: ['amend', 'muut', 'version', 'versioon', 'supersede', 'asend', 'replace'],
+    timeline: true,
+  },
+};
+
+function _presetTable() {
+  var t = (typeof window !== 'undefined' && window.__explorerPresets) || null;
+  if (t && typeof t === 'object' && Object.keys(t).length > 0) return t;
+  return LEGAL_VIEW_PRESETS_FALLBACK;
+}
+
+function _presetConfig(slug) {
+  if (!slug) return null;
+  var t = _presetTable();
+  return Object.prototype.hasOwnProperty.call(t, slug) ? t[slug] : null;
+}
+
+// Does this link's predicate label match any of the preset's relation
+// keywords? Empty keyword list ⇒ "keep every relation" (the ajalugu preset
+// relies on this for the cross-category overview links it has no name for).
+function _linkMatchesPreset(link, relKeywords) {
+  if (!relKeywords || relKeywords.length === 0) return true;
+  var lbl = String((link && link.label) || '').toLowerCase();
+  // The synthetic category→entity / cross-category overview edges carry
+  // generic labels ('', 'hasInstance', 'otsing'); keep them so categories
+  // don't end up as orphan dots after a node filter.
+  if (lbl === '' || lbl === 'hasinstance' || lbl === 'otsing' || link.isCross) return true;
+  for (var i = 0; i < relKeywords.length; i++) {
+    if (lbl.indexOf(relKeywords[i]) !== -1) return true;
+  }
+  return false;
+}
+
+// Repaint the toolbar so the chip for *slug* (or none) is the active one.
+function _paintActivePresetChip(slug) {
+  var group = document.getElementById('explorer-presets');
+  if (group) group.setAttribute('data-active-vaade', slug || '');
+  var chips = document.querySelectorAll('#explorer-presets .preset-chip');
+  for (var i = 0; i < chips.length; i++) {
+    var c = chips[i];
+    var on = c.getAttribute('data-vaade') === slug;
+    c.classList.toggle('active', on);
+    c.setAttribute('aria-pressed', on ? 'true' : 'false');
+  }
+}
+
+// Mirror the active preset into the URL (?vaade=<slug>) without a navigation
+// or a history entry — deep-linkable, but the back button isn't littered.
+function _reflectPresetInUrl(slug) {
+  if (typeof history === 'undefined' || !history.replaceState) return;
+  try {
+    var url = new URL(window.location.href);
+    if (slug) url.searchParams.set('vaade', slug);
+    else url.searchParams.delete('vaade');
+    history.replaceState(history.state, '', url.toString());
+  } catch (e) { /* old browser without URL/searchParams — skip silently */ }
+}
+
+// Apply a preset's filter combo on top of the (full) overview graph: keep only
+// nodes in the preset's categories (empty ⇒ all), keep links whose predicate
+// matches the preset's relation keywords, and turn the timeline on/off. Then
+// re-frame. Idempotent. Unknown slug → clear any active preset (back to the
+// unfiltered overview), still graceful.
+async function applyLegalViewPreset(slug, opts) {
+  opts = opts || {};
+  _dismissStartPanel();
+  state.startPanelMode = false;
+
+  var cfg = _presetConfig(slug);
+  if (!cfg) {
+    // Unknown / cleared: drop back to the plain overview.
+    state.activePreset = null;
+    _paintActivePresetChip(null);
+    if (opts.reflectUrl !== false) _reflectPresetInUrl(null);
+    if (!state.overviewLoaded) { await loadFullOverview(); }
+    return;
+  }
+
+  // Make sure we have the full overview to filter (and start from it, not from
+  // a previous preset's already-trimmed node set). ``freshOverview`` lets the
+  // init() path skip a redundant re-fetch — it just loaded the overview.
+  if (!state.overviewLoaded) {
+    await loadFullOverview();
+  } else if (!opts.freshOverview) {
+    collapseToOverview(false);
+    var fresh = await loadOverview();
+    state.nodes = fresh.nodes;
+    state.links = fresh.links;
+    state.view = 'overview';
+  }
+
+  var cats = cfg.categories || [];
+  if (cats.length > 0) {
+    var keep = new Set(cats);
+    state.nodes = state.nodes.filter(function(n) { return keep.has(n.category); });
+    var nodeIds = new Set(state.nodes.map(function(n) { return n.id; }));
+    state.links = state.links.filter(function(l) {
+      var sid = typeof l.source === 'object' ? l.source.id : l.source;
+      var tid = typeof l.target === 'object' ? l.target.id : l.target;
+      return nodeIds.has(sid) && nodeIds.has(tid);
+    });
+  }
+  // Relation-type filter (best-effort — explorer edges are predicate names).
+  var nodeIds2 = new Set(state.nodes.map(function(n) { return n.id; }));
+  state.links = state.links.filter(function(l) {
+    var sid = typeof l.source === 'object' ? l.source.id : l.source;
+    var tid = typeof l.target === 'object' ? l.target.id : l.target;
+    if (!nodeIds2.has(sid) || !nodeIds2.has(tid)) return false;
+    return _linkMatchesPreset(l, cfg.relKeywords);
+  });
+
+  state.expandedCategory = null;
+  state.pinnedNodes.clear();
+  closeDetail();
+  updateBreadcrumb();
+  render();
+
+  // Timeline mode: presets that want it turn the existing temporal filter on;
+  // the others make sure it's off (so switching presets is clean).
+  if (cfg.timeline) {
+    var slider = document.getElementById('timeline-slider');
+    var year = slider ? parseInt(slider.value, 10) : state.timelineYear;
+    if (!year || isNaN(year)) year = state.timelineYear;
+    // applyTimelineFilter() replaces the graph with its own temporal layout —
+    // fine; the categories shown are still driven by what's valid at that year.
+    await applyTimelineFilter(year);
+  } else if (state.timelineActive) {
+    state.timelineActive = false;
+    var sl = document.getElementById('timeline-slider');
+    if (sl) sl.value = '2026';
+    var ve = document.getElementById('timeline-value');
+    if (ve) ve.textContent = 'Väljas';
+  }
+
+  state.activePreset = slug;
+  _paintActivePresetChip(slug);
+  if (opts.reflectUrl !== false) _reflectPresetInUrl(slug);
+  setTimeout(function() { zoomToFit(600); }, 800);
+}
+
+// Toolbar chip onclick → apply (and reflect in the URL). Clicking the already
+// active chip toggles it off (back to the unfiltered overview).
+window.explorerApplyPreset = function(slug) {
+  if (slug && state.activePreset === slug) {
+    applyLegalViewPreset(null, {});
+    return;
+  }
+  applyLegalViewPreset(slug, {});
+};
+
+// ---------------------------------------------------------------------------
 // Drag handlers
 // ---------------------------------------------------------------------------
 
@@ -1829,6 +2014,14 @@ async function init() {
     try { searchTerm = new URLSearchParams(window.location.search).get('search'); }
     catch (e) { searchTerm = null; }
   }
+  // #756: ?vaade=<slug> deep link — apply that legal-view preset on load.
+  // ?focus= / ?search= are more specific, so they win when combined; an
+  // unknown slug is ignored (applyLegalViewPreset() just falls back).
+  var vaadeSlug = (focusUri || searchTerm) ? null : window.__explorerVaade;
+  if (!focusUri && !searchTerm && !vaadeSlug) {
+    try { vaadeSlug = new URLSearchParams(window.location.search).get('vaade'); }
+    catch (e) { vaadeSlug = null; }
+  }
   if (focusUri) {
     await focusOnEntity(focusUri);
   } else if (searchTerm && String(searchTerm).trim()) {
@@ -1836,6 +2029,10 @@ async function init() {
     if (searchInput) searchInput.value = String(searchTerm);
     await performSearch();
     setTimeout(function() { zoomToFit(600); }, 800);
+  } else if (vaadeSlug && _presetConfig(vaadeSlug)) {
+    // Don't re-write the URL we were given — it's already ?vaade=<slug> — and
+    // skip the redundant overview re-fetch (loadFullOverview just ran).
+    await applyLegalViewPreset(vaadeSlug, { reflectUrl: false, freshOverview: true });
   } else {
     // Plain overview — centre the graph once the simulation settles.
     setTimeout(function() { zoomToFit(600); }, 800);

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -359,6 +359,137 @@ def test_explorer_start_panel_lists_bookmarks_reports_and_drafts():
 
 
 # ---------------------------------------------------------------------------
+# #756 — legal-view preset chips in the toolbar (?vaade=<slug>)
+# ---------------------------------------------------------------------------
+
+# Keep this in sync with ``_LEGAL_VIEW_PRESETS`` in app/explorer/pages.py.
+_PRESET_SLUGS = ("kehtiv-oigus", "eelnou-mojud", "el-seosed", "kohtupraktika", "ajalugu")
+_PRESET_LABELS = ("Kehtiv õigus", "Eelnõu mõjud", "EL seosed", "Kohtupraktika", "Ajalugu")
+
+
+def test_explorer_toolbar_renders_the_five_legal_view_preset_chips():
+    """The toolbar offers the five legal-view presets as a labelled chip group;
+    the raw graph knobs stay under "Vaate seaded". Cold open is fine — the
+    chips live in the (idle) graph chrome behind the start panel."""
+    html = _html()
+    # The chip group + its accessible labelling.
+    assert 'id="explorer-presets"' in html
+    assert 'aria-label="Õiguskaardi vaated"' in html
+    assert "Õigusvaated" in html
+    # All five preset labels + their slugs, each as a clickable chip.
+    for label in _PRESET_LABELS:
+        assert label in html, label
+    for slug in _PRESET_SLUGS:
+        assert f'data-vaade="{slug}"' in html, slug
+        assert f"explorerApplyPreset('{slug}')" in html, slug
+    # The raw simulation knobs are still under "Vaate seaded", not surfaced
+    # at the top level alongside the presets.
+    assert "Vaate seaded" in html
+    assert "Lähtesta paigutus" in html
+    # explorer.js gets the preset table (and no active slug on a cold open).
+    assert "window.__explorerPresets" in html
+    assert "window.__explorerVaade" not in html
+    # No preset chip is active on a cold open.
+    assert "preset-chip active" not in html
+    assert 'data-active-vaade=""' in html
+
+
+def test_explorer_known_vaade_slug_marks_that_preset_active():
+    """``/explorer?vaade=el-seosed`` renders the graph view with the EL-seosed
+    chip active and hands the slug to explorer.js."""
+    html = _html("vaade=el-seosed")
+    # The graph view (no start panel — a preset needs the graph to filter).
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+    assert 'id="canvas"' in html
+    # The matching chip is active; explorer.js gets the resolved slug.
+    assert 'data-active-vaade="el-seosed"' in html
+    assert 'data-vaade="el-seosed"' in html
+    assert "preset-chip active" in html
+    assert 'aria-pressed="true"' in html
+    assert "window.__explorerVaade" in html
+    assert "el-seosed" in html
+    assert "window.__explorerPresets" in html
+
+
+def test_explorer_each_known_vaade_slug_is_addressable():
+    """Every preset slug, given as ?vaade=, marks its own chip active."""
+    for slug in _PRESET_SLUGS:
+        html = _html(f"vaade={slug}")
+        assert f'data-active-vaade="{slug}"' in html, slug
+        assert "preset-chip active" in html, slug
+        assert "window.__explorerVaade" in html, slug
+        # A preset bypasses the start panel.
+        assert "window.__explorerStartPanel" not in html, slug
+
+
+def test_explorer_vaade_preset_is_handed_to_js_with_full_table():
+    """The preset table embedded for explorer.js carries every slug's config
+    keys (categories / relKeywords / timeline)."""
+    html = _html("vaade=kohtupraktika")
+    assert "window.__explorerPresets" in html
+    # The table mentions each slug + the per-preset keys.
+    for slug in _PRESET_SLUGS:
+        assert slug in html, slug
+    assert "categories" in html
+    assert "relKeywords" in html
+    assert "timeline" in html
+    # A representative ontology category + relation keyword from the configs.
+    assert "CourtDecision" in html
+    assert "interpret" in html
+
+
+def test_explorer_unknown_vaade_value_is_ignored():
+    """An unrecognised ``?vaade=`` value renders the page as if it were absent:
+    a cold open (start panel + no preset active), no JS preset blob."""
+    html = _html("vaade=ei-ole-olemas")
+    # Falls through to the #754 cold-open behaviour.
+    assert 'id="explorer-start-panel"' in html
+    assert "window.__explorerStartPanel" in html
+    # No preset is active and no slug is handed to JS.
+    assert "preset-chip active" not in html
+    assert 'data-active-vaade=""' in html
+    assert "window.__explorerVaade" not in html
+    # The chip group + the preset table are still present (the chips just sit
+    # idle behind the start panel).
+    assert 'id="explorer-presets"' in html
+    assert "window.__explorerPresets" in html
+
+
+def test_explorer_vaade_koik_is_not_a_preset():
+    """``?vaade=koik`` keeps its #754 meaning (force the full graph view) — it
+    does not mark a preset chip active."""
+    html = _html("vaade=koik")
+    assert 'id="explorer-start-panel"' not in html
+    assert "preset-chip active" not in html
+    assert 'data-active-vaade=""' in html
+    assert "window.__explorerVaade" not in html
+
+
+def test_explorer_focus_param_wins_over_vaade_preset():
+    """When both ?focus= and ?vaade=<preset> are present, the focus deep link
+    is the more specific intent — ?vaade= is ignored entirely (no active chip,
+    no preset blob)."""
+    uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+    html = _html(f"focus={uri}&vaade=el-seosed")
+    assert "window.__explorerFocus" in html
+    assert "window.__explorerVaade" not in html
+    assert "preset-chip active" not in html
+    assert 'data-active-vaade=""' in html
+    # The chip group itself is still present (the chips just sit idle).
+    assert 'id="explorer-presets"' in html
+
+
+def test_explorer_search_param_wins_over_vaade_preset():
+    """Same as the ?focus= case: ?search= is the more specific intent, so a
+    co-present ?vaade= is ignored."""
+    html = _html("search=andmekaitse&vaade=kohtupraktika")
+    assert "window.__explorerSearch" in html
+    assert "window.__explorerVaade" not in html
+    assert "preset-chip active" not in html
+
+
+# ---------------------------------------------------------------------------
 # #754 — app/explorer/start_panel.py: the org-scoped data queries
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds **legal-view preset chips** to the Õiguskaart toolbar (`#explorer-toolbar`). Each preset applies a named filter combo — which entity types to show, which relation types to keep, and the timeline mode:

| Slug (`?vaade=`) | Label | Entity types kept | Relation-type keywords | Timeline |
|---|---|---|---|---|
| `kehtiv-oigus` | **Kehtiv õigus** | EnactedLaw, LegalProvision, Section, Division, Chapter, Subdivision, LegalPart | `contains`, `haspart`, `ispartof`, `hasprovision`, `hasinstance` | off |
| `eelnou-mojud` | **Eelnõu mõjud** | DraftLegislation, LegalProvision, EnactedLaw | `reference`, `viit`, `affect`, `mojut`, `conflict`, `vastuolu`, `amend`, `muut` | off |
| `el-seosed` | **EL seosed** | EULegislation, LegalProvision, EnactedLaw | `transpos`, `ulevot`, `directive`, `direktiiv`, `harmonis`, `harmonee`, `implement` | off |
| `kohtupraktika` | **Kohtupraktika** | CourtDecision, EUCourtDecision, LegalProvision | `interpret`, `tolgenda`, `appl`, `kohalda`, `cite`, `viit` | off |
| `ajalugu` | **Ajalugu** | (all types) | `amend`, `muut`, `version`, `versioon`, `supersede`, `asend`, `replace` | **on** |

A preset is just a named bundle of the knobs the explorer already had (category filter on `state.nodes`, an edge-label keyword filter on `state.links`, and the existing temporal "ajaline vaade") — no new filtering engine.

## URL contract

- `?vaade=<known-slug>` → graph view with that preset's chip active + the config handed to `explorer.js` (`window.__explorerVaade` / `window.__explorerPresets`) so the combo is applied on load. Like `?vaade=koik`, it bypasses the #754 start panel (a preset needs the graph to filter).
- Clicking a chip applies it and mirrors the slug into the URL via `history.replaceState` (deep-linkable, no history spam). Clicking the active chip toggles it off.
- Unknown `?vaade=` value → ignored gracefully (renders as a normal cold open).
- `?focus=` / `?search=` are more specific intents — when present, `?vaade=` is ignored entirely (no active chip, no preset blob) so `explorer.js` init doesn't fight the deep link.

## Notes / best-effort calls

- The ontology doesn't expose a clean relation-type grouping, so the keyword lists match on the predicate names `explorer.js` already renders as edge labels, erring toward "show a bit more". Synthetic category→entity (`hasInstance`) and cross-category overview edges are always kept so categories don't become orphan dots after a node filter.
- The `Ajalugu` preset turns on the existing `applyTimelineFilter` (which replaces the graph with its temporal layout) rather than adding a new amendment-relation view — the timeline endpoint has no version-edge data anyway, and `Ajalugu` has no category filter to lose.

## Raw knobs stay put

`Lähtesta paigutus`, `Näita/peida seosenimed`, `Rühmita liigi järgi`, the timeline slider, and `Näita kogu kaarti` remain under the existing `Vaate seaded ▾` `<details>` dropdown — not surfaced at the top level.

## Files

- `app/explorer/pages.py` — `_LEGAL_VIEW_PRESETS` table, preset-chip group in the toolbar, `?vaade=` resolution + JS bridge blobs.
- `app/static/js/explorer.js` — `explorerApplyPreset(slug)`, the preset filter/timeline application, active-chip painting, URL reflection, `init()` deep-link hook.
- `app/static/css/explorer.css` — `.preset-group` / `.preset-chip` styling + active state + responsive wrap.
- `tests/test_explorer_pages.py` — toolbar renders the five chips; each known slug marks its chip active + hands the config to JS; unknown slug ignored; `?vaade=koik` is not a preset; `?focus=` / `?search=` win over `?vaade=`.

## Toolchain

`ruff format` ✓ · `ruff check` ✓ · `pyright` (whole repo) ✓ 0 errors · `pytest` ✓ 2369 passed, 25 skipped · `node --check app/static/js/explorer.js` ✓

Part of epic #762 (design doc `docs/2026-05-12-oiguskaart-evidence-map.md`, workstream C). Builds on #754.

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)