### PR TITLE
feat(explorer): #755 — Õiguskaart `?draft=<id>` → the draft's impact subgraph

### DIFF
--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -310,6 +310,67 @@ def _fetch_draft_overlay(req: Request, draft_id_raw: str) -> list[str]:
     return uris
 
 
+# #755: epic #762, workstream B — ``?draft=<id>`` renders the draft's impact
+# subgraph (its affected / conflicting / gap provisions + the inter-relations)
+# as the actual graph content, not the full 90k overview. The subgraph data
+# itself is fetched client-side from ``/explorer/draft-subgraph/{draft_id}``
+# (a small auth-gated, org-scoped JSON endpoint in :mod:`app.explorer.routes`);
+# this page handler just needs to know *whether* to switch explorer.js into
+# subgraph mode — which depends on the draft being resolvable + owned by the
+# caller's org. A draft with no impact report yet still switches into the mode
+# (the JS shows a "run the analysis" fallback rather than the cold 90k graph).
+#
+# Distinct from :func:`_fetch_draft_overlay` (which conflates "cross-org" and
+# "no report" into an empty list and feeds the legacy node-highlight overlay):
+# here we need the three-way result {cross-org → fall back to start panel,
+# resolvable+report → subgraph, resolvable+no report → subgraph w/ fallback msg}.
+
+
+def _resolve_draft_for_subgraph(req: Request, draft_id_raw: str) -> dict | None:
+    """Return ``{draft_id, title, draft_url, report_url, has_report}`` or ``None``.
+
+    ``None`` means "don't switch into subgraph mode" — i.e. unauthenticated,
+    non-UUID id, missing draft, or a draft owned by another org. In those cases
+    the caller falls back to the normal flow (start panel on a cold open). A
+    valid, org-owned draft returns the dict even when it has no impact report
+    yet (``has_report=False``); explorer.js then shows the graceful fallback.
+
+    Any DB error is logged and treated as "can't resolve" → ``None`` so the
+    explorer still renders (degrading to the start panel / overview).
+    """
+    auth = req.scope.get("auth")
+    if not auth or not auth.get("org_id"):
+        return None
+    try:
+        draft_uuid = uuid.UUID(draft_id_raw)
+    except (TypeError, ValueError):
+        return None
+    org_id = str(auth.get("org_id"))
+    try:
+        with _connect() as conn:
+            draft_row = conn.execute(
+                "SELECT org_id, title FROM drafts WHERE id = %s",
+                (str(draft_uuid),),
+            ).fetchone()
+            if draft_row is None or str(draft_row[0]) != org_id:
+                return None
+            title = str(draft_row[1] or "Eelnõu")
+            report_row = conn.execute(
+                "SELECT 1 FROM impact_reports WHERE draft_id = %s LIMIT 1",
+                (str(draft_uuid),),
+            ).fetchone()
+    except Exception:
+        logger.exception("explorer draft-subgraph resolve: DB error for draft=%s", draft_id_raw)
+        return None
+    return {
+        "draft_id": str(draft_uuid),
+        "title": title,
+        "draft_url": f"/drafts/{draft_uuid}",
+        "report_url": f"/drafts/{draft_uuid}/report",
+        "has_report": report_row is not None,
+    }
+
+
 # ---------------------------------------------------------------------------
 # <head> resources — D3 v7 CDN + the explorer stylesheet. Kept off the global
 # ``_HDRS`` in app/main.py: D3 is ~270 KB and only the Õiguskaart page uses
@@ -764,14 +825,22 @@ def _start_panel(data: StartPanelData):  # noqa: ANN202
 def explorer_page(req: Request):
     """GET /explorer -- the Õiguskaart graph inside the standard app chrome.
 
-    When called with ``?draft=<uuid>`` and the caller's org owns that
-    draft, the affected-entity URIs from its latest impact report are
-    embedded as a JSON blob in a ``<script id="draft-overlay-data">``
-    tag. The explorer JS reads this blob on load and applies the
-    ``d3-node-highlighted`` class to matching nodes. Cross-org or
-    malformed draft params are silently dropped (no error UI) so the
-    page stays usable as a generic ontology browser even when the
-    overlay can't be applied.
+    #755 (epic #762, workstream B): when called with ``?draft=<uuid>`` and the
+    caller's org owns that draft, the page switches ``explorer.js`` into
+    **impact-subgraph mode** — it fetches ``/explorer/draft-subgraph/{id}`` (a
+    small org-scoped JSON endpoint that reshapes the draft's *already-computed*
+    latest ``impact_reports`` row into D3 ``{nodes, links}`` — no fresh 90k
+    traversal) and renders only that subgraph (the draft itself + its affected /
+    conflicting / gap provisions + the inter-relations), with a "← Tagasi eelnõu
+    juurde" link back to the draft. A valid draft with no impact report yet
+    still enters the mode (the JS shows a "run the analysis" fallback rather
+    than the cold 90k graph). Cross-org / malformed / non-UUID ``?draft=``
+    params don't switch modes — they fall through to the normal flow (the
+    contextual start panel on a cold open), never a 500. When ``?focus=`` is
+    *also* present it wins: that's the legacy node-highlight overlay path (the
+    affected-entity URIs from the latest report are embedded as a JSON blob in a
+    ``<script id="draft-overlay-data">`` tag and ``explorer.js`` applies the
+    ``d3-node-highlighted`` class to matching nodes in the full graph).
 
     When called with ``?focus=<uri>`` (URL-encoded — see
     :func:`app.docs.report_routes.explorer_focus_url`) the JS loads that
@@ -811,7 +880,20 @@ def explorer_page(req: Request):
     if not focus_param and not search_param:
         active_preset = vaade_param if vaade_param in _LEGAL_VIEW_PRESETS else None
     overlay_uris: list[str] = []
-    if draft_param:
+    # #755: ``?draft=<id>`` (without ``?focus=``) → render the draft's impact
+    # subgraph (not the 90k graph). Resolve the draft org-scoped here so we can
+    # tell explorer.js to switch into subgraph mode; the subgraph data itself is
+    # fetched client-side from /explorer/draft-subgraph/{id}. ``None`` (unknown
+    # / cross-org / non-UUID) → fall through to the normal flow (the start panel
+    # on a cold open). When ``?focus=`` is *also* present (a report's deep link —
+    # see :func:`app.docs.report_routes.explorer_focus_url`) the legacy
+    # node-highlight overlay path takes over instead: the affected-entity URIs
+    # are embedded as the ``draft-overlay-data`` blob and highlighted on the
+    # full graph around the focused entity.
+    draft_subgraph: dict | None = None
+    if draft_param and not focus_param:
+        draft_subgraph = _resolve_draft_for_subgraph(req, draft_param)
+    elif draft_param and focus_param:
         overlay_uris = _fetch_draft_overlay(req, draft_param)
 
     # #754 / #756: the start panel shows only when there is nothing to deep-link
@@ -853,7 +935,27 @@ def explorer_page(req: Request):
         # the more specific intent). Escaped exactly like the focus blob.
         search_payload = _escape_for_script(json.dumps(search_param))
         bridge_tags.append(Script(f"window.__explorerSearch={search_payload};"))
-    if overlay_uris:
+    # #755: when ``?draft=<id>`` resolves to an org-owned draft, switch
+    # explorer.js into impact-subgraph mode (it fetches the subgraph from the
+    # data endpoint below and renders *only* that). This takes priority over
+    # the legacy node-highlight overlay — we don't load the 90k graph at all in
+    # this mode — so the ``draft-overlay-data`` blob + its init script are
+    # suppressed here. The blob is escaped exactly like the other bridge tags.
+    if draft_subgraph is not None:
+        subgraph_payload = _escape_for_script(
+            json.dumps(
+                {
+                    "draftId": draft_subgraph["draft_id"],
+                    "title": draft_subgraph["title"],
+                    "dataUrl": f"/explorer/draft-subgraph/{draft_subgraph['draft_id']}",
+                    "draftUrl": draft_subgraph["draft_url"],
+                    "reportUrl": draft_subgraph["report_url"],
+                    "hasReport": bool(draft_subgraph["has_report"]),
+                }
+            )
+        )
+        bridge_tags.append(Script(f"window.__explorerDraftSubgraph={subgraph_payload};"))
+    elif overlay_uris:
         # #464: escape closing-tag + Unicode line-separator sequences in
         # the JSON payload before embedding in a <script>.
         payload = _escape_for_script(json.dumps({"uris": overlay_uris}))
@@ -863,7 +965,11 @@ def explorer_page(req: Request):
     # "Back to report/analysis" context: the page was opened from an impact
     # report / analysis result (?focus= or ?draft=) — explorer.js detects
     # the same thing from document.referrer for the detail-panel back link.
-    has_back_context = bool(focus_param) or bool(overlay_uris) or bool(draft_param)
+    # #755: the draft-subgraph mode also wires "← Tagasi eelnõu juurde" from the
+    # blob's draftUrl, so it counts as back-context too.
+    has_back_context = (
+        bool(focus_param) or bool(overlay_uris) or bool(draft_param) or draft_subgraph is not None
+    )
     # The small ?draft= toolbar tip is only useful in the classic graph view
     # with no focus/draft/overlay — the start panel makes it redundant.
     show_draft_tip = (

--- a/app/explorer/routes.py
+++ b/app/explorer/routes.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
+import uuid
+from typing import Any
 from urllib.parse import unquote
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from app.db import get_connection as _connect
 from app.ontology.queries import (
     CATEGORY_OVERVIEW,
     ENTITIES_AT_DATE,
@@ -588,6 +592,342 @@ def explorer_timeline(req: Request) -> JSONResponse:
 
 
 # ---------------------------------------------------------------------------
+# #755 — draft impact subgraph (epic #762, workstream B)
+#
+# ``/explorer?draft=<uuid>`` renders only that draft's impact subgraph — the
+# affected / conflicting / gap provisions and the relations between them —
+# instead of the full 90k-entity graph. The data comes straight out of the
+# draft's latest ``impact_reports`` row (the same JSON the report page and the
+# .docx export read), so this is *not* a fresh full-ontology traversal: it is
+# the already-computed :class:`~app.docs.impact.analyzer.ImpactFindings`
+# reshaped into D3 ``{nodes, links}`` form.
+#
+# Access control mirrors ``app.explorer.pages._fetch_draft_overlay``:
+#   - unauthenticated → 401 (defensive; the middleware redirects first)
+#   - malformed / non-UUID id → 404 (graceful, never a 500)
+#   - draft owned by another org → 404 (existence not revealed)
+#   - no impact report yet → 200 with ``has_report=False`` so the JS can show
+#     a "run the analysis" fallback instead of a blank graph.
+# ---------------------------------------------------------------------------
+
+# How many of each finding kind we surface as graph nodes. The full findings
+# list is still in the impact_reports row + the .docx export contains every
+# row — this is purely page-weight control for the D3 canvas (mirrors
+# ``app.docs.report_routes._MAX_INLINE_ROWS`` in spirit).
+_SUBGRAPH_MAX_PER_KIND = 60
+
+
+def _category_for_type_uri(type_uri: str) -> str:
+    """Map an ontology type URI to one of explorer.js' CATEGORY_COLORS keys.
+
+    A loose mirror of explorer.js ``categoryFromUri`` so the subgraph nodes
+    pick up sensible colours. Anything unrecognised falls back to
+    ``LegalProvision`` (the affected/conflict entities are overwhelmingly
+    provisions); the JS resolver applies its own fuzzy fallback on top.
+    """
+    if not type_uri:
+        return "LegalProvision"
+    short = type_uri.rsplit("#", 1)[-1] if "#" in type_uri else type_uri.rsplit("/", 1)[-1]
+    lower = short.lower()
+    if "draft" in lower:
+        return "DraftLegislation"
+    if "eucourt" in lower or "eu_court" in lower:
+        return "EUCourtDecision"
+    if "court" in lower or "decision" in lower:
+        return "CourtDecision"
+    if "directive" in lower or "regulation" in lower or lower.startswith("eu"):
+        return "EULegislation"
+    if "enacted" in lower or short in ("Act", "EnactedLaw"):
+        return "EnactedLaw"
+    if "topiccluster" in lower or "topic_cluster" in lower or "cluster" in lower:
+        return "TopicCluster"
+    if "concept" in lower:
+        return "LegalConcept"
+    if "provision" in lower or "section" in lower or short in ("Section", "LegalProvision"):
+        return "LegalProvision"
+    return "LegalProvision"
+
+
+def _parse_report_json(raw: Any) -> dict[str, Any]:
+    """Normalise the JSONB ``report_data`` value into a dict.
+
+    Mirrors ``app.docs.report_routes._parse_report_data`` (kept local so this
+    module doesn't reach into ``app/docs/`` for a one-liner).
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            return json.loads(raw.decode())
+        except (TypeError, ValueError, UnicodeDecodeError):
+            return {}
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+    return {}
+
+
+def _short_name_from_uri(uri: str) -> str:
+    """Best-effort short label from a URI fragment / last path segment."""
+    if not uri:
+        return ""
+    tail = uri.rsplit("#", 1)[-1] if "#" in uri else uri.rsplit("/", 1)[-1]
+    return tail or uri
+
+
+def build_draft_subgraph(
+    draft_id: str,
+    title: str,
+    findings: dict[str, Any],
+    *,
+    max_per_kind: int = _SUBGRAPH_MAX_PER_KIND,
+) -> dict[str, Any]:
+    """Reshape a draft's :class:`ImpactFindings` JSON into a D3 ``{nodes, links}``.
+
+    The central node is the draft itself; spokes are the affected / conflicting
+    / gap entities, each linked back to the draft with a labelled edge
+    ("mõjutab" / "konflikt" / "lünk"). Nodes are de-duplicated by URI so an
+    entity that is both affected *and* in a conflict appears once. Pure +
+    side-effect-free so it's unit-testable without a DB (Phase 5 readiness:
+    same shape can back an MCP tool).
+
+    Args:
+        draft_id: The draft's UUID (string) — used as the central node id.
+        title: The draft's human title (panel label).
+        findings: The parsed ``impact_reports.report_data`` dict.
+        max_per_kind: Cap on nodes contributed per finding kind.
+
+    Returns:
+        ``{"draft_id", "title", "nodes": [...], "links": [...]}``. ``nodes`` and
+        ``links`` use the same field names explorer.js' graph layer expects
+        (``id`` / ``label`` / ``category`` / ``uri`` / ``isCategory``;
+        ``source`` / ``target`` / ``label``).
+    """
+    draft_node_id = f"draft:{draft_id}"
+    nodes: list[dict[str, Any]] = [
+        {
+            "id": draft_node_id,
+            "uri": "",
+            "label": title or "Eelnõu",
+            "category": "DraftLegislation",
+            "isCategory": False,
+            "isDraft": True,
+            "kind": "draft",
+        }
+    ]
+    links: list[dict[str, Any]] = []
+    seen: set[str] = {draft_node_id}
+
+    def _add_spoke(
+        node_id: str,
+        label: str,
+        category: str,
+        kind: str,
+        edge_label: str,
+        *,
+        uri: str = "",
+        note: str = "",
+    ) -> None:
+        if not node_id or node_id in seen:
+            # Still draw the edge if the node already exists (e.g. affected ∩
+            # conflict) so the relationship isn't lost — but only one edge
+            # per (kind) to keep it readable.
+            if node_id and node_id in seen and node_id != draft_node_id:
+                already = any(
+                    (link.get("target") == node_id and link.get("kind") == kind) for link in links
+                )
+                if not already:
+                    links.append(
+                        {
+                            "source": draft_node_id,
+                            "target": node_id,
+                            "label": edge_label,
+                            "kind": kind,
+                        }
+                    )
+            return
+        seen.add(node_id)
+        node: dict[str, Any] = {
+            "id": node_id,
+            "uri": uri,
+            "label": label or _short_name_from_uri(uri) or node_id,
+            "category": category,
+            "isCategory": False,
+            "kind": kind,
+        }
+        if note:
+            node["note"] = note
+        nodes.append(node)
+        links.append(
+            {
+                "source": draft_node_id,
+                "target": node_id,
+                "label": edge_label,
+                "kind": kind,
+            }
+        )
+
+    # --- Affected entities (the 2-hop BFS hits) ---
+    for row in list(findings.get("affected_entities") or [])[:max_per_kind]:
+        if not isinstance(row, dict):
+            continue
+        uri = str(row.get("uri") or "").strip()
+        if not uri:
+            continue
+        _add_spoke(
+            uri,
+            str(row.get("label") or ""),
+            _category_for_type_uri(str(row.get("type") or "")),
+            "affected",
+            "mõjutab",
+            uri=uri,
+        )
+
+    # --- Conflicts (overlaps with other drafts / court decisions) ---
+    for row in list(findings.get("conflicts") or [])[:max_per_kind]:
+        if not isinstance(row, dict):
+            continue
+        uri = str(row.get("conflicting_entity") or "").strip()
+        label = str(row.get("conflicting_label") or "") or _short_name_from_uri(uri)
+        reason = str(row.get("reason") or "")
+        if uri:
+            _add_spoke(
+                uri,
+                label,
+                _category_for_type_uri(uri),
+                "conflict",
+                "konflikt",
+                uri=uri,
+                note=reason,
+            )
+        else:
+            # A conflict with no URI still gets a (synthetic) node so the
+            # finding isn't silently dropped from the map.
+            draft_ref = str(row.get("draft_ref") or "")
+            synth_id = f"conflict:{draft_ref or label or len(nodes)}"
+            _add_spoke(
+                synth_id,
+                label or draft_ref or "Konflikt",
+                "DraftLegislation",
+                "conflict",
+                "konflikt",
+                note=reason,
+            )
+
+    # --- Gaps (under-referenced topic clusters) ---
+    for row in list(findings.get("gaps") or [])[:max_per_kind]:
+        if not isinstance(row, dict):
+            continue
+        uri = str(row.get("topic_cluster") or "").strip()
+        label = str(row.get("topic_cluster_label") or "") or _short_name_from_uri(uri)
+        desc = str(row.get("description") or "")
+        node_id = uri or f"gap:{label or len(nodes)}"
+        _add_spoke(
+            node_id,
+            label or "Teemaklaster",
+            "TopicCluster",
+            "gap",
+            "lünk",
+            uri=uri,
+            note=desc,
+        )
+
+    return {
+        "draft_id": draft_id,
+        "title": title or "Eelnõu",
+        "nodes": nodes,
+        "links": links,
+    }
+
+
+def explorer_draft_subgraph(req: Request, draft_id: str) -> JSONResponse:
+    """GET /explorer/draft-subgraph/{draft_id} — the draft's impact subgraph.
+
+    Returns a JSON ``{nodes, links}`` built from the draft's latest impact
+    report. Org-scoped: a user from another org gets a 404 (the draft's
+    existence is not revealed). Malformed ids → 404. No impact report yet →
+    200 with ``has_report=False`` and empty ``nodes``/``links`` so explorer.js
+    can show a graceful "run the analysis" fallback.
+    """
+    auth = req.scope.get("auth")
+    if not auth or not auth.get("id") or not auth.get("org_id"):
+        return JSONResponse({"error": "Authentication required"}, status_code=401)
+
+    try:
+        draft_uuid = uuid.UUID(str(draft_id))
+    except (TypeError, ValueError):
+        return JSONResponse({"error": "Eelnõu ei leitud"}, status_code=404)
+
+    org_id = str(auth.get("org_id"))
+    try:
+        with _connect() as conn:
+            draft_row = conn.execute(
+                "SELECT org_id, title FROM drafts WHERE id = %s",
+                (str(draft_uuid),),
+            ).fetchone()
+            if draft_row is None or str(draft_row[0]) != org_id:
+                # Missing or cross-org → 404 (don't reveal which).
+                return JSONResponse({"error": "Eelnõu ei leitud"}, status_code=404)
+            title = str(draft_row[1] or "Eelnõu")
+            report_row = conn.execute(
+                """
+                SELECT report_data
+                FROM impact_reports
+                WHERE draft_id = %s
+                ORDER BY generated_at DESC
+                LIMIT 1
+                """,
+                (str(draft_uuid),),
+            ).fetchone()
+    except Exception:
+        logger.exception("draft subgraph: DB error for draft=%s", draft_id)
+        # Degrade to "no report" rather than 500 — the JS shows the fallback.
+        return JSONResponse(
+            {
+                "data": {"draft_id": str(draft_uuid), "title": "Eelnõu", "nodes": [], "links": []},
+                "meta": {"has_report": False, "draft_id": str(draft_uuid)},
+            }
+        )
+
+    if report_row is None:
+        return JSONResponse(
+            {
+                "data": {"draft_id": str(draft_uuid), "title": title, "nodes": [], "links": []},
+                "meta": {"has_report": False, "draft_id": str(draft_uuid)},
+            }
+        )
+
+    findings = _parse_report_json(report_row[0])
+    subgraph = build_draft_subgraph(str(draft_uuid), title, findings)
+    affected = len(list(findings.get("affected_entities") or []))
+    conflicts = len(list(findings.get("conflicts") or []))
+    gaps = len(list(findings.get("gaps") or []))
+    return JSONResponse(
+        {
+            "data": subgraph,
+            "meta": {
+                "has_report": True,
+                "draft_id": str(draft_uuid),
+                "affected_count": affected,
+                "conflict_count": conflicts,
+                "gap_count": gaps,
+                "node_count": len(subgraph["nodes"]),
+                # The report itself is unbounded; the graph is capped per kind.
+                "truncated": (
+                    affected > _SUBGRAPH_MAX_PER_KIND
+                    or conflicts > _SUBGRAPH_MAX_PER_KIND
+                    or gaps > _SUBGRAPH_MAX_PER_KIND
+                ),
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Route registration
 # ---------------------------------------------------------------------------
 
@@ -599,3 +939,5 @@ def register_explorer_routes(rt) -> None:  # type: ignore[no-untyped-def]
     rt("/api/explorer/entity/{entity_id:path}", methods=["GET"])(explorer_entity)
     rt("/api/explorer/search", methods=["GET"])(explorer_search)
     rt("/api/explorer/timeline", methods=["GET"])(explorer_timeline)
+    # #755: the draft's impact subgraph (org-scoped; backs ?draft=<id>).
+    rt("/explorer/draft-subgraph/{draft_id}", methods=["GET"])(explorer_draft_subgraph)

--- a/app/static/css/explorer.css
+++ b/app/static/css/explorer.css
@@ -680,4 +680,42 @@ g.node.you-are-here text.you-are-here-badge {
   .start-panel-secondary-link { margin-left: 0; }
   .start-panel-actions { flex-direction: column; }
   .start-panel-action { text-align: center; }
+
+  /* #755: draft-subgraph fallback box also goes edge-to-edge on a phone. */
+  .explorer-draft-fallback { max-width: 92%; padding: 24px 18px; }
 }
+
+/* #755: ------- draft impact subgraph mode (?draft=<id>) -------
+ * The "no impact report yet" / "report found nothing" fallback — a centred
+ * card over the (idle) canvas area pointing the user at the analysis or back
+ * to the draft. (The subgraph graph itself reuses the normal node styling;
+ * the draft node just renders larger via its r=26 in explorer.js.) */
+.explorer-draft-fallback {
+  position: absolute; top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 20;
+  max-width: 460px; width: calc(100% - 64px);
+  background: rgba(15, 23, 41, 0.97);
+  border: 1px solid rgba(100, 116, 139, 0.3);
+  border-radius: 12px;
+  padding: 28px 24px;
+  text-align: center;
+}
+.explorer-draft-fallback h2 {
+  font-size: 18px; font-weight: 700; color: #f1f5f9; margin: 0 0 10px;
+}
+.explorer-draft-fallback p {
+  font-size: 13px; color: #94a3b8; line-height: 1.6; margin: 0 0 18px;
+}
+.explorer-draft-fallback-actions {
+  display: flex; flex-direction: column; gap: 8px; align-items: center;
+}
+.explorer-draft-fallback-link {
+  display: inline-block;
+  background: rgba(56, 189, 248, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: #38bdf8; padding: 8px 16px; border-radius: 8px;
+  font-size: 13px; cursor: pointer; text-decoration: none;
+  transition: all 0.15s;
+}
+.explorer-draft-fallback-link:hover { background: rgba(56, 189, 248, 0.25); }

--- a/app/static/js/explorer.js
+++ b/app/static/js/explorer.js
@@ -133,6 +133,9 @@ const state = {
   // #758: the URI of the node the page was opened on (?focus= / ?draft=), if
   // any — given a persistent "you are here" ring + pin so it's never lost.
   youAreHereUri: null,
+  // #755: in ?draft=<id> mode, the {draftId,title,dataUrl,draftUrl,reportUrl}
+  // blob from the server (null otherwise).
+  draftSubgraph: null,
 };
 
 // ---------------------------------------------------------------------------
@@ -1752,6 +1755,185 @@ function collapseToOverview(resetView) {
   }
 }
 
+// #755: ---------------------------------------------------------------------
+// Draft impact subgraph mode (epic #762, workstream B)
+//
+// When the page is opened with ?draft=<id> and the org owns it, the server
+// sets window.__explorerDraftSubgraph = { draftId, title, dataUrl, draftUrl,
+// reportUrl, hasReport }. Instead of loading the cold 90k category overview we
+// fetch dataUrl (a small org-scoped JSON endpoint that reshapes the draft's
+// *already-computed* latest impact_reports row into {nodes, links}) and render
+// only that subgraph: the draft itself in the centre, its affected /
+// conflicting / gap provisions as spokes, with a "← Tagasi eelnõu juurde"
+// link back to /drafts/<id>. No fresh full-ontology traversal happens here.
+// ---------------------------------------------------------------------------
+
+// #755: wire the "← Tagasi …" links to an explicit URL (the draft / report)
+// rather than document.referrer — the user may have arrived from a bookmark
+// or a typed URL, not from the report page.
+function _wireBackToUrl(el, url, label) {
+  if (!el) return;
+  el.textContent = label || '← Tagasi';
+  el.style.display = '';
+  if (url) { el.href = url; }
+  el.onclick = function (e) {
+    e.preventDefault();
+    if (url) {
+      window.location.href = url;
+    } else if (document.referrer) {
+      window.location.href = document.referrer;
+    } else {
+      window.history.back();
+    }
+  };
+}
+
+// #755: shape a server subgraph row into a graph node. The draft node is
+// rendered bigger + flagged so the rest of the layout (and the legend) treats
+// it as the "you are here" anchor. Affected/conflict/gap spokes get a stable
+// radius keyed off their kind so the picture reads consistently.
+function _subgraphNode(row) {
+  var isDraft = !!row.isDraft || row.kind === 'draft';
+  var radius = isDraft ? 26 : (row.kind === 'gap' ? 16 : 14);
+  return {
+    id: row.id,
+    uri: row.uri || (isDraft ? '' : row.id),
+    label: row.label || (row.uri ? _fallbackLabel(row.uri) : row.id),
+    category: row.category || (isDraft ? 'DraftLegislation' : 'LegalProvision'),
+    desc: row.note || '',
+    count: 0,
+    r: radius,
+    isCategory: false,
+    isDraft: isDraft,
+    kind: row.kind || '',
+    note: row.note || '',
+  };
+}
+
+// #755: the empty / no-report fallback — an overlay message inside the canvas
+// area pointing the user at the analysis. Reuses the loading-overlay slot's
+// neighbour DOM; built with DOM methods (no innerHTML of untrusted strings).
+function _showDraftSubgraphFallback(meta, message) {
+  var existing = document.getElementById('explorer-draft-fallback');
+  if (existing) existing.remove();
+  var box = document.createElement('div');
+  box.id = 'explorer-draft-fallback';
+  box.className = 'explorer-draft-fallback';
+  box.setAttribute('role', 'status');
+
+  var h = document.createElement('h2');
+  h.textContent = (meta && meta.title) ? meta.title : 'Eelnõu mõjukaart';
+  box.appendChild(h);
+
+  var p = document.createElement('p');
+  p.textContent = message || 'Sellel eelnõul pole veel mõjuaruannet, mille põhjal mõjukaarti kuvada.';
+  box.appendChild(p);
+
+  var actions = document.createElement('div');
+  actions.className = 'explorer-draft-fallback-actions';
+  if (meta && meta.reportUrl) {
+    var a1 = document.createElement('a');
+    a1.href = meta.reportUrl;
+    a1.className = 'explorer-draft-fallback-link';
+    a1.textContent = 'Ava mõjuaruanne →';
+    actions.appendChild(a1);
+  }
+  if (meta && meta.draftUrl) {
+    var a2 = document.createElement('a');
+    a2.href = meta.draftUrl;
+    a2.className = 'explorer-draft-fallback-link';
+    a2.textContent = '← Tagasi eelnõu juurde';
+    actions.appendChild(a2);
+  }
+  var a3 = document.createElement('button');
+  a3.type = 'button';
+  a3.className = 'explorer-draft-fallback-link';
+  a3.textContent = 'Näita kogu kaarti';
+  a3.onclick = function () { box.remove(); window.explorerShowFullMap(); };
+  actions.appendChild(a3);
+  box.appendChild(actions);
+
+  var mount = document.getElementById('main-content') || document.body;
+  mount.appendChild(box);
+}
+
+async function loadDraftSubgraph(meta) {
+  if (!meta || !meta.dataUrl) return;
+  state.view = 'draft-subgraph';
+  state.draftSubgraph = meta;
+
+  // Wire the "back to draft" links right away — independent of the fetch.
+  var backLabel = '← Tagasi eelnõu juurde';
+  _wireBackToUrl(document.getElementById('toolbar-back'), meta.draftUrl, backLabel);
+
+  // The server told us up front whether a report exists; skip the fetch if not.
+  if (meta.hasReport === false) {
+    _showDraftSubgraphFallback(meta, null);
+    return;
+  }
+
+  var json = null;
+  try {
+    var resp = await fetch(meta.dataUrl);
+    if (resp.ok) { json = await resp.json(); }
+  } catch (e) {
+    json = null;
+  }
+
+  var data = json && json.data ? json.data : null;
+  var serverMeta = json && json.meta ? json.meta : {};
+  if (data && serverMeta && serverMeta.has_report === false) {
+    // Race: report disappeared between the page render and this fetch.
+    _showDraftSubgraphFallback(meta, null);
+    return;
+  }
+  if (!data || !Array.isArray(data.nodes) || data.nodes.length === 0) {
+    _showDraftSubgraphFallback(
+      meta,
+      'Selle eelnõu mõjuaruanne ei tuvastanud ühtegi seotud üksust.'
+    );
+    return;
+  }
+
+  var nodes = data.nodes.map(_subgraphNode);
+  var nodeIds = new Set(nodes.map(function (n) { return n.id; }));
+  var links = (Array.isArray(data.links) ? data.links : [])
+    .filter(function (l) {
+      var s = typeof l.source === 'object' ? l.source.id : l.source;
+      var t = typeof l.target === 'object' ? l.target.id : l.target;
+      return nodeIds.has(s) && nodeIds.has(t);
+    })
+    .map(function (l) {
+      return {
+        source: l.source,
+        target: l.target,
+        label: l.label || '',
+        kind: l.kind || '',
+        isCross: false,
+      };
+    });
+
+  state.nodes = nodes;
+  state.links = links;
+  state.expandedCategory = null;
+  state.pinnedNodes.clear();
+  // Pin the draft node at the centre so the spokes radiate around it.
+  var draftNode = nodes.find(function (n) { return n.isDraft; });
+  if (draftNode) {
+    draftNode.x = 0; draftNode.y = 0;
+    draftNode.fx = 0; draftNode.fy = 0;
+  }
+  updateBreadcrumb();
+  render();
+
+  if (serverMeta && serverMeta.truncated) {
+    showToast('Mõjukaart on suure aruande puhul kärbitud — täielik nimekiri on aruandes.', 'info');
+  }
+
+  // Re-frame once the simulation settles (mirrors the other entry paths).
+  setTimeout(function () { zoomToFit(600); }, 800);
+}
+
 // ---------------------------------------------------------------------------
 // Search
 // ---------------------------------------------------------------------------
@@ -1809,6 +1991,20 @@ function updateBreadcrumb() {
     breadcrumb.style.display = 'none';
     return;
   }
+  // #755: draft-subgraph mode shows a single "Eeln\u00f5u m\u00f5jukaart:
+  // <title>" crumb (no "\u00dclevaade \u203a" lead \u2014 there's no overview
+  // behind it in this mode).
+  if (state.view === 'draft-subgraph') {
+    breadcrumb.style.display = '';
+    const dsCrumb = document.createElement('span');
+    dsCrumb.className = 'current';
+    const dsTitle = (state.draftSubgraph && state.draftSubgraph.title) || 'Eeln\u00f5u';
+    const dsShort = dsTitle.length > 40 ? dsTitle.slice(0, 40) + '\u2026' : dsTitle;
+    dsCrumb.textContent = 'Eeln\u00f5u m\u00f5jukaart: ' + dsShort;
+    breadcrumb.appendChild(dsCrumb);
+    return;
+  }
+
   breadcrumb.style.display = '';
 
   const overview = document.createElement('span');
@@ -2655,6 +2851,20 @@ async function init() {
     state.startPanelMode = true;
     // The detail panel can still be Escape-closed etc.; just no graph data.
     // WebSocket sync notifications are still useful — connect once.
+    if (!wsInitialized) {
+      wsInitialized = true;
+      initWebSocket();
+    }
+    return;
+  }
+
+  // #755: ?draft=<id> mode — the server resolved an org-owned draft and set
+  // window.__explorerDraftSubgraph. Render ONLY that draft's impact subgraph
+  // (its affected/conflict/gap provisions, fetched from the data endpoint),
+  // not the cold 90k overview. If the draft has no report yet, this shows a
+  // graceful "run the analysis" fallback rather than the full graph.
+  if (window.__explorerDraftSubgraph && window.__explorerDraftSubgraph.dataUrl) {
+    await loadDraftSubgraph(window.__explorerDraftSubgraph);
     if (!wsInitialized) {
       wsInitialized = true;
       initWebSocket();

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -280,13 +280,155 @@ def test_explorer_focus_param_skips_the_start_panel():
 
 def test_explorer_draft_param_skips_the_start_panel():
     # ?draft= (even a malformed/cross-org one whose overlay is dropped) must
-    # bypass the start panel and render the classic graph view (#755 handles
-    # the proper draft subgraph — for #754 the panel just gets skipped).
+    # bypass the start panel and render the classic graph view (#755's subgraph
+    # mode only kicks in for a resolvable, org-owned draft — for an unresolvable
+    # one the panel just gets skipped and the classic chrome is shown).
     html = _html("draft=not-a-uuid")
     assert 'id="explorer-start-panel"' not in html
     assert "window.__explorerStartPanel" not in html
+    # No subgraph blob either — the draft id didn't resolve.
+    assert "window.__explorerDraftSubgraph" not in html
     # The graph toolbar is the visible chrome here (not hidden behind a panel).
     assert 'id="explorer-toolbar"' in html
+
+
+# ---------------------------------------------------------------------------
+# #755 — ?draft=<id> renders the draft's impact subgraph (epic #762, ws B)
+# ---------------------------------------------------------------------------
+
+
+# A draft connection stub for ``app.explorer.pages._resolve_draft_for_subgraph``
+# (``SELECT org_id, title FROM drafts`` then ``SELECT 1 FROM impact_reports``).
+class _DraftResolveCur:
+    def __init__(self, draft_row, report_row):
+        self._rows = [draft_row, report_row]
+        self._i = -1
+
+    def __call__(self, sql, params=()):
+        self._i += 1
+        return self
+
+    def fetchone(self):
+        return self._rows[self._i] if 0 <= self._i < len(self._rows) else None
+
+
+class _DraftResolveConn:
+    def __init__(self, draft_row, report_row):
+        self.execute = _DraftResolveCur(draft_row, report_row)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+_SUBGRAPH_DRAFT_ID = "44444444-4444-4444-4444-444444444444"
+_SUBGRAPH_ORG_ID = "11111111-1111-1111-1111-111111111111"  # matches _req()'s auth
+
+
+def _draft_subgraph_html(draft_id: str, *, draft_row, report_row) -> str:
+    """Render ``explorer_page`` for ``?draft=<id>`` with a mocked draft conn."""
+    from app.explorer.pages import explorer_page
+
+    with patch(
+        "app.explorer.pages._connect",
+        return_value=_DraftResolveConn(draft_row, report_row),
+    ):
+        return to_xml(explorer_page(_req(f"draft={draft_id}")))
+
+
+def test_explorer_draft_param_renders_impact_subgraph_blob():
+    """?draft=<id> for an org-owned draft with an impact report switches
+    explorer.js into subgraph mode — it gets a window.__explorerDraftSubgraph
+    blob pointing at /explorer/draft-subgraph/<id>, NOT the legacy
+    draft-overlay-data blob, NOT the start panel, NOT the cold-graph bootstrap."""
+    html = _draft_subgraph_html(
+        _SUBGRAPH_DRAFT_ID,
+        draft_row=(_SUBGRAPH_ORG_ID, "Liiklusseaduse muutmise eelnõu"),
+        report_row=(1,),
+    )
+    # The subgraph bridge blob — carries the data endpoint + back links.
+    assert "window.__explorerDraftSubgraph" in html
+    assert f"/explorer/draft-subgraph/{_SUBGRAPH_DRAFT_ID}" in html
+    assert f"/drafts/{_SUBGRAPH_DRAFT_ID}" in html  # draftUrl / reportUrl
+    assert '"hasReport": true' in html or '"hasReport":true' in html
+    # NOT the legacy node-highlight overlay (that's the ?focus=&draft= path).
+    assert 'id="draft-overlay-data"' not in html
+    # NOT the start panel, NOT the cold-graph flag.
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+    # The toolbar back link is rendered (explorer.js wires it to the draft).
+    assert 'id="toolbar-back"' in html
+    assert 'id="panel-back"' in html
+    # The graph DOM + JS are still present (explorer.js fetches the subgraph).
+    assert 'id="canvas"' in html
+    assert "/static/js/explorer.js" in html
+
+
+def test_explorer_draft_param_no_report_still_enters_subgraph_mode():
+    """A valid, org-owned draft with no impact report yet still switches into
+    subgraph mode (hasReport=false) — explorer.js shows a "run the analysis"
+    fallback rather than the cold 90k graph. No 500, no start panel."""
+    html = _draft_subgraph_html(
+        _SUBGRAPH_DRAFT_ID,
+        draft_row=(_SUBGRAPH_ORG_ID, "Analüüsimata eelnõu"),
+        report_row=None,
+    )
+    assert "window.__explorerDraftSubgraph" in html
+    assert '"hasReport": false' in html or '"hasReport":false' in html
+    assert f"/explorer/draft-subgraph/{_SUBGRAPH_DRAFT_ID}" in html
+    assert 'id="explorer-start-panel"' not in html
+    assert "window.__explorerStartPanel" not in html
+
+
+def test_explorer_draft_param_cross_org_falls_back_no_subgraph():
+    """A draft owned by a different org → _resolve_draft_for_subgraph returns
+    None, so no subgraph blob is emitted. The page falls back to the classic
+    graph view (never a 500, the draft's existence isn't revealed)."""
+    html = _draft_subgraph_html(
+        _SUBGRAPH_DRAFT_ID,
+        draft_row=("99999999-9999-9999-9999-999999999999", "Teise asutuse eelnõu"),
+        report_row=None,
+    )
+    assert "window.__explorerDraftSubgraph" not in html
+    assert 'id="draft-overlay-data"' not in html
+    # Classic graph chrome (no start panel, no subgraph blob).
+    assert 'id="explorer-start-panel"' not in html
+    assert 'id="explorer-toolbar"' in html
+    assert 'id="canvas"' in html
+
+
+def test_explorer_draft_param_db_error_falls_back_no_subgraph():
+    """A DB error while resolving the draft → no subgraph blob, classic graph
+    view, never a 500."""
+    from app.explorer.pages import explorer_page
+
+    with patch("app.explorer.pages._connect", side_effect=RuntimeError("no db")):
+        html = to_xml(explorer_page(_req(f"draft={_SUBGRAPH_DRAFT_ID}")))
+    assert "window.__explorerDraftSubgraph" not in html
+    assert 'id="explorer-toolbar"' in html
+
+
+def test_explorer_focus_and_draft_uses_legacy_overlay_not_subgraph():
+    """When ?focus= is *also* present (a report deep link), the legacy
+    node-highlight overlay path wins — the draft-overlay-data blob is embedded,
+    NOT the subgraph blob (the user wants the entity neighbourhood, not the
+    whole impact subgraph)."""
+    uri = "https://data.riik.ee/ontology/estleg#KarS_par_133"
+    # _fetch_draft_overlay does SELECT org_id then SELECT report_data.
+    report_data = {"affected_entities": [{"uri": "urn:x:1"}]}
+    with patch(
+        "app.explorer.pages._connect",
+        return_value=_DraftResolveConn((_SUBGRAPH_ORG_ID,), (report_data,)),
+    ):
+        from app.explorer.pages import explorer_page
+
+        html = to_xml(explorer_page(_req(f"focus={uri}&draft={_SUBGRAPH_DRAFT_ID}")))
+    assert 'id="draft-overlay-data"' in html
+    assert "urn:x:1" in html
+    assert "window.__explorerDraftSubgraph" not in html
+    assert "window.__explorerFocus" in html
 
 
 def test_explorer_search_param_skips_the_start_panel():

--- a/tests/test_explorer_routes.py
+++ b/tests/test_explorer_routes.py
@@ -396,6 +396,7 @@ class TestExplorerAuthRequired:
 
 # ---------------------------------------------------------------------------
 # Phase 2 Batch 4 — Explorer draft overlay
+# (+ #755 — ?draft=<id> impact subgraph mode, epic #762 workstream B)
 # ---------------------------------------------------------------------------
 
 
@@ -425,6 +426,15 @@ def _overlay_authed_client() -> TestClient:
     client = TestClient(app, follow_redirects=False)
     client.cookies.set("access_token", "stub-token")
     return client
+
+
+# A focus URI to pair with ?draft= so the legacy node-highlight overlay path
+# (which embeds the `draft-overlay-data` blob) is exercised. Post-#755 a bare
+# ?draft= goes into subgraph mode instead, so the overlay tests use ?focus=&draft=
+# — the exact shape `app.docs.report_routes.explorer_focus_url(uri, draft_id)`
+# emits from impact-report links (the `#` in estleg: URIs is percent-encoded so
+# the browser doesn't treat it as a fragment).
+_OVERLAY_FOCUS_URI = "https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23KarS_par_133"
 
 
 class _ConnectCM:
@@ -460,6 +470,28 @@ def _make_overlay_conn(
     return conn
 
 
+def _make_subgraph_resolve_conn(
+    *,
+    draft_org_id: str | None,
+    draft_title: str = "Test eelnõu",
+    has_report: bool = True,
+) -> MagicMock:
+    """Connection mock for ``app.explorer.pages._resolve_draft_for_subgraph``.
+
+    That helper does ``SELECT org_id, title FROM drafts`` then
+    ``SELECT 1 FROM impact_reports … LIMIT 1`` (the latter only when the draft
+    exists + is in-org). ``draft_org_id=None`` → missing draft; ``has_report``
+    toggles whether the impact_reports probe finds a row.
+    """
+    conn = MagicMock()
+    cursor1 = MagicMock()
+    cursor1.fetchone.return_value = (draft_org_id, draft_title) if draft_org_id else None
+    cursor2 = MagicMock()
+    cursor2.fetchone.return_value = (1,) if has_report else None
+    conn.execute.side_effect = [cursor1, cursor2]
+    return conn
+
+
 class TestExplorerDraftOverlay:
     """End-to-end overlay tests using a real authenticated session.
 
@@ -472,6 +504,11 @@ class TestExplorerDraftOverlay:
     DB connection used by ``_fetch_draft_overlay``. Any future
     regression that bypasses the middleware would surface as a 303
     redirect to ``/auth/login``.
+
+    Post-#755: a *bare* ``?draft=<id>`` switches into impact-subgraph mode
+    (covered by ``TestExplorerDraftSubgraphMode`` below). These overlay tests
+    therefore use the ``?focus=…&draft=…`` form — the legacy node-highlight
+    path that impact-report deep links still use.
     """
 
     @patch("app.explorer.pages._connect")
@@ -497,7 +534,8 @@ class TestExplorerDraftOverlay:
         mock_connect.return_value = _ConnectCM(conn)
 
         client = _overlay_authed_client()
-        resp = client.get(f"/explorer?draft={_OVERLAY_DRAFT_ID}")
+        # ?focus=&draft= → the legacy overlay path (an impact-report deep link).
+        resp = client.get(f"/explorer?focus={_OVERLAY_FOCUS_URI}&draft={_OVERLAY_DRAFT_ID}")
 
         assert resp.status_code == 200, (
             f"explorer page must require auth via cookie (#442); got {resp.status_code}"
@@ -528,20 +566,22 @@ class TestExplorerDraftOverlay:
         mock_connect: MagicMock,
     ):
         mock_get_provider.return_value = _overlay_provider()
-        # Draft belongs to a different org — _fetch_draft_overlay
-        # short-circuits on the org check and returns an empty list.
-        conn = _make_overlay_conn(
+        # Bare ?draft= with a draft owned by a different org: the #755
+        # subgraph resolver short-circuits on the org check and returns None,
+        # so no subgraph blob is emitted — the page falls back to the classic
+        # graph view (no error UI, the draft's existence is not revealed).
+        conn = _make_subgraph_resolve_conn(
             draft_org_id=_OVERLAY_OTHER_ORG_ID,
-            findings=None,
         )
         mock_connect.return_value = _ConnectCM(conn)
 
         client = _overlay_authed_client()
         resp = client.get(f"/explorer?draft={_OVERLAY_DRAFT_ID}")
 
-        # Page still renders normally — no overlay tag, no error UI.
+        # Page still renders normally — no overlay tag, no subgraph blob.
         assert resp.status_code == 200
         assert 'id="draft-overlay-data"' not in resp.text
+        assert "window.__explorerDraftSubgraph" not in resp.text
         # The explorer page still works (Otsi search button as a smoke check).
         assert "Otsi" in resp.text
 
@@ -551,13 +591,14 @@ class TestExplorerDraftOverlay:
         mock_get_provider: MagicMock,
     ):
         mock_get_provider.return_value = _overlay_provider()
-        # _fetch_draft_overlay short-circuits before any DB lookup when
-        # the UUID is malformed, so no _connect mock is needed.
+        # Both the #755 subgraph resolver and the legacy overlay short-circuit
+        # before any DB lookup when the UUID is malformed — no _connect needed.
         client = _overlay_authed_client()
         resp = client.get("/explorer?draft=not-a-uuid")
 
         assert resp.status_code == 200
         assert 'id="draft-overlay-data"' not in resp.text
+        assert "window.__explorerDraftSubgraph" not in resp.text
         # Standard explorer chrome is still present.
         assert "Otsi" in resp.text
 
@@ -596,7 +637,8 @@ class TestExplorerDraftOverlay:
         mock_connect.return_value = _ConnectCM(conn)
 
         client = _overlay_authed_client()
-        resp = client.get(f"/explorer?draft={_OVERLAY_DRAFT_ID}")
+        # ?focus=&draft= → the legacy overlay path that embeds the blob.
+        resp = client.get(f"/explorer?focus={_OVERLAY_FOCUS_URI}&draft={_OVERLAY_DRAFT_ID}")
 
         assert resp.status_code == 200
         # The JSON tag must contain the escaped form ``<\/script>``.
@@ -634,7 +676,9 @@ class TestExplorerDraftOverlay:
         Without the TTL cache the explorer re-queries both ``drafts``
         and ``impact_reports`` on every page load (including every
         HTMX polling fragment). This test asserts the second hit does
-        NOT call ``_connect`` again.
+        NOT call ``_connect`` again — exercised via the ``?focus=&draft=``
+        overlay path (a bare ``?draft=`` is the #755 subgraph mode, which
+        resolves the draft separately and is *not* cached server-side).
         """
         mock_get_provider.return_value = _overlay_provider()
         report_data = {"affected_entities": [{"uri": "urn:x:1"}]}
@@ -656,14 +700,15 @@ class TestExplorerDraftOverlay:
         mock_connect.side_effect = _factory
 
         client = _overlay_authed_client()
+        url = f"/explorer?focus={_OVERLAY_FOCUS_URI}&draft={_OVERLAY_DRAFT_ID}"
         # First request — cache miss, DB queried.
-        resp1 = client.get(f"/explorer?draft={_OVERLAY_DRAFT_ID}")
+        resp1 = client.get(url)
         assert resp1.status_code == 200
         assert "urn:x:1" in resp1.text
         assert call_counter["n"] == 1
 
         # Second request — cache hit, DB NOT queried.
-        resp2 = client.get(f"/explorer?draft={_OVERLAY_DRAFT_ID}")
+        resp2 = client.get(url)
         assert resp2.status_code == 200
         assert "urn:x:1" in resp2.text
         assert call_counter["n"] == 1, (
@@ -849,3 +894,211 @@ class TestEntityDetailEvidenceFields:
         labels = {row["label"]: row["value"] for row in date_info}
         assert labels.get("Jõustunud") == "1993-12-01"
         assert labels.get("Kohtuasja number") == "3-1-1-5-13"
+
+
+# ---------------------------------------------------------------------------
+# #755 — GET /explorer/draft-subgraph/{draft_id} (epic #762, workstream B)
+# ---------------------------------------------------------------------------
+
+
+def _make_subgraph_data_conn(
+    *,
+    draft_org_id: str | None,
+    draft_title: str = "Test eelnõu",
+    report_data: dict | None = None,
+) -> MagicMock:
+    """Connection mock for ``app.explorer.routes.explorer_draft_subgraph``.
+
+    It does ``SELECT org_id, title FROM drafts`` then (if in-org)
+    ``SELECT report_data FROM impact_reports … LIMIT 1``.
+    """
+    conn = MagicMock()
+    cursor1 = MagicMock()
+    cursor1.fetchone.return_value = (draft_org_id, draft_title) if draft_org_id else None
+    cursor2 = MagicMock()
+    cursor2.fetchone.return_value = (report_data,) if report_data is not None else None
+    conn.execute.side_effect = [cursor1, cursor2]
+    return conn
+
+
+class TestExplorerDraftSubgraphData:
+    """The org-scoped JSON endpoint that backs ?draft=<id> subgraph mode."""
+
+    @patch("app.explorer.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_returns_subgraph_nodes_and_links(
+        self,
+        mock_get_provider: MagicMock,
+        mock_connect: MagicMock,
+    ):
+        mock_get_provider.return_value = _overlay_provider()
+        report_data = {
+            "affected_entities": [
+                {"uri": "urn:x:1", "label": "§ 1", "type": "estleg#LegalProvision"},
+                {"uri": "urn:x:2", "label": "§ 2", "type": "estleg#LegalProvision"},
+            ],
+            "conflicts": [
+                {
+                    "draft_ref": "§ 1",
+                    "conflicting_entity": "urn:c:1",
+                    "conflicting_label": "Vastuolu säte",
+                    "reason": "Sama paragrahvi muudab teine eelnõu",
+                }
+            ],
+            "gaps": [
+                {
+                    "topic_cluster": "urn:tc:1",
+                    "topic_cluster_label": "Andmekaitse",
+                    "description": "Viitab 1 / 5 sättele",
+                }
+            ],
+        }
+        mock_connect.return_value = _ConnectCM(
+            _make_subgraph_data_conn(draft_org_id=_OVERLAY_ORG_ID, report_data=report_data)
+        )
+
+        client = _overlay_authed_client()
+        resp = client.get(f"/explorer/draft-subgraph/{_OVERLAY_DRAFT_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["meta"]["has_report"] is True
+        data = body["data"]
+        # The central node is the draft itself.
+        draft_nodes = [n for n in data["nodes"] if n.get("kind") == "draft"]
+        assert len(draft_nodes) == 1
+        assert draft_nodes[0]["id"] == f"draft:{_OVERLAY_DRAFT_ID}"
+        # Affected / conflict / gap entities are all present as nodes.
+        node_ids = {n["id"] for n in data["nodes"]}
+        assert "urn:x:1" in node_ids and "urn:x:2" in node_ids
+        assert "urn:c:1" in node_ids
+        assert "urn:tc:1" in node_ids
+        # Every spoke is linked back to the draft node with a labelled edge.
+        link_targets = {edge["target"] for edge in data["links"]}
+        assert "urn:x:1" in link_targets and "urn:c:1" in link_targets
+        kinds = {edge["kind"] for edge in data["links"]}
+        assert {"affected", "conflict", "gap"}.issubset(kinds)
+
+    @patch("app.explorer.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_report_returns_has_report_false_not_500(
+        self,
+        mock_get_provider: MagicMock,
+        mock_connect: MagicMock,
+    ):
+        mock_get_provider.return_value = _overlay_provider()
+        mock_connect.return_value = _ConnectCM(
+            _make_subgraph_data_conn(draft_org_id=_OVERLAY_ORG_ID, report_data=None)
+        )
+        client = _overlay_authed_client()
+        resp = client.get(f"/explorer/draft-subgraph/{_OVERLAY_DRAFT_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["meta"]["has_report"] is False
+        assert body["data"]["nodes"] == []
+        assert body["data"]["links"] == []
+
+    @patch("app.explorer.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_cross_org_draft_returns_404(
+        self,
+        mock_get_provider: MagicMock,
+        mock_connect: MagicMock,
+    ):
+        mock_get_provider.return_value = _overlay_provider()
+        # Draft belongs to a different org — must 404 (existence not revealed).
+        mock_connect.return_value = _ConnectCM(
+            _make_subgraph_data_conn(draft_org_id=_OVERLAY_OTHER_ORG_ID, report_data=None)
+        )
+        client = _overlay_authed_client()
+        resp = client.get(f"/explorer/draft-subgraph/{_OVERLAY_DRAFT_ID}")
+        assert resp.status_code == 404
+
+    @patch("app.explorer.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_unknown_draft_returns_404(
+        self,
+        mock_get_provider: MagicMock,
+        mock_connect: MagicMock,
+    ):
+        mock_get_provider.return_value = _overlay_provider()
+        # Missing draft row → 404.
+        mock_connect.return_value = _ConnectCM(
+            _make_subgraph_data_conn(draft_org_id=None, report_data=None)
+        )
+        client = _overlay_authed_client()
+        resp = client.get(f"/explorer/draft-subgraph/{_OVERLAY_DRAFT_ID}")
+        assert resp.status_code == 404
+
+    @patch("app.auth.middleware._get_provider")
+    def test_non_uuid_draft_returns_404_no_db(
+        self,
+        mock_get_provider: MagicMock,
+    ):
+        mock_get_provider.return_value = _overlay_provider()
+        # Malformed id short-circuits before any DB lookup.
+        client = _overlay_authed_client()
+        resp = client.get("/explorer/draft-subgraph/not-a-uuid")
+        assert resp.status_code == 404
+
+    @patch("app.explorer.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_db_error_degrades_to_no_report_not_500(
+        self,
+        mock_get_provider: MagicMock,
+        mock_connect: MagicMock,
+    ):
+        mock_get_provider.return_value = _overlay_provider()
+        mock_connect.side_effect = RuntimeError("no db")
+        client = _overlay_authed_client()
+        resp = client.get(f"/explorer/draft-subgraph/{_OVERLAY_DRAFT_ID}")
+        # Degrades gracefully — never a 500 for the explorer canvas.
+        assert resp.status_code == 200
+        assert resp.json()["meta"]["has_report"] is False
+
+    def test_requires_auth(self):
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get(f"/explorer/draft-subgraph/{_OVERLAY_DRAFT_ID}")
+        # Unauthenticated → the middleware redirects to login.
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/auth/login"
+
+
+class TestBuildDraftSubgraph:
+    """Unit tests for the pure ``build_draft_subgraph`` reshaper."""
+
+    def test_dedupes_entity_in_affected_and_conflict(self):
+        from app.explorer.routes import build_draft_subgraph
+
+        findings = {
+            "affected_entities": [{"uri": "urn:x:1", "label": "§ 1"}],
+            "conflicts": [
+                {"conflicting_entity": "urn:x:1", "conflicting_label": "§ 1", "reason": "r"}
+            ],
+            "gaps": [],
+        }
+        sg = build_draft_subgraph("d-1", "Eelnõu X", findings)
+        # urn:x:1 appears once as a node, but gets two edges (affected + conflict).
+        node_ids = [n["id"] for n in sg["nodes"]]
+        assert node_ids.count("urn:x:1") == 1
+        edges_to_x1 = [edge for edge in sg["links"] if edge["target"] == "urn:x:1"]
+        assert {edge["kind"] for edge in edges_to_x1} == {"affected", "conflict"}
+
+    def test_empty_findings_yields_lone_draft_node(self):
+        from app.explorer.routes import build_draft_subgraph
+
+        sg = build_draft_subgraph("d-2", "Tühi eelnõu", {})
+        assert len(sg["nodes"]) == 1
+        assert sg["nodes"][0]["kind"] == "draft"
+        assert sg["links"] == []
+
+    def test_caps_nodes_per_kind(self):
+        from app.explorer.routes import build_draft_subgraph
+
+        findings = {
+            "affected_entities": [{"uri": f"urn:a:{i}"} for i in range(200)],
+            "conflicts": [],
+            "gaps": [],
+        }
+        sg = build_draft_subgraph("d-3", "Suur eelnõu", findings, max_per_kind=10)
+        affected_nodes = [n for n in sg["nodes"] if n.get("kind") == "affected"]
+        assert len(affected_nodes) == 10


### PR DESCRIPTION
Closes #755. Part of epic #762 (Õiguskaart contextual evidence map), workstream B. Builds on #754 (the contextual start panel — already merged).

## What this does

`/explorer?draft=<uuid>` now renders **only the draft's impact subgraph** — its affected / conflicting / gap provisions and the relations between them — instead of the cold 90k-entity graph.

- When the caller's org owns the draft, the page switches `explorer.js` into a new **impact-subgraph render mode**: it fetches a small org-scoped `GET /explorer/draft-subgraph/{id}` endpoint and draws the draft node in the centre with its affected/conflict/gap entities as spokes (labelled edges: `mõjutab` / `konflikt` / `lünk`). The toolbar gets a "← Tagasi eelnõu juurde" link back to `/drafts/{id}`; the breadcrumb shows `Eelnõu mõjukaart: <title>`.
- **The subgraph data is reshaped from the draft's already-computed latest `impact_reports` row** (the same `ImpactFindings` JSON the report page + the `.docx` export read) — `build_draft_subgraph()` in `app/explorer/routes.py`. No fresh full-ontology traversal.

## Fallback behaviour (never a 500)

| Situation | Behaviour |
|---|---|
| Valid, org-owned draft, **no impact report yet** | Enters subgraph mode with `hasReport=false`; `explorer.js` shows a "run the analysis" fallback card (links to the report + back to the draft + "Näita kogu kaarti"), not the cold 90k graph |
| Unknown / cross-org draft id | `_resolve_draft_for_subgraph` returns `None` → no subgraph blob; the page falls through to the normal flow (the contextual start panel on a cold open). The data endpoint returns **404** (existence not revealed) |
| Non-UUID `?draft=` | Same — short-circuits before any DB lookup |
| DB error while resolving | Page falls through (no blob); the data endpoint degrades to `has_report=false` |
| `?focus=` **also** present (an impact-report deep link) | The legacy node-highlight overlay path wins — the `draft-overlay-data` blob is embedded and matching nodes are highlighted on the full graph around the focused entity (a `?focus=` link wants the entity neighbourhood, not the whole impact subgraph) |

## Files

- `app/explorer/routes.py` — `build_draft_subgraph()` (pure reshaper, Phase-5-ready signature) + `GET /explorer/draft-subgraph/{draft_id}` (auth-gated, org-scoped JSON)
- `app/explorer/pages.py` — `_resolve_draft_for_subgraph()` + the `window.__explorerDraftSubgraph` bridge blob (the legacy `?focus=&draft=` overlay path is untouched)
- `app/static/js/explorer.js` — `loadDraftSubgraph()` render mode, the no-report fallback card, the back-link wiring, a `draft-subgraph` view in the breadcrumb (`node --check` clean)
- `app/static/css/explorer.css` — the fallback card styling (minimal, additive)
- `tests/test_explorer_pages.py` / `tests/test_explorer_routes.py` — subgraph-mode page tests + data-endpoint tests (org-scoping, 404s, no-report fallback, DB-error degradation) + `build_draft_subgraph` unit tests. The pre-existing `TestExplorerDraftOverlay` tests were updated to use the `?focus=&draft=` form (the legacy path) since a bare `?draft=` is now subgraph mode.

> All changes are demarcated with `# #755:` / `// #755:` / `/* #755 */` comments and kept localized/additive to ease the merge with the sibling #756/#757/#758 PRs touching the same files.

## Toolchain

`ruff format` ✓ · `ruff check` ✓ (All checks passed) · `pyright` ✓ (0 errors) · `pytest -q` ✓ (2376 passed, 25 skipped) · `node --check app/static/js/explorer.js` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)