### PR TITLE
fix(annotations): #773 — URL- and CSS-safe annotation URI targets

### DIFF
--- a/app/annotations/routes.py
+++ b/app/annotations/routes.py
@@ -47,6 +47,7 @@ from app.annotations.models import (
     resolve_annotation,
     resolve_row_thread,
 )
+from app.annotations.row_keys import decode_row_key, safe_row_key
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.provider import UserDict
 from app.auth.users import get_user
@@ -585,6 +586,14 @@ def delete_annotation_handler(req: Request, id: str):
 #
 # row_kind is validated against ``VALID_ROW_KINDS`` at the handler boundary
 # so a malformed value short-circuits before any DB call.
+#
+# #773: row_key arrives percent-encoded for entity / EU rows because the
+# raw ontology URIs contain ``/``, ``:``, and ``#`` characters. The route
+# uses Starlette's ``:path`` converter so a multi-segment URI matches one
+# parameter; each handler then calls :func:`decode_row_key` to recover the
+# original URI for DB reads. The matching encoder is
+# :func:`app.annotations.row_keys.safe_row_key`, used by the report
+# renderer when minting ``hx-get`` URLs.
 # ---------------------------------------------------------------------------
 
 
@@ -742,7 +751,12 @@ def _row_panel_fragment(
     whole inner fragment via ``outerHTML`` from the resolve/reopen
     handlers).
     """
-    base = f"/annotations/version/{draft_version_id}/{row_kind}/{row_key}"
+    # #773: the URLs the fragment's buttons / form POST to must carry
+    # the SAME percent-encoded form the report renderer mints, otherwise
+    # the resolve/reopen/compose actions submit to a path containing raw
+    # ``/`` and ``#`` (the keys here are the already-decoded raw URIs).
+    encoded_row_key = safe_row_key(row_key)
+    base = f"/annotations/version/{draft_version_id}/{row_kind}/{encoded_row_key}"
 
     # Resolve mention UUIDs → display names once per fragment so each
     # message item can render badges without re-querying.
@@ -924,6 +938,11 @@ def get_row_panel_handler(
         return resolved
     version_uuid, _org_id = resolved
 
+    # #773: row_key arrives percent-encoded so URI characters (``/``, ``#``,
+    # ``:``) survive the path-segment round trip. Decode back to the raw
+    # ontology URI before any DB / renderer work.
+    row_key = decode_row_key(row_key)
+
     messages = _load_panel_messages(version_uuid, row_kind, row_key)
     return _row_panel_fragment(version_uuid, row_kind, row_key, messages, auth)
 
@@ -958,6 +977,10 @@ async def post_row_message_handler(
     if isinstance(resolved, Response):
         return resolved
     version_uuid, org_id = resolved
+
+    # #773: see ``get_row_panel_handler`` — decode the URL-encoded URI row
+    # key before persisting / replaying it through the renderer.
+    row_key = decode_row_key(row_key)
 
     raw_content, parse_error = await _read_content(req)
     if parse_error is not None:
@@ -1035,6 +1058,9 @@ def post_row_resolve_handler(
         return resolved
     version_uuid, _org_id = resolved
 
+    # #773: row_key arrives percent-encoded; decode before DB writes.
+    row_key = decode_row_key(row_key)
+
     try:
         with _connect() as conn:
             updated = resolve_row_thread(
@@ -1081,6 +1107,9 @@ def post_row_reopen_handler(
         return resolved
     version_uuid, _org_id = resolved
 
+    # #773: row_key arrives percent-encoded; decode before DB writes.
+    row_key = decode_row_key(row_key)
+
     try:
         with _connect() as conn:
             updated = reopen_row_thread(
@@ -1117,7 +1146,20 @@ def register_annotation_routes(rt) -> None:  # type: ignore[no-untyped-def]
     # §9.4 row-annotation routes (PR-B).  The unprefixed ``/annotations``
     # path matches the sprint plan §6 contract; PR-C wires it up from the
     # impact-report side panel.
-    base = "/annotations/version/{draft_version_id}/{row_kind}/{row_key}"
+    #
+    # #773: ``row_key`` uses the ``:path`` converter because affected-entity
+    # and EU-compliance rows store the raw ontology URI as the key, and URIs
+    # contain ``/``, ``:``, and ``#`` which Starlette decodes BEFORE routing
+    # — a plain ``{row_key}`` segment would 404 once a URI key arrives.
+    # ``:path`` matches greedily (incl. ``/``) so percent-encoded URIs
+    # round-trip via :func:`app.annotations.row_keys.safe_row_key` /
+    # :func:`decode_row_key` at the handler boundary.
+    #
+    # The POST sub-routes (``/messages``, ``/resolve``, ``/reopen``) keep
+    # their own methods so no greedy ``:path`` ambiguity arises — Starlette
+    # routes by ``(path, method)`` and the GET base + POST tail-suffix
+    # patterns each match only on their own verb.
+    base = "/annotations/version/{draft_version_id}/{row_kind}/{row_key:path}"
     rt(base, methods=["GET"])(get_row_panel_handler)
     rt(f"{base}/messages", methods=["POST"])(post_row_message_handler)
     rt(f"{base}/resolve", methods=["POST"])(post_row_resolve_handler)

--- a/app/annotations/routes.py
+++ b/app/annotations/routes.py
@@ -587,13 +587,15 @@ def delete_annotation_handler(req: Request, id: str):
 # row_kind is validated against ``VALID_ROW_KINDS`` at the handler boundary
 # so a malformed value short-circuits before any DB call.
 #
-# #773: row_key arrives percent-encoded for entity / EU rows because the
-# raw ontology URIs contain ``/``, ``:``, and ``#`` characters. The route
-# uses Starlette's ``:path`` converter so a multi-segment URI matches one
-# parameter; each handler then calls :func:`decode_row_key` to recover the
-# original URI for DB reads. The matching encoder is
-# :func:`app.annotations.row_keys.safe_row_key`, used by the report
-# renderer when minting ``hx-get`` URLs.
+# #773 / #781 follow-up: row_key arrives base64url-encoded for every
+# row kind, including entity / EU rows whose raw values are ontology URIs
+# (and sometimes contain literal ``%XX`` substrings, e.g. CELEX). The
+# route uses Starlette's ``:path`` converter so the matcher accepts the
+# whole opaque segment, and each handler calls :func:`decode_row_key` to
+# recover the raw row key before any DB / renderer work. The encoder /
+# decoder pair is the only encode/decode the app performs — base64url
+# uses ``[A-Za-z0-9_-]`` so no transport layer (httpx, Starlette
+# TestClient, uvicorn, reverse proxies) mutates the value in flight.
 # ---------------------------------------------------------------------------
 
 
@@ -938,10 +940,11 @@ def get_row_panel_handler(
         return resolved
     version_uuid, _org_id = resolved
 
-    # #773: row_key arrives percent-encoded so URI characters (``/``, ``#``,
-    # ``:``) survive the path-segment round trip. Decode back to the raw
-    # ontology URI before any DB / renderer work.
-    row_key = decode_row_key(row_key)
+    # #781 follow-up: base64url → raw row key. Malformed input → 400.
+    try:
+        row_key = decode_row_key(row_key)
+    except (ValueError, UnicodeDecodeError):
+        return Response(status_code=400)
 
     messages = _load_panel_messages(version_uuid, row_kind, row_key)
     return _row_panel_fragment(version_uuid, row_kind, row_key, messages, auth)
@@ -978,9 +981,11 @@ async def post_row_message_handler(
         return resolved
     version_uuid, org_id = resolved
 
-    # #773: see ``get_row_panel_handler`` — decode the URL-encoded URI row
-    # key before persisting / replaying it through the renderer.
-    row_key = decode_row_key(row_key)
+    # #781 follow-up: base64url → raw row key. Malformed input → 400.
+    try:
+        row_key = decode_row_key(row_key)
+    except (ValueError, UnicodeDecodeError):
+        return Response(status_code=400)
 
     raw_content, parse_error = await _read_content(req)
     if parse_error is not None:
@@ -1058,8 +1063,11 @@ def post_row_resolve_handler(
         return resolved
     version_uuid, _org_id = resolved
 
-    # #773: row_key arrives percent-encoded; decode before DB writes.
-    row_key = decode_row_key(row_key)
+    # #781 follow-up: base64url → raw row key. Malformed input → 400.
+    try:
+        row_key = decode_row_key(row_key)
+    except (ValueError, UnicodeDecodeError):
+        return Response(status_code=400)
 
     try:
         with _connect() as conn:
@@ -1107,8 +1115,11 @@ def post_row_reopen_handler(
         return resolved
     version_uuid, _org_id = resolved
 
-    # #773: row_key arrives percent-encoded; decode before DB writes.
-    row_key = decode_row_key(row_key)
+    # #781 follow-up: base64url → raw row key. Malformed input → 400.
+    try:
+        row_key = decode_row_key(row_key)
+    except (ValueError, UnicodeDecodeError):
+        return Response(status_code=400)
 
     try:
         with _connect() as conn:
@@ -1151,9 +1162,13 @@ def register_annotation_routes(rt) -> None:  # type: ignore[no-untyped-def]
     # and EU-compliance rows store the raw ontology URI as the key, and URIs
     # contain ``/``, ``:``, and ``#`` which Starlette decodes BEFORE routing
     # — a plain ``{row_key}`` segment would 404 once a URI key arrives.
-    # ``:path`` matches greedily (incl. ``/``) so percent-encoded URIs
-    # round-trip via :func:`app.annotations.row_keys.safe_row_key` /
-    # :func:`decode_row_key` at the handler boundary.
+    # ``:path`` matches greedily; the actual segment is base64url so it
+    # never contains ``/`` in practice (base64url alphabet is
+    # ``[A-Za-z0-9_-]``), but the ``:path`` converter is kept because
+    # older URLs encoded with the previous percent-encoding scheme may
+    # still be in flight during a rolling deploy. Outbound encoding goes
+    # through :func:`app.annotations.row_keys.safe_row_key`; inbound
+    # decoding goes through :func:`app.annotations.row_keys.decode_row_key`.
     #
     # The POST sub-routes (``/messages``, ``/resolve``, ``/reopen``) keep
     # their own methods so no greedy ``:path`` ambiguity arises — Starlette

--- a/app/annotations/row_keys.py
+++ b/app/annotations/row_keys.py
@@ -21,25 +21,40 @@ FastHTML/UI import baggage.
 URL + CSS safety (#773):
 
 The ``entity`` and ``eu`` row keys are raw ontology URIs that contain
-``/``, ``:``, and ``#`` characters. Embedding them directly into URL
-path segments (e.g. ``/annotations/version/<v>/<kind>/<row_key>``) or
-CSS id selectors (``#annotation-popover-entity-<row_key>``) breaks
-routing and DOM lookups. Three helpers mediate the boundary:
+``/``, ``:``, ``#``, and sometimes literal ``%XX`` substrings (e.g. EU
+CELEX identifiers stored as ``CELEX%3A32016R0679``). Embedding them
+directly into URL path segments (e.g.
+``/annotations/version/<v>/<kind>/<row_key>``) or CSS id selectors
+(``#annotation-popover-entity-<row_key>``) breaks routing and DOM
+lookups. Three helpers mediate the boundary:
 
-* :func:`safe_row_key` — percent-encode for URL path embedding.
+* :func:`safe_row_key` — base64url-encode for opaque path embedding.
 * :func:`decode_row_key` — server-side decode at the handler boundary.
 * :func:`target_dom_id` — derive a CSS-safe DOM id from any raw target.
 
 The original URI stays the round-trip identity; only the URL path
 segment and the DOM id use the encoded / hashed form.
+
+Why base64url instead of percent-encoding (#781 follow-up):
+
+Percent-encoding only round-trips if the raw value contains no
+literal ``%XX`` substrings. CELEX URIs like ``CELEX%3A32016R0679``
+break that invariant — ``quote`` turns the ``%`` into ``%25``, then
+the ASGI server (and Starlette's TestClient, on top of httpx) decodes
+percent sequences along the transport chain. The number of decodes is
+not contractually fixed by ASGI servers and known to differ between
+uvicorn, Starlette's TestClient, and reverse proxies. Base64url uses
+only ``[A-Za-z0-9_-]`` — none of which are special in any URL, CSS,
+or HTML context — so the encoded form is opaque to every transport
+layer and the only encode/decode happens in this module.
 """
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 from typing import Any
-from urllib.parse import quote, unquote
 
 
 def stable_hash(parts: list[str]) -> str:
@@ -130,33 +145,40 @@ def collect_row_specs(findings: dict[str, Any]) -> list[tuple[str, str]]:
 
 
 def safe_row_key(raw: str) -> str:
-    """Percent-encode a row_key for safe embedding in URL path segments.
+    """Base64url-encode a row_key for opaque, transport-safe path embedding.
 
-    Entity and EU row keys are raw ontology URIs like
-    ``https://data.riik.ee/ontology/estleg#KarS`` — they contain ``/``,
-    ``:``, and ``#`` which a browser treats as path separators / fragment
-    markers if left unescaped, so the path segment never reaches the
-    server intact.  ``quote(..., safe="")`` percent-encodes every reserved
-    character so the encoded form is a single, opaque path segment that
-    round-trips through :func:`decode_row_key`.
+    Returns a string drawn from the alphabet ``[A-Za-z0-9_-]`` — none of
+    which are reserved in URL path segments, query strings, CSS selectors,
+    or HTML attribute values — so the encoded form passes through the
+    entire request pipeline (browser → reverse proxy → ASGI server →
+    Starlette router) with zero transport-layer mutation. The matching
+    decoder is :func:`decode_row_key`; the pair is the only encode /
+    decode the application performs on this value.
 
-    Hashed row_keys (conflict / gap) are sha256-32 hex digests so this is
-    a no-op for them — they only contain ``[0-9a-f]`` — but applying the
-    helper uniformly keeps the call sites simple.
+    Trailing ``=`` padding is stripped to keep URLs short and clean. The
+    decoder pads it back before decoding.
+
+    Empty / falsy input returns the empty string so a missing row key
+    doesn't become the encoding of ``""``.
     """
-    return quote(str(raw or ""), safe="")
+    if not raw:
+        return ""
+    return base64.urlsafe_b64encode(str(raw).encode("utf-8")).rstrip(b"=").decode("ascii")
 
 
-def decode_row_key(quoted: str) -> str:
-    """Reverse :func:`safe_row_key` server-side at the route handler boundary.
+def decode_row_key(encoded: str) -> str:
+    """Inverse of :func:`safe_row_key`. Returns the original raw row key.
 
-    Starlette decodes a path segment once by default, but ``%23`` in the
-    raw URI (``#``) survives the first decode step because routing
-    matches on the *encoded* segment when the path includes reserved
-    characters. The handler should call ``decode_row_key`` to recover
-    the original URI before reading the DB / passing to the renderer.
+    Adds back the stripped base64 padding before decoding so any 1-4
+    char tail length is accepted. Decoding errors propagate as
+    ``binascii.Error`` / ``UnicodeDecodeError`` so route handlers can
+    surface them as 400 responses if a client sends a malformed value
+    — the helper itself does not catch them.
     """
-    return unquote(str(quoted or ""))
+    if not encoded:
+        return ""
+    padded = encoded + "=" * (-len(encoded) % 4)
+    return base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
 
 
 def target_dom_id(target_kind: str, target_id: str) -> str:

--- a/app/annotations/row_keys.py
+++ b/app/annotations/row_keys.py
@@ -17,6 +17,21 @@ ARE the annotation contract: both the report renderer (UI side) and the
 analyze pipeline (stale-flag side) consume them, and pulling them out
 of :mod:`app.docs.report_routes` keeps the analyze handler free of the
 FastHTML/UI import baggage.
+
+URL + CSS safety (#773):
+
+The ``entity`` and ``eu`` row keys are raw ontology URIs that contain
+``/``, ``:``, and ``#`` characters. Embedding them directly into URL
+path segments (e.g. ``/annotations/version/<v>/<kind>/<row_key>``) or
+CSS id selectors (``#annotation-popover-entity-<row_key>``) breaks
+routing and DOM lookups. Three helpers mediate the boundary:
+
+* :func:`safe_row_key` — percent-encode for URL path embedding.
+* :func:`decode_row_key` — server-side decode at the handler boundary.
+* :func:`target_dom_id` — derive a CSS-safe DOM id from any raw target.
+
+The original URI stays the round-trip identity; only the URL path
+segment and the DOM id use the encoded / hashed form.
 """
 
 from __future__ import annotations
@@ -24,6 +39,7 @@ from __future__ import annotations
 import hashlib
 import json
 from typing import Any
+from urllib.parse import quote, unquote
 
 
 def stable_hash(parts: list[str]) -> str:
@@ -106,3 +122,59 @@ def collect_row_specs(findings: dict[str, Any]) -> list[tuple[str, str]]:
         if key:
             specs.append(("gap", key))
     return specs
+
+
+# ---------------------------------------------------------------------------
+# URL- and CSS-safety helpers (#773)
+# ---------------------------------------------------------------------------
+
+
+def safe_row_key(raw: str) -> str:
+    """Percent-encode a row_key for safe embedding in URL path segments.
+
+    Entity and EU row keys are raw ontology URIs like
+    ``https://data.riik.ee/ontology/estleg#KarS`` — they contain ``/``,
+    ``:``, and ``#`` which a browser treats as path separators / fragment
+    markers if left unescaped, so the path segment never reaches the
+    server intact.  ``quote(..., safe="")`` percent-encodes every reserved
+    character so the encoded form is a single, opaque path segment that
+    round-trips through :func:`decode_row_key`.
+
+    Hashed row_keys (conflict / gap) are sha256-32 hex digests so this is
+    a no-op for them — they only contain ``[0-9a-f]`` — but applying the
+    helper uniformly keeps the call sites simple.
+    """
+    return quote(str(raw or ""), safe="")
+
+
+def decode_row_key(quoted: str) -> str:
+    """Reverse :func:`safe_row_key` server-side at the route handler boundary.
+
+    Starlette decodes a path segment once by default, but ``%23`` in the
+    raw URI (``#``) survives the first decode step because routing
+    matches on the *encoded* segment when the path includes reserved
+    characters. The handler should call ``decode_row_key`` to recover
+    the original URI before reading the DB / passing to the renderer.
+    """
+    return unquote(str(quoted or ""))
+
+
+def target_dom_id(target_kind: str, target_id: str) -> str:
+    """Return a CSS-safe DOM id for an annotation container.
+
+    The id must be selectable via ``getElementById`` AND via CSS
+    selectors / HTMX ``hx-target="#..."`` queries.  Raw ontology URIs
+    contain ``/``, ``:``, ``#``, and ``%`` (after percent-encoding) —
+    all of which are CSS structural characters that need backslash
+    escapes inside a selector.  Hashing the raw ``target_id`` into a
+    sha256-truncated hex digest sidesteps the problem entirely: the
+    result is ``[0-9a-f]+`` and therefore always a valid CSS identifier.
+
+    The 16-char digest gives ~64 bits of collision resistance which is
+    plenty for one report page worth of rows.  Data attributes still
+    carry the original URI for round-trip identification — only the
+    DOM id is the hashed form.
+    """
+    raw = f"{target_kind}:{target_id or ''}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"annotation-popover-{target_kind}-{digest}"

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -239,12 +239,12 @@ def _row_annotation_button(
             cls="annotation-count-badge",
         )
 
-    # #773: ``row_key`` for ``entity`` / ``eu`` rows is the raw ontology
-    # URI (contains ``/``, ``:``, ``#``). Percent-encode it before
-    # embedding in the path segment so the browser / router delivers
-    # the whole URI to the handler instead of fragmenting on ``#`` or
-    # treating ``/`` as a sub-path. Conflict / gap rows are already
-    # sha256-32 hex digests so this is a no-op for them.
+    # #773 / #781 follow-up: ``row_key`` for ``entity`` / ``eu`` rows is
+    # the raw ontology URI (contains ``/``, ``:``, ``#``, and sometimes
+    # literal ``%XX``). Base64url-encode it before embedding in the path
+    # segment so the encoded form is opaque to every transport layer
+    # (httpx, Starlette TestClient, uvicorn, reverse proxies) — none of
+    # them will decode or re-encode the value in flight.
     encoded_row_key = _safe_row_key(row_key)
     base = f"/annotations/version/{draft_version_id}/{row_kind}/{encoded_row_key}"
     return Button(  # noqa: F405

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -44,6 +44,9 @@ from app.annotations.row_keys import (
 from app.annotations.row_keys import (
     row_key_for_gap as _row_key_for_gap,
 )
+from app.annotations.row_keys import (
+    safe_row_key as _safe_row_key,
+)
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_view_draft
@@ -236,7 +239,14 @@ def _row_annotation_button(
             cls="annotation-count-badge",
         )
 
-    base = f"/annotations/version/{draft_version_id}/{row_kind}/{row_key}"
+    # #773: ``row_key`` for ``entity`` / ``eu`` rows is the raw ontology
+    # URI (contains ``/``, ``:``, ``#``). Percent-encode it before
+    # embedding in the path segment so the browser / router delivers
+    # the whole URI to the handler instead of fragmenting on ``#`` or
+    # treating ``/`` as a sub-path. Conflict / gap rows are already
+    # sha256-32 hex digests so this is a no-op for them.
+    encoded_row_key = _safe_row_key(row_key)
+    base = f"/annotations/version/{draft_version_id}/{row_kind}/{encoded_row_key}"
     return Button(  # noqa: F405
         NotStr("&#128172;"),  # noqa: F405  # speech balloon glyph
         badge,
@@ -248,7 +258,8 @@ def _row_annotation_button(
         aria_label=f"Ava märkuste paneel ({unresolved_count} lahendamata)",
         title="Ava märkuste paneel",
         # Data attrs make the button addressable from tests + future JS
-        # without parsing the URL again.
+        # without parsing the URL again. Note: data attrs keep the raw
+        # (non-encoded) row_key so JS callers don't have to decode.
         data_row_kind=row_kind,
         data_row_key=row_key,
         data_draft_version_id=draft_version_id,

--- a/app/explorer/pages.py
+++ b/app/explorer/pages.py
@@ -432,6 +432,13 @@ _DRAFT_OVERLAY_INIT_SCRIPT = (
 # popover container) into #panel-annotation-btn via HTMX — keeping
 # explorer.js itself untouched. Built with DOM methods (no innerHTML);
 # hx-get defaults its swap to innerHTML so no hx-swap attribute is needed.
+#
+# #773: the popover container uses a STATIC id (``panel-annotation-popover``)
+# instead of an id derived from the entity URI. Only one detail panel is
+# open at any moment, so a single, fixed CSS-safe id is the simplest fix
+# for "raw URI characters in CSS selectors break HTMX hx-target". The
+# raw URI is still encoded for the ?target_id= query string via
+# encodeURIComponent so the GET payload reaches the server intact.
 _PANEL_ANNOTATION_SCRIPT = (
     "(function(){"
     "var panelBtn=document.getElementById('panel-annotation-btn');"
@@ -440,19 +447,28 @@ _PANEL_ANNOTATION_SCRIPT = (
     "var obs=new MutationObserver(function(){"
     "var uri=panelTitle.dataset.entityUri||panelTitle.textContent.trim();"
     "if(!uri){panelBtn.style.display='none';return;}"
-    "var safeId=encodeURIComponent(uri).replace(/'/g,'%27');"
+    # encodeURIComponent for the query-string value only; the popover
+    # container id below is a fixed string so CSS selectors stay valid.
+    "var encUri=encodeURIComponent(uri);"
     "while(panelBtn.firstChild){panelBtn.removeChild(panelBtn.firstChild);}"
     "var wrap=document.createElement('div');"
     "wrap.className='annotation-button-wrapper';"
+    # data-target-id carries the original URI so JS callers can recover
+    # the raw identity without re-decoding.
+    "wrap.setAttribute('data-target-type','entity');"
+    "wrap.setAttribute('data-target-id',uri);"
     "var btn=document.createElement('button');"
     "btn.type='button';btn.className='annotation-button';"
-    "btn.setAttribute('hx-get','/api/annotations?target_type=entity&target_id='+safeId);"
-    "btn.setAttribute('hx-target','#annotation-popover-entity-'+safeId);"
+    "btn.setAttribute('hx-get','/api/annotations?target_type=entity&target_id='+encUri);"
+    "btn.setAttribute('hx-target','#panel-annotation-popover');"
+    "btn.setAttribute('hx-swap','innerHTML');"
     "btn.setAttribute('aria-label','Markused');"
     "btn.setAttribute('title','Markused');"
     "btn.textContent='\\uD83D\\uDCAC';"
     "var pop=document.createElement('div');"
-    "pop.id='annotation-popover-entity-'+safeId;"
+    # Fixed CSS-safe id — see header comment.  hx-target above resolves
+    # to this element regardless of which entity is focused.
+    "pop.id='panel-annotation-popover';"
     "pop.className='annotation-popover-container';"
     "wrap.appendChild(btn);wrap.appendChild(pop);"
     "panelBtn.appendChild(wrap);"

--- a/app/ui/primitives/annotation_button.py
+++ b/app/ui/primitives/annotation_button.py
@@ -6,8 +6,11 @@ popover via HTMX into a sibling container.
 
 from __future__ import annotations
 
+from urllib.parse import urlencode
+
 from fasthtml.common import *  # noqa: F403
 
+from app.annotations.row_keys import target_dom_id
 from app.ui.primitives.badge import Badge
 
 
@@ -23,11 +26,22 @@ def AnnotationButton(
     target_type:
         The type of the annotated target (e.g. ``"draft"``, ``"provision"``).
     target_id:
-        The ID of the annotated target.
+        The ID of the annotated target.  Ontology URIs are accepted as-is —
+        they are hashed via :func:`target_dom_id` for the CSS id and
+        URL-encoded via :func:`urlencode` for the HTMX query string.
     count:
         Number of existing annotations to display in the badge.
     """
-    popover_id = f"annotation-popover-{target_type}-{target_id}"
+    # #773: derive a CSS-safe DOM id from a sha256-truncated hash of the
+    # raw target_id so URIs (with ``/``, ``:``, ``#``) don't break HTMX's
+    # ``hx-target="#..."`` selector. The original target_id is exposed as
+    # a data attribute on the wrapper for round-trip identification.
+    popover_id = target_dom_id(target_type, target_id)
+
+    # #773: build the HTMX URL with structured encoding so reserved
+    # characters in target_type / target_id are escaped exactly once.
+    qs = urlencode({"target_type": target_type, "target_id": target_id})
+    hx_get_url = f"/api/annotations?{qs}"
 
     badge = Badge(str(count), variant="primary", cls="annotation-count-badge") if count > 0 else ""
 
@@ -35,7 +49,7 @@ def AnnotationButton(
         NotStr("&#128172;"),  # speech balloon character
         badge,
         type="button",
-        hx_get=f"/api/annotations?target_type={target_type}&target_id={target_id}",
+        hx_get=hx_get_url,
         hx_target=f"#{popover_id}",
         hx_swap="innerHTML",
         cls="annotation-button",
@@ -52,4 +66,8 @@ def AnnotationButton(
         btn,
         container,
         cls="annotation-button-wrapper",
+        # The original raw target_id stays here so JS / test code can find
+        # the wrapper by the entity URI without re-hashing.
+        data_target_type=target_type,
+        data_target_id=target_id,
     )

--- a/app/ui/surfaces/annotation_popover.py
+++ b/app/ui/surfaces/annotation_popover.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from fasthtml.common import *  # noqa: F403
 
+from app.annotations.row_keys import target_dom_id
 from app.ui.primitives.badge import Badge
 
 
@@ -38,6 +39,12 @@ def AnnotationPopover(
     """
     count = len(annotations)
 
+    # #773: derive the same hashed CSS id as the AnnotationButton primitive
+    # so the trigger's ``hx-target`` and the popover's outer id stay in
+    # lockstep.  Raw ontology URIs as target_id would otherwise blow up
+    # the ``#annotation-popover-...`` selector.
+    popover_id = target_dom_id(target_type, target_id)
+
     # Header
     header = Div(  # noqa: F405
         Span("Markused", cls="annotation-popover-title"),  # noqa: F405
@@ -57,7 +64,8 @@ def AnnotationPopover(
             cls="annotation-list annotation-list-empty",
         )
 
-    # New annotation form
+    # New annotation form. The hidden inputs still carry the RAW target_id
+    # — the POST handler reads them as form fields, not as URL segments.
     new_form = Form(  # noqa: F405
         Input(type="hidden", name="target_type", value=target_type),  # noqa: F405
         Input(type="hidden", name="target_id", value=target_id),  # noqa: F405
@@ -74,7 +82,7 @@ def AnnotationPopover(
             cls="btn btn-primary btn-sm",
         ),
         hx_post="/api/annotations",
-        hx_target=f"#annotation-popover-{target_type}-{target_id}",
+        hx_target=f"#{popover_id}",
         hx_swap="outerHTML",
         cls="annotation-form",
     )
@@ -84,6 +92,9 @@ def AnnotationPopover(
         annotation_list,
         Hr(cls="annotation-divider"),  # noqa: F405
         new_form,
-        id=f"annotation-popover-{target_type}-{target_id}",
+        id=popover_id,
         cls="annotation-popover",
+        # Data attrs preserve the original URI for the round-trip identity.
+        data_target_type=target_type,
+        data_target_id=target_id,
     )

--- a/tests/test_annotations_routes.py
+++ b/tests/test_annotations_routes.py
@@ -403,3 +403,74 @@ class TestDeleteAnnotation:
             resp = client.delete(f"/api/annotations/{_ANN_ID}")
 
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# #773: AnnotationPopover with URI target_id stays CSS-safe
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationPopoverWithUriTargetId:
+    """Õiguskaart entity popovers pass the entity URI as target_id.
+
+    The popover Div outer id and its inner form's hx-target must be
+    CSS-safe (no raw ``/``, ``:``, ``#``, or ``%`` — all of which the
+    explorer's old ``encodeURIComponent``-based id used to embed).
+    """
+
+    _URI_TARGET_ID = "https://data.riik.ee/ontology/estleg#KarS"
+
+    @patch("app.annotations.routes._load_annotations_with_replies")
+    @patch("app.auth.middleware._get_provider")
+    def test_list_returns_popover_with_css_safe_id_for_uri(self, mock_prov, mock_load):
+        from urllib.parse import quote
+
+        mock_prov.return_value = _stub_provider()
+        mock_load.return_value = []
+
+        encoded_target = quote(self._URI_TARGET_ID, safe="")
+        url = f"/api/annotations?target_type=entity&target_id={encoded_target}"
+
+        client = _authed_client()
+        resp = client.get(url)
+
+        assert resp.status_code == 200
+        body = resp.text
+        # Popover renders.
+        assert "annotation-popover" in body
+        # The popover's outer id (and the form's hx-target) must NOT
+        # contain raw URI structural chars — those break CSS selectors.
+        # Find every id="annotation-popover-...:..." or id with ``/``.
+        import re
+
+        ids = re.findall(r'id="(annotation-popover-[^"]*)"', body)
+        assert ids, "popover did not render with an id attribute"
+        for popover_id in ids:
+            assert "/" not in popover_id
+            assert "#" not in popover_id
+            assert "%" not in popover_id
+
+    def test_popover_component_renders_for_uri_target_id(self):
+        """Direct unit test on the surface component — must not raise."""
+        from app.ui.surfaces.annotation_popover import AnnotationPopover
+
+        result = AnnotationPopover(
+            target_type="entity",
+            target_id=self._URI_TARGET_ID,
+            annotations=[],
+            auth={"id": _USER_ID},
+        )
+        # The raw URI is preserved in data attributes.
+        assert result is not None
+
+    def test_annotation_button_primitive_uri_target_id(self):
+        """AnnotationButton's id + hx-target must be CSS-safe for URIs."""
+        from app.ui.primitives.annotation_button import AnnotationButton
+
+        # Should not raise; the wrapper's id is hashed.
+        result = AnnotationButton(
+            target_type="entity",
+            target_id=self._URI_TARGET_ID,
+            count=2,
+        )
+        assert result is not None

--- a/tests/test_annotations_row_integration.py
+++ b/tests/test_annotations_row_integration.py
@@ -355,12 +355,12 @@ class TestReportPageRendersAnnotationButtons:
         assert resp.status_code == 200
         # Per-row buttons must use the version-scoped path; the
         # affected-entities row_key for "urn:entity:0" is the URI itself.
-        # #773: URI chars (``:``) are percent-encoded so the path segment
-        # survives the browser-to-server round trip even when URIs contain
-        # ``/`` and ``#``.
-        from urllib.parse import quote
+        # #773 / #781 follow-up: URI chars (``:``, ``/``, ``#``, and any
+        # literal ``%XX``) go through opaque base64url encoding so the
+        # path segment is transport-safe end to end.
+        from app.annotations.row_keys import safe_row_key
 
-        encoded_key = quote("urn:entity:0", safe="")
+        encoded_key = safe_row_key("urn:entity:0")
         expected = f"/annotations/version/{_VERSION_ID}/entity/{encoded_key}"
         assert expected in resp.text
 
@@ -388,8 +388,12 @@ class TestReportPageRendersAnnotationButtons:
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
         assert resp.status_code == 200
-        # The conflict row's row_key is a sha256-32 hex digest.
-        expected_key = row_key_for_conflict(findings["conflicts"][0])
+        # The conflict row's row_key is a sha256-32 hex digest; the URL
+        # carries its base64url-encoded form because the encoder is
+        # applied uniformly to every row kind.
+        from app.annotations.row_keys import safe_row_key
+
+        expected_key = safe_row_key(row_key_for_conflict(findings["conflicts"][0]))
         assert f"/annotations/version/{_VERSION_ID}/conflict/{expected_key}" in resp.text
 
     @patch("app.docs.report_routes._load_unresolved_counts")
@@ -416,10 +420,11 @@ class TestReportPageRendersAnnotationButtons:
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
         assert resp.status_code == 200
-        # #773: URI characters (``:``) percent-encoded into the path segment.
-        from urllib.parse import quote
+        # #773 / #781 follow-up: URI chars (``:``) go through opaque
+        # base64url so the path segment is transport-safe.
+        from app.annotations.row_keys import safe_row_key
 
-        encoded_key = quote("urn:eu:act:0", safe="")
+        encoded_key = safe_row_key("urn:eu:act:0")
         assert f"/annotations/version/{_VERSION_ID}/eu/{encoded_key}" in resp.text
 
     @patch("app.docs.report_routes._load_unresolved_counts")
@@ -446,7 +451,9 @@ class TestReportPageRendersAnnotationButtons:
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
         assert resp.status_code == 200
-        expected_key = row_key_for_gap(findings["gaps"][0])
+        from app.annotations.row_keys import safe_row_key
+
+        expected_key = safe_row_key(row_key_for_gap(findings["gaps"][0]))
         assert f"/annotations/version/{_VERSION_ID}/gap/{expected_key}" in resp.text
 
     @patch("app.docs.report_routes._load_unresolved_counts")
@@ -909,10 +916,10 @@ class TestSectionPagerFragment:
 
         assert resp.status_code == 200
         # The fragment renders a per-row button targeting the version-scoped route.
-        # #773: URI characters (``:``) percent-encoded into the path segment.
-        from urllib.parse import quote
+        # #773 / #781 follow-up: URI chars go through opaque base64url encoding.
+        from app.annotations.row_keys import safe_row_key
 
-        encoded_key = quote("urn:entity:1", safe="")
+        encoded_key = safe_row_key("urn:entity:1")
         assert f"/annotations/version/{_VERSION_ID}/entity/{encoded_key}" in resp.text
 
 
@@ -963,9 +970,10 @@ def test_findings_json_roundtrip_preserves_keys():
 class TestReportRowWithUriRowKey:
     """Affected-entity and EU rows carry raw ontology URIs as row_keys.
 
-    The rendered ``hx_get`` must percent-encode the URI so the path
-    segment survives the browser-to-server round trip (URIs contain
-    ``/``, ``:``, and ``#`` — all routing-significant characters).
+    The rendered ``hx_get`` must base64url-encode the URI so the path
+    segment is opaque end to end (URIs contain ``/``, ``:``, ``#``, and
+    sometimes literal ``%XX`` — all routing-significant characters or
+    transport-layer ambiguities).
     """
 
     _URI_ROW_KEY = "https://data.riik.ee/ontology/estleg#KarS"
@@ -984,10 +992,10 @@ class TestReportRowWithUriRowKey:
         mock_load_counts,
     ):
         """An entity row whose URI contains ``/`` and ``#`` must produce
-        an HTMX URL with the URI percent-encoded — the literal URI must
+        an HTMX URL with the URI base64url-encoded — the literal URI must
         NOT appear inside the ``hx-get`` path segment, since the browser
         would otherwise fragment on ``#`` before sending."""
-        from urllib.parse import quote
+        from app.annotations.row_keys import safe_row_key
 
         mock_provider.return_value = _stub_provider()
         mock_fetch_draft.return_value = _make_draft()
@@ -1011,8 +1019,8 @@ class TestReportRowWithUriRowKey:
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
         assert resp.status_code == 200
-        # The percent-encoded URI appears in the HTMX URL.
-        encoded = quote(self._URI_ROW_KEY, safe="")
+        # The base64url-encoded URI appears in the HTMX URL.
+        encoded = safe_row_key(self._URI_ROW_KEY)
         expected = f"/annotations/version/{_VERSION_ID}/entity/{encoded}"
         assert expected in resp.text
         # And the raw URI must NOT appear inside any hx-get path — the
@@ -1037,7 +1045,7 @@ class TestReportRowWithUriRowKey:
     ):
         """EU compliance rows pass the EU directive URI as the row_key —
         same encoding contract as the entity rows."""
-        from urllib.parse import quote
+        from app.annotations.row_keys import safe_row_key
 
         eu_uri = "https://eur-lex.europa.eu/eli/dir/2016/679/oj#article-1"
 
@@ -1065,6 +1073,6 @@ class TestReportRowWithUriRowKey:
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
         assert resp.status_code == 200
-        encoded = quote(eu_uri, safe="")
+        encoded = safe_row_key(eu_uri)
         expected = f"/annotations/version/{_VERSION_ID}/eu/{encoded}"
         assert expected in resp.text

--- a/tests/test_annotations_row_integration.py
+++ b/tests/test_annotations_row_integration.py
@@ -355,7 +355,13 @@ class TestReportPageRendersAnnotationButtons:
         assert resp.status_code == 200
         # Per-row buttons must use the version-scoped path; the
         # affected-entities row_key for "urn:entity:0" is the URI itself.
-        expected = f"/annotations/version/{_VERSION_ID}/entity/urn:entity:0"
+        # #773: URI chars (``:``) are percent-encoded so the path segment
+        # survives the browser-to-server round trip even when URIs contain
+        # ``/`` and ``#``.
+        from urllib.parse import quote
+
+        encoded_key = quote("urn:entity:0", safe="")
+        expected = f"/annotations/version/{_VERSION_ID}/entity/{encoded_key}"
         assert expected in resp.text
 
     @patch("app.docs.report_routes._load_unresolved_counts")
@@ -410,7 +416,11 @@ class TestReportPageRendersAnnotationButtons:
         resp = client.get(f"/drafts/{_DRAFT_ID}/report")
 
         assert resp.status_code == 200
-        assert f"/annotations/version/{_VERSION_ID}/eu/urn:eu:act:0" in resp.text
+        # #773: URI characters (``:``) percent-encoded into the path segment.
+        from urllib.parse import quote
+
+        encoded_key = quote("urn:eu:act:0", safe="")
+        assert f"/annotations/version/{_VERSION_ID}/eu/{encoded_key}" in resp.text
 
     @patch("app.docs.report_routes._load_unresolved_counts")
     @patch("app.docs.report_routes._fetch_latest_report_version_id")
@@ -899,7 +909,11 @@ class TestSectionPagerFragment:
 
         assert resp.status_code == 200
         # The fragment renders a per-row button targeting the version-scoped route.
-        assert f"/annotations/version/{_VERSION_ID}/entity/urn:entity:1" in resp.text
+        # #773: URI characters (``:``) percent-encoded into the path segment.
+        from urllib.parse import quote
+
+        encoded_key = quote("urn:entity:1", safe="")
+        assert f"/annotations/version/{_VERSION_ID}/entity/{encoded_key}" in resp.text
 
 
 # ===========================================================================
@@ -939,3 +953,118 @@ def test_findings_json_roundtrip_preserves_keys():
     assert row_key_for_conflict(findings["conflicts"][0]) == row_key_for_conflict(
         roundtripped["conflicts"][0]
     )
+
+
+# ===========================================================================
+# #773: Report rows with URI row_keys (entity / eu) render safe URLs
+# ===========================================================================
+
+
+class TestReportRowWithUriRowKey:
+    """Affected-entity and EU rows carry raw ontology URIs as row_keys.
+
+    The rendered ``hx_get`` must percent-encode the URI so the path
+    segment survives the browser-to-server round trip (URIs contain
+    ``/``, ``:``, and ``#`` — all routing-significant characters).
+    """
+
+    _URI_ROW_KEY = "https://data.riik.ee/ontology/estleg#KarS"
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_entity_row_with_uri_renders_encoded_path(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        """An entity row whose URI contains ``/`` and ``#`` must produce
+        an HTMX URL with the URI percent-encoded — the literal URI must
+        NOT appear inside the ``hx-get`` path segment, since the browser
+        would otherwise fragment on ``#`` before sending."""
+        from urllib.parse import quote
+
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        findings = {
+            "affected_entities": [
+                {
+                    "uri": self._URI_ROW_KEY,
+                    "label": "KarS",
+                    "type": "https://data.riik.ee/ontology/estleg#EnactedLaw",
+                }
+            ],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+        }
+        mock_fetch_report.return_value = _make_report_row(findings)
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        # The percent-encoded URI appears in the HTMX URL.
+        encoded = quote(self._URI_ROW_KEY, safe="")
+        expected = f"/annotations/version/{_VERSION_ID}/entity/{encoded}"
+        assert expected in resp.text
+        # And the raw URI must NOT appear inside any hx-get path — the
+        # browser would treat ``#`` as a fragment marker.
+        assert (
+            f'hx-get="/annotations/version/{_VERSION_ID}/entity/{self._URI_ROW_KEY}'
+            not in resp.text
+        )
+
+    @patch("app.docs.report_routes._load_unresolved_counts")
+    @patch("app.docs.report_routes._fetch_latest_report_version_id")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_eu_row_with_uri_renders_encoded_path(
+        self,
+        mock_provider,
+        mock_fetch_draft,
+        mock_fetch_report,
+        mock_fetch_version,
+        mock_load_counts,
+    ):
+        """EU compliance rows pass the EU directive URI as the row_key —
+        same encoding contract as the entity rows."""
+        from urllib.parse import quote
+
+        eu_uri = "https://eur-lex.europa.eu/eli/dir/2016/679/oj#article-1"
+
+        mock_provider.return_value = _stub_provider()
+        mock_fetch_draft.return_value = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [
+                {
+                    "eu_act": eu_uri,
+                    "eu_label": "GDPR",
+                    "estonian_provision": "urn:ee:0",
+                    "provision_label": "§ 1",
+                    "transposition_status": "linked",
+                }
+            ],
+            "gaps": [],
+        }
+        mock_fetch_report.return_value = _make_report_row(findings)
+        mock_fetch_version.return_value = str(_VERSION_ID)
+        mock_load_counts.return_value = {}
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        encoded = quote(eu_uri, safe="")
+        expected = f"/annotations/version/{_VERSION_ID}/eu/{encoded}"
+        assert expected in resp.text

--- a/tests/test_annotations_version_routes.py
+++ b/tests/test_annotations_version_routes.py
@@ -48,8 +48,14 @@ _OTHER_VERSION_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
 _ANN_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
 
 _ROW_KIND = "conflict"
-_ROW_KEY = "abc-123"
-_ROW_BASE = f"/annotations/version/{_VERSION_ID}/{_ROW_KIND}/{_ROW_KEY}"
+_ROW_KEY = "abc-123"  # the raw row_key the handler should see
+# The URL path segment is the base64url encoding of _ROW_KEY (#781 follow-up).
+# Built inline rather than importing here to keep this fixture block free of
+# app imports at module load.
+import base64 as _base64  # noqa: E402
+
+_ROW_KEY_ENCODED = _base64.urlsafe_b64encode(_ROW_KEY.encode("utf-8")).rstrip(b"=").decode("ascii")
+_ROW_BASE = f"/annotations/version/{_VERSION_ID}/{_ROW_KIND}/{_ROW_KEY_ENCODED}"
 
 
 def _authed_user(
@@ -1017,11 +1023,11 @@ class TestRowKindWhitelist:
 class TestUriRowKeyRoundTrip:
     """Affected-entity + EU rows store the raw ontology URI as the row_key.
 
-    These URIs carry ``/``, ``:``, and ``#`` characters — all of which
-    Starlette decodes BEFORE routing, so a plain ``{row_key}`` path
-    segment 404s. The route uses the ``:path`` converter + the handler
-    decodes the percent-encoded segment so the original URI reaches the
-    DB layer intact.
+    These URIs carry ``/``, ``:``, ``#``, and sometimes literal ``%XX``
+    substrings. Encoding goes through :func:`safe_row_key` (base64url,
+    opaque to every transport layer); decoding goes through
+    :func:`decode_row_key` at the handler boundary. The pair is the only
+    encode/decode the app performs on this value.
     """
 
     _URI_ROW_KEY = "https://data.riik.ee/ontology/estleg#KarS"
@@ -1030,14 +1036,14 @@ class TestUriRowKeyRoundTrip:
     @patch("app.annotations.routes._connect")
     @patch("app.auth.middleware._get_provider")
     def test_get_panel_resolves_encoded_uri_to_original(self, mock_prov, mock_connect, mock_load):
-        from urllib.parse import quote
+        from app.annotations.row_keys import safe_row_key
 
         mock_prov.return_value = _stub_provider()
         mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
         mock_connect.side_effect = mock_conn
         mock_load.return_value = []
 
-        encoded = quote(self._URI_ROW_KEY, safe="")
+        encoded = safe_row_key(self._URI_ROW_KEY)
         url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}"
 
         client = _authed_client()
@@ -1045,7 +1051,7 @@ class TestUriRowKeyRoundTrip:
 
         assert resp.status_code == 200
         # _load_panel_messages received the DECODED URI, not the
-        # percent-encoded path segment.
+        # base64url path segment.
         assert mock_load.call_args is not None
         _, kwargs = mock_load.call_args
         if kwargs:
@@ -1059,14 +1065,14 @@ class TestUriRowKeyRoundTrip:
     @patch("app.auth.middleware._get_provider")
     def test_uri_row_key_handler_renders_fragment(self, mock_prov, mock_connect, mock_load):
         """The handler renders the panel without raising for a URI row_key."""
-        from urllib.parse import quote
+        from app.annotations.row_keys import safe_row_key
 
         mock_prov.return_value = _stub_provider()
         mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
         mock_connect.side_effect = mock_conn
         mock_load.return_value = []
 
-        encoded = quote(self._URI_ROW_KEY, safe="")
+        encoded = safe_row_key(self._URI_ROW_KEY)
         # Use "entity" row_kind because entity URIs are the real-world
         # source of URI row keys.
         url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}"
@@ -1084,7 +1090,7 @@ class TestUriRowKeyRoundTrip:
     @patch("app.annotations.routes._connect")
     @patch("app.auth.middleware._get_provider")
     def test_post_message_with_uri_row_key(self, mock_prov, mock_connect, mock_create, mock_load):
-        from urllib.parse import quote
+        from app.annotations.row_keys import safe_row_key
 
         mock_prov.return_value = _stub_provider()
         mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
@@ -1098,7 +1104,7 @@ class TestUriRowKeyRoundTrip:
         mock_load.side_effect = [[], [new_ann]]
         mock_create.return_value = new_ann
 
-        encoded = quote(self._URI_ROW_KEY, safe="")
+        encoded = safe_row_key(self._URI_ROW_KEY)
         url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}/messages"
 
         with patch(
@@ -1110,7 +1116,7 @@ class TestUriRowKeyRoundTrip:
 
         assert resp.status_code == 200
         # The create call received the DECODED URI as row_key, not the
-        # percent-encoded form.
+        # base64url-encoded form.
         _, create_kwargs = mock_create.call_args
         assert create_kwargs.get("row_key") == self._URI_ROW_KEY
 
@@ -1119,7 +1125,7 @@ class TestUriRowKeyRoundTrip:
     @patch("app.annotations.routes._connect")
     @patch("app.auth.middleware._get_provider")
     def test_post_resolve_with_uri_row_key(self, mock_prov, mock_connect, mock_resolve, mock_load):
-        from urllib.parse import quote
+        from app.annotations.row_keys import safe_row_key
 
         mock_prov.return_value = _stub_provider()
         mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
@@ -1127,7 +1133,7 @@ class TestUriRowKeyRoundTrip:
         mock_resolve.return_value = 1
         mock_load.return_value = []
 
-        encoded = quote(self._URI_ROW_KEY, safe="")
+        encoded = safe_row_key(self._URI_ROW_KEY)
         url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}/resolve"
 
         client = _authed_client()
@@ -1139,7 +1145,109 @@ class TestUriRowKeyRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# #773: safe_row_key / decode_row_key / target_dom_id helpers
+# #781 follow-up: regression — raw row keys carrying literal %XX bytes
+# ---------------------------------------------------------------------------
+
+
+class TestUriRowKeyWithPercentBytes:
+    """CELEX URIs and similar already contain percent-encoded bytes.
+
+    Example: an EU directive row_key stored as ``CELEX%3A32016R0679``
+    (the ``%3A`` is part of the raw URI, not transport-layer encoding).
+    With percent-encoding, the literal ``%`` would have to be escaped to
+    ``%25`` and the round-trip depended on every transport layer
+    decoding the path exactly once — which httpx + Starlette TestClient
+    do NOT do (they decode twice), and reverse proxies sometimes don't
+    either. Base64url encoding is opaque, so the raw row key reaches the
+    handler intact regardless of how many transport-layer decodes happen.
+    """
+
+    _PERCENT_ROW_KEY = "CELEX%3A32016R0679"
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_get_panel_preserves_literal_percent_bytes(self, mock_prov, mock_connect, mock_load):
+        from app.annotations.row_keys import safe_row_key
+
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+        mock_load.return_value = []
+
+        encoded = safe_row_key(self._PERCENT_ROW_KEY)
+        # base64url emits only [A-Za-z0-9_-] so no transport layer mutates it.
+        assert "%" not in encoded
+        url = f"/annotations/version/{_VERSION_ID}/eu/{encoded}"
+
+        client = _authed_client()
+        resp = client.get(url)
+
+        assert resp.status_code == 200
+        # Handler must receive the ORIGINAL raw row key (with %3A still
+        # in it), NOT the double-decoded "CELEX:32016R0679".
+        if mock_load.call_args.kwargs:
+            received = mock_load.call_args.kwargs.get("row_key")
+        else:
+            received = mock_load.call_args.args[2]
+        assert received == self._PERCENT_ROW_KEY
+        assert received != "CELEX:32016R0679"
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes.create_row_annotation")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_post_message_preserves_literal_percent_bytes(
+        self, mock_prov, mock_connect, mock_create, mock_load
+    ):
+        from app.annotations.row_keys import safe_row_key
+
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+
+        new_ann = _make_annotation(
+            target_id=f"eu:{self._PERCENT_ROW_KEY}",
+            content="Märkus CELEX rea kohta.",
+        )
+        mock_load.side_effect = [[], [new_ann]]
+        mock_create.return_value = new_ann
+
+        encoded = safe_row_key(self._PERCENT_ROW_KEY)
+        url = f"/annotations/version/{_VERSION_ID}/eu/{encoded}/messages"
+
+        with patch(
+            "app.annotations.routes._user_display_name",
+            return_value="Test Kasutaja",
+        ):
+            client = _authed_client()
+            resp = client.post(url, json={"content": "Märkus CELEX rea kohta."})
+
+        assert resp.status_code == 200
+        _, create_kwargs = mock_create.call_args
+        # Writes must land on the raw CELEX row key, not a double-decoded
+        # variant — otherwise the create + the later read would target
+        # different threads.
+        assert create_kwargs.get("row_key") == self._PERCENT_ROW_KEY
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_malformed_base64url_returns_400(self, mock_prov, mock_connect):
+        """A row_key that isn't decodable base64url surfaces as 400, not 500."""
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+
+        # "%" is not in the base64url alphabet; decode raises binascii.Error.
+        url = f"/annotations/version/{_VERSION_ID}/entity/not%25valid"
+
+        client = _authed_client()
+        resp = client.get(url)
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# #773: safe_row_key / target_dom_id helpers
 # ---------------------------------------------------------------------------
 
 
@@ -1148,28 +1256,49 @@ class TestRowKeyEncodingHelpers:
 
     _URI = "https://data.riik.ee/ontology/estleg#KarS"
 
-    def test_safe_row_key_percent_encodes_slash_colon_hash(self):
+    def test_safe_row_key_uses_base64url_alphabet(self):
+        """Encoded form draws only from ``[A-Za-z0-9_-]`` — no URL/CSS specials."""
+        import re
+
         from app.annotations.row_keys import safe_row_key
 
         encoded = safe_row_key(self._URI)
-        # No literal ``/``, ``#``, or ``:`` in the encoded form.
-        assert "/" not in encoded
-        assert "#" not in encoded
-        assert ":" not in encoded
-        # The Estonian provision name still round-trips.
-        assert "KarS" in encoded
+        # None of the chars that would force escaping in URLs / CSS.
+        for ch in ("/", "#", ":", "%", "+", "=", "?", "&"):
+            assert ch not in encoded, f"unexpected {ch!r} in {encoded!r}"
+        # Strict base64url alphabet check (no padding — we strip it).
+        assert re.fullmatch(r"[A-Za-z0-9_-]+", encoded), encoded
 
     def test_decode_row_key_inverts_safe_row_key(self):
+        """The opaque encoder/decoder pair round-trips for any raw value."""
         from app.annotations.row_keys import decode_row_key, safe_row_key
 
-        assert decode_row_key(safe_row_key(self._URI)) == self._URI
+        for raw in [
+            self._URI,
+            "CELEX%3A32016R0679",  # #781 — literal %XX in the raw row key
+            "x%2Fy",  # encoded slash inside a raw value
+            "ÕIE/§5",  # non-ASCII (UTF-8 round-trip)
+            "abcdef0123456789abcdef0123456789",  # sha256-32 hashed key
+        ]:
+            assert decode_row_key(safe_row_key(raw)) == raw, raw
 
-    def test_safe_row_key_is_noop_for_hashed_keys(self):
-        """sha256-32 hex digests contain only [0-9a-f] so safe_row_key is a no-op."""
-        from app.annotations.row_keys import safe_row_key
+    def test_safe_row_key_round_trip_for_hashed_keys(self):
+        """sha256-32 hex digests round-trip through the encoder/decoder pair.
+
+        The encoded form differs from the input (base64url is not a no-op
+        on hex digits), but the inverse must recover the original digest.
+        """
+        from app.annotations.row_keys import decode_row_key, safe_row_key
 
         digest = "abcdef0123456789abcdef0123456789"
-        assert safe_row_key(digest) == digest
+        assert decode_row_key(safe_row_key(digest)) == digest
+
+    def test_safe_row_key_empty_input_round_trips(self):
+        """Empty / falsy input encodes to '' and decodes back to ''."""
+        from app.annotations.row_keys import decode_row_key, safe_row_key
+
+        assert safe_row_key("") == ""
+        assert decode_row_key("") == ""
 
     def test_target_dom_id_is_css_safe(self):
         """The returned id contains only chars valid in CSS / HTMX selectors."""

--- a/tests/test_annotations_version_routes.py
+++ b/tests/test_annotations_version_routes.py
@@ -1007,3 +1007,203 @@ class TestRowKindWhitelist:
                 row_kind="bogus",
                 row_key="x",
             )
+
+
+# ---------------------------------------------------------------------------
+# #773: URL-encoded URI row_key round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestUriRowKeyRoundTrip:
+    """Affected-entity + EU rows store the raw ontology URI as the row_key.
+
+    These URIs carry ``/``, ``:``, and ``#`` characters — all of which
+    Starlette decodes BEFORE routing, so a plain ``{row_key}`` path
+    segment 404s. The route uses the ``:path`` converter + the handler
+    decodes the percent-encoded segment so the original URI reaches the
+    DB layer intact.
+    """
+
+    _URI_ROW_KEY = "https://data.riik.ee/ontology/estleg#KarS"
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_get_panel_resolves_encoded_uri_to_original(self, mock_prov, mock_connect, mock_load):
+        from urllib.parse import quote
+
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+        mock_load.return_value = []
+
+        encoded = quote(self._URI_ROW_KEY, safe="")
+        url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}"
+
+        client = _authed_client()
+        resp = client.get(url)
+
+        assert resp.status_code == 200
+        # _load_panel_messages received the DECODED URI, not the
+        # percent-encoded path segment.
+        assert mock_load.call_args is not None
+        _, kwargs = mock_load.call_args
+        if kwargs:
+            decoded_arg = kwargs.get("row_key")
+        else:
+            decoded_arg = mock_load.call_args.args[2]
+        assert decoded_arg == self._URI_ROW_KEY
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_uri_row_key_handler_renders_fragment(self, mock_prov, mock_connect, mock_load):
+        """The handler renders the panel without raising for a URI row_key."""
+        from urllib.parse import quote
+
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+        mock_load.return_value = []
+
+        encoded = quote(self._URI_ROW_KEY, safe="")
+        # Use "entity" row_kind because entity URIs are the real-world
+        # source of URI row keys.
+        url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}"
+
+        client = _authed_client()
+        resp = client.get(url)
+
+        assert resp.status_code == 200
+        # The fragment carries the original URI in its data attribute so
+        # JS / tests can round-trip it.
+        assert self._URI_ROW_KEY in resp.text
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes.create_row_annotation")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_post_message_with_uri_row_key(self, mock_prov, mock_connect, mock_create, mock_load):
+        from urllib.parse import quote
+
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+
+        new_ann = _make_annotation(
+            target_id=f"entity:{self._URI_ROW_KEY}",
+            content="Märkus URI rea kohta.",
+        )
+        # Pre-count empty, after-write returns the new ann.
+        mock_load.side_effect = [[], [new_ann]]
+        mock_create.return_value = new_ann
+
+        encoded = quote(self._URI_ROW_KEY, safe="")
+        url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}/messages"
+
+        with patch(
+            "app.annotations.routes._user_display_name",
+            return_value="Test Kasutaja",
+        ):
+            client = _authed_client()
+            resp = client.post(url, json={"content": "Märkus URI rea kohta."})
+
+        assert resp.status_code == 200
+        # The create call received the DECODED URI as row_key, not the
+        # percent-encoded form.
+        _, create_kwargs = mock_create.call_args
+        assert create_kwargs.get("row_key") == self._URI_ROW_KEY
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes.resolve_row_thread")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_post_resolve_with_uri_row_key(self, mock_prov, mock_connect, mock_resolve, mock_load):
+        from urllib.parse import quote
+
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+        mock_resolve.return_value = 1
+        mock_load.return_value = []
+
+        encoded = quote(self._URI_ROW_KEY, safe="")
+        url = f"/annotations/version/{_VERSION_ID}/entity/{encoded}/resolve"
+
+        client = _authed_client()
+        resp = client.post(url)
+
+        assert resp.status_code == 200
+        _, kwargs = mock_resolve.call_args
+        assert kwargs.get("row_key") == self._URI_ROW_KEY
+
+
+# ---------------------------------------------------------------------------
+# #773: safe_row_key / decode_row_key / target_dom_id helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRowKeyEncodingHelpers:
+    """Unit tests for the URL- + CSS-safety helpers."""
+
+    _URI = "https://data.riik.ee/ontology/estleg#KarS"
+
+    def test_safe_row_key_percent_encodes_slash_colon_hash(self):
+        from app.annotations.row_keys import safe_row_key
+
+        encoded = safe_row_key(self._URI)
+        # No literal ``/``, ``#``, or ``:`` in the encoded form.
+        assert "/" not in encoded
+        assert "#" not in encoded
+        assert ":" not in encoded
+        # The Estonian provision name still round-trips.
+        assert "KarS" in encoded
+
+    def test_decode_row_key_inverts_safe_row_key(self):
+        from app.annotations.row_keys import decode_row_key, safe_row_key
+
+        assert decode_row_key(safe_row_key(self._URI)) == self._URI
+
+    def test_safe_row_key_is_noop_for_hashed_keys(self):
+        """sha256-32 hex digests contain only [0-9a-f] so safe_row_key is a no-op."""
+        from app.annotations.row_keys import safe_row_key
+
+        digest = "abcdef0123456789abcdef0123456789"
+        assert safe_row_key(digest) == digest
+
+    def test_target_dom_id_is_css_safe(self):
+        """The returned id contains only chars valid in CSS / HTMX selectors."""
+        from app.annotations.row_keys import target_dom_id
+
+        dom_id = target_dom_id("entity", self._URI)
+        # No reserved characters that need backslash-escaping in CSS.
+        for ch in ("/", ":", "#", "%", "?", "&", "="):
+            assert ch not in dom_id
+        # Stable prefix so callers can grep / identify it.
+        assert dom_id.startswith("annotation-popover-entity-")
+
+    def test_target_dom_id_is_deterministic(self):
+        """Same input always yields the same id."""
+        from app.annotations.row_keys import target_dom_id
+
+        a = target_dom_id("entity", self._URI)
+        b = target_dom_id("entity", self._URI)
+        assert a == b
+
+    def test_target_dom_id_distinguishes_kind(self):
+        """Same target_id under different kinds yields different ids."""
+        from app.annotations.row_keys import target_dom_id
+
+        a = target_dom_id("entity", self._URI)
+        b = target_dom_id("conflict", self._URI)
+        assert a != b
+
+    def test_target_dom_id_handles_empty(self):
+        """Empty target_id still produces a valid CSS id (no crash)."""
+        from app.annotations.row_keys import target_dom_id
+
+        dom_id = target_dom_id("entity", "")
+        assert dom_id.startswith("annotation-popover-entity-")
+        # No invalid chars.
+        for ch in ("/", ":", "#", "%"):
+            assert ch not in dom_id

--- a/tests/test_explorer_pages.py
+++ b/tests/test_explorer_pages.py
@@ -717,6 +717,28 @@ def test_explorer_detail_panel_keeps_back_link_and_metadata_sections():
     assert 'id="panel-link"' in html
 
 
+def test_panel_annotation_script_uses_css_safe_hx_target():
+    """#773: the entity-detail annotation script must NOT inject HTMX
+    targets that interpolate the entity URI (or its percent-encoded form)
+    into a CSS selector — ``%``, ``/``, and ``#`` all break the selector.
+
+    The fix uses a fixed ``#panel-annotation-popover`` id for the
+    container regardless of which entity is focused, since only one
+    detail panel is open at any time.
+    """
+    html = _html("focus=https://data.riik.ee/ontology/estleg#KarS")
+    # The CSS-safe fixed id appears in the page.
+    assert "panel-annotation-popover" in html
+    # The old broken pattern (concatenating an encoded URI into the
+    # hx-target selector) must NOT be present anywhere.
+    assert "'#annotation-popover-entity-'+safeId" not in html
+    assert "'#annotation-popover-entity-'+encUri" not in html
+    # The script still URL-encodes the URI for the QUERY STRING value —
+    # ``encodeURIComponent`` of the URI is used for the ``target_id=``
+    # parameter, not the CSS selector.
+    assert "encodeURIComponent" in html
+
+
 # ---------------------------------------------------------------------------
 # #754 — app/explorer/start_panel.py: the org-scoped data queries
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Annotation UI paths used to build route URLs and DOM targets directly from raw ontology URIs (e.g. `https://data.riik.ee/ontology/estleg#KarS`). The URI characters `/`, `:`, and `#` are routing-significant: Starlette decodes percent-encoded `%2F` to `/` BEFORE matching the route, so a `{row_key}` path segment 404s the instant a URI key reaches it. The same characters also break CSS selectors, so HTMX's `hx-target="#annotation-popover-..."` lookup fails silently. The visible "Lisa märkus" affordance was therefore broken for the exact URI-backed entities this app is built around.

## Changes

**New helpers (`app/annotations/row_keys.py`)**
- `safe_row_key(raw) -> str` — `quote(raw, safe="")` percent-encodes a URI for one URL path segment. No-op for sha256-32 hashed keys (conflict / gap rows).
- `decode_row_key(quoted) -> str` — server-side `unquote` at the handler boundary.
- `target_dom_id(target_kind, target_id) -> str` — sha256-trunc-16 hash → `annotation-popover-<kind>-<digest>` CSS-safe DOM id.

**Route layer (`app/annotations/routes.py`)**
- `/annotations/version/{draft_version_id}/{row_kind}/{row_key:path}` now uses Starlette's `:path` converter so a multi-segment URI matches one parameter. The POST sub-routes (`/messages`, `/resolve`, `/reopen`) keep their own HTTP methods so no greedy-match ambiguity arises (routing is by `(path, method)`).
- Each of the four version-scoped handlers calls `decode_row_key(row_key)` at the boundary before any DB read or write.
- `_row_panel_fragment` calls `safe_row_key` when minting the fragment's resolve / reopen / compose URLs (the keys at that layer are already decoded raw URIs).

**Report renderer (`app/docs/report_routes.py`)**
- `_row_annotation_button` calls `safe_row_key` before interpolating `row_key` into the `hx-get` path. Data attributes still carry the raw `row_key` for JS round-trip identity.

**UI primitives (`app/ui/primitives/annotation_button.py`, `app/ui/surfaces/annotation_popover.py`)**
- Both derive their outer Div `id` from `target_dom_id(target_type, target_id)` so URI-typed `target_id`s no longer leak into CSS selectors. The HTMX URL uses `urlencode({...})` for structured encoding of the `target_type` / `target_id` query string. Original URI is preserved via `data-target-type` / `data-target-id` attrs.

**Explorer (`app/explorer/pages.py`)**
- `_PANEL_ANNOTATION_SCRIPT` now points `hx-target` at a fixed `#panel-annotation-popover` id instead of `#annotation-popover-entity-<encoded-uri>` — only one detail panel is open at a time, so a single CSS-safe id suffices. The `?target_id=` query string still uses `encodeURIComponent` so the entity URI survives the round trip.

## Testing

- `uv run pytest tests/test_annotations_routes.py tests/test_annotations_row_integration.py tests/test_annotations_version_routes.py tests/test_explorer_pages.py tests/test_docs_report_routes.py -x` — **196 passed**
- `uv run pytest -k "explorer or report" -x` — **193 passed**
- `uv run pytest` (full suite) — **2426 passed, 25 skipped**
- `uv run ruff check` / `uv run ruff format` / `uv run pyright` on all touched files — **clean**

New tests cover (using `https://data.riik.ee/ontology/estleg#KarS` as the URI):
- `TestUriRowKeyRoundTrip` — GET / POST messages / POST resolve with a URI row_key, asserting the handlers receive the decoded URI not the percent-encoded path segment.
- `TestRowKeyEncodingHelpers` — `safe_row_key` ⇄ `decode_row_key` inverse, `target_dom_id` is CSS-safe + deterministic + kind-distinguished.
- `TestAnnotationPopoverWithUriTargetId` — `AnnotationPopover` / `AnnotationButton` render for URI target_ids without raw `/`, `#`, or `%` in their DOM ids.
- `TestReportRowWithUriRowKey` — entity / EU rows render percent-encoded paths in `hx-get` and never embed raw URIs.
- `test_panel_annotation_script_uses_css_safe_hx_target` — Õiguskaart entity popover script asserts the fixed-id pattern and that the old broken concat-into-selector pattern is gone.

Closes #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)