### PR TITLE
fix(chat): #775 — unify HTMX search with the chat list table state

### DIFF
--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -56,7 +56,6 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
-from fasthtml.common import A, Div, Li, P, Ul
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
@@ -71,7 +70,6 @@ from app.chat.models import (
     delete_messages_from,
     fork_conversation,
     get_conversation,
-    list_conversations_for_user,
     list_messages,
     set_conversation_archived,
     set_conversation_pinned,
@@ -991,82 +989,79 @@ def export_docx_handler(req: Request, conv_id: str):
 # ---------------------------------------------------------------------------
 
 
-def _search_conversations_impl(
-    conn: Any, user_id: str, term: str, limit: int = 25
-) -> list[Conversation]:
-    """Return conversations whose title matches *term* (case-insensitive).
+def _build_chat_redirect_target(*, q: str, archived: bool) -> str:
+    """Compose the ``/chat?…`` redirect target for the non-HTMX search path."""
+    from urllib.parse import urlencode
 
-    Delegates to :func:`list_conversations_for_user` with the ``search``
-    kwarg which performs an ILIKE substring match against ``title``.
-    Full-text search on message bodies is out of scope for this sweep;
-    that would need a tsvector column migration.
-    """
-    try:
-        return list_conversations_for_user(conn, user_id, limit=limit, search=term)
-    except Exception:
-        logger.exception("Search failed for term=%r user=%s", term, user_id)
-        return []
-
-
-def _render_search_results(conversations: list[Conversation], term: str) -> Any:
-    """Render an HTML fragment suitable for ``hx-target`` replacement."""
-    if not conversations:
-        return Div(
-            P(f'Otsingule "{term}" ei vastanud ukski vestlus.', cls="muted-text"),
-            id="chat-search-results",
-            cls="chat-search-results chat-search-empty",
-        )
-    items = []
-    for conv in conversations:
-        items.append(
-            Li(
-                A(
-                    conv.title or "Nõustamine",
-                    href=f"/chat/{conv.id}",
-                    cls="chat-search-result-link",
-                ),
-                cls="chat-search-result-item",
-            )
-        )
-    return Div(
-        Ul(*items, cls="chat-search-result-list"),
-        id="chat-search-results",
-        cls="chat-search-results",
-    )
+    params: list[tuple[str, str]] = []
+    if q:
+        params.append(("q", q))
+    if archived:
+        params.append(("archived", "1"))
+    if not params:
+        return "/chat"
+    return "/chat?" + urlencode(params)
 
 
 def search_conversations_handler(req: Request):
-    """GET /chat/search?q=<term>.
+    """GET /chat/search?q=<term>&archived=<0|1>&page=<n>.
 
-    HTMX callers get an HTML fragment keyed on ``#chat-search-results``;
-    plain browsers are redirected to ``/chat?q=<term>`` so the main list
-    renderer (owned by ``routes.py``) can handle the query parameter.
+    #775: HTMX callers now receive the same ``#chat-list-body`` fragment
+    that :func:`app.chat.routes.chat_list_page` renders for the full GET
+    page. The fragment carries the conversation table (pin / archive /
+    rename / delete row controls) and pagination footer with ``q`` +
+    ``archived`` preserved, so the toolbar's HTMX swap behaves exactly
+    like the standard ``/chat`` reload — just without the page chrome.
+
+    The previous lightweight ``#chat-search-results`` fragment is gone:
+    it dropped the row action controls and ignored the archived toggle,
+    which made the HTMX swap a regression compared to the full page
+    render (#775 evidence).
+
+    Plain browsers (no HTMX) are still redirected to ``/chat?q=…`` so
+    the main list renderer owns the page-level state. The redirect
+    target now carries the ``archived`` toggle too so a non-JS user
+    who unticks ``Näita arhiveeritud`` and submits keeps that intent
+    on the redirected page.
     """
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
         return auth_or_redirect
     auth = auth_or_redirect
 
-    term = (req.query_params.get("q") or "").strip()
-    if not _is_htmx(req):
-        target = f"/chat?q={term}" if term else "/chat"
-        return RedirectResponse(url=target, status_code=303)
+    # Read q + archived + page from the request the same way the full
+    # GET /chat page does, so the HTMX swap and the redirected page
+    # share one filter contract.
+    from app.chat.routes import (  # imported lazily to avoid the routes <-> handlers cycle
+        _chat_list_state_from_request,
+        _render_chat_list_body,
+    )
 
-    if not term:
-        return _render_search_results([], "")
+    page, search_q, include_archived = _chat_list_state_from_request(req)
+
+    if not _is_htmx(req):
+        return RedirectResponse(
+            url=_build_chat_redirect_target(q=search_q, archived=include_archived),
+            status_code=303,
+        )
 
     user_id = auth.get("id")
     if not user_id:
-        return _render_search_results([], term)
+        # No user identity — render an empty list-body fragment so the
+        # HTMX swap still hits a stable ``#chat-list-body`` anchor.
+        return _render_chat_list_body(
+            "",
+            page=1,
+            search_q="",
+            include_archived=False,
+        )
 
-    try:
-        with _connect() as conn:
-            conversations = _search_conversations_impl(conn, str(user_id), term)
-    except Exception:
-        logger.exception("Failed to search conversations for term=%r", term)
-        conversations = []
-
-    return _render_search_results(conversations, term)
+    return _render_chat_list_body(
+        str(user_id),
+        page=page,
+        search_q=search_q,
+        include_archived=include_archived,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -353,6 +353,27 @@ def _count_conversations_for_user(
         return 0
 
 
+def _chat_list_base_url(*, search_q: str, include_archived: bool) -> str:
+    """Build the ``/chat`` base URL with the active filter params preserved.
+
+    Used as :class:`Pagination`'s ``base_url`` so paging through search
+    results / archived views keeps the same filter set (#775). The
+    :func:`app.ui.data.pagination._build_url` helper strips any
+    pre-existing ``page=`` value and appends the requested page, so
+    ``q`` / ``archived`` survive unchanged across page links.
+    """
+    from urllib.parse import urlencode
+
+    params: list[tuple[str, str]] = []
+    if search_q:
+        params.append(("q", search_q))
+    if include_archived:
+        params.append(("archived", "1"))
+    if not params:
+        return "/chat"
+    return "/chat?" + urlencode(params)
+
+
 def _render_chat_list_body(
     user_id: str,
     *,
@@ -373,6 +394,13 @@ def _render_chat_list_body(
     footer inside a single ``#chat-list-body`` div so one swap updates
     both. Empty-state and "no results" branches are shaped so the
     parent container stays stable.
+
+    #775: the toolbar's HTMX search now delegates to this same renderer
+    so the swapped fragment carries the full conversation table
+    (pin / archive / rename / delete row actions) and respects the
+    ``Näita arhiveeritud`` toggle. Pagination links carry ``q`` and
+    ``archived`` so paging through filtered results does not silently
+    drop the filters.
 
     Args:
         user_id: caller's user UUID (already validated by the caller).
@@ -425,7 +453,10 @@ def _render_chat_list_body(
         Pagination(
             current_page=page,
             total_pages=total_pages,
-            base_url="/chat",
+            base_url=_chat_list_base_url(
+                search_q=search_q,
+                include_archived=include_archived,
+            ),
             page_size=_PAGE_SIZE,
             total=total,
         )
@@ -507,7 +538,21 @@ def chat_list_page(req: Request):
             include_archived=include_archived,
         )
 
-    # Search + archived toolbar
+    # Search + archived toolbar.
+    #
+    # #775: the form serialises ``q`` and ``archived`` together so HTMX
+    # search requests carry both \u2014 the same filter contract the full
+    # ``/chat`` GET page uses. The hidden ``page=1`` input resets the
+    # offset on every keystroke / toggle change so a search executed
+    # while standing on page 5 doesn't try to render "page 5 of the
+    # filtered set". ``hx-swap=outerHTML`` matches the swap shape
+    # ``_render_chat_list_body`` already uses for the archive / delete
+    # HTMX paths so the ``#chat-list-body`` wrapper is replaced in one
+    # go. (We deliberately do not push the URL on the HTMX path: the
+    # toolbar input is updated as the user types, and the in-fragment
+    # pagination links carry the filters server-side \u2014 keeping the
+    # address bar pinned to ``/chat`` avoids exposing the internal
+    # ``/chat/search`` endpoint via browser history.)
     toolbar = Form(  # noqa: F405
         Input(  # noqa: F405
             type="search",
@@ -527,11 +572,14 @@ def chat_list_page(req: Request):
             " N\u00e4ita arhiveeritud",
             cls="chat-archived-toggle",
         ),
+        # Hidden marker so the HTMX search request resets the offset.
+        Input(type="hidden", name="page", value="1"),  # noqa: F405
         Button("Otsi", variant="secondary", size="sm", type="submit"),
         method="get",
         action="/chat",
         hx_get="/chat/search",
         hx_target="#chat-list-body",
+        hx_swap="outerHTML",
         hx_trigger=(
             "input changed delay:300ms from:input[name='q'], "
             "change from:input[name='archived'], submit"

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -857,34 +857,121 @@ class TestExport:
 
 
 class TestSearch:
+    """Issue #775: ``/chat/search`` now returns the same ``#chat-list-body``
+    fragment ``/chat`` renders, so the HTMX swap keeps the conversation
+    action controls (pin / archive / rename / delete) and respects the
+    archived toggle. The old lightweight ``#chat-search-results`` shape
+    is gone.
+    """
+
     def test_search_non_htmx_redirects(self, provider_patch, mock_conn):
         client = _authed_client()
         resp = client.get("/chat/search?q=eelnou")
         assert resp.status_code == 303
         assert resp.headers["location"] == "/chat?q=eelnou"
 
-    def test_search_htmx_returns_fragment(self, provider_patch, mock_conn):
+    def test_search_non_htmx_redirect_preserves_archived(self, provider_patch, mock_conn):
+        """#775: the non-HTMX redirect carries ``archived`` through too."""
+        client = _authed_client()
+        resp = client.get("/chat/search?q=eelnou&archived=1")
+        assert resp.status_code == 303
+        # urlencode renders the params in insertion order.
+        assert resp.headers["location"] == "/chat?q=eelnou&archived=1"
+
+    def test_search_htmx_returns_chat_list_body_fragment(self, provider_patch, mock_conn):
+        """HTMX search swap renders the conversation table — same anchor
+        ``/chat`` uses — so pin/archive/rename/delete forms are present.
+        """
         conv = _make_conversation(title="Eelnou X analuus")
-        with patch("app.chat.handlers._search_conversations_impl", return_value=[conv]):
+        with (
+            patch("app.chat.routes._connect", mock_conn[0]),
+            patch("app.chat.routes.list_conversations_for_user", return_value=[conv]),
+            patch("app.chat.routes._count_conversations_for_user", return_value=1),
+            patch("app.chat.routes._get_message_count", return_value=0),
+            patch("app.chat.routes._get_last_message_at", return_value=None),
+        ):
             client = _authed_client()
             resp = client.get("/chat/search?q=eelnou", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        # Same anchor the toolbar swaps in /chat — replaces the table
+        # carrier in one go.
+        assert 'id="chat-list-body"' in resp.text
+        # The matching conversation row is rendered.
+        assert "Eelnou X analuus" in resp.text
+        # And the row carries the action controls — pin / archive /
+        # rename / delete — which the old fragment dropped (#775).
+        assert f"/chat/{_CONV_ID}/pin" in resp.text
+        assert f"/chat/{_CONV_ID}/archive" in resp.text
+        assert f"/chat/{_CONV_ID}/rename" in resp.text
+        assert f"/chat/{_CONV_ID}/delete" in resp.text
+
+    def test_search_htmx_archived_toggle_is_respected(self, provider_patch, mock_conn):
+        """``?archived=1`` flips ``include_archived=True`` on the query."""
+        conv = _make_conversation(title="Vana vestlus")
+        with (
+            patch("app.chat.routes._connect", mock_conn[0]),
+            patch("app.chat.routes.list_conversations_for_user", return_value=[conv]) as mock_list,
+            patch("app.chat.routes._count_conversations_for_user", return_value=1),
+            patch("app.chat.routes._get_message_count", return_value=0),
+            patch("app.chat.routes._get_last_message_at", return_value=None),
+        ):
+            client = _authed_client()
+            resp = client.get(
+                "/chat/search?q=vana&archived=1",
+                headers={"HX-Request": "true"},
+            )
+        assert resp.status_code == 200
+        # The kwargs that hit the model layer carry the archived flag.
+        kwargs = mock_list.call_args.kwargs
+        assert kwargs.get("include_archived") is True
+        assert kwargs.get("search") == "vana"
+
+    def test_search_htmx_archived_defaults_to_false(self, provider_patch, mock_conn):
+        """Without ``archived=1`` archived rows stay hidden (the default)."""
+        with (
+            patch("app.chat.routes._connect", mock_conn[0]),
+            patch("app.chat.routes.list_conversations_for_user", return_value=[]) as mock_list,
+            patch("app.chat.routes._count_conversations_for_user", return_value=0),
+        ):
+            client = _authed_client()
+            resp = client.get("/chat/search?q=tere", headers={"HX-Request": "true"})
             assert resp.status_code == 200
-            assert "chat-search-results" in resp.text
-            assert "Eelnou X analuus" in resp.text
+            assert mock_list.call_args.kwargs.get("include_archived") is False
 
     def test_search_htmx_empty_term_returns_fragment(self, provider_patch, mock_conn):
-        client = _authed_client()
-        resp = client.get("/chat/search?q=", headers={"HX-Request": "true"})
+        """Empty term: the request still goes through the shared renderer
+        and returns the ``#chat-list-body`` anchor (or the genuine empty
+        state when the user has no conversations).
+        """
+        with (
+            patch("app.chat.routes._connect", mock_conn[0]),
+            patch("app.chat.routes.list_conversations_for_user", return_value=[]),
+            patch("app.chat.routes._count_conversations_for_user", return_value=0),
+        ):
+            client = _authed_client()
+            resp = client.get("/chat/search?q=", headers={"HX-Request": "true"})
         assert resp.status_code == 200
-        # No term → empty state fragment.
-        assert "chat-search-results" in resp.text
+        # Either the empty-state Div (id="chat-list-body") or the
+        # "Vestlusi pole" copy is rendered — both come from the shared
+        # helper so the swap target stays stable.
+        assert 'id="chat-list-body"' in resp.text
+        assert "Vestlusi pole" in resp.text
 
-    def test_search_htmx_no_matches(self, provider_patch, mock_conn):
-        with patch("app.chat.handlers._search_conversations_impl", return_value=[]):
+    def test_search_htmx_no_matches_renders_empty_table_state(self, provider_patch, mock_conn):
+        """No matches with an active query: the table-level empty copy
+        is rendered (and the anchor stays stable).
+        """
+        with (
+            patch("app.chat.routes._connect", mock_conn[0]),
+            patch("app.chat.routes.list_conversations_for_user", return_value=[]),
+            patch("app.chat.routes._count_conversations_for_user", return_value=0),
+        ):
             client = _authed_client()
             resp = client.get("/chat/search?q=zzz", headers={"HX-Request": "true"})
-            assert resp.status_code == 200
-            assert "ei vastanud" in resp.text
+        assert resp.status_code == 200
+        assert 'id="chat-list-body"' in resp.text
+        # DataTable's empty-message string lives in routes.py.
+        assert "Vestlusi ei leitud" in resp.text
 
 
 # ---------------------------------------------------------------------------
@@ -969,13 +1056,20 @@ class TestRouteOrdering:
         ``register_chat_handler_routes`` first, so the reorder is a
         no-op. This test locks in the registration order.
         """
-        client = _authed_client()
-        resp = client.get("/chat/search?q=test", headers={"HX-Request": "true"})
-        # The search handler responds 200 with the results fragment; the
-        # dynamic conv_id route would either 404 (bad UUID "search") or
-        # render a completely different page.
+        # Stub the model layer so the search renderer doesn't try to
+        # talk to a real DB while we only care about the routing path.
+        with (
+            patch("app.chat.routes._connect", mock_conn[0]),
+            patch("app.chat.routes.list_conversations_for_user", return_value=[]),
+            patch("app.chat.routes._count_conversations_for_user", return_value=0),
+        ):
+            client = _authed_client()
+            resp = client.get("/chat/search?q=test", headers={"HX-Request": "true"})
+        # The search handler responds 200 with the chat-list-body
+        # fragment (#775); the dynamic conv_id route would either 404
+        # (bad UUID "search") or render a completely different page.
         assert resp.status_code == 200
-        assert "chat-search-results" in resp.text
+        assert 'id="chat-list-body"' in resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -932,6 +932,88 @@ class TestChatListPolish:
             kwargs = mock_list.call_args.kwargs
             assert kwargs.get("search") == "karistus"
 
+    # ------------------------------------------------------------------
+    # #775: pagination URLs preserve the active filter set
+    # ------------------------------------------------------------------
+
+    @patch("app.chat.routes._count_conversations_for_user", return_value=60)
+    @patch("app.chat.routes._get_last_message_at", return_value=None)
+    @patch("app.chat.routes._get_message_count", return_value=0)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_pagination_links_preserve_q_and_archived(
+        self,
+        mock_provider,
+        mock_connect,
+        _mock_msg_count,
+        _mock_last,
+        _mock_total,
+    ):
+        """`/chat?q=…&archived=1` page-2 link must keep both filters.
+
+        Before #775, pagination's ``base_url="/chat"`` dropped ``q`` and
+        ``archived`` on every page jump, silently widening the result
+        set when the user clicked "Järgmine".
+        """
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        conv = _make_conversation()
+        with patch("app.chat.routes.list_conversations_for_user", return_value=[conv]):
+            client = _authed_client()
+            resp = client.get("/chat?q=tere&archived=1")
+        assert resp.status_code == 200
+        # 60 rows / 25 per page = 3 pages, current=1 → "Järgmine" link
+        # must point at page=2 with q + archived still attached.
+        # Both ``&amp;`` (escaped) and ``&`` shapes are accepted because
+        # HTMX renders attribute values with HTML escaping.
+        body = resp.text
+        assert (
+            "/chat?q=tere&archived=1&page=2" in body
+            or "/chat?q=tere&amp;archived=1&amp;page=2" in body
+        )
+
+    @patch("app.chat.routes._count_conversations_for_user", return_value=60)
+    @patch("app.chat.routes._get_last_message_at", return_value=None)
+    @patch("app.chat.routes._get_message_count", return_value=0)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_pagination_links_preserve_q_only(
+        self,
+        mock_provider,
+        mock_connect,
+        _mock_msg_count,
+        _mock_last,
+        _mock_total,
+    ):
+        """A search without ``archived=1`` keeps only ``q`` on page links."""
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        conv = _make_conversation()
+        with patch("app.chat.routes.list_conversations_for_user", return_value=[conv]):
+            client = _authed_client()
+            resp = client.get("/chat?q=karistus")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "/chat?q=karistus&page=2" in body or "/chat?q=karistus&amp;page=2" in body
+        # archived must NOT have leaked in.
+        assert "archived=1" not in body or "archived=1&" not in body.replace("&amp;", "&")
+
+    def test_chat_list_base_url_helper(self):
+        """Unit test the ``_chat_list_base_url`` helper used by pagination."""
+        from app.chat.routes import _chat_list_base_url
+
+        assert _chat_list_base_url(search_q="", include_archived=False) == "/chat"
+        assert _chat_list_base_url(search_q="foo", include_archived=False) == "/chat?q=foo"
+        assert _chat_list_base_url(search_q="", include_archived=True) == "/chat?archived=1"
+        assert (
+            _chat_list_base_url(search_q="foo bar", include_archived=True)
+            == "/chat?q=foo+bar&archived=1"
+        )
+
 
 class TestChatRouteOrdering:
     """Route-registration order regression tests.
@@ -964,11 +1046,18 @@ class TestChatRouteOrdering:
         # And should be a 2xx or the documented 303 redirect for non-HTMX.
         assert resp.status_code in (200, 303)
 
-    @patch("app.chat.handlers._search_conversations_impl", return_value=[])
-    @patch("app.chat.handlers._connect")
+    @patch("app.chat.routes._count_conversations_for_user", return_value=0)
+    @patch("app.chat.routes.list_conversations_for_user", return_value=[])
+    @patch("app.chat.routes._connect")
     @patch("app.auth.middleware._get_provider")
-    def test_search_path_htmx_returns_fragment(self, mock_provider, mock_connect, _mock_search):
-        """HTMX request hits the search handler directly (no redirect)."""
+    def test_search_path_htmx_returns_fragment(
+        self, mock_provider, mock_connect, _mock_list, _mock_count
+    ):
+        """HTMX request hits the search handler directly (no redirect).
+
+        Post-#775: the response is the ``#chat-list-body`` fragment,
+        not the old ``#chat-search-results`` shape.
+        """
         mock_provider.return_value = _stub_provider()
         conn = MagicMock()
         mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
@@ -977,7 +1066,7 @@ class TestChatRouteOrdering:
         client = _authed_client()
         resp = client.get("/chat/search?q=foo", headers={"HX-Request": "true"})
         assert resp.status_code == 200
-        assert "chat-search-results" in resp.text
+        assert 'id="chat-list-body"' in resp.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

`POST /chat/search` was a parallel render path that returned a lightweight `#chat-search-results` fragment containing only conversation links — dropping the pin / archive / rename / delete row controls and ignoring the `Näita arhiveeritud` toggle. Pagination links on `/chat` also lost any active `q` / `archived` filter on every page jump.

This PR makes `/chat/search` delegate to the same `_render_chat_list_body(...)` helper the full `GET /chat` page uses, so the toolbar's HTMX swap renders the actionable conversation table with pin / archive / rename / delete controls intact, respects `?archived=1`, and resets the offset to page 1 on each keystroke / toggle change.

Pagination URLs now thread `q` and `archived` through a new `_chat_list_base_url(...)` helper so paging through a filtered search keeps the filter set — instead of silently widening the result on the next page click.

### Files touched

- `app/chat/routes.py`
  - New `_chat_list_base_url(search_q, include_archived)` helper that builds `/chat?q=…&archived=1` for the `Pagination` `base_url`.
  - `_render_chat_list_body` uses the helper so paging through filtered results keeps the filters.
  - Search toolbar gains a hidden `page=1` input + `hx-swap=outerHTML` so the HTMX swap matches the archive / delete contract and resets the offset on each keystroke.
- `app/chat/handlers.py`
  - `search_conversations_handler` reads `q + archived + page` via the shared `_chat_list_state_from_request(...)` and delegates the HTMX render to `_render_chat_list_body(...)`.
  - Non-HTMX redirect now carries `archived` through too via the new `_build_chat_redirect_target(...)` helper.
  - Old `_render_search_results(...)` + `_search_conversations_impl(...)` + the `fasthtml.common A / Div / Li / P / Ul` imports are removed; the search path no longer needs them.
- `tests/test_chat_handlers.py`
  - `TestSearch` re-written to assert the new `#chat-list-body` contract: action controls present in the row, archived toggle flips `include_archived`, empty-state copy renders inside the stable anchor.
  - `TestRouteOrdering` updated to the new fragment shape.
- `tests/test_chat_routes.py`
  - `TestChatListPolish` gains pagination tests proving `/chat?q=tere&archived=1` keeps both params on the page-2 link.
  - `_chat_list_base_url` gains a small unit test covering the `q-only`, `archived-only`, and combined / empty branches.
  - `test_search_path_htmx_returns_fragment` updated to the new `#chat-list-body` contract.

## Testing

```
uv run pytest tests/ -k chat -x   # 450 passed, 2 skipped
uv run ruff check app/chat/routes.py app/chat/handlers.py tests/test_chat_routes.py tests/test_chat_handlers.py
uv run pyright app/chat/routes.py app/chat/handlers.py
```

New / updated test coverage:
- `TestSearch::test_search_non_htmx_redirect_preserves_archived` — non-HTMX redirect carries `archived=1` through.
- `TestSearch::test_search_htmx_returns_chat_list_body_fragment` — HTMX search returns the action-controls table.
- `TestSearch::test_search_htmx_archived_toggle_is_respected` — `?archived=1` reaches the model layer as `include_archived=True`.
- `TestSearch::test_search_htmx_archived_defaults_to_false` — default keeps archived rows hidden.
- `TestSearch::test_search_htmx_empty_term_returns_fragment` + `..._no_matches_renders_empty_table_state` — stable `#chat-list-body` anchor on the empty-state branches.
- `TestChatListPolish::test_pagination_links_preserve_q_and_archived` + `..._preserve_q_only` — page-2 links keep filters.
- `TestChatListPolish::test_chat_list_base_url_helper` — unit-level coverage of the helper.

Closes #775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)