### PR TITLE
fix(drafter): #774 — preserve clause controls after regenerate

### DIFF
--- a/app/drafter/routes.py
+++ b/app/drafter/routes.py
@@ -1054,6 +1054,93 @@ def _step_4_page(session: DraftingSession, auth: UserDict):
 # ---------------------------------------------------------------------------
 
 
+def _render_clause_card(
+    clause: dict[str, Any],
+    session_id: uuid.UUID,
+    idx: int,
+    *,
+    success_alert: bool = False,
+):
+    """Render a single drafter step-5 clause card.
+
+    Shared renderer (#774) for the initial step-5 page and the
+    ``regenerate_clause_status`` HTMX success fragment. Both paths MUST
+    emit identical markup so HTMX outerHTML swaps keep the
+    ``.clause-actions`` row (Muuda + Genereeri uuesti + AnnotationButton)
+    after a regeneration — otherwise the user loses the ability to edit,
+    regenerate again, or annotate the clause until they navigate away.
+
+    Parameters
+    ----------
+    clause:
+        Decoded clause dict from ``session.draft_content_encrypted``.
+    session_id:
+        Drafting session UUID — used to build the edit/regenerate URLs.
+    idx:
+        Position of the clause in the list — used to build the DOM id
+        (``clause-{idx}``) and HTMX targets.
+    success_alert:
+        When ``True``, append a ``"Uuesti genereeritud."`` success Alert
+        below the citations. Used by ``regenerate_clause_status`` after
+        a successful regeneration so the user gets feedback.
+    """
+    chapter = clause.get("chapter", "")
+    chapter_title = clause.get("chapter_title", "")
+    para = clause.get("paragraph", "")
+    title = clause.get("title", "")
+    text = clause.get("text", "")
+    citations = clause.get("citations", [])
+    notes = clause.get("notes", "")
+
+    citation_links: list[Any] = []
+    for cit in citations:
+        citation_links.append(
+            A(
+                cit,
+                href=f"/explorer?search={url_quote(cit)}",
+                cls="citation-link",
+                target="_blank",
+            )  # noqa: F405
+        )
+
+    return Div(  # noqa: F405
+        H4(f"{para} {title}", cls="clause-heading"),  # noqa: F405
+        Small(  # noqa: F405
+            f"Peatükk: {chapter} {chapter_title}",
+            cls="clause-chapter-ref muted-text",
+        ),
+        Div(  # noqa: F405
+            P(text, cls="clause-text") if text else P("(Sisu puudub)", cls="muted-text"),  # noqa: F405
+            cls="clause-body",
+        ),
+        Div(*citation_links, cls="clause-citations") if citation_links else None,  # noqa: F405
+        P(Em(f"Märkus: {notes}"), cls="clause-notes muted-text") if notes else None,  # noqa: F405
+        Alert("Uuesti genereeritud.", variant="success") if success_alert else None,
+        Div(  # noqa: F405
+            Button(  # noqa: F405
+                "Muuda",
+                hx_get=f"/drafter/{session_id}/step/5/edit/{idx}",
+                hx_target=f"#clause-{idx}",
+                hx_swap="outerHTML",
+                variant="ghost",
+                size="sm",
+            ),
+            Button(  # noqa: F405
+                "Genereeri uuesti",
+                hx_post=f"/drafter/{session_id}/step/5/regenerate/{idx}",
+                hx_target=f"#clause-{idx}",
+                hx_swap="outerHTML",
+                variant="ghost",
+                size="sm",
+            ),
+            AnnotationButton("provision", f"{session_id}-clause-{idx}"),
+            cls="clause-actions",
+        ),
+        id=f"clause-{idx}",
+        cls="clause-item",
+    )
+
+
 def _step_5_page(session: DraftingSession, auth: UserDict):
     """Render Step 5: Drafted clauses with inline editing."""
     if session.draft_content_encrypted is None:
@@ -1077,61 +1164,9 @@ def _step_5_page(session: DraftingSession, auth: UserDict):
         except Exception:
             logger.warning("Could not decrypt draft content for session %s", session.id)
 
-    clause_items: list[Any] = []
-    for i, clause in enumerate(clauses):
-        chapter = clause.get("chapter", "")
-        chapter_title = clause.get("chapter_title", "")
-        para = clause.get("paragraph", "")
-        title = clause.get("title", "")
-        text = clause.get("text", "")
-        citations = clause.get("citations", [])
-        notes = clause.get("notes", "")
-
-        citation_links: list[Any] = []
-        for cit in citations:
-            citation_links.append(
-                A(
-                    cit,
-                    href=f"/explorer?search={url_quote(cit)}",
-                    cls="citation-link",
-                    target="_blank",
-                )  # noqa: F405
-            )
-
-        clause_items.append(
-            Div(  # noqa: F405
-                H4(f"{para} {title}", cls="clause-heading"),  # noqa: F405
-                Small(f"Peatükk: {chapter} {chapter_title}", cls="clause-chapter-ref muted-text"),  # noqa: F405
-                Div(  # noqa: F405
-                    P(text, cls="clause-text") if text else P("(Sisu puudub)", cls="muted-text"),  # noqa: F405
-                    cls="clause-body",
-                ),
-                Div(*citation_links, cls="clause-citations") if citation_links else None,  # noqa: F405
-                P(Em(f"Märkus: {notes}"), cls="clause-notes muted-text") if notes else None,  # noqa: F405
-                Div(  # noqa: F405
-                    Button(  # noqa: F405
-                        "Muuda",
-                        hx_get=f"/drafter/{session.id}/step/5/edit/{i}",
-                        hx_target=f"#clause-{i}",
-                        hx_swap="outerHTML",
-                        variant="ghost",
-                        size="sm",
-                    ),
-                    Button(  # noqa: F405
-                        "Genereeri uuesti",
-                        hx_post=f"/drafter/{session.id}/step/5/regenerate/{i}",
-                        hx_target=f"#clause-{i}",
-                        hx_swap="outerHTML",
-                        variant="ghost",
-                        size="sm",
-                    ),
-                    AnnotationButton("provision", f"{session.id}-clause-{i}"),
-                    cls="clause-actions",
-                ),
-                id=f"clause-{i}",
-                cls="clause-item",
-            )
-        )
+    clause_items: list[Any] = [
+        _render_clause_card(clause, session.id, i) for i, clause in enumerate(clauses)
+    ]
 
     # Advance form
     advance_form = AppForm(
@@ -2376,36 +2411,14 @@ def regenerate_clause_status(req: Request, session_id: str, clause_idx: str):
                 pass
 
         if 0 <= idx < len(clauses):
-            clause = clauses[idx]
-            citations = clause.get("citations", [])
-            citation_links: list[Any] = []
-            for cit in citations:
-                citation_links.append(
-                    A(
-                        cit,
-                        href=f"/explorer?search={url_quote(cit)}",
-                        cls="citation-link",
-                        target="_blank",
-                    )  # noqa: F405
-                )
-
-            return Div(  # noqa: F405
-                H4(
-                    f"{clause.get('paragraph', '')} {clause.get('title', '')}",
-                    cls="clause-heading",
-                ),  # noqa: F405
-                Small(  # noqa: F405
-                    f"Peatükk: {clause.get('chapter', '')} {clause.get('chapter_title', '')}",
-                    cls="clause-chapter-ref muted-text",
-                ),
-                Div(  # noqa: F405
-                    P(clause.get("text", ""), cls="clause-text"),  # noqa: F405
-                    cls="clause-body",
-                ),
-                Div(*citation_links, cls="clause-citations") if citation_links else None,  # noqa: F405
-                Alert("Uuesti genereeritud.", variant="success"),
-                id=f"clause-{clause_idx}",
-                cls="clause-item",
+            # #774: render via the shared helper so the regenerated clause
+            # keeps its Muuda / Genereeri uuesti / AnnotationButton action
+            # row after the HTMX outerHTML swap. Before, this branch
+            # emitted a stripped-down clause Div without ``.clause-actions``
+            # and the user lost the ability to edit / regenerate / annotate
+            # the clause until they refreshed the page.
+            return _render_clause_card(
+                clause=clauses[idx], session_id=parsed, idx=idx, success_alert=True
             )
 
     if job and job["status"] == "failed":

--- a/tests/test_drafter_clause_regen.py
+++ b/tests/test_drafter_clause_regen.py
@@ -1,0 +1,223 @@
+"""Regression tests for #774 — clause controls survive regeneration.
+
+The drafter step-5 ``regenerate_clause_status`` HTMX polling endpoint
+must, on a successful regeneration, return a clause fragment that still
+carries:
+
+    - the ``.clause-actions`` row,
+    - the ``Muuda`` button (edit URL: ``/drafter/.../step/5/edit/{idx}``),
+    - the ``Genereeri uuesti`` button (regenerate URL:
+      ``/drafter/.../step/5/regenerate/{idx}``),
+    - and the ``AnnotationButton`` wrapper for the clause's provision.
+
+Before the fix, the success branch emitted a stripped-down ``Div``
+without the action row, so the regenerated clause became
+non-interactive until the user refreshed the page. The fix extracts a
+shared ``_render_clause_card`` helper used by both the initial step-5
+page render and the success polling fragment.
+
+Patterns follow ``tests/test_drafter_routes.py`` (TestClient + patched
+auth provider + mocked DB / job lookups).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.drafter.session_model import DraftingSession
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_SESSION_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "koostaja@seadusloome.ee",
+        "full_name": "Test Koostaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _make_session(*, current_step: int = 5) -> DraftingSession:
+    now = datetime.now(UTC)
+    return DraftingSession(
+        id=_SESSION_ID,
+        user_id=uuid.UUID(_USER_ID),
+        org_id=uuid.UUID(_ORG_ID),
+        workflow_type="full_law",
+        current_step=current_step,
+        intent="Test intent",
+        clarifications=[],
+        research_data_encrypted=None,
+        proposed_structure=None,
+        draft_content_encrypted=b"encrypted",
+        integrated_draft_id=None,
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+def _clauses_json() -> str:
+    return json.dumps(
+        {
+            "clauses": [
+                {
+                    "chapter": "1",
+                    "chapter_title": "Üldsätted",
+                    "paragraph": "§ 1",
+                    "title": "Reguleerimisala",
+                    "text": "Käesolev seadus sätestab uue korra.",
+                    "citations": ["estleg:TsiviilS/par/1"],
+                    "notes": "",
+                }
+            ]
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# regenerate_clause_status — success branch keeps clause controls (#774)
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateClauseStatusSuccessFragment:
+    """The success fragment MUST emit the same action row as the initial
+    step-5 page so an inline HTMX swap doesn't strip ``Muuda``,
+    ``Genereeri uuesti``, or the ``AnnotationButton``.
+    """
+
+    @patch("app.drafter.routes._find_latest_job")
+    @patch("app.drafter.routes.decrypt_text")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_success_fragment_preserves_clause_actions(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_find_job: MagicMock,
+    ):
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_session(current_step=5)
+        mock_decrypt.return_value = _clauses_json()
+        mock_find_job.return_value = {
+            "status": "success",
+            "payload": {"clause_index": 0},
+        }
+
+        client = _authed_client()
+        resp = client.get(f"/drafter/{_SESSION_ID}/step/5/regenerate/0/status")
+
+        assert resp.status_code == 200
+        body = resp.text
+
+        # The success alert appears so users see the regeneration completed.
+        assert "Uuesti genereeritud." in body
+        # The action row is restored — this is the regression that #774
+        # specifically guards against.
+        assert "clause-actions" in body
+        # The clause content is rendered.
+        assert "Käesolev seadus sätestab uue korra." in body
+
+    @patch("app.drafter.routes._find_latest_job")
+    @patch("app.drafter.routes.decrypt_text")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_success_fragment_carries_edit_and_regenerate_urls(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_find_job: MagicMock,
+    ):
+        """Both inline HTMX URLs (``edit`` + ``regenerate``) MUST be wired
+        up in the swap, otherwise the clause becomes read-only until the
+        user navigates away.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_session(current_step=5)
+        mock_decrypt.return_value = _clauses_json()
+        mock_find_job.return_value = {
+            "status": "success",
+            "payload": {"clause_index": 0},
+        }
+
+        client = _authed_client()
+        resp = client.get(f"/drafter/{_SESSION_ID}/step/5/regenerate/0/status")
+
+        assert resp.status_code == 200
+        body = resp.text
+
+        # Muuda HTMX target.
+        assert f"/drafter/{_SESSION_ID}/step/5/edit/0" in body
+        assert "Muuda" in body
+        # Genereeri uuesti HTMX target.
+        assert f"/drafter/{_SESSION_ID}/step/5/regenerate/0" in body
+        assert "Genereeri uuesti" in body
+
+    @patch("app.drafter.routes._find_latest_job")
+    @patch("app.drafter.routes.decrypt_text")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_success_fragment_includes_annotation_button(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_find_job: MagicMock,
+    ):
+        """The clause-scoped AnnotationButton wrapper MUST appear so users
+        can still add notes after a regeneration.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_session(current_step=5)
+        mock_decrypt.return_value = _clauses_json()
+        mock_find_job.return_value = {
+            "status": "success",
+            "payload": {"clause_index": 0},
+        }
+
+        client = _authed_client()
+        resp = client.get(f"/drafter/{_SESSION_ID}/step/5/regenerate/0/status")
+
+        assert resp.status_code == 200
+        body = resp.text
+
+        # The AnnotationButton wraps its trigger button + popover container
+        # in a ``annotation-button-wrapper`` Div. The trigger button itself
+        # carries the ``annotation-button`` class and HXes the annotation
+        # API with both ``target_type=provision`` and the clause-scoped
+        # ``target_id=<session_id>-clause-<idx>``.
+        assert "annotation-button-wrapper" in body
+        assert "annotation-button" in body
+        assert "target_type=provision" in body
+        assert f"target_id={_SESSION_ID}-clause-0" in body


### PR DESCRIPTION
## Changes

Extracted a shared **\`_render_clause_card()\`** helper in \`app/drafter/routes.py\` so the drafter step-5 initial page render and the \`regenerate_clause_status()\` HTMX success fragment now emit **identical markup**.

Both code paths produce the full clause \`Div\` with:
- \`H4\` heading + chapter \`Small\`
- \`P\` body + optional citations row + optional notes line
- The \`.clause-actions\` row containing:
  - \`Muuda\` button → \`/drafter/{session}/step/5/edit/{idx}\`
  - \`Genereeri uuesti\` button → \`/drafter/{session}/step/5/regenerate/{idx}\`
  - \`AnnotationButton("provision", "{session}-clause-{idx}")\`

When called from the regen polling endpoint, the helper additionally renders an inline \`"Uuesti genereeritud."\` success \`Alert\` (\`success_alert=True\` flag).

### Why

Before this change, the polling endpoint's success branch returned a stripped-down clause Div without \`.clause-actions\`. After a regeneration the HTMX \`outerHTML\` swap dropped the action row, leaving the clause **non-interactive** (no edit, no further regenerate, no annotation) until the user reloaded the page. A pure UI-state regression in the inline HTMX flow.

## Testing

- \`uv run pytest tests/test_drafter_clause_regen.py -v\` — 3/3 pass
- \`uv run pytest tests/ -k drafter -x\` — 140/140 pass (2 unrelated admin skips)
- \`uv run pytest tests/ -x -q\` — 2412/2412 pass (full suite)
- \`uv run ruff format app/drafter/routes.py tests/test_drafter_clause_regen.py\` — clean
- \`uv run ruff check app/drafter/routes.py tests/test_drafter_clause_regen.py\` — clean
- \`uv run pyright app/drafter/routes.py tests/test_drafter_clause_regen.py\` — 0 errors

The new test class **\`TestRegenerateClauseStatusSuccessFragment\`** covers three assertions over the success-branch response:

1. \`test_success_fragment_preserves_clause_actions\` — \`.clause-actions\` class is present.
2. \`test_success_fragment_carries_edit_and_regenerate_urls\` — both \`/edit/{idx}\` and \`/regenerate/{idx}\` URLs appear.
3. \`test_success_fragment_includes_annotation_button\` — \`annotation-button-wrapper\` + \`target_type=provision\` + \`target_id={session}-clause-{idx}\` all present.

Closes #774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)