### PR TITLE
fix(drafter): #816 — show 'Jätka' after 3 answered clarifications (renderer + state-machine)

### DIFF
--- a/app/drafter/_step_renderers.py
+++ b/app/drafter/_step_renderers.py
@@ -258,7 +258,12 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
             unanswered_idx = i
             break
 
-    all_answered = unanswered_idx is None and len(clarifications) >= 3
+    # #816: the user can advance after answering >= 3 questions, even if
+    # additional unanswered questions remain. Counting only rows whose
+    # ``answer`` is populated (mirrors the state-machine guard in
+    # ``state_machine._can_leave_clarify``).
+    answered_count = sum(1 for c in clarifications if c.get("answer"))
+    can_advance = answered_count >= 3
 
     children: list[Any] = []
 
@@ -313,19 +318,28 @@ def _step_2_page(session: DraftingSession, auth: UserDict):
             )
         )
 
-    # Show "proceed" button if all answered
-    if all_answered:
+    # #816: show the "proceed" button once 3 questions have been answered;
+    # additional questions remain optional. The state-machine guard
+    # (``state_machine._can_leave_clarify``) uses the same rule.
+    if can_advance:
+        all_answered = unanswered_idx is None
+        alert_text = (
+            "Kõik küsimused on vastatud. Võite jätkata uurimise sammuga."
+            if all_answered
+            else "Olete vastanud piisavale arvule küsimustele. Võite jätkata uurimise sammuga."
+        )
         children.append(
             Div(  # noqa: F405
-                Alert(
-                    "Kõik küsimused on vastatud. Võite jätkata uurimise sammuga.",
-                    variant="success",
-                ),
+                Alert(alert_text, variant="success"),
                 AppForm(
                     Button("Jätka uurimisega", type="submit", variant="primary"),
                     Input(type="hidden", name="action", value="advance"),  # noqa: F405
                     method="post",
                     action=f"/drafter/{session.id}/step/2",
+                ),
+                Small(  # noqa: F405
+                    "Võite jätkata 3 vastuse järel — ülejäänud küsimused on valikulised.",
+                    cls="form-field-help",
                 ),
                 cls="step-advance",
             )

--- a/app/drafter/state_machine.py
+++ b/app/drafter/state_machine.py
@@ -66,11 +66,17 @@ def _can_leave_intent(session: Any) -> bool:
 
 
 def _can_leave_clarify(session: Any) -> bool:
-    """CLARIFY -> RESEARCH: at least 3 clarifications recorded."""
+    """CLARIFY -> RESEARCH: at least 3 *answered* clarifications recorded.
+
+    #816: counts only rows with a non-empty ``answer`` field. The renderer
+    populates an unanswered ``question`` row per LLM-proposed question
+    (e.g. 8 rows for an 8-question interview); counting all rows would
+    let the user advance without actually answering anything.
+    """
     clarifications = session.clarifications
     if clarifications is None:
         return False
-    return len(clarifications) >= 3
+    return sum(1 for c in clarifications if c.get("answer")) >= 3
 
 
 def _can_leave_research(session: Any) -> bool:

--- a/tests/test_drafter_routes.py
+++ b/tests/test_drafter_routes.py
@@ -424,6 +424,74 @@ class TestStepPage:
         assert resp.status_code == 200
         assert "Jätka uurimisega" in resp.text
 
+    @patch("app.drafter.routes._find_latest_job")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_step_2_shows_advance_after_3_of_8_answered(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_find_job: MagicMock,
+    ):
+        """#816: the continue button must appear after 3 answers even if
+        additional unanswered questions remain (8 total, 3 answered)."""
+        mock_get_provider.return_value = _stub_provider()
+        session = _make_session(current_step=2)
+        session.clarifications = [
+            {"question": "Q1?", "answer": "A1"},
+            {"question": "Q2?", "answer": "A2"},
+            {"question": "Q3?", "answer": "A3"},
+            {"question": "Q4?", "answer": None},
+            {"question": "Q5?", "answer": None},
+            {"question": "Q6?", "answer": None},
+            {"question": "Q7?", "answer": None},
+            {"question": "Q8?", "answer": None},
+        ]
+        mock_fetch.return_value = session
+        mock_find_job.return_value = {"status": "success", "result": {}, "error_message": None}
+
+        client = _authed_client()
+        resp = client.get(f"/drafter/{_SESSION_ID}/step/2")
+
+        assert resp.status_code == 200
+        assert "Jätka uurimisega" in resp.text
+        # The Q4 form is still rendered for the remaining questions.
+        assert "Q4?" in resp.text
+        # Helper copy clarifying the partial-answer semantics.
+        assert "Võite jätkata 3 vastuse järel — ülejäänud küsimused on valikulised." in resp.text
+
+    @patch("app.drafter.routes._find_latest_job")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_step_2_hides_advance_when_no_answers(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_find_job: MagicMock,
+    ):
+        """#816: the continue button must NOT appear before any answer is
+        given — prevents trivial skip past the clarification step."""
+        mock_get_provider.return_value = _stub_provider()
+        session = _make_session(current_step=2)
+        session.clarifications = [
+            {"question": "Q1?", "answer": None},
+            {"question": "Q2?", "answer": None},
+            {"question": "Q3?", "answer": None},
+            {"question": "Q4?", "answer": None},
+            {"question": "Q5?", "answer": None},
+            {"question": "Q6?", "answer": None},
+            {"question": "Q7?", "answer": None},
+            {"question": "Q8?", "answer": None},
+        ]
+        mock_fetch.return_value = session
+        mock_find_job.return_value = {"status": "success", "result": {}, "error_message": None}
+
+        client = _authed_client()
+        resp = client.get(f"/drafter/{_SESSION_ID}/step/2")
+
+        assert resp.status_code == 200
+        assert "Jätka uurimisega" not in resp.text
+
     @patch("app.drafter.routes.fetch_session")
     @patch("app.auth.middleware._get_provider")
     def test_nonexistent_session_returns_404(

--- a/tests/test_drafter_state_machine.py
+++ b/tests/test_drafter_state_machine.py
@@ -93,15 +93,83 @@ class TestCanAdvance:
         assert can_advance(session, Step.CLARIFY) is True
 
     def test_can_advance_clarify_requires_3_answers(self):
+        """#816: counts ``answer``-populated rows, not raw list length."""
         session = FakeSession(current_step=2, intent="ok")
         session.clarifications = []
         assert can_advance(session, Step.RESEARCH) is False
 
-        session.clarifications = [{"q": "a"}, {"q": "b"}]
+        # Two answered rows — not enough.
+        session.clarifications = [
+            {"question": "a", "answer": "yes"},
+            {"question": "b", "answer": "no"},
+        ]
         assert can_advance(session, Step.RESEARCH) is False
 
-        session.clarifications = [{"q": "a"}, {"q": "b"}, {"q": "c"}]
+        # Three answered rows — exactly the threshold.
+        session.clarifications = [
+            {"question": "a", "answer": "yes"},
+            {"question": "b", "answer": "no"},
+            {"question": "c", "answer": "maybe"},
+        ]
         assert can_advance(session, Step.RESEARCH) is True
+
+    def test_can_advance_clarify_rejects_unanswered_rows(self):
+        """#816: rows without an ``answer`` must not count toward the threshold."""
+        session = FakeSession(current_step=2, intent="ok")
+
+        # 3 rows but all have ``answer=None`` — guard must reject.
+        session.clarifications = [
+            {"question": "x", "answer": None},
+            {"question": "y", "answer": None},
+            {"question": "z", "answer": None},
+        ]
+        assert can_advance(session, Step.RESEARCH) is False
+
+        # 3 rows all answered — accepted.
+        session.clarifications = [
+            {"question": "x", "answer": "a"},
+            {"question": "y", "answer": "b"},
+            {"question": "z", "answer": "c"},
+        ]
+        assert can_advance(session, Step.RESEARCH) is True
+
+        # 8 rows total, only 2 answered — rejected (the bug case).
+        session.clarifications = [
+            {"question": "x", "answer": "a"},
+            {"question": "y", "answer": "b"},
+            {"question": "z", "answer": None},
+            {"question": "w", "answer": None},
+            {"question": "v", "answer": None},
+            {"question": "u", "answer": None},
+            {"question": "t", "answer": None},
+            {"question": "s", "answer": None},
+        ]
+        assert can_advance(session, Step.RESEARCH) is False
+
+    def test_can_advance_clarify_accepts_3_of_8_answered(self):
+        """#816: the original bug — 3 answered of 8 must allow advance."""
+        session = FakeSession(current_step=2, intent="ok")
+        session.clarifications = [
+            {"question": "x", "answer": "a"},
+            {"question": "y", "answer": "b"},
+            {"question": "z", "answer": "c"},
+            {"question": "w", "answer": None},
+            {"question": "v", "answer": None},
+            {"question": "u", "answer": None},
+            {"question": "t", "answer": None},
+            {"question": "s", "answer": None},
+        ]
+        assert can_advance(session, Step.RESEARCH) is True
+
+    def test_can_advance_clarify_empty_string_answer_does_not_count(self):
+        """#816: an empty-string answer is falsy and must not count."""
+        session = FakeSession(current_step=2, intent="ok")
+        session.clarifications = [
+            {"question": "x", "answer": "a"},
+            {"question": "y", "answer": "b"},
+            {"question": "z", "answer": ""},
+        ]
+        assert can_advance(session, Step.RESEARCH) is False
 
     def test_can_advance_clarify_none_clarifications_fails(self):
         session = FakeSession(current_step=2, intent="ok")


### PR DESCRIPTION
## Summary

Closes #816.

The drafter Step 2 ("Täpsustamine") tells the user *"Vastake vähemalt 3 küsimusele enne jätkamist"* — but after answering 3, the **Jätka uurimisega** button never appeared. The bug existed on both sides:

1. **Renderer** (`app/drafter/_step_renderers.py:260`) computed `all_answered = unanswered_idx is None and len(clarifications) >= 3` — only rendered the continue button when *every* question was answered.
2. **State-machine guard** (`app/drafter/state_machine.py::_can_leave_clarify`) returned `len(clarifications) >= 3` — counted raw rows including unanswered ones, so it would have *also* let users advance with zero answers if there happened to be ≥3 question rows.

Both layers now use the same rule: count rows whose `answer` is truthy (rejecting `None` and `""`), and the threshold is 3. The renderer also gets a helper line below the button: *"Võite jätkata 3 vastuse järel — ülejäänud küsimused on valikulised."*

## Changes

- `app/drafter/state_machine.py` — `_can_leave_clarify` now `sum(1 for c in clarifications if c.get("answer")) >= 3`.
- `app/drafter/_step_renderers.py` — `_step_2_page` replaces `all_answered` with `can_advance = answered_count >= 3`; continue button is rendered out of the `all_answered` branch.
- `tests/test_drafter_state_machine.py` — updated `test_can_advance_clarify_requires_3_answers` for new semantics; added `test_can_advance_clarify_rejects_unanswered_rows`, `test_can_advance_clarify_accepts_3_of_8_answered`, `test_can_advance_clarify_empty_string_answer_does_not_count`.
- `tests/test_drafter_routes.py` — added `test_step_2_shows_advance_after_3_of_8_answered` and `test_step_2_hides_advance_when_no_answers`.

Per the design doc constraint (`docs/2026-05-19-usability-fixes-plan.md` §4.1) and the #813 bool-attr hardening: no new bool-form HTML attrs added.

## Test plan

- [x] `uv run ruff check app/drafter/ tests/` clean
- [x] `uv run pyright app/drafter/ tests/test_drafter*` clean (0 errors)
- [x] `uv run pytest tests/test_drafter*.py -q` — 159 passed
- [ ] On prod after deploy: open `/drafter/<id>/step/2` for a session with 8 questions, answer 3, see "Jätka uurimisega" rendered with the helper line below
- [ ] Verify clicking it advances to step 3 (state-machine guard accepts the same 3-of-8 case)
- [ ] Verify pre-answer page (0/8) does NOT render the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)