### PR TITLE
feat(explorer): #757 evidence-card detail panel with actions

### DIFF
--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -974,7 +974,16 @@ def explorer_page(req: Request):
             ),
             id="timeline-bar",
         ),
-        # ----- Detail panel (slides in from the right edge of the content) -----
+        # ----- Detail panel — the evidence card (#757; epic #762, design doc
+        # docs/2026-05-12-oiguskaart-evidence-map.md, workstream D). Restructured
+        # from a plain metadata dump into: Allikas (source act/draft/court) ·
+        # Kuupäev / versioon · Seose liik (relation type in legal language) ·
+        # Miks see oluline on (a deterministic one-line note) · Tegevused (four
+        # action buttons). The original element IDs (#panel-title, #panel-meta,
+        # #panel-neighbors, #panel-bookmark-btn, #panel-annotation-btn,
+        # #panel-link, #panel-back, #panel-category, #panel-versions,
+        # #version-history-section) are kept so explorer.js + the panel
+        # annotation MutationObserver above keep working unchanged. -----
         Div(
             # #719: shown only when the page was opened via ?focus= (i.e.
             # from an impact report / analysis) — explorer.js unhides it
@@ -998,6 +1007,42 @@ def explorer_page(req: Request):
                 cls="panel-header",
             ),
             Span(id="panel-category", cls="panel-category"),
+            # #757: Allikas — the parent law / draft / court the entity belongs
+            # to. explorer.js fills #panel-source-row (and hides the section
+            # when there's no derivable source).
+            Div(
+                H4("Allikas"),
+                Div(id="panel-source-row", cls="evidence-source-row"),
+                id="evidence-source-section",
+                cls="meta-section evidence-section",
+                style="display:none;",
+            ),
+            # #757: Kuupäev / versioon — the entity's date / version literals.
+            Div(
+                H4("Kuupäev / versioon"),
+                Div(id="panel-date-info", cls="evidence-date-info"),
+                id="evidence-date-section",
+                cls="meta-section evidence-section",
+                style="display:none;",
+            ),
+            # #757: Seose liik — the relation type, in legal language, to the
+            # previously-focused node (or to whatever opened the panel).
+            Div(
+                H4("Seose liik"),
+                Div(id="panel-relation", cls="evidence-relation"),
+                id="evidence-relation-section",
+                cls="meta-section evidence-section",
+                style="display:none;",
+            ),
+            # #757: Miks see oluline on — a deterministic one-line note derived
+            # from (relation type) + (impact band if known). Not an LLM call.
+            Div(
+                H4("Miks see oluline on"),
+                P(id="panel-why", cls="evidence-why"),
+                id="evidence-why-section",
+                cls="meta-section evidence-section",
+                style="display:none;",
+            ),
             Div(
                 H4("Metaandmed"),
                 Div(id="panel-meta"),
@@ -1016,22 +1061,55 @@ def explorer_page(req: Request):
                 Ul(id="panel-neighbors", cls="neighbor-list"),
                 cls="meta-section",
             ),
-            # ----- Annotation button (entity-level) -----
+            # ----- #757: Tegevused — the evidence card's four action buttons.
+            # 1) Küsi nõustajalt selle kohta — a tiny <form> POSTed to the
+            #    existing /chat/seed single-use-token route (explorer.js fills
+            #    the hidden seed_text/draft_id inputs before showing it).
+            # 2) Ava analüüsikeskuses — link to /analyysikeskus/normi-mojuahel
+            #    ?sisend=<entity-uri> (explorer.js sets the href).
+            # 3) Lisa märkus — reuses #panel-annotation-btn (the entity-level
+            #    AnnotationButton wired by _PANEL_ANNOTATION_SCRIPT above);
+            #    hidden when the entity has no annotation target.
+            # 4) Lisa järjehoidja — the existing #743 XHR bookmark button. -----
             Div(
-                id="panel-annotation-btn",
-                cls="annotation-section",
-                style="display:none;",
-            ),
-            # ----- Bookmark button -----
-            Div(
+                H4("Tegevused"),
+                # (1) Küsi nõustajalt — POST /chat/seed (server-side token).
+                Form(
+                    Hidden(name="seed_text", value="", id="panel-chat-seed-text"),
+                    Hidden(name="draft_id", value="", id="panel-chat-seed-draft"),
+                    Button(
+                        "Küsi nõustajalt selle kohta",
+                        type="submit",
+                        cls="evidence-action evidence-action-chat",
+                    ),
+                    method="post",
+                    action="/chat/seed",
+                    id="panel-chat-seed-form",
+                    cls="evidence-action-form",
+                ),
+                # (2) Ava analüüsikeskuses — /analyysikeskus/normi-mojuahel?sisend=
+                A(
+                    "Ava analüüsikeskuses",
+                    id="panel-analyysikeskus-link",
+                    href="/analyysikeskus/normi-mojuahel",
+                    cls="evidence-action evidence-action-analyysikeskus",
+                ),
+                # (3) Lisa märkus — the entity-level annotation button (filled
+                # by _PANEL_ANNOTATION_SCRIPT; hidden when there's no target).
+                Div(
+                    id="panel-annotation-btn",
+                    cls="annotation-section evidence-action-annotation",
+                    style="display:none;",
+                ),
+                # (4) Lisa järjehoidja — the #743 XHR bookmark button.
                 Button(
-                    "Lisa järjehoidjatesse",
+                    "Lisa järjehoidja",
                     type="button",
                     id="panel-bookmark-btn",
-                    cls="bookmark-btn",
+                    cls="bookmark-btn evidence-action evidence-action-bookmark",
                     onclick="explorerBookmark()",
                 ),
-                cls="bookmark-section",
+                cls="meta-section evidence-actions-section",
             ),
             A(
                 "Ava allikas",

--- a/app/explorer/routes.py
+++ b/app/explorer/routes.py
@@ -28,6 +28,221 @@ _DEFAULT_PAGE_SIZE = 20
 _MAX_PAGE_SIZE = 100
 _MAX_SEARCH_LIMIT = 50
 
+
+# #757: evidence-card detail panel (epic #762, design doc
+# ``docs/2026-05-12-oiguskaart-evidence-map.md`` workstream D).
+#
+# The node detail panel turns into an "evidence card": source / date-version /
+# relation-type-in-legal-language / a deterministic "why it matters" line / four
+# actions. The relation-phrase map and the "why it matters" rule table below are
+# *small static rule tables* — there is deliberately no LLM call here. Both are
+# keyed on the ontology relation's local name (the bit after ``#`` / ``/``),
+# matched case-insensitively so ``estleg:amendsProvision`` and a bare ``amends``
+# both resolve.
+
+#: Ontology relation local-name → Estonian *legal* phrase. The values read as a
+#: legal lawyer would name the relationship ("muudab", "tunnistab kehtetuks",
+#: "võtab üle direktiivi", …) rather than as a raw predicate name. Keys are
+#: lower-cased for the case-insensitive lookup in :func:`relation_legal_phrase`.
+_RELATION_LEGAL_PHRASES: dict[str, str] = {
+    # Amendments / repeals.
+    "amendsprovision": "muudab",
+    "amends": "muudab",
+    "amendedby": "muudetud õigusaktiga",
+    "repealsprovision": "tunnistab kehtetuks",
+    "repeals": "tunnistab kehtetuks",
+    "repealedby": "tunnistatud kehtetuks õigusaktiga",
+    "replaces": "asendab",
+    "replacedby": "asendatud õigusaktiga",
+    # EU transposition / harmonisation.
+    "transposesdirective": "võtab üle direktiivi",
+    "transposes": "võtab üle",
+    "transposedby": "üle võetud õigusaktiga",
+    "implementseu": "rakendab EL õigust",
+    "implementseulaw": "rakendab EL õigust",
+    "harmonisedwith": "on harmoneeritud õigusaktiga",
+    "harmonizedwith": "on harmoneeritud õigusaktiga",
+    # Citations / references.
+    "references": "viitab",
+    "cites": "viitab",
+    "citedby": "viidatud õigusaktiga",
+    "relatedto": "on seotud",
+    "basedon": "tugineb",
+    # Court-decision relations.
+    "appliesprovision": "kohaldab",
+    "applies": "kohaldab",
+    "interpretsprovision": "tõlgendab",
+    "interprets": "tõlgendab",
+    # Structure / membership.
+    "sourceact": "kuulub õigusakti",
+    "partof": "on osa",
+    "hasprovision": "sisaldab sätet",
+    "hastopic": "kuulub teemavaldkonda",
+    "topiccluster": "kuulub teemavaldkonda",
+    "definesconcept": "määratleb mõiste",
+}
+
+
+#: The "why it matters" rule table — a deterministic one-line plain-language
+#: note keyed on ``(relation_local_name_lowercased, impact_band_or_None)``. When
+#: a band is known (a draft-overlay / impact-report context) the high-stakes
+#: bands ("high" / "critical") get a punchier line; otherwise the band-agnostic
+#: variant is used. The phrasing mirrors the Analüüsikeskus ``Tõendid`` rows
+#: ("Tunnistab kehtetuks — eelnõu kaotaks selle sätte."). Anything not in the
+#: table falls through to :func:`why_it_matters`'s generic line.
+_WHY_IT_MATTERS: dict[str, str] = {
+    # repeals — the strongest signal: the provision disappears.
+    "repeals": "Tunnistab kehtetuks — eelnõu kaotaks selle sätte.",
+    "repealsprovision": "Tunnistab kehtetuks — eelnõu kaotaks selle sätte.",
+    "repealedby": "On tunnistatud kehtetuks — see säte ei kehti enam.",
+    # amends — the provision changes.
+    "amends": "Muudab — säte saaks uue redaktsiooni.",
+    "amendsprovision": "Muudab — säte saaks uue redaktsiooni.",
+    "amendedby": "On muudetud — kontrolli kehtivat redaktsiooni.",
+    "replaces": "Asendab — varasem säte kaotaks kehtivuse.",
+    "replacedby": "On asendatud — kontrolli, milline säte praegu kehtib.",
+    # EU transposition.
+    "transposesdirective": "Võtab üle direktiivi — muudatus mõjutab EL nõuete täitmist.",
+    "transposes": "Võtab üle EL õigust — muudatus mõjutab EL nõuete täitmist.",
+    "transposedby": "On üle võetud — muudatus võib mõjutada EL nõuete täitmist.",
+    "implementseu": "Rakendab EL õigust — muudatus mõjutab EL nõuete täitmist.",
+    "implementseulaw": "Rakendab EL õigust — muudatus mõjutab EL nõuete täitmist.",
+    "harmonisedwith": "On harmoneeritud EL õigusaktiga — kontrolli kooskõla.",
+    "harmonizedwith": "On harmoneeritud EL õigusaktiga — kontrolli kooskõla.",
+    # citations / references.
+    "references": "Viitab — eelnõu tugineb sellele sättele.",
+    "cites": "Viitab — eelnõu tugineb sellele sättele.",
+    "citedby": "Viidatakse — teised aktid tuginevad sellele sättele.",
+    "relatedto": "On seotud — muudatus võib mõjutada ka seda üksust.",
+    "basedon": "Tugineb — kontrolli, kas alus jääb kehtima.",
+    # court decisions.
+    "applies": "Kohaldab — kohtupraktika tugineb sellele sättele.",
+    "appliesprovision": "Kohaldab — kohtupraktika tugineb sellele sättele.",
+    "interprets": "Tõlgendab — kohtupraktika sisustab selle sätte tähenduse.",
+    "interpretsprovision": "Tõlgendab — kohtupraktika sisustab selle sätte tähenduse.",
+}
+
+#: Estonian labels for impact bands used by :func:`why_it_matters` — kept here
+#: (rather than imported from :mod:`app.docs.impact.scoring`) so the explorer
+#: API has no dependency on the document-analysis layer for this small rule.
+_BAND_LABELS_ET: dict[str, str] = {
+    "low": "madal mõju",
+    "medium": "keskmine mõju",
+    "high": "kõrge risk",
+    "critical": "kriitiline mõju",
+}
+
+
+def _relation_key(name_or_uri: str) -> str:
+    """Reduce a relation IRI / prefixed name / bare name to its lookup key.
+
+    Strips a namespace (``…#local`` / ``…/local`` / ``prefix:local``) and
+    lower-cases the result so the rule tables can be keyed once.
+    """
+    if not name_or_uri:
+        return ""
+    s = str(name_or_uri).strip()
+    if "#" in s:
+        s = s.rsplit("#", 1)[-1]
+    elif "/" in s:
+        s = s.rsplit("/", 1)[-1]
+    if ":" in s:
+        s = s.rsplit(":", 1)[-1]
+    return s.lower()
+
+
+def relation_legal_phrase(name_or_uri: str) -> str:
+    """Return the Estonian legal phrase for a relation, or its short name.
+
+    ``relation_legal_phrase("estleg:amendsProvision")`` → ``"muudab"``,
+    ``relation_legal_phrase("repeals")`` → ``"tunnistab kehtetuks"``. Unknown
+    relations fall back to the bare local name so the panel never shows an
+    empty "Seose liik" slot.
+    """
+    key = _relation_key(name_or_uri)
+    if not key:
+        return ""
+    phrase = _RELATION_LEGAL_PHRASES.get(key)
+    if phrase:
+        return phrase
+    # Fallback: the short name from the original input, un-mangled by the
+    # lower-casing the key needed.
+    s = str(name_or_uri).strip()
+    if "#" in s:
+        s = s.rsplit("#", 1)[-1]
+    elif "/" in s:
+        s = s.rsplit("/", 1)[-1]
+    if ":" in s:
+        s = s.rsplit(":", 1)[-1]
+    return s
+
+
+def why_it_matters(name_or_uri: str, band: str | None = None) -> str:
+    """Return a one-line plain-language "miks see oluline on" note.
+
+    Deterministic — a lookup in :data:`_WHY_IT_MATTERS` keyed on the relation's
+    local name, with the optional :data:`~app.docs.impact.scoring.ImpactBand`
+    appended for context when it's a high-stakes band. There is no LLM call.
+
+    Examples::
+
+        why_it_matters("repeals", "critical")
+        # → "Tunnistab kehtetuks — eelnõu kaotaks selle sätte. (kriitiline mõju)"
+        why_it_matters("amendsProvision")
+        # → "Muudab — säte saaks uue redaktsiooni."
+
+    Unknown relations get a generic line built from
+    :func:`relation_legal_phrase`.
+    """
+    key = _relation_key(name_or_uri)
+    base = _WHY_IT_MATTERS.get(key)
+    if not base:
+        phrase = relation_legal_phrase(name_or_uri)
+        if phrase:
+            base = f"Seos: {phrase}. Muudatus võib mõjutada seda üksust."
+        else:
+            base = "Muudatus võib mõjutada seda üksust."
+    band_key = (band or "").strip().lower()
+    if band_key in ("high", "critical"):
+        return f"{base} ({_BAND_LABELS_ET.get(band_key, band_key)})"
+    return base
+
+
+# Metadata predicate local-name → Estonian "kuupäev / versioon" label. Used to
+# pull a date / version line out of an entity's literal metadata for the
+# evidence card's "Kuupäev / versioon" slot. Matched case-insensitively.
+_DATE_METADATA_LABELS_ET: dict[str, str] = {
+    "validfrom": "Jõustunud",
+    "validuntil": "Kehtetu alates",
+    "dateadopted": "Vastu võetud",
+    "vastuvõtmiskuupäev": "Vastu võetud",
+    "datepublished": "Avaldatud",
+    "avaldamiskuupäev": "Avaldatud",
+    "dateenacted": "Jõustunud",
+    "jõustumiskuupäev": "Jõustunud",
+    "decisiondate": "Otsuse kuupäev",
+    "lahendikuupäev": "Otsuse kuupäev",
+    "version": "Redaktsioon",
+    "versioon": "Redaktsioon",
+    "redaktsioon": "Redaktsioon",
+    "casenumber": "Kohtuasja number",
+    "celexnumber": "CELEX-number",
+}
+
+# Metadata predicate local-name → "Allikas" label, for relations that point at
+# the parent act / law / court the entity belongs to. The companion
+# ``_SOURCE_RELATIONS`` set drives which *outgoing* relations are treated as
+# "this entity's source".
+_SOURCE_RELATIONS_ET: dict[str, str] = {
+    "sourceact": "Õigusakt",
+    "partof": "Kuulub",
+    "decidedby": "Kohus",
+    "court": "Kohus",
+    "fromcourt": "Kohus",
+    "topiccluster": "Teemavaldkond",
+    "hastopic": "Teemavaldkond",
+}
+
 # Shared client instance (created lazily so env vars are read at first use)
 _client: SparqlClient | None = None
 
@@ -160,8 +375,64 @@ def explorer_category(req: Request, name: str) -> JSONResponse:
     )
 
 
+def _build_date_info(metadata: dict[str, str]) -> list[dict[str, str]]:
+    """#757: extract the evidence card's "Kuupäev / versioon" rows from metadata.
+
+    Returns a list of ``{"label": <Estonian label>, "value": <literal>}`` for
+    every metadata predicate whose local name maps in
+    :data:`_DATE_METADATA_LABELS_ET` and that has a non-empty value. Order
+    follows :data:`_DATE_METADATA_LABELS_ET` (jõustunud/vastu võetud/… first).
+    """
+    date_info: list[dict[str, str]] = []
+    # Lower-case keys → original values for the case-insensitive lookup.
+    lc_meta = {k.lower(): v for k, v in metadata.items() if v}
+    seen_labels: set[str] = set()
+    for key, label in _DATE_METADATA_LABELS_ET.items():
+        val = lc_meta.get(key)
+        if val and label not in seen_labels:
+            date_info.append({"label": label, "value": str(val)})
+            seen_labels.add(label)
+    return date_info
+
+
+def _build_source(outgoing: list[dict[str, str]]) -> dict[str, str] | None:
+    """#757: derive the evidence card's "Allikas" (parent act / law / court).
+
+    Scans the entity's outgoing relations for the first one whose local name is
+    in :data:`_SOURCE_RELATIONS_ET` (``sourceAct``, ``partOf``, ``decidedBy``,
+    …) and returns ``{"uri", "label", "relationLabel", "kindLabel"}``. Returns
+    ``None`` when the entity has no such relation (e.g. a top-level act).
+    """
+    for rel in outgoing:
+        key = _relation_key(rel.get("predicateName") or rel.get("predicate") or "")
+        kind_label = _SOURCE_RELATIONS_ET.get(key)
+        if kind_label:
+            obj = rel.get("object", "")
+            if not obj:
+                continue
+            label = rel.get("objectLabel") or ""
+            if not label:
+                # Fall back to the URI fragment so the card always has text.
+                label = obj.rsplit("#", 1)[-1] if "#" in obj else obj.rsplit("/", 1)[-1]
+            return {
+                "uri": obj,
+                "label": label,
+                "relationLabel": relation_legal_phrase(key),
+                "kindLabel": kind_label,
+            }
+    return None
+
+
 def explorer_entity(req: Request, entity_id: str) -> JSONResponse:
-    """GET /api/explorer/entity/{entity_id} -- entity detail + neighbors."""
+    """GET /api/explorer/entity/{entity_id} -- entity detail + neighbors.
+
+    #757: the response also carries the *evidence-card* fields the detail panel
+    renders — ``source`` (the parent act / law / court the entity belongs to),
+    ``dateInfo`` (the entity's date / version literals, Estonian-labelled), and
+    a ``predicateLabel`` ("seose liik" in legal language) + ``whyText`` ("miks
+    see oluline on") on every outgoing / incoming relation. These are computed
+    from small static rule tables — there is no LLM call.
+    """
     entity_uri = unquote(entity_id)
     if not _validate_uri(entity_uri):
         return JSONResponse(
@@ -189,6 +460,11 @@ def explorer_entity(req: Request, entity_id: str) -> JSONResponse:
             {
                 "predicate": pred,
                 "predicateName": short_pred,
+                # #757: the relation type in legal language + the deterministic
+                # "why it matters" line, so the detail panel's evidence card
+                # need not re-derive them client-side.
+                "predicateLabel": relation_legal_phrase(short_pred),
+                "whyText": why_it_matters(short_pred),
                 "object": row.get("object", ""),
                 "objectLabel": row.get("objectLabel", ""),
             }
@@ -206,6 +482,10 @@ def explorer_entity(req: Request, entity_id: str) -> JSONResponse:
                 "subjectLabel": row.get("subjectLabel", ""),
                 "predicate": pred,
                 "predicateName": short_pred,
+                # #757: same pair on the incoming side (e.g. "this provision is
+                # repealed by …").
+                "predicateLabel": relation_legal_phrase(short_pred),
+                "whyText": why_it_matters(short_pred),
             }
         )
 
@@ -216,6 +496,9 @@ def explorer_entity(req: Request, entity_id: str) -> JSONResponse:
                 "metadata": metadata,
                 "outgoing": outgoing,
                 "incoming": incoming,
+                # #757 — evidence-card extras.
+                "source": _build_source(outgoing),
+                "dateInfo": _build_date_info(metadata),
             },
             "meta": {},
         }

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -379,6 +379,68 @@ summary.ctrl-settings-summary::-webkit-details-marker { display: none; }
 .version-label { color: #cbd5e1; }
 .version-empty { color: #64748b; font-size: 12px; font-style: italic; }
 
+/* #757 — evidence-card detail panel (epic #762, design doc
+ * docs/2026-05-12-oiguskaart-evidence-map.md, workstream D). The node detail
+ * panel becomes an "evidence card": Allikas (source act/draft/court) · Kuupäev
+ * / versioon · Seose liik (relation type in legal language) · Miks see oluline
+ * on (a deterministic one-line note) · Tegevused (four action buttons). Each
+ * .evidence-section is shown/hidden by explorer.js depending on whether the
+ * entity has that datum. */
+#detail-panel .evidence-section { margin-bottom: 18px; }
+
+/* Allikas row: "<Kind>: <linked source label>". */
+#detail-panel .evidence-source-row { font-size: 12px; line-height: 1.5; }
+#detail-panel .evidence-source-kind { color: #64748b; }
+#detail-panel .evidence-source-link {
+  color: #38bdf8; text-decoration: none;
+  border-bottom: 1px solid rgba(56, 189, 248, 0.3);
+  word-break: break-word;
+}
+#detail-panel .evidence-source-link:hover { border-bottom-color: #38bdf8; }
+
+/* Kuupäev / versioon: a small key→value list. */
+#detail-panel .evidence-date-row {
+  display: flex; gap: 8px; padding: 3px 0;
+  font-size: 12px; border-bottom: 1px solid rgba(100, 116, 139, 0.1);
+}
+#detail-panel .evidence-date-label { color: #64748b; min-width: 110px; flex-shrink: 0; }
+#detail-panel .evidence-date-value { color: #cbd5e1; word-break: break-word; }
+
+/* Seose liik: the relation type in legal language, set apart as a chip. */
+#detail-panel .evidence-relation {
+  font-size: 13px; color: #e2e8f0; font-weight: 600;
+  background: rgba(56, 189, 248, 0.08);
+  border-left: 3px solid rgba(56, 189, 248, 0.5);
+  padding: 6px 10px; border-radius: 4px;
+}
+
+/* Miks see oluline on: the plain-language note. */
+#detail-panel .evidence-why {
+  font-size: 12px; color: #cbd5e1; line-height: 1.5; margin: 0;
+  background: rgba(100, 116, 139, 0.08);
+  padding: 8px 10px; border-radius: 4px;
+}
+
+/* Tegevused: stack the four action buttons full-width with a small gap. */
+#detail-panel .evidence-actions-section { margin-bottom: 14px; }
+#detail-panel .evidence-action-form { margin: 0 0 8px; }
+#detail-panel .evidence-action {
+  display: block; width: 100%; box-sizing: border-box;
+  text-align: center; font-size: 12px; cursor: pointer;
+  padding: 8px 16px; border-radius: 8px; margin-bottom: 8px;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  background: rgba(56, 189, 248, 0.1); color: #38bdf8;
+  text-decoration: none; transition: background 0.15s, border-color 0.15s;
+}
+#detail-panel .evidence-action:hover { background: rgba(56, 189, 248, 0.2); }
+/* The bookmark button keeps its existing .bookmark-btn rules (incl. the
+ * green .bookmarked state) — .evidence-action just adds the shared box model;
+ * .bookmark-btn's own margin-bottom-less rule is overridden above. */
+#detail-panel .evidence-action-annotation { margin-bottom: 8px; }
+#detail-panel .evidence-action-annotation .annotation-button {
+  width: 100%; text-align: center;
+}
+
 /* ------- #754: contextual start panel (cold-open overlay) -------
  * A "cold" /explorer open (no ?focus / ?draft / ?search / ?vaade=koik)
  * renders this panel over the (idle) graph chrome instead of auto-loading

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -822,6 +822,10 @@ async function expandCategory(categoryKey) {
 }
 
 async function showEntityDetail(d) {
+  // #757: remember the entity the panel was showing *before* this click, so
+  // the evidence card's "Seose liik" slot can name the relation from the
+  // previously-focused node to the newly-selected one.
+  const prevEntity = state.selectedEntity;
   state.selectedEntity = d.uri || d.id;
   state.view = 'entity';
   updateBreadcrumb();
@@ -837,9 +841,17 @@ async function showEntityDetail(d) {
   const panelLink = document.getElementById('panel-link');
 
   panelTitle.textContent = d.label;
+  // #757: stash the entity URI on the title element so _PANEL_ANNOTATION_SCRIPT
+  // (the MutationObserver wiring the entity-level AnnotationButton) picks the
+  // real URI rather than the human-readable label.
+  panelTitle.dataset.entityUri = d.uri || d.id || '';
   panelCategory.textContent = CATEGORY_LABELS[d.category] || d.category;
   panelCategory.style.background = colorFor(d.category) + '22';
   panelCategory.style.color = colorFor(d.category);
+
+  // #757: the evidence-card slots (Allikas / Kuupäev-versioon / Seose liik /
+  // Miks see oluline on) + the four action buttons.
+  populateEvidenceCard(d, detail ? detail.entity : null, prevEntity);
 
   // Metadata
   panelMeta.innerHTML = '';
@@ -911,10 +923,11 @@ async function showEntityDetail(d) {
   state.selectedEntityData = detail ? detail.entity : null;
   renderVersionHistory(detail ? detail.entity : null);
 
-  // Reset bookmark button
+  // Reset bookmark button (#757: relabelled "Lisa j\u00e4rjehoidja" to fit the
+  // evidence card's "Tegevused" group; the XHR path itself is unchanged).
   const bookmarkBtn = document.getElementById('panel-bookmark-btn');
   if (bookmarkBtn) {
-    bookmarkBtn.textContent = 'Lisa j\u00e4rjehoidjatesse';
+    bookmarkBtn.textContent = 'Lisa j\u00e4rjehoidja';
     bookmarkBtn.classList.remove('bookmarked');
   }
 
@@ -933,6 +946,200 @@ async function showEntityDetail(d) {
 
 function closeDetail() {
   detailPanel.classList.remove('open');
+}
+
+// ---------------------------------------------------------------------------
+// #757: evidence-card detail panel (epic #762, design doc
+// docs/2026-05-12-oiguskaart-evidence-map.md, workstream D).
+//
+// Fills the panel's evidence-card slots — Allikas (source act / draft / court)
+// · Kuupäev / versioon · Seose liik (relation type in legal language) · Miks
+// see oluline on (a deterministic one-line note) — and wires the four action
+// buttons (Küsi nõustajalt → POST /chat/seed · Ava analüüsikeskuses →
+// /analyysikeskus/normi-mojuahel?sisend=<uri> · Lisa märkus → the entity-level
+// annotation button · Lisa järjehoidja → the #743 XHR bookmark button).
+//
+// The relation-phrase + "why it matters" strings come from the entity-detail
+// API (which derives them from a small static rule table — no LLM call); this
+// function only picks the right one and renders it.
+// ---------------------------------------------------------------------------
+
+// The optional ?draft=<uuid> on /explorer — threaded into the "Küsi nõustajalt"
+// form so the new conversation picks up the draft's impact context. UUID-only,
+// so exposing it via location.search is harmless.
+function _explorerDraftParam() {
+  try {
+    var d = new URLSearchParams(window.location.search).get('draft') || '';
+    return /^[0-9a-fA-F-]{1,64}$/.test(d) ? d : '';
+  } catch (e) {
+    return '';
+  }
+}
+
+function _showEvidenceSection(sectionId, show) {
+  var el = document.getElementById(sectionId);
+  if (el) el.style.display = show ? '' : 'none';
+}
+
+// Append a <span class="evidence-date-label">…</span><span class="evidence-date-value">…</span>
+// pair to a container using DOM methods (no innerHTML).
+function _appendKvRow(container, rowClass, keyClass, keyText, valClass, valText) {
+  var row = document.createElement('div');
+  row.className = rowClass;
+  var k = document.createElement('span');
+  k.className = keyClass;
+  k.textContent = keyText;
+  var v = document.createElement('span');
+  v.className = valClass;
+  v.textContent = valText;
+  row.appendChild(k);
+  row.appendChild(v);
+  container.appendChild(row);
+}
+
+// Find the relation (predicateLabel + whyText) from the previously-focused
+// entity to the now-selected one, by scanning the new entity's incoming /
+// outgoing relations for one whose other endpoint is `prevEntity`.
+function _relationToPrev(entityData, prevEntity, selfUri) {
+  if (!entityData || !prevEntity || prevEntity === selfUri) return null;
+  var incoming = Array.isArray(entityData.incoming) ? entityData.incoming : [];
+  for (var i = 0; i < incoming.length; i++) {
+    if (incoming[i] && incoming[i].subject === prevEntity) {
+      return {
+        label: incoming[i].predicateLabel || incoming[i].predicateName || '',
+        why: incoming[i].whyText || '',
+        otherLabel: incoming[i].subjectLabel || '',
+      };
+    }
+  }
+  var outgoing = Array.isArray(entityData.outgoing) ? entityData.outgoing : [];
+  for (var j = 0; j < outgoing.length; j++) {
+    if (outgoing[j] && outgoing[j].object === prevEntity) {
+      return {
+        label: outgoing[j].predicateLabel || outgoing[j].predicateName || '',
+        why: outgoing[j].whyText || '',
+        otherLabel: outgoing[j].objectLabel || '',
+      };
+    }
+  }
+  return null;
+}
+
+// Pick a "primary" relation for the entity when there's no previously-focused
+// node to relate to — the first outgoing relation with a known legal phrase
+// (so a freshly-opened ?focus= panel still shows *something* sensible).
+function _primaryRelation(entityData) {
+  if (!entityData) return null;
+  var outgoing = Array.isArray(entityData.outgoing) ? entityData.outgoing : [];
+  // Prefer relations the rule table actually phrases (predicateLabel + whyText
+  // present) and skip the rdf:type / rdfs:label noise.
+  for (var i = 0; i < outgoing.length; i++) {
+    var rel = outgoing[i];
+    if (!rel) continue;
+    var name = (rel.predicateName || '').toLowerCase();
+    if (name === 'type' || name === 'label') continue;
+    if (rel.predicateLabel && rel.whyText) {
+      return {
+        label: rel.predicateLabel,
+        why: rel.whyText,
+        otherLabel: rel.objectLabel || '',
+      };
+    }
+  }
+  return null;
+}
+
+function populateEvidenceCard(d, entityData, prevEntity) {
+  var selfUri = d.uri || d.id || '';
+
+  // ---- Allikas (source: parent act / draft / court) -------------------------
+  var sourceRow = document.getElementById('panel-source-row');
+  var source = entityData && entityData.source ? entityData.source : null;
+  if (sourceRow && source && source.uri) {
+    while (sourceRow.firstChild) sourceRow.removeChild(sourceRow.firstChild);
+    var kind = document.createElement('span');
+    kind.className = 'evidence-source-kind';
+    kind.textContent = (source.kindLabel || 'Allikas') + ': ';
+    var link = document.createElement('a');
+    link.className = 'evidence-source-link';
+    // Deep-link the source itself into the map (the existing ?focus= contract).
+    link.href = '/explorer?focus=' + encodeURIComponent(source.uri);
+    link.textContent = source.label || source.uri;
+    sourceRow.appendChild(kind);
+    sourceRow.appendChild(link);
+    _showEvidenceSection('evidence-source-section', true);
+  } else {
+    _showEvidenceSection('evidence-source-section', false);
+  }
+
+  // ---- Kuupäev / versioon ---------------------------------------------------
+  var dateInfoEl = document.getElementById('panel-date-info');
+  var dateInfo = (entityData && Array.isArray(entityData.dateInfo)) ? entityData.dateInfo : [];
+  if (dateInfoEl && dateInfo.length) {
+    while (dateInfoEl.firstChild) dateInfoEl.removeChild(dateInfoEl.firstChild);
+    dateInfo.forEach(function(di) {
+      _appendKvRow(
+        dateInfoEl, 'evidence-date-row',
+        'evidence-date-label', String(di.label || ''),
+        'evidence-date-value', String(di.value || '')
+      );
+    });
+    _showEvidenceSection('evidence-date-section', true);
+  } else {
+    _showEvidenceSection('evidence-date-section', false);
+  }
+
+  // ---- Seose liik + Miks see oluline on -------------------------------------
+  var rel = _relationToPrev(entityData, prevEntity, selfUri) || _primaryRelation(entityData);
+  var relationEl = document.getElementById('panel-relation');
+  var whyEl = document.getElementById('panel-why');
+  if (rel && rel.label) {
+    if (relationEl) {
+      relationEl.textContent = rel.otherLabel ? (rel.label + ' — ' + rel.otherLabel) : rel.label;
+    }
+    _showEvidenceSection('evidence-relation-section', true);
+  } else {
+    _showEvidenceSection('evidence-relation-section', false);
+  }
+  if (rel && rel.why) {
+    if (whyEl) whyEl.textContent = rel.why;
+    _showEvidenceSection('evidence-why-section', true);
+  } else {
+    _showEvidenceSection('evidence-why-section', false);
+  }
+
+  // ---- Tegevused (action buttons) -------------------------------------------
+  // (1) Küsi nõustajalt selle kohta — fill the /chat/seed form's hidden inputs.
+  var seedTextEl = document.getElementById('panel-chat-seed-text');
+  var seedDraftEl = document.getElementById('panel-chat-seed-draft');
+  if (seedTextEl) {
+    var label = d.label || selfUri;
+    var seedParts = ['«' + label + '»'];
+    if (rel && rel.label && rel.otherLabel) {
+      seedParts.push(rel.label + ' «' + rel.otherLabel + '»');
+    } else if (rel && rel.label) {
+      seedParts.push(rel.label);
+    }
+    var finding = seedParts.join(' ');
+    seedTextEl.value = 'Selgita seda õiguskaardi leidu: ' + finding +
+      '. Mida peaksin selle puhul tähele panema?';
+  }
+  if (seedDraftEl) seedDraftEl.value = _explorerDraftParam();
+
+  // (2) Ava analüüsikeskuses — /analyysikeskus/normi-mojuahel?sisend=<uri>.
+  var akLink = document.getElementById('panel-analyysikeskus-link');
+  if (akLink) {
+    if (selfUri && selfUri.indexOf('http') === 0) {
+      akLink.href = '/analyysikeskus/normi-mojuahel?sisend=' + encodeURIComponent(selfUri);
+      akLink.style.display = '';
+    } else {
+      akLink.style.display = 'none';
+    }
+  }
+  // (3) Lisa märkus — handled by _PANEL_ANNOTATION_SCRIPT (it watches
+  //     #panel-title and (un)hides #panel-annotation-btn). Nothing to do here.
+  // (4) Lisa järjehoidja — the #743 XHR button; its reset happens below in
+  //     showEntityDetail() (kept where it was).
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -490,6 +490,84 @@ def test_explorer_search_param_wins_over_vaade_preset():
 
 
 # ---------------------------------------------------------------------------
+# #757 — evidence-card detail panel (epic #762, design doc workstream D)
+# ---------------------------------------------------------------------------
+
+
+def test_explorer_detail_panel_renders_evidence_card_structure():
+    """The node detail panel exposes the evidence-card slots — Allikas,
+    Kuupäev / versioon, Seose liik, "Miks see oluline on" — plus the heading
+    of the Tegevused (actions) group. explorer.js fills + (un)hides each one."""
+    # ?focus= still renders the detail panel DOM (explorer.js unhides it).
+    uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+    html = _html(f"focus={uri}")
+    assert 'id="detail-panel"' in html
+    # The four evidence-card section containers + their fill targets.
+    assert 'id="evidence-source-section"' in html
+    assert 'id="panel-source-row"' in html
+    assert 'id="evidence-date-section"' in html
+    assert 'id="panel-date-info"' in html
+    assert 'id="evidence-relation-section"' in html
+    assert 'id="panel-relation"' in html
+    assert 'id="evidence-why-section"' in html
+    assert 'id="panel-why"' in html
+    # The Estonian section headings.
+    assert "Allikas" in html
+    assert "Kuupäev / versioon" in html
+    assert "Seose liik" in html
+    assert "Miks see oluline on" in html
+    assert "Tegevused" in html
+    # The evidence sections start hidden (explorer.js shows the ones with data).
+    assert "evidence-section" in html
+    assert "display:none" in html
+
+
+def test_explorer_detail_panel_has_four_actions_wired():
+    """The evidence card's four actions point at the right places:
+    1) Küsi nõustajalt → POST /chat/seed (the single-use pending_chat_seed flow);
+    2) Ava analüüsikeskuses → /analyysikeskus/normi-mojuahel;
+    3) Lisa märkus → the entity-level annotation button (#panel-annotation-btn);
+    4) Lisa järjehoidja → the #743 XHR bookmark button (#panel-bookmark-btn)."""
+    html = _html("focus=https://data.riik.ee/ontology/estleg#KarS")
+    # (1) Küsi nõustajalt selle kohta — a <form method=post action=/chat/seed>
+    # with the seed_text + draft_id hidden inputs explorer.js fills in.
+    assert "Küsi nõustajalt selle kohta" in html
+    assert 'id="panel-chat-seed-form"' in html
+    assert 'action="/chat/seed"' in html
+    assert 'name="seed_text"' in html
+    assert 'name="draft_id"' in html
+    # (2) Ava analüüsikeskuses — links to the Normi mõjuahel workflow (the
+    # ?sisend=<uri> is appended client-side by explorer.js).
+    assert "Ava analüüsikeskuses" in html
+    assert 'id="panel-analyysikeskus-link"' in html
+    assert "/analyysikeskus/normi-mojuahel" in html
+    # (3) Lisa märkus — the entity-level annotation slot, filled by
+    # _PANEL_ANNOTATION_SCRIPT (which POSTs annotations the standard way).
+    assert 'id="panel-annotation-btn"' in html
+    # (4) Lisa järjehoidja — the existing XHR bookmark button (kept working).
+    assert "Lisa järjehoidja" in html
+    assert 'id="panel-bookmark-btn"' in html
+    assert 'onclick="explorerBookmark()"' in html
+    # The bookmark XHR endpoint is still the one the #743 path uses (the JS
+    # POSTs /api/bookmarks with X-Requested-With) — assert the JS bundle is
+    # still wired in (the actual fetch lives in explorer.js).
+    assert "/static/js/explorer.js" in html
+
+
+def test_explorer_detail_panel_keeps_back_link_and_metadata_sections():
+    """The evidence-card restyle is additive — the panel still carries the
+    #719 back link, the metadata dump, the version history, and the relations
+    list (so explorer.js' existing populate logic keeps working)."""
+    html = _html("focus=https://data.riik.ee/ontology/estleg#KarS")
+    assert 'id="panel-back"' in html
+    assert 'id="panel-meta"' in html
+    assert 'id="version-history-section"' in html
+    assert 'id="panel-neighbors"' in html
+    assert 'id="panel-title"' in html
+    assert 'id="panel-link"' in html
+
+
+# ---------------------------------------------------------------------------
 # #754 — app/explorer/start_panel.py: the org-scoped data queries
 # ---------------------------------------------------------------------------
 

--- a/tests/test_explorer_routes.py
+++ b/tests/test_explorer_routes.py
@@ -669,3 +669,183 @@ class TestExplorerDraftOverlay:
         assert call_counter["n"] == 1, (
             "overlay cache should have absorbed the second request (#475)"
         )
+
+
+# ---------------------------------------------------------------------------
+# #757 — evidence-card detail panel: relation-phrase map + "why it matters"
+# rule table + the enhanced entity-detail payload (epic #762 workstream D)
+# ---------------------------------------------------------------------------
+
+
+class TestRelationLegalPhrase:
+    """The relation IRI / short-name → Estonian legal phrase mapping."""
+
+    def test_common_relations_map_to_legal_phrases(self):
+        from app.explorer.routes import relation_legal_phrase
+
+        assert relation_legal_phrase("estleg:amendsProvision") == "muudab"
+        assert relation_legal_phrase("amendsProvision") == "muudab"
+        assert relation_legal_phrase("repealsProvision") == "tunnistab kehtetuks"
+        assert relation_legal_phrase("transposesDirective") == "võtab üle direktiivi"
+        assert relation_legal_phrase("references") == "viitab"
+        assert relation_legal_phrase("appliesProvision") == "kohaldab"
+        assert relation_legal_phrase("interpretsProvision") == "tõlgendab"
+
+    def test_full_iri_is_reduced_to_local_name(self):
+        from app.explorer.routes import relation_legal_phrase
+
+        iri = "https://data.riik.ee/ontology/estleg#amendsProvision"
+        assert relation_legal_phrase(iri) == "muudab"
+
+    def test_unknown_relation_falls_back_to_short_name(self):
+        from app.explorer.routes import relation_legal_phrase
+
+        # Not in the table → the bare local name, not an empty string.
+        assert relation_legal_phrase("estleg:somethingNobodyMapped") == "somethingNobodyMapped"
+        assert relation_legal_phrase("") == ""
+
+
+class TestWhyItMatters:
+    """The deterministic 'miks see oluline on' rule table."""
+
+    def test_repeals_critical_produces_expected_line(self):
+        from app.explorer.routes import why_it_matters
+
+        line = why_it_matters("repeals", "critical")
+        assert line.startswith("Tunnistab kehtetuks — eelnõu kaotaks selle sätte.")
+        # The high-stakes band is appended in parentheses.
+        assert "kriitiline" in line
+
+    def test_amends_without_band_is_band_agnostic(self):
+        from app.explorer.routes import why_it_matters
+
+        line = why_it_matters("amendsProvision")
+        assert line == "Muudab — säte saaks uue redaktsiooni."
+        # No parenthetical when the band is unknown.
+        assert "(" not in line
+
+    def test_transposes_directive_high_band(self):
+        from app.explorer.routes import why_it_matters
+
+        line = why_it_matters("transposesDirective", "high")
+        assert line.startswith("Võtab üle direktiivi —")
+        assert "kõrge risk" in line
+
+    def test_unknown_relation_gets_generic_line(self):
+        from app.explorer.routes import why_it_matters
+
+        # Unknown but mappable relation name → a generic but non-empty note.
+        line = why_it_matters("relatedTo")
+        assert "On seotud" in line
+        # Truly unknown predicate → still non-empty.
+        fallback = why_it_matters("estleg:somethingNobodyMapped")
+        assert fallback
+        assert "mõjutada" in fallback
+
+
+class TestEntityDetailEvidenceFields:
+    """``GET /api/explorer/entity/{uri}`` carries the evidence-card extras."""
+
+    @patch("app.auth.middleware._get_provider")
+    def test_relations_carry_legal_phrase_and_why_text(self, mock_get_provider: MagicMock):
+        mock_get_provider.return_value = _api_provider()
+        with patch("app.explorer.routes._get_client") as mock_get:
+            mock_client = mock_get.return_value
+            mock_client.query.side_effect = _mock_query
+            resp = _api_client().get(
+                "/api/explorer/entity/https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23Act_1"
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        # Every outgoing / incoming relation gets predicateLabel + whyText.
+        for rel in data["outgoing"]:
+            assert "predicateLabel" in rel
+            assert "whyText" in rel
+        for rel in data["incoming"]:
+            assert "predicateLabel" in rel
+            assert "whyText" in rel
+        # The incoming mock relation is estleg:sourceAct → its legal phrase.
+        assert any(
+            rel.get("predicateName") == "sourceAct"
+            and rel.get("predicateLabel") == "kuulub õigusakti"
+            for rel in data["incoming"]
+        )
+
+    @patch("app.auth.middleware._get_provider")
+    def test_payload_has_source_and_date_info_keys(self, mock_get_provider: MagicMock):
+        mock_get_provider.return_value = _api_provider()
+        with patch("app.explorer.routes._get_client") as mock_get:
+            mock_client = mock_get.return_value
+            mock_client.query.side_effect = _mock_query
+            resp = _api_client().get(
+                "/api/explorer/entity/https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23Act_1"
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        # The evidence-card extras are always present (may be null / empty).
+        assert "source" in data
+        assert "dateInfo" in data
+        assert isinstance(data["dateInfo"], list)
+
+    @patch("app.auth.middleware._get_provider")
+    def test_source_is_derived_from_source_act_relation(self, mock_get_provider: MagicMock):
+        mock_get_provider.return_value = _api_provider()
+
+        def _mock_with_source(sparql, bindings=None, uri_bindings=None):
+            if "?predicate ?object" in sparql:
+                return [
+                    {
+                        "predicate": "https://data.riik.ee/ontology/estleg#sourceAct",
+                        "object": "https://data.riik.ee/ontology/estleg#KarS",
+                        "objectLabel": "Karistusseadustik",
+                    }
+                ]
+            return _mock_query(sparql, bindings, uri_bindings)
+
+        with patch("app.explorer.routes._get_client") as mock_get:
+            mock_client = mock_get.return_value
+            mock_client.query.side_effect = _mock_with_source
+            resp = _api_client().get(
+                "/api/explorer/entity/https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23KarS_par_1"
+            )
+
+        assert resp.status_code == 200
+        source = resp.json()["data"]["source"]
+        assert source is not None
+        assert source["uri"] == "https://data.riik.ee/ontology/estleg#KarS"
+        assert source["label"] == "Karistusseadustik"
+        assert source["kindLabel"] == "Õigusakt"
+        assert source["relationLabel"] == "kuulub õigusakti"
+
+    @patch("app.auth.middleware._get_provider")
+    def test_date_info_is_derived_from_metadata(self, mock_get_provider: MagicMock):
+        mock_get_provider.return_value = _api_provider()
+
+        def _mock_with_dates(sparql, bindings=None, uri_bindings=None):
+            if "isLiteral" in sparql:
+                return [
+                    {
+                        "predicate": "https://data.riik.ee/ontology/estleg#validFrom",
+                        "value": "1993-12-01",
+                    },
+                    {
+                        "predicate": "https://data.riik.ee/ontology/estleg#caseNumber",
+                        "value": "3-1-1-5-13",
+                    },
+                ]
+            return _mock_query(sparql, bindings, uri_bindings)
+
+        with patch("app.explorer.routes._get_client") as mock_get:
+            mock_client = mock_get.return_value
+            mock_client.query.side_effect = _mock_with_dates
+            resp = _api_client().get(
+                "/api/explorer/entity/https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23Act_1"
+            )
+
+        assert resp.status_code == 200
+        date_info = resp.json()["data"]["dateInfo"]
+        labels = {row["label"]: row["value"] for row in date_info}
+        assert labels.get("Jõustunud") == "1993-12-01"
+        assert labels.get("Kohtuasja number") == "3-1-1-5-13"


### PR DESCRIPTION
## What

Turns the Õiguskaart node detail panel (`#detail-panel`) into an **evidence card** — part of epic #762 (design doc `docs/2026-05-12-oiguskaart-evidence-map.md`, workstream D), built on top of #754.

### The card layout
- **Allikas** (source) — the parent act / draft / court the entity belongs to. Derived server-side from the entity's outgoing relations (`estleg:sourceAct`, `partOf`, `decidedBy`, `topicCluster`, …); rendered as a linked title that itself deep-links into the map (`?focus=`). Section hidden when no source is derivable (e.g. a top-level act).
- **Kuupäev / versioon** — the entity's date / version literals, pulled from its metadata and Estonian-labelled (`validFrom` → "Jõustunud", `dateAdopted` → "Vastu võetud", `caseNumber` → "Kohtuasja number", `celexNumber` → "CELEX-number", …). Hidden when there are none.
- **Seose liik** — the relation type in **legal language**, from a small static IRI/short-name → phrase map (`amendsProvision` → "muudab", `repealsProvision` → "tunnistab kehtetuks", `transposesDirective` → "võtab üle direktiivi", `references` → "viitab", `appliesProvision` → "kohaldab", `interpretsProvision` → "tõlgendab", …). When the panel was opened by clicking through from another node, it names the relation **between the previously-focused node and the new one**; otherwise it falls back to the entity's first "phrased" outgoing relation. Hidden when there's no meaningful relation.
- **Miks see oluline on** — a deterministic one-line note from a `(relation, impact-band)` rule table — **not an LLM call**. E.g. `why_it_matters("repeals", "critical")` → *"Tunnistab kehtetuks — eelnõu kaotaks selle sätte. (kriitiline mõju)"*; `why_it_matters("amendsProvision")` → *"Muudab — säte saaks uue redaktsiooni."* Unknown predicates get a generic-but-non-empty line.
- **Tegevused** — four actions:
  1. **Küsi nõustajalt selle kohta** — a tiny `<form method="post" action="/chat/seed">` whose `seed_text` (a phrased finding: «entity» relation «other») + optional `draft_id` (the `?draft=` param, if any) hidden inputs `explorer.js` fills in before display. Reuses the existing single-use `pending_chat_seed` token route — `POST /chat/seed` → `/chat/new?seed=<token>` → conversation view with the input pre-filled. No new route added.
  2. **Ava analüüsikeskuses** — `A` whose `href` `explorer.js` sets to `/analyysikeskus/normi-mojuahel?sisend=<encodeURIComponent(entity-uri)>`.
  3. **Lisa märkus** — reuses the existing entity-level annotation button (`#panel-annotation-btn`, wired by `_PANEL_ANNOTATION_SCRIPT` — a `MutationObserver` that injects an `AnnotationButton` for `target_type=entity`). `showEntityDetail` now stamps the real entity URI onto `panel-title`'s `data-entity-uri` so the annotation `target_id` is the URI, not the label. (Scoped down per the issue's "don't over-build" — annotations already work for any ontology entity URI via the existing mechanism, so I fit that into the new "Tegevused" group rather than building a draft-provision-specific flow.)
  4. **Lisa järjehoidja** — the existing #743 XHR bookmark button (`#panel-bookmark-btn`, `onclick="explorerBookmark()"` → `POST /api/bookmarks` with `X-Requested-With`, branching on `resp.ok` vs 401/403), relabelled and slotted into the card. The bookmark endpoint (`app/templates/dashboard.py`) is untouched.

### API
`/api/explorer/entity/{uri}` now also returns `source` (`{uri, label, relationLabel, kindLabel}` or `null`), `dateInfo` (`[{label, value}]`), and a `predicateLabel` + `whyText` on every outgoing / incoming relation. The relation-phrase map and "why it matters" rules live in `app/explorer/routes.py` (`relation_legal_phrase`, `why_it_matters`) — clean signatures, unit-tested.

The restyle is **additive**: the #719 back link, the metadata dump, version history, and the relations list are all still in the panel, so `explorer.js`' existing populate logic keeps working unchanged.

## Tests
`tests/test_explorer_pages.py`: the panel renders the evidence-card structure (source / date / relation / "why it matters" slots + the Tegevused group); the four actions point at the right URLs (`/chat/seed`, `/analyysikeskus/normi-mojuahel`, `#panel-annotation-btn`, `#panel-bookmark-btn` + `explorerBookmark()`); the back link / metadata / version-history / relations sections survive.
`tests/test_explorer_routes.py`: the relation → legal-phrase map (common relations, full-IRI reduction, unknown fallback); the "why it matters" rule (repeals+critical, amends+no-band, transposes+high, unknown→generic); the enhanced entity payload (`source` derived from `sourceAct`, `dateInfo` from metadata, `predicateLabel`/`whyText` on every relation).

## Toolchain (all green)
`ruff format` · `ruff check` · `pyright` (whole repo, 0 errors) · `pytest -q` (2375 passed, 25 skipped) · `node --check app/static/js/explorer.js`.

Closes #757
Part of epic #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)