### PR TITLE
fix(docs): #776 — derive upload size UI from server configuration

### DIFF
--- a/app/docs/routes/__init__.py
+++ b/app/docs/routes/__init__.py
@@ -140,10 +140,9 @@ from app.docs.routes._shared import (
 from app.docs.routes._status_tracker import _status_tracker
 from app.docs.routes._upload import (
     _DOC_TYPE_TOGGLE_SCRIPT,
-    _FILE_PICKER_SCRIPT,
-    _UPLOAD_MAX_BYTES,
     _VALID_DOC_TYPES,
     _doc_type_radio,
+    _file_picker_script,
     _upload_form,
     _validate_parent_vtk_fk,
     _version_picker,
@@ -174,11 +173,10 @@ __all__ = [
     "_status_tracker",
     # _upload.py constants
     "_DOC_TYPE_TOGGLE_SCRIPT",
-    "_FILE_PICKER_SCRIPT",
-    "_UPLOAD_MAX_BYTES",
     "_VALID_DOC_TYPES",
     # _upload.py helpers
     "_doc_type_radio",
+    "_file_picker_script",
     "_upload_form",
     "_validate_parent_vtk_fk",
     "_version_picker",

--- a/app/docs/routes/_list.py
+++ b/app/docs/routes/_list.py
@@ -68,6 +68,7 @@ from app.docs.status import (
 from app.docs.status import (
     VALID_STATUSES as _VALID_STATUSES,
 )
+from app.docs.upload import max_upload_mb_display
 from app.ui.data.data_table import Column, DataTable
 from app.ui.data.pagination import Pagination
 from app.ui.feedback.empty_state import EmptyState
@@ -655,10 +656,10 @@ def drafts_list_page(req: Request):
             ),
             P(
                 "Vajutage „Laadi üles uus eelnõu“, et alustada. "
-                "Maksimaalne failisuurus on 50 MB. Eelnõud säilivad kuni "
-                "nende kustutamiseni; tundlikud failid on krüpteeritud "
-                "puhkeolekus ja nähtavad ainult teie organisatsiooni "
-                "liikmetele."
+                f"Maksimaalne failisuurus on {max_upload_mb_display()}. "
+                "Eelnõud säilivad kuni nende kustutamiseni; tundlikud failid "
+                "on krüpteeritud puhkeolekus ja nähtavad ainult teie "
+                "organisatsiooni liikmetele."
             ),
             variant="info",
             dismissible=True,

--- a/app/docs/routes/_upload.py
+++ b/app/docs/routes/_upload.py
@@ -14,9 +14,10 @@ Routes registered (wired by :func:`app.docs.routes.register_draft_routes`):
 Public-ish helpers re-exported by ``app.docs.routes.__init__`` for
 back-compat:
 
-    ``_UPLOAD_MAX_BYTES`` / ``_FILE_PICKER_SCRIPT`` / ``_DOC_TYPE_TOGGLE_SCRIPT``
+    ``_DOC_TYPE_TOGGLE_SCRIPT``
     ``_VALID_DOC_TYPES``
     ``_doc_type_radio``
+    ``_file_picker_script`` — renders the upload-size-aware picker JS (#776)
     ``_vtk_picker``         — also used by the link-vtk modal in __init__.py
     ``_version_picker``
     ``_upload_form``
@@ -52,7 +53,12 @@ from app.docs.draft_model import (
     list_versionable_drafts_for_org,
     list_vtks_for_org,
 )
-from app.docs.upload import DraftUploadError, handle_upload
+from app.docs.upload import (
+    DraftUploadError,
+    handle_upload,
+    max_upload_bytes,
+    max_upload_mb_display,
+)
 from app.ui.feedback.flash import push_flash
 from app.ui.layout import PageShell
 from app.ui.primitives.button import Button
@@ -66,55 +72,63 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Client-side upload helpers (#602, #640)
+# Client-side upload helpers (#602, #640, #776)
 # ---------------------------------------------------------------------------
 
 
-# #602: client-side 50 MB cap matches the server-side limit in
-# ``app/docs/upload.py``. Surfaced in the browser so users don't wait
-# for a large upload to transfer before being told it's too big. The
-# inline script also renders "filename — 12.3 MB" below the picker so
-# there is immediate visual confirmation of the selection.
-_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+def _file_picker_script() -> str:
+    """Render the file-picker JS with the *current* upload-size limit (#776).
 
-_FILE_PICKER_SCRIPT = (
-    "(function () {\n"
-    "  var input = document.getElementById('field-file');\n"
-    "  if (!input) return;\n"
-    "  var info = document.getElementById('field-file-info');\n"
-    "  var err = document.getElementById('field-file-error');\n"
-    "  var submit = document.getElementById('upload-submit');\n"
-    f"  var MAX = {_UPLOAD_MAX_BYTES};\n"
-    "  function fmt(bytes) {\n"
-    "    if (bytes < 1024) return bytes + ' B';\n"
-    "    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';\n"
-    "    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';\n"
-    "  }\n"
-    "  input.addEventListener('change', function () {\n"
-    "    var file = input.files && input.files[0];\n"
-    "    if (!file) {\n"
-    "      if (info) info.textContent = '';\n"
-    "      if (err) { err.textContent = ''; err.hidden = true; }\n"
-    "      if (submit) submit.disabled = false;\n"
-    "      return;\n"
-    "    }\n"
-    "    if (info) info.textContent = file.name + ' \\u2014 ' + fmt(file.size);\n"
-    "    if (file.size > MAX) {\n"
-    "      if (err) {\n"
-    "        err.textContent = 'Fail on liiga suur (' + fmt(file.size) "
-    "+ '). Maksimaalne suurus on 50 MB.';\n"
-    "        err.hidden = false;\n"
-    "      }\n"
-    "      if (submit) submit.disabled = true;\n"
-    "      input.value = '';\n"
-    "      if (info) info.textContent = '';\n"
-    "    } else {\n"
-    "      if (err) { err.textContent = ''; err.hidden = true; }\n"
-    "      if (submit) submit.disabled = false;\n"
-    "    }\n"
-    "  });\n"
-    "})();\n"
-)
+    #602: client-side size cap matches the server-side limit in
+    ``app/docs/upload.py`` so users don't wait for a large upload to
+    transfer before being told it's too big. The inline script also
+    renders "filename — 12.3 MB" below the picker so there is immediate
+    visual confirmation of the selection.
+
+    The byte constant and the user-facing error string both derive from
+    the same ``MAX_UPLOAD_SIZE_MB`` read (#776) so the JS gate and the
+    server-side validator are guaranteed to agree.
+    """
+    max_bytes = max_upload_bytes()
+    max_label = max_upload_mb_display()
+    return (
+        "(function () {\n"
+        "  var input = document.getElementById('field-file');\n"
+        "  if (!input) return;\n"
+        "  var info = document.getElementById('field-file-info');\n"
+        "  var err = document.getElementById('field-file-error');\n"
+        "  var submit = document.getElementById('upload-submit');\n"
+        f"  var MAX = {max_bytes};\n"
+        "  function fmt(bytes) {\n"
+        "    if (bytes < 1024) return bytes + ' B';\n"
+        "    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';\n"
+        "    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';\n"
+        "  }\n"
+        "  input.addEventListener('change', function () {\n"
+        "    var file = input.files && input.files[0];\n"
+        "    if (!file) {\n"
+        "      if (info) info.textContent = '';\n"
+        "      if (err) { err.textContent = ''; err.hidden = true; }\n"
+        "      if (submit) submit.disabled = false;\n"
+        "      return;\n"
+        "    }\n"
+        "    if (info) info.textContent = file.name + ' \\u2014 ' + fmt(file.size);\n"
+        "    if (file.size > MAX) {\n"
+        "      if (err) {\n"
+        "        err.textContent = 'Fail on liiga suur (' + fmt(file.size) "
+        f"+ '). Maksimaalne suurus on {max_label}.';\n"
+        "        err.hidden = false;\n"
+        "      }\n"
+        "      if (submit) submit.disabled = true;\n"
+        "      input.value = '';\n"
+        "      if (info) info.textContent = '';\n"
+        "    } else {\n"
+        "      if (err) { err.textContent = ''; err.hidden = true; }\n"
+        "      if (submit) submit.disabled = false;\n"
+        "    }\n"
+        "  });\n"
+        "})();\n"
+    )
 
 
 # #640: inline toggle that disables the "Seotud VTK" picker when the
@@ -374,13 +388,17 @@ def _upload_form(
                 cls="input input-file",
             ),
             Small(  # noqa: F405
-                "Toetatud failitüübid: .docx, .pdf. Maksimaalne suurus 50 MB.",
+                f"Toetatud failitüübid: .docx, .pdf. "
+                f"Maksimaalne suurus {max_upload_mb_display()}.",
                 cls="form-field-help",
             ),
             # #602: client-side picker feedback — filename + formatted
             # size, plus an inline error when the picked file exceeds
-            # 50 MB so the user is not forced to wait for a large
-            # upload to transfer before being told it's too big.
+            # the configured limit so the user is not forced to wait
+            # for a large upload to transfer before being told it's too
+            # big. The actual byte cap is derived at render time so a
+            # change to ``MAX_UPLOAD_SIZE_MB`` propagates without a
+            # redeploy of the routes module (#776).
             P("", id="field-file-info", cls="form-field-help muted-text"),  # noqa: F405
             Div(  # noqa: F405
                 "",
@@ -406,7 +424,7 @@ def _upload_form(
             Span("", cls="btn-spinner upload-spinner", aria_hidden="true"),  # noqa: F405
             cls="form-actions",
         ),
-        Script(_FILE_PICKER_SCRIPT),  # noqa: F405
+        Script(_file_picker_script()),  # noqa: F405
         Script(_DOC_TYPE_TOGGLE_SCRIPT),  # noqa: F405
         method="post",
         action="/drafts",
@@ -467,7 +485,7 @@ def new_draft_page(req: Request):
         H1("Uus eelnõu", cls="page-title"),  # noqa: F405
         InfoBox(
             P(
-                "Valige fail (.docx või .pdf, kuni 50 MB) ja andke sellele "
+                f"Valige fail (.docx või .pdf, kuni {max_upload_mb_display()}) ja andke sellele "
                 "pealkiri. Pärast üleslaadimist analüüsib "
                 "süsteem eelnõu automaatselt."
             ),

--- a/app/docs/upload.py
+++ b/app/docs/upload.py
@@ -116,21 +116,51 @@ class _UploadLike(Protocol):
 # ---------------------------------------------------------------------------
 
 
-def _max_upload_bytes() -> int:
-    """Return the maximum accepted upload size in bytes.
+_DEFAULT_MAX_UPLOAD_MB = 50
+
+
+def _max_upload_mb() -> int:
+    """Return the configured ``MAX_UPLOAD_SIZE_MB`` clamped to ``[1, ∞)``.
 
     Controlled by ``MAX_UPLOAD_SIZE_MB`` so ops can raise/lower the limit
     per environment without a redeploy. Defaults to 50 MB — Phase 2 spec
     §3 calls for 25 MB but 50 MB leaves headroom for scanned PDFs and is
     still well below the encryption overhead budget.
     """
-    raw = os.environ.get("MAX_UPLOAD_SIZE_MB", "50")
+    raw = os.environ.get("MAX_UPLOAD_SIZE_MB", str(_DEFAULT_MAX_UPLOAD_MB))
     try:
         mb = int(raw)
     except ValueError:
-        logger.warning("Invalid MAX_UPLOAD_SIZE_MB=%r, falling back to 50", raw)
-        mb = 50
-    return max(1, mb) * 1024 * 1024
+        logger.warning(
+            "Invalid MAX_UPLOAD_SIZE_MB=%r, falling back to %d",
+            raw,
+            _DEFAULT_MAX_UPLOAD_MB,
+        )
+        mb = _DEFAULT_MAX_UPLOAD_MB
+    return max(1, mb)
+
+
+def max_upload_bytes() -> int:
+    """Return the maximum accepted upload size in bytes.
+
+    Single source of truth shared between server-side validation
+    (:func:`_validate_size`) and the upload-form UI (#776). Reads
+    ``MAX_UPLOAD_SIZE_MB`` from the environment on every call so a
+    runtime override (e.g. ``monkeypatch.setenv`` in tests, or a Coolify
+    env-var change) is picked up without a restart.
+    """
+    return _max_upload_mb() * 1024 * 1024
+
+
+def max_upload_mb_display() -> str:
+    """Return the configured upload size as a user-facing ``"<N> MB"`` label.
+
+    Companion helper to :func:`max_upload_bytes` — both derive from the
+    same ``MAX_UPLOAD_SIZE_MB`` read so the JS byte constant and the
+    Estonian copy in the upload form / listing page stay in lockstep
+    (#776).
+    """
+    return f"{_max_upload_mb()} MB"
 
 
 # ---------------------------------------------------------------------------
@@ -180,15 +210,15 @@ def _validate_size(size: int | None, contents: bytes) -> int:
     actual = len(contents)
     # Prefer the post-read length — ``UploadFile.size`` is advisory and
     # some clients lie about it.
-    limit = _max_upload_bytes()
+    limit = max_upload_bytes()
     if actual == 0:
         raise DraftUploadError("Üleslaaditud fail on tühi.")
     if actual > limit:
-        mb = limit // (1024 * 1024)
-        raise DraftUploadError(f"Fail on liiga suur. Maksimaalne lubatud suurus on {mb} MB.")
+        label = max_upload_mb_display()
+        raise DraftUploadError(f"Fail on liiga suur. Maksimaalne lubatud suurus on {label}.")
     if size is not None and size > limit:
-        mb = limit // (1024 * 1024)
-        raise DraftUploadError(f"Fail on liiga suur. Maksimaalne lubatud suurus on {mb} MB.")
+        label = max_upload_mb_display()
+        raise DraftUploadError(f"Fail on liiga suur. Maksimaalne lubatud suurus on {label}.")
     return actual
 
 

--- a/tests/test_docs_upload_routes.py
+++ b/tests/test_docs_upload_routes.py
@@ -1,0 +1,227 @@
+"""Route tests for the configurable upload-size UI (#776).
+
+The upload form embeds the byte cap as a JS constant and renders the
+human-readable MB label in three places (the page InfoBox, the file
+input's helper text, and the drafts-list InfoBox). All four must derive
+from the *same* ``MAX_UPLOAD_SIZE_MB`` env var so a Coolify override
+propagates without a redeploy.
+
+These tests monkeypatch ``MAX_UPLOAD_SIZE_MB`` on the way into the
+TestClient and then assert that:
+
+* GET /drafts/new bakes the right byte count into ``MAX = <bytes>;``
+* GET /drafts/new renders the matching ``"<N> MB"`` label in the help copy
+* GET /drafts renders the matching ``"<N> MB"`` label in the workspace banner
+
+The default-50 byte constant remains pinned by
+:class:`tests.test_docs_routes.TestUploadPrecheck` so we don't duplicate
+that here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors tests/test_docs_routes.py to keep both suites independent)
+# ---------------------------------------------------------------------------
+
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "koostaja@seadusloome.ee",
+        "full_name": "Test Koostaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client() -> TestClient:
+    client = TestClient(__import__("app.main", fromlist=["app"]).app, follow_redirects=False)
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMaxUploadHelpers:
+    """``max_upload_bytes`` / ``max_upload_mb_display`` round-trip the env var."""
+
+    def test_helpers_round_trip_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MAX_UPLOAD_SIZE_MB", raising=False)
+        from app.docs.upload import max_upload_bytes, max_upload_mb_display
+
+        assert max_upload_bytes() == 50 * 1024 * 1024
+        assert max_upload_mb_display() == "50 MB"
+
+    def test_helpers_round_trip_override(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "10")
+        from app.docs.upload import max_upload_bytes, max_upload_mb_display
+
+        assert max_upload_bytes() == 10 * 1024 * 1024
+        assert max_upload_mb_display() == "10 MB"
+
+    def test_helpers_round_trip_large_override(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "200")
+        from app.docs.upload import max_upload_bytes, max_upload_mb_display
+
+        assert max_upload_bytes() == 200 * 1024 * 1024
+        assert max_upload_mb_display() == "200 MB"
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch):
+        """A malformed env var must not crash — fall back to 50 MB."""
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "not-a-number")
+        from app.docs.upload import max_upload_bytes, max_upload_mb_display
+
+        assert max_upload_bytes() == 50 * 1024 * 1024
+        assert max_upload_mb_display() == "50 MB"
+
+
+# ---------------------------------------------------------------------------
+# GET /drafts/new — server-rendered JS + copy follow MAX_UPLOAD_SIZE_MB
+# ---------------------------------------------------------------------------
+
+
+class TestUploadFormSizeFromConfig:
+    """The byte count and MB label in the upload form must track the env var."""
+
+    @patch("app.auth.middleware._get_provider")
+    def test_form_uses_configured_10mb_limit(
+        self,
+        mock_get_provider: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """With MAX_UPLOAD_SIZE_MB=10 the JS constant + copy must match."""
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "10")
+        mock_get_provider.return_value = _stub_provider()
+
+        client = _authed_client()
+        resp = client.get("/drafts/new")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # 10 MB = 10485760 bytes — embedded in the picker JS.
+        assert "10485760" in body
+        # The default 50 MB constant must NOT leak through.
+        assert "52428800" not in body
+        # Human copy in the InfoBox + Small must match the configured value.
+        assert "10 MB" in body
+        # Spot-check both surfaces: the InfoBox uses "kuni 10 MB" and the
+        # input help text uses "Maksimaalne suurus 10 MB".
+        assert "kuni 10 MB" in body
+        assert "Maksimaalne suurus 10 MB" in body
+
+    @patch("app.auth.middleware._get_provider")
+    def test_form_uses_configured_200mb_limit(
+        self,
+        mock_get_provider: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """With MAX_UPLOAD_SIZE_MB=200 the JS constant + copy must match."""
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "200")
+        mock_get_provider.return_value = _stub_provider()
+
+        client = _authed_client()
+        resp = client.get("/drafts/new")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # 200 MB = 209715200 bytes.
+        assert "209715200" in body
+        # Old default must not appear.
+        assert "52428800" not in body
+        assert "200 MB" in body
+        assert "kuni 200 MB" in body
+        assert "Maksimaalne suurus 200 MB" in body
+
+    @patch("app.auth.middleware._get_provider")
+    def test_form_default_50mb_when_env_unset(
+        self,
+        mock_get_provider: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """No env var → 50 MB is the documented default."""
+        monkeypatch.delenv("MAX_UPLOAD_SIZE_MB", raising=False)
+        mock_get_provider.return_value = _stub_provider()
+
+        client = _authed_client()
+        resp = client.get("/drafts/new")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # 50 MB = 52428800 bytes.
+        assert "52428800" in body
+        assert "50 MB" in body
+        assert "kuni 50 MB" in body
+
+
+# ---------------------------------------------------------------------------
+# GET /drafts — workspace InfoBox follows MAX_UPLOAD_SIZE_MB
+# ---------------------------------------------------------------------------
+
+
+class TestDraftsListSizeFromConfig:
+    """The /drafts InfoBox advertises the same limit as the upload form."""
+
+    @patch("app.docs.routes._list.list_users")
+    @patch("app.docs.routes._list.list_drafts_for_org_filtered")
+    @patch("app.auth.middleware._get_provider")
+    def test_drafts_list_uses_configured_10mb_limit(
+        self,
+        mock_get_provider: MagicMock,
+        mock_list_filtered: MagicMock,
+        mock_list_users: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "10")
+        mock_get_provider.return_value = _stub_provider()
+        mock_list_filtered.return_value = ([], 0)
+        mock_list_users.return_value = []
+
+        client = _authed_client()
+        resp = client.get("/drafts")
+
+        assert resp.status_code == 200
+        # The empty-state workspace banner must advertise the configured limit.
+        assert "Maksimaalne failisuurus on 10 MB" in resp.text
+        # And must not hard-code 50 MB anywhere.
+        assert "50 MB" not in resp.text
+
+    @patch("app.docs.routes._list.list_users")
+    @patch("app.docs.routes._list.list_drafts_for_org_filtered")
+    @patch("app.auth.middleware._get_provider")
+    def test_drafts_list_uses_configured_200mb_limit(
+        self,
+        mock_get_provider: MagicMock,
+        mock_list_filtered: MagicMock,
+        mock_list_users: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "200")
+        mock_get_provider.return_value = _stub_provider()
+        mock_list_filtered.return_value = ([], 0)
+        mock_list_users.return_value = []
+
+        client = _authed_client()
+        resp = client.get("/drafts")
+
+        assert resp.status_code == 200
+        assert "Maksimaalne failisuurus on 200 MB" in resp.text


### PR DESCRIPTION
## Changes

- Added `max_upload_bytes()` / `max_upload_mb_display()` helpers in
  `app/docs/upload.py` so the server validator and every UI surface
  read `MAX_UPLOAD_SIZE_MB` from the same place. The internal
  `_validate_size` was rewired through the new public helper.
- Replaced the hard-coded `50 * 1024 * 1024` JS constant in
  `app/docs/routes/_upload.py` with a `_file_picker_script()` factory
  that bakes the configured byte count + human label into the script at
  render time.
- Updated the three "50 MB" copy occurrences in the upload form
  (`InfoBox`, the file input's `Small` hint, the inline pre-check error
  message) and the workspace empty-state `InfoBox` in
  `app/docs/routes/_list.py` to derive from `max_upload_mb_display()`.
- Removed the now-stale module-level `_UPLOAD_MAX_BYTES` /
  `_FILE_PICKER_SCRIPT` constants and their re-exports from
  `app/docs/routes/__init__.py`. Nothing outside the package imported
  them (verified with `grep -rn` across `app/` and `tests/`).

## Testing

- New `tests/test_docs_upload_routes.py` (9 cases):
  - `TestMaxUploadHelpers` — round-trips the env var through
    `max_upload_bytes()` / `max_upload_mb_display()` (default, 10 MB,
    200 MB, malformed value → fallback).
  - `TestUploadFormSizeFromConfig` — monkeypatches
    `MAX_UPLOAD_SIZE_MB={10, 200}` and asserts the rendered
    `/drafts/new` HTML contains the matching byte constant
    (`10485760` / `209715200`), the matching `"N MB"` label, and does
    not leak `52428800` / `50 MB`.
  - `TestDraftsListSizeFromConfig` — same monkeypatch round-trip for
    the `/drafts` empty-state InfoBox.
- Existing pre-check test (`tests/test_docs_routes.py::TestUploadPrecheck`)
  still passes because the default-50 byte constant is unchanged.
- `uv run pytest tests/ -k "upload or docs_list"` — 61 passed.
- `uv run pytest tests/ -k "docs"` — 526 passed.
- `uv run ruff check` and `uv run pyright` clean on all five touched
  files.

## Caveats

- The "back-compat" re-exports `_UPLOAD_MAX_BYTES` and
  `_FILE_PICKER_SCRIPT` are gone from `app/docs/routes/__init__.py`. A
  repo-wide `grep` confirmed no external caller relies on them; if
  anything downstream does, the fix is to import `max_upload_bytes()`
  from `app.docs.upload` instead.

Closes #776.

🤖 Generated with [Claude Code](https://claude.com/claude-code)