### PR TITLE
fix(impact): #805 + #815 — graceful unresolved EU CELEX warnings

### DIFF
--- a/app/analyysikeskus/eu_lookup.py
+++ b/app/analyysikeskus/eu_lookup.py
@@ -21,12 +21,87 @@ the "ei tuvastanud EL õigusakti" warning rather than 500.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from app.docs.impact.queries import PREFIXES
 from app.ontology.sparql_client import SparqlClient
 
 logger = logging.getLogger(__name__)
+
+# Canonical CELEX shape: 1-digit sector (1-9) + 4-digit year + single
+# uppercase form letter (R/L/D/H/…) + 4-digit running number.
+# Examples: ``32016R0679`` (GDPR), ``32019L1152`` (Working Conditions).
+# Counter-examples: ``12abc34``, ``GDPR``, ``directive 95/46``,
+# ``32016X0679`` (invalid form letter — see below).
+#
+# Form-letter whitelist: the documented binding-instrument letters that
+# a Seadusloome user is realistically going to look up. ``X`` and other
+# rarely-used letters are deliberately excluded so the warning message
+# stays a high-signal "this looks like a real CELEX missing from data"
+# rather than firing on every alphanumeric near-CELEX shape. Tightening
+# this set would require a follow-up change with user data on which
+# letters get typed in practice.
+#
+# Note this is intentionally STRICTER than the matchers in
+# :mod:`app.analyysikeskus.input_parser` (``\\d{5}[A-Z]\\d{1,4}``).
+# Those have to accept sloppy CELEX shapes embedded in pasted phrases
+# so the resolver gets a chance to look them up. This helper is the
+# user-facing "is this a CELEX we should report as canonical-but-missing
+# from the ontology" check — when it matches, we tell the user "this
+# looks like a real CELEX number, it's just not in our data yet";
+# when it doesn't, we keep the generic "ei tuvastatud" message.
+_CANONICAL_CELEX_RE = re.compile(r"^[1-9]\d{4}[RLDHSFGABCEJMOPQTUK]\d{4}$")
+
+
+def is_canonical_celex_shape(s: str) -> bool:
+    """True if *s* looks like a real CELEX number.
+
+    Used by the EL ülevõtt route (#805) and the impact-report renderer
+    (#815) to distinguish "user typed a canonical-shaped CELEX that
+    happens to be missing from our ontology" from "user typed prose /
+    garbage that doesn't look like an EU reference at all". When True,
+    the UI surfaces a "kontrollige käsitsi" warning naming the CELEX;
+    when False, it shows the generic "Ei tuvastanud EL õigusakti" hint.
+
+    The regex matches the canonical CELEX shape:
+
+    * Sector: a single non-zero digit (``1`` – ``9``) — sector ``0``
+      doesn't exist in EurLex.
+    * Year: four digits (``1957`` – present).
+    * Form letter: one uppercase ASCII letter drawn from the binding-
+      instrument whitelist (``R`` regulation, ``L`` directive,
+      ``D`` decision, ``H`` recommendation, …). The rarely-used ``X``
+      ("other") is deliberately excluded — see the regex comment
+      above for the rationale.
+    * Running number: four digits (zero-padded).
+
+    Args:
+        s: The candidate string. Leading/trailing whitespace is
+            stripped before matching; an empty/blank input returns
+            ``False``.
+
+    Returns:
+        ``True`` when *s* (stripped) matches the canonical CELEX shape;
+        ``False`` otherwise. Never raises.
+
+    Examples:
+        >>> is_canonical_celex_shape("32016R0679")  # GDPR
+        True
+        >>> is_canonical_celex_shape("32019L1152")  # Working Conditions
+        True
+        >>> is_canonical_celex_shape("12abc34")
+        False
+        >>> is_canonical_celex_shape("GDPR")
+        False
+        >>> is_canonical_celex_shape("")
+        False
+    """
+    stripped = (s or "").strip()
+    if not stripped:
+        return False
+    return bool(_CANONICAL_CELEX_RE.match(stripped))
+
 
 # Cap the candidate list — the disambiguation card stays scannable, and
 # a 2-char query like "EL" shouldn't dump hundreds of rows.

--- a/app/analyysikeskus/eu_lookup.py
+++ b/app/analyysikeskus/eu_lookup.py
@@ -57,6 +57,13 @@ _CANONICAL_CELEX_RE = re.compile(r"^[1-9]\d{4}[RLDHSFGABCEJMOPQTUK]\d{4}$")
 def is_canonical_celex_shape(s: str) -> bool:
     """True if *s* looks like a real CELEX number.
 
+    Case-insensitive: ``32016R0679`` and ``32016r0679`` both match.
+    The resolver itself uppercases lowercase form-letters before
+    SPARQL lookup (see :func:`app.docs.reference_resolver._normalize_celex`),
+    so the user-facing classifier must do the same — otherwise lowercase
+    CELEX input that the resolver *would* recognise still fell through
+    to the generic "ei tuvastatud" message.
+
     Used by the EL ülevõtt route (#805) and the impact-report renderer
     (#815) to distinguish "user typed a canonical-shaped CELEX that
     happens to be missing from our ontology" from "user typed prose /
@@ -88,6 +95,8 @@ def is_canonical_celex_shape(s: str) -> bool:
     Examples:
         >>> is_canonical_celex_shape("32016R0679")  # GDPR
         True
+        >>> is_canonical_celex_shape("32016r0679")  # lowercase form letter
+        True
         >>> is_canonical_celex_shape("32019L1152")  # Working Conditions
         True
         >>> is_canonical_celex_shape("12abc34")
@@ -100,7 +109,10 @@ def is_canonical_celex_shape(s: str) -> bool:
     stripped = (s or "").strip()
     if not stripped:
         return False
-    return bool(_CANONICAL_CELEX_RE.match(stripped))
+    # Uppercase the form letter (and any incidental letter casing) before
+    # the strict whitelist match. The resolver itself uppercases CELEX
+    # form letters before SPARQL lookup, so this helper must agree.
+    return bool(_CANONICAL_CELEX_RE.match(stripped.upper()))
 
 
 # Cap the candidate list — the disambiguation card stays scannable, and

--- a/app/analyysikeskus/eu_lookup.py
+++ b/app/analyysikeskus/eu_lookup.py
@@ -58,11 +58,11 @@ def is_canonical_celex_shape(s: str) -> bool:
     """True if *s* looks like a real CELEX number.
 
     Case-insensitive: ``32016R0679`` and ``32016r0679`` both match.
-    The resolver itself uppercases lowercase form-letters before
-    SPARQL lookup (see :func:`app.docs.reference_resolver._normalize_celex`),
-    so the user-facing classifier must do the same — otherwise lowercase
-    CELEX input that the resolver *would* recognise still fell through
-    to the generic "ei tuvastatud" message.
+    The resolver itself uppercases CELEX form-letters before SPARQL
+    lookup (inline ``.upper()`` calls at ``reference_resolver.py:664``
+    and ``:669``), so this user-facing classifier must do the same —
+    otherwise lowercase CELEX input that the resolver *would* recognise
+    still fell through to the generic "ei tuvastatud" message.
 
     Used by the EL ülevõtt route (#805) and the impact-report renderer
     (#815) to distinguish "user typed a canonical-shaped CELEX that

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -81,7 +81,7 @@ from app.analyysikeskus.court_practice import (
     list_decisions_for_act,
     list_decisions_for_provision,
 )
-from app.analyysikeskus.eu_lookup import search_eu_acts_by_label
+from app.analyysikeskus.eu_lookup import is_canonical_celex_shape, search_eu_acts_by_label
 from app.analyysikeskus.history import get_history_bundle, temporal_status_label
 from app.analyysikeskus.input_parser import parse_user_reference
 from app.analyysikeskus.result_shell import analysis_result_shell
@@ -2338,15 +2338,39 @@ def _render_eu_unresolved(
     sisend: str,
     scope: _Scope,
 ) -> Any:
-    """Render the "Ei tuvastanud EL õigusakti" warning page."""
+    """Render the "Ei tuvastanud EL õigusakti" warning page.
+
+    Two message variants (#805):
+
+    * **Canonical-CELEX shape** (e.g. ``32016R0679`` for GDPR,
+      ``32019L1152`` for Working Conditions): the user typed a
+      well-formed CELEX that simply hasn't been imported into the
+      ontology yet. Tell them *which* CELEX is missing so they know
+      to check the act manually rather than wondering if they
+      mistyped.
+    * **Anything else** (free prose, garbage, malformed CELEX): keep
+      the generic "Ei tuvastatud" hint with an example to nudge the
+      user toward a structured input.
+
+    The same ``Alert`` warning variant is used in both branches so the
+    surrounding scope block / actions / result-shell layout is
+    identical — only the copy changes.
+    """
+    if is_canonical_celex_shape(sisend):
+        message = (
+            f"EL õigusakt CELEX-numbriga {sisend.strip()} ei ole veel "
+            "ontoloogias kaardistatud. Kontrollige käsitsi või "
+            "proovige akti pealkirja."
+        )
+    else:
+        message = (
+            "Ei tuvastanud EL õigusakti. Proovige CELEX-numbrit "
+            "(nt 32016R0679) või akti pealkirja."
+        )
     return analysis_result_shell(
         workflow_title="EL ülevõtt ja harmoneerimine",
         input_summary=P(f"Sisestasite: «{sisend}»"),  # noqa: F405
-        results_block=Alert(
-            "Ei tuvastanud EL õigusakti. Proovige CELEX-numbrit (nt 32016R0679) "
-            "või akti pealkirja.",
-            variant="warning",
-        ),
+        results_block=Alert(message, variant="warning"),
         evidence_block=_missing_row("—"),
         actions=[
             {"label": "Küsi nõustajalt", "href": "/chat/new"},

--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -108,6 +108,25 @@ def analyze_impact(
         draft = get_draft(conn, draft_id)
         if draft is None:
             raise ValueError(f"Draft {draft_id} not found")
+        # #815: fetch fully-unresolved EU references BEFORE the resolved
+        # SELECT below filters them out. The downstream analyzer never
+        # sees these rows (entity_uri IS NULL AND partial_match IS NULL),
+        # but the impact-report renderer + .docx export use them to
+        # surface a "we detected EU refs but couldn't map them" warning
+        # so the user knows the analysis is missing coverage rather
+        # than silently treating "no EU findings" as "no EU impact".
+        unresolved_eu_rows = conn.execute(
+            """
+            select ref_text, confidence
+            from draft_entities
+            where draft_id = %s
+              and ref_type = 'eu_act'
+              and entity_uri is null
+              and partial_match is null
+            order by confidence desc
+            """,
+            (str(draft_id),),
+        ).fetchall()
         entity_rows = conn.execute(
             """
             select ref_text, entity_uri, confidence, ref_type, location,
@@ -118,6 +137,27 @@ def analyze_impact(
             """,
             (str(draft_id),),
         ).fetchall()
+
+    # Normalise the unresolved rows into the JSON-friendly shape that
+    # gets persisted in ``report_data["unresolved_eu_refs"]``.
+    # Tolerates both tuple-style rows (psycopg default) and dict-style
+    # rows (rare; some test fixtures use DictRow).
+    unresolved_eu_refs: list[dict[str, Any]] = []
+    for row in unresolved_eu_rows or []:
+        if isinstance(row, dict):
+            ref_text = row.get("ref_text")
+            confidence = row.get("confidence")
+        else:
+            ref_text = row[0] if len(row) > 0 else None
+            confidence = row[1] if len(row) > 1 else None
+        ref_text_str = str(ref_text or "").strip()
+        if not ref_text_str:
+            continue
+        try:
+            conf = float(confidence) if confidence is not None else 0.0
+        except (TypeError, ValueError):
+            conf = 0.0
+        unresolved_eu_refs.append({"ref_text": ref_text_str, "confidence": conf})
 
     resolved_refs = [_row_to_resolved_ref(row) for row in entity_rows]
     logger.info(
@@ -191,6 +231,13 @@ def analyze_impact(
             findings_dict_for_report["sanctions_delta"] = dataclasses.asdict(sanctions_delta)
         if burden_delta is not None:
             findings_dict_for_report["burden_delta"] = dataclasses.asdict(burden_delta)
+        # #815: persist unresolved-EU-ref list (may be empty). The
+        # renderer + .docx export read this key to surface a "EU refs
+        # detected but couldn't be mapped" warning when non-empty.
+        # Legacy reports lack the key entirely; readers use
+        # ``report_data.get("unresolved_eu_refs", [])`` to stay
+        # backward-compatible.
+        findings_dict_for_report["unresolved_eu_refs"] = unresolved_eu_refs
         report_data = json.dumps(findings_dict_for_report)
 
         with get_connection() as conn:

--- a/app/docs/docx_export.py
+++ b/app/docs/docx_export.py
@@ -403,6 +403,56 @@ def _add_eu_compliance(
     return 1 + extra_units
 
 
+def _add_unresolved_eu_refs(doc: Any, findings: dict[str, Any]) -> int:
+    """Write the "EL-i kaardistamata viited" warning section (#815).
+
+    Mirrors the renderer's :func:`_unresolved_eu_refs_section` so the
+    exported .docx surfaces the same warning the on-page report does:
+    the analyzer detected EU references in the draft text but couldn't
+    map them against the ontology snapshot. Returns 0 work units when
+    there's nothing to render (legacy reports or clean resolution), so
+    progress reporting is unaffected. Returns 1 unit when the section
+    is rendered.
+    """
+    raw = findings.get("unresolved_eu_refs") or []
+    if not raw:
+        return 0
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        ref_text = str(entry.get("ref_text") or "").strip()
+        if not ref_text or ref_text in seen:
+            continue
+        seen.add(ref_text)
+        unique.append(ref_text)
+    if not unique:
+        return 0
+
+    doc.add_heading("EL-i kaardistamata viited", level=1)
+    count = len(unique)
+    doc.add_paragraph(
+        f"Tuvastasime dokumendis viiteid EL õigusele "
+        f"({count} CELEX-numbrit), mida ei õnnestunud ontoloogias "
+        "kaardistada:"
+    )
+    # List each CELEX as its own bullet so they're easy to scan in the
+    # printed report. python-docx's "List Bullet" style ships with the
+    # default template.
+    for ref_text in unique:
+        para = doc.add_paragraph(ref_text, style="List Bullet")
+        # Render the CELEX text in monospace via the run-level font
+        # attribute so it visually matches the on-page <code> styling.
+        for run in para.runs:
+            run.font.name = "Courier New"
+    doc.add_paragraph(
+        "Kontrollige käsitsi — kaardistamata aktid ei kajastu mõjuanalüüsi tulemustes."
+    )
+    return 1
+
+
 def _add_gaps(
     doc: Any,
     findings: dict[str, Any],
@@ -520,6 +570,10 @@ def _compute_progress_total(report_data: dict[str, Any]) -> int:
     the ``<progress>`` bar's ``max`` attribute is right from the first
     push (browsers can render an indeterminate bar if ``value > max``,
     which looks broken).
+
+    The #815 "unresolved EU refs" section contributes 1 unit when
+    non-empty and 0 otherwise — it's an alert-style block (no per-row
+    table) so the cost is constant.
     """
     fixed = 4  # cover, summary, footer, save
     sections = ("affected_entities", "conflicts", "eu_compliance", "gaps")
@@ -528,6 +582,14 @@ def _compute_progress_total(report_data: dict[str, Any]) -> int:
         rows = report_data.get(key) or []
         # 1 unit for the section heading + 1 unit per N rows.
         table_units += 1 + (len(rows) // _PROGRESS_BATCH)
+    # #815: optional unresolved-EU-refs warning. Detect by the same
+    # rule the helper uses (non-empty list of ref_text-bearing dicts).
+    unresolved = report_data.get("unresolved_eu_refs") or []
+    if any(
+        isinstance(entry, dict) and str(entry.get("ref_text") or "").strip()
+        for entry in unresolved
+    ):
+        table_units += 1
     return fixed + table_units
 
 
@@ -608,6 +670,15 @@ def build_impact_report_docx(
     )
     done += consumed
     _safe_publish(progress_callback, done, total)
+
+    # #815: render the unresolved-EU-refs warning between EU compliance
+    # and Lüngad so it sits next to the EU section it qualifies. The
+    # helper returns 0 work units when there's nothing to warn about,
+    # which matches the zero contribution from ``_compute_progress_total``.
+    consumed = _add_unresolved_eu_refs(doc, report_data)
+    done += consumed
+    if consumed:
+        _safe_publish(progress_callback, done, total)
 
     consumed = _add_gaps(
         doc,

--- a/app/docs/docx_export.py
+++ b/app/docs/docx_export.py
@@ -433,18 +433,23 @@ def _add_unresolved_eu_refs(doc: Any, findings: dict[str, Any]) -> int:
 
     doc.add_heading("EL-i kaardistamata viited", level=1)
     count = len(unique)
+    # The persisted ``unresolved_eu_refs`` rows can include both
+    # canonical CELEX numbers (e.g. ``32016R0679``) and title/acronym
+    # mentions (e.g. ``GDPR``) — the extractor accepts both forms — so
+    # the copy says "EL viidet" (EU references), not "CELEX-numbrit".
     doc.add_paragraph(
         f"Tuvastasime dokumendis viiteid EL õigusele "
-        f"({count} CELEX-numbrit), mida ei õnnestunud ontoloogias "
+        f"({count} EL viidet), mida ei õnnestunud ontoloogias "
         "kaardistada:"
     )
-    # List each CELEX as its own bullet so they're easy to scan in the
+    # List each ref as its own bullet so they're easy to scan in the
     # printed report. python-docx's "List Bullet" style ships with the
     # default template.
     for ref_text in unique:
         para = doc.add_paragraph(ref_text, style="List Bullet")
-        # Render the CELEX text in monospace via the run-level font
-        # attribute so it visually matches the on-page <code> styling.
+        # Render the ref text in monospace via the run-level font
+        # attribute so it visually matches the on-page <code> styling
+        # (works equally for CELEX shapes and acronyms).
         for run in para.runs:
             run.font.name = "Courier New"
     doc.add_paragraph(

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -947,6 +947,72 @@ def _eu_compliance_section(
     )
 
 
+def _unresolved_eu_refs_section(findings: dict[str, Any]) -> Any:
+    """Build the "EU references detected but not mapped" warning (#815).
+
+    The analyze handler persists every ``ref_type='eu_act'`` row that
+    failed to resolve to either an ``entity_uri`` or an act-level
+    ``partial_match`` into ``report_data["unresolved_eu_refs"]``. When
+    that list is non-empty, the user uploaded a draft mentioning EU
+    references (typically a CELEX number such as ``32016R0679`` for
+    GDPR) that the resolver couldn't map against the current ontology
+    snapshot — usually because the act simply hasn't been imported
+    yet. Without this warning, the impact report shows the misleading
+    "EL-i õigusaktide seoseid ei tuvastatud" copy as if the draft
+    had no EU references at all.
+
+    Returns the empty string when the key is missing (legacy reports)
+    or empty (resolver mapped everything cleanly), so it composes
+    cleanly into the page tree.
+    """
+    refs = list(findings.get("unresolved_eu_refs") or [])
+    if not refs:
+        return ""
+
+    # Deduplicate identical ``ref_text`` values (a long draft can
+    # mention the same CELEX many times). Preserve first-seen order so
+    # the list reads naturally.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for entry in refs:
+        if not isinstance(entry, dict):
+            continue
+        ref_text = str(entry.get("ref_text") or "").strip()
+        if not ref_text or ref_text in seen:
+            continue
+        seen.add(ref_text)
+        unique.append(ref_text)
+    if not unique:
+        return ""
+
+    count = len(unique)
+    # Render the CELEX values as inline <code> for visual emphasis and
+    # so they're easily copy-paste-able into EurLex by the user.
+    code_items: list[Any] = []
+    for index, ref_text in enumerate(unique):
+        if index > 0:
+            code_items.append(", ")
+        code_items.append(Code(ref_text))  # noqa: F405
+
+    body = Div(  # noqa: F405
+        P(  # noqa: F405
+            f"Tuvastasime dokumendis viiteid EL õigusele "
+            f"({count} CELEX-numbrit), mida ei õnnestunud "
+            "ontoloogias kaardistada:",
+        ),
+        P(*code_items, cls="unresolved-eu-refs-list"),  # noqa: F405
+        P(  # noqa: F405
+            "Kontrollige käsitsi — kaardistamata aktid ei kajastu mõjuanalüüsi tulemustes.",
+            cls="muted-text",
+        ),
+    )
+    return Alert(
+        body,
+        variant="warning",
+        title="EL-i kaardistamata viited",
+    )
+
+
 def _gaps_section(
     findings: dict[str, Any],
     draft_id: str = "",
@@ -1549,6 +1615,12 @@ def draft_report_page(req: Request, draft_id: str):
             draft_version_id=draft_version_id,
             counts=unresolved_counts,
         ),
+        # #815: surfaces draft_entities rows where the resolver detected
+        # an EU reference (typically a CELEX number) but couldn't map it
+        # against the ontology snapshot. Returns "" when there are no
+        # such rows so the section disappears cleanly when ontology
+        # coverage catches up (no app change needed in that case).
+        _unresolved_eu_refs_section(findings),
         _gaps_section(
             findings,
             draft_id=str(draft.id),

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -986,8 +986,12 @@ def _unresolved_eu_refs_section(findings: dict[str, Any]) -> Any:
         return ""
 
     count = len(unique)
-    # Render the CELEX values as inline <code> for visual emphasis and
-    # so they're easily copy-paste-able into EurLex by the user.
+    # Render the ref values (CELEX numbers AND title/acronym mentions
+    # like "GDPR") as inline <code> for visual emphasis and so they're
+    # easily copy-paste-able into EurLex by the user. The persisted
+    # `unresolved_eu_refs` rows come from any extracted ``eu_act`` ref
+    # that didn't resolve — not only canonical CELEX shapes — so the
+    # copy says "EL viidet" (EU references), not "CELEX-numbrit".
     code_items: list[Any] = []
     for index, ref_text in enumerate(unique):
         if index > 0:
@@ -997,7 +1001,7 @@ def _unresolved_eu_refs_section(findings: dict[str, Any]) -> Any:
     body = Div(  # noqa: F405
         P(  # noqa: F405
             f"Tuvastasime dokumendis viiteid EL õigusele "
-            f"({count} CELEX-numbrit), mida ei õnnestunud "
+            f"({count} EL viidet), mida ei õnnestunud "
             "ontoloogias kaardistada:",
         ),
         P(*code_items, cls="unresolved-eu-refs-list"),  # noqa: F405

--- a/tests/test_analyysikeskus_eu_lookup.py
+++ b/tests/test_analyysikeskus_eu_lookup.py
@@ -65,9 +65,17 @@ class TestIsCanonicalCelexShape:
         # behaviour is cheap and prevents a TypeError if a caller forgets.
         assert is_canonical_celex_shape(None) is False  # type: ignore[arg-type]
 
-    def test_rejects_lowercase_form_letter(self):
-        # Real CELEX form letters are always uppercase.
-        assert is_canonical_celex_shape("32016r0679") is False
+    def test_accepts_lowercase_form_letter(self):
+        # The resolver itself uppercases CELEX form letters before SPARQL
+        # lookup (see reference_resolver._normalize_celex). The shape helper
+        # must agree, otherwise lowercase input that the resolver *would*
+        # have recognised falls through to the generic "ei tuvastatud"
+        # message instead of the canonical "ei ole veel ontoloogias
+        # kaardistatud" warning. Reported as #821 P3.
+        assert is_canonical_celex_shape("32016r0679") is True
+        assert is_canonical_celex_shape("32019l1152") is True
+        # Mixed case also accepted.
+        assert is_canonical_celex_shape("32016r0679".upper()) is True
 
     def test_rejects_invalid_form_letter_x(self):
         # Acceptance criterion from #805 plan: X is outside the

--- a/tests/test_analyysikeskus_eu_lookup.py
+++ b/tests/test_analyysikeskus_eu_lookup.py
@@ -1,0 +1,139 @@
+"""Unit tests for :mod:`app.analyysikeskus.eu_lookup`.
+
+Pins the shape recognition + label-search degradation rules. The
+SPARQL-backed branch of :func:`search_eu_acts_by_label` is covered
+indirectly through ``test_analyysikeskus_routes.py`` — these tests
+focus on the pure shape helper introduced for #805/#815 and the
+defensive fallbacks around label search.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.analyysikeskus.eu_lookup import is_canonical_celex_shape, search_eu_acts_by_label
+
+
+class TestIsCanonicalCelexShape:
+    """``is_canonical_celex_shape`` — strict canonical-CELEX recogniser.
+
+    The helper exists to discriminate "user typed a real CELEX that
+    just isn't in our ontology snapshot" (warning copy names the
+    CELEX) from "user typed prose or garbage" (generic hint copy).
+    The acceptance contract for #805 is:
+
+    * True for canonical CELEXes (sector 1-9, 4-digit year, uppercase
+      form letter from the documented whitelist, 4-digit running #)
+    * False for everything else
+    """
+
+    def test_gdpr_celex(self):
+        # The bug-report CELEX from #805 (GDPR).
+        assert is_canonical_celex_shape("32016R0679") is True
+
+    def test_working_conditions_celex(self):
+        # A directive — different form letter from the regulation case.
+        assert is_canonical_celex_shape("32019L1152") is True
+
+    def test_decision_celex(self):
+        assert is_canonical_celex_shape("32020D0001") is True
+
+    def test_recommendation_celex(self):
+        assert is_canonical_celex_shape("32023H0001") is True
+
+    def test_with_leading_and_trailing_whitespace(self):
+        # The helper must strip — the route hands ``sisend`` straight in.
+        assert is_canonical_celex_shape("  32016R0679  ") is True
+
+    def test_rejects_short_alphanumeric_garbage(self):
+        # Acceptance criterion from #805 plan.
+        assert is_canonical_celex_shape("12abc34") is False
+
+    def test_rejects_word_acronym(self):
+        # Users type "GDPR" — that's NOT a canonical CELEX.
+        assert is_canonical_celex_shape("GDPR") is False
+
+    def test_rejects_empty(self):
+        assert is_canonical_celex_shape("") is False
+
+    def test_rejects_blank(self):
+        assert is_canonical_celex_shape("   ") is False
+
+    def test_rejects_none_safely(self):
+        # The route passes ``(req.query_params.get(...) or "").strip()``
+        # so the helper never sees None in production, but defensive
+        # behaviour is cheap and prevents a TypeError if a caller forgets.
+        assert is_canonical_celex_shape(None) is False  # type: ignore[arg-type]
+
+    def test_rejects_lowercase_form_letter(self):
+        # Real CELEX form letters are always uppercase.
+        assert is_canonical_celex_shape("32016r0679") is False
+
+    def test_rejects_invalid_form_letter_x(self):
+        # Acceptance criterion from #805 plan: X is outside the
+        # binding-instrument whitelist.
+        assert is_canonical_celex_shape("32016X0679") is False
+
+    def test_rejects_zero_sector(self):
+        # Sector 0 doesn't exist in EurLex's CELEX scheme.
+        assert is_canonical_celex_shape("02016R0679") is False
+
+    def test_rejects_too_short_year(self):
+        assert is_canonical_celex_shape("3216R0679") is False
+
+    def test_rejects_too_short_running_number(self):
+        # input_parser accepts 1-4 digits to be lenient with paste-noise;
+        # this canonical helper requires exactly 4.
+        assert is_canonical_celex_shape("32016R067") is False
+        assert is_canonical_celex_shape("32016R67") is False
+        assert is_canonical_celex_shape("32016R6") is False
+
+    def test_rejects_too_long_running_number(self):
+        assert is_canonical_celex_shape("32016R06799") is False
+
+    def test_rejects_celex_embedded_in_phrase(self):
+        # ``parse_user_reference`` *does* lift an embedded CELEX out, but
+        # this helper is intentionally exact-shape only — the route
+        # already calls ``parse_user_reference`` first; what falls
+        # through to ``_render_eu_unresolved`` is whatever the user
+        # typed verbatim.
+        assert is_canonical_celex_shape("GDPR (32016R0679)") is False
+
+    def test_rejects_with_internal_whitespace(self):
+        assert is_canonical_celex_shape("32016 R 0679") is False
+
+
+class TestSearchEuActsByLabelDegradation:
+    """Defensive fallbacks — short queries + SPARQL failures yield ``[]``.
+
+    The happy path (a successful Jena query returning labelled
+    candidates) is covered by route-level integration tests.
+    """
+
+    def test_short_query_returns_empty(self):
+        # The helper short-circuits before hitting Jena when the query
+        # is too narrow to be useful — prevents a stray 1-char input
+        # from dumping the entire EU corpus.
+        assert search_eu_acts_by_label("") == []
+        assert search_eu_acts_by_label(" ") == []
+        assert search_eu_acts_by_label("A") == []
+
+    def test_sparql_exception_degrades_to_empty(self):
+        # Jena dead / unreachable → ``[]`` so the route falls through to
+        # the "ei tuvastatud" warning rather than 500-ing.
+        client = MagicMock()
+        client.query.side_effect = RuntimeError("boom")
+        with patch(
+            "app.analyysikeskus.eu_lookup.SparqlClient",
+            return_value=client,
+        ):
+            assert search_eu_acts_by_label("isikuandmete kaitse") == []
+
+    def test_empty_rows_returns_empty(self):
+        client = MagicMock()
+        client.query.return_value = []
+        with patch(
+            "app.analyysikeskus.eu_lookup.SparqlClient",
+            return_value=client,
+        ):
+            assert search_eu_acts_by_label("isikuandmete kaitse") == []

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -665,6 +665,103 @@ def test_el_ulevott_unrecognised_input_shows_warning(
     assert "Uuenda ulatust" in body
 
 
+# ---------------------------------------------------------------------------
+# #805 — canonical-shaped CELEX missing from the ontology gets its own copy
+# ---------------------------------------------------------------------------
+#
+# Distinguishes "user typed a real CELEX (GDPR / Working Conditions / …)
+# that just isn't in our snapshot yet" from "user typed prose / garbage".
+# The route reaches ``_render_eu_unresolved`` when:
+#   * resolver returns nothing (no entity_uri match), AND
+#   * label search returns nothing (CELEX is unknown, label is empty).
+# Both paths are mocked here so the test pins the BRANCH inside
+# ``_render_eu_unresolved`` (canonical-shape vs. generic) rather than
+# the upstream wiring.
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.routes.search_eu_acts_by_label", return_value=[])
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_el_ulevott_canonical_celex_missing_from_data_shows_specific_warning(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_search: MagicMock,
+    mock_recent: MagicMock,
+):
+    """The user typed GDPR's CELEX, which is well-formed but missing
+    from the ontology — the warning must name the CELEX so they know
+    to look it up manually rather than wonder if they mistyped.
+    """
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/el-ulevott?sisend=32016R0679")
+    assert resp.status_code == 200
+    body = resp.text
+    # The canonical-CELEX message names the input + tells the user to
+    # check manually.
+    assert "32016R0679" in body
+    assert "ei ole veel" in body and "ontoloogias kaardistatud" in body
+    assert "Kontrollige käsitsi" in body
+    # The generic copy must NOT appear (avoids confusing double messaging).
+    assert "Ei tuvastanud EL õigusakti" not in body
+    # Still a full result shell with the standard headings + scope form.
+    for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
+        assert heading in body, heading
+    assert "Uuenda ulatust" in body
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.routes.search_eu_acts_by_label", return_value=[])
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_el_ulevott_near_celex_garbage_shows_generic_warning(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_search: MagicMock,
+    mock_recent: MagicMock,
+):
+    """An alphanumeric string that ISN'T a canonical CELEX (``12abc34``)
+    keeps the generic "Ei tuvastatud" copy with the CELEX example as
+    a hint — we don't want to imply ``12abc34`` is a real CELEX.
+    """
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/el-ulevott?sisend=12abc34")
+    assert resp.status_code == 200
+    body = resp.text
+    # Generic copy + the example CELEX hint.
+    assert "Ei tuvastanud EL õigusakti" in body
+    assert "32016R0679" in body  # example hint
+    # The canonical-CELEX-specific copy must NOT fire.
+    assert "ei ole veel" not in body or "ontoloogias kaardistatud" not in body
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.routes.search_eu_acts_by_label", return_value=[])
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_el_ulevott_directive_title_shows_generic_warning(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_search: MagicMock,
+    mock_recent: MagicMock,
+):
+    """A free-text directive name with no label-search match keeps
+    the generic "Ei tuvastatud" copy — we don't have anything specific
+    to tell the user about a string that doesn't even look like a
+    CELEX.
+    """
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/el-ulevott?sisend=just+some+directive+name")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Ei tuvastanud EL õigusakti" in body
+    # No canonical-shape copy.
+    assert "ontoloogias kaardistatud" not in body
+
+
 @patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
 @patch("app.analyysikeskus.routes.search_eu_acts_by_label")
 @patch("app.docs.reference_resolver.ReferenceResolver.resolve", return_value=[])

--- a/tests/test_analyysikeskus_routes.py
+++ b/tests/test_analyysikeskus_routes.py
@@ -715,6 +715,34 @@ def test_el_ulevott_canonical_celex_missing_from_data_shows_specific_warning(
 @patch("app.analyysikeskus.routes.search_eu_acts_by_label", return_value=[])
 @patch("app.docs.reference_resolver.ReferenceResolver.resolve", return_value=[])
 @patch("app.auth.middleware._get_provider")
+def test_el_ulevott_lowercase_celex_shows_specific_warning(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_search: MagicMock,
+    mock_recent: MagicMock,
+):
+    """#821 P3 regression: the resolver uppercases CELEX form letters
+    before SPARQL lookup, so the shape classifier must agree.
+    Lowercase ``32016r0679`` should fire the canonical-but-missing
+    warning, not the generic "ei tuvastatud" copy.
+    """
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/el-ulevott?sisend=32016r0679")
+    assert resp.status_code == 200
+    body = resp.text
+    # Lowercase CELEX should be recognised as canonical-shape.
+    assert "32016r0679" in body  # input echoed verbatim
+    assert "ei ole veel" in body and "ontoloogias kaardistatud" in body
+    assert "Kontrollige käsitsi" in body
+    # The generic copy must NOT appear.
+    assert "Ei tuvastanud EL õigusakti" not in body
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.routes.search_eu_acts_by_label", return_value=[])
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve", return_value=[])
+@patch("app.auth.middleware._get_provider")
 def test_el_ulevott_near_celex_garbage_shows_generic_warning(
     mock_provider: MagicMock,
     mock_resolve: MagicMock,

--- a/tests/test_docs_analyze_handler.py
+++ b/tests/test_docs_analyze_handler.py
@@ -103,15 +103,39 @@ def _make_load_conn(
     *,
     draft: Draft | None = None,
     entity_rows: list[tuple] | None = None,
+    unresolved_eu_rows: list[tuple] | None = None,
 ) -> MagicMock:
     """Build a mock for the initial ``get_connection`` block.
 
     ``get_draft`` is patched separately, so this connection only needs
-    to answer the ``select ... from draft_entities`` query.
+    to answer the two ``select ... from draft_entities`` queries:
+
+    1. ``where ref_type='eu_act' AND entity_uri IS NULL ...`` — the
+       #815 unresolved-EU-refs query. ``unresolved_eu_rows`` (each row
+       a ``(ref_text, confidence)`` tuple) drives this.
+    2. ``where (entity_uri IS NOT NULL OR partial_match IS NOT NULL)``
+       — the existing resolved-refs query. ``entity_rows`` (each row a
+       6-tuple per ``_row_to_resolved_ref``) drives this.
+
+    The order is preserved by ``side_effect``: the handler calls (1)
+    BEFORE (2), so the first execute → first list, second → second.
     """
     conn = MagicMock()
-    fetchall_result = entity_rows or []
-    conn.execute.return_value.fetchall.return_value = fetchall_result
+    unresolved_rows = unresolved_eu_rows or []
+    resolved_rows = entity_rows or []
+
+    # The handler issues the unresolved-EU query first, then the
+    # resolved-refs query. Build cursor-mocks for each so .fetchall()
+    # returns the matching row list per call.
+    def _cursor_for(rows: list[tuple]) -> MagicMock:
+        cursor = MagicMock()
+        cursor.fetchall.return_value = rows
+        return cursor
+
+    conn.execute.side_effect = [
+        _cursor_for(unresolved_rows),
+        _cursor_for(resolved_rows),
+    ]
     return conn
 
 
@@ -685,15 +709,37 @@ class TestAnalyzeImpactPartialMatch:
             ]
             analyze_impact({"draft_id": str(_DRAFT_ID)})
 
-        # The load-connection's SELECT must contain ``partial_match``
-        # (widened column projection) and must NOT have the old
-        # ``entity_uri is not null`` filter that hid act-level rows.
-        select_calls = [
+        # Post-#815 the handler issues TWO SELECTs against
+        # ``draft_entities``: one for fully-unresolved EU refs (no
+        # ``partial_match`` in the projection), and one for resolved /
+        # act-level rows (which MUST project ``partial_match``). We
+        # filter to the resolved-refs SELECT for the original
+        # column-widening assertion — that one is identified by the
+        # ``entity_uri`` column appearing in the projection (the
+        # unresolved-EU SELECT projects only ref_text + confidence).
+        all_drafts_selects = [
             c.args[0]
             for c in load_conn.execute.call_args_list
             if "from draft_entities" in c.args[0].lower()
         ]
-        assert len(select_calls) == 1
+        assert len(all_drafts_selects) == 2, (
+            "Post-#815 the handler must issue exactly two SELECTs from "
+            "draft_entities (unresolved-EU + resolved/partial-match). "
+            f"Got: {all_drafts_selects!r}"
+        )
+        # Identify the resolved-refs SELECT by the ``entity_uri`` token
+        # appearing BEFORE the FROM clause — only that projection lists
+        # entity_uri as a column. The unresolved-EU SELECT only
+        # references it in the WHERE clause.
+        select_calls = [
+            s
+            for s in all_drafts_selects
+            if "entity_uri" in s.lower().split("from draft_entities")[0]
+        ]
+        assert len(select_calls) == 1, (
+            "Exactly one SELECT must project entity_uri (the resolved-refs "
+            "query). Got: " + repr(select_calls)
+        )
         select_sql = select_calls[0].lower()
         assert "partial_match" in select_sql, (
             "The entity-load SELECT must project partial_match — "
@@ -716,6 +762,228 @@ class TestAnalyzeImpactPartialMatch:
                 "it must be paired with OR partial_match is not null "
                 "so act-level rows still flow through"
             )
+
+
+class TestUnresolvedEuRefs:
+    """#815 — unresolved EU refs surface in ``report_data``.
+
+    The analyzer is explicitly Postgres-free, so the warning must come
+    from the handler. Before the resolver's filtered SELECT runs, we
+    query for rows where ``ref_type='eu_act'`` and BOTH ``entity_uri``
+    AND ``partial_match`` are NULL. Those rows are persisted into
+    ``report_data["unresolved_eu_refs"]`` so the renderer / .docx
+    export can surface them as a warning to the user.
+    """
+
+    def _run_with_rows(
+        self,
+        *,
+        unresolved_eu_rows: list[tuple],
+        entity_rows: list[tuple] | None = None,
+    ) -> str:
+        """Run analyze_impact with the given row fixtures and return
+        the JSON-encoded ``report_data`` blob written to impact_reports.
+        """
+        draft = _make_draft()
+        load_conn = _make_load_conn(
+            entity_rows=entity_rows or [],
+            unresolved_eu_rows=unresolved_eu_rows,
+        )
+        insert_conn = _make_insert_conn()
+        sync_conn = _make_sync_conn((datetime(2026, 5, 19, 12, 0, tzinfo=UTC), 1))
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = _findings(affected=0)
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
+            patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
+            patch("app.docs.analyze_handler.put_named_graph", return_value=True),
+            patch("app.docs.analyze_handler.write_doc_lineage", return_value=None),
+            patch("app.docs.analyze_handler.fetch_draft", return_value=None),
+            patch(
+                "app.docs.analyze_handler.ImpactAnalyzer",
+                return_value=mock_analyzer,
+            ),
+            patch(
+                "app.docs.analyze_handler.calculate_impact_score",
+                return_value=0,
+            ),
+        ):
+            mock_get_conn.side_effect = [
+                _ConnectCM(load_conn),
+                _ConnectCM(sync_conn),
+                _ConnectCM(insert_conn),
+            ]
+            analyze_impact({"draft_id": str(_DRAFT_ID)})
+
+        # Pull the report_data JSON out of the INSERT params.
+        insert_calls = [
+            c
+            for c in insert_conn.execute.call_args_list
+            if "insert into impact_reports" in c.args[0].lower()
+        ]
+        assert insert_calls, "No INSERT into impact_reports found"
+        params = insert_calls[0].args[1]
+        for value in params:
+            if isinstance(value, str) and "affected_entities" in value:
+                return value
+        raise AssertionError("report_data JSON not present in INSERT params")
+
+    def test_unresolved_eu_rows_appear_in_report_data(self):
+        """A draft mentioning GDPR + Working Conditions whose CELEXes
+        weren't resolved must surface both ref_texts in
+        ``report_data["unresolved_eu_refs"]``.
+        """
+        unresolved_rows: list[tuple] = [
+            ("32016R0679", 0.95),
+            ("32019L1152", 0.88),
+        ]
+        report_data_json = self._run_with_rows(unresolved_eu_rows=unresolved_rows)
+        report_data = json.loads(report_data_json)
+
+        assert "unresolved_eu_refs" in report_data, (
+            "report_data must always carry the unresolved_eu_refs key "
+            "(empty list when nothing to warn about)"
+        )
+        refs = report_data["unresolved_eu_refs"]
+        assert len(refs) == 2
+        ref_texts = {r["ref_text"] for r in refs}
+        assert ref_texts == {"32016R0679", "32019L1152"}
+        # Confidence is preserved as a float so the renderer can sort
+        # or filter by it in a follow-up.
+        for ref in refs:
+            assert isinstance(ref["confidence"], float)
+            assert 0.0 <= ref["confidence"] <= 1.0
+
+    def test_no_unresolved_rows_yields_empty_list(self):
+        """When the resolver maps every EU ref cleanly,
+        ``unresolved_eu_refs`` is an empty list — never missing — so
+        the renderer's ``.get(...)`` fallback hits a consistent shape.
+        """
+        report_data_json = self._run_with_rows(unresolved_eu_rows=[])
+        report_data = json.loads(report_data_json)
+
+        assert report_data.get("unresolved_eu_refs") == []
+
+    def test_resolved_rows_do_not_appear_in_unresolved_list(self):
+        """A row that the resolver mapped to an ``entity_uri`` must NOT
+        appear in ``unresolved_eu_refs`` — the handler's two SELECTs
+        partition draft_entities by resolution status and only the
+        first one feeds the warning list.
+        """
+        # The DB layer is mocked, so this test pins the contract:
+        # rows whose resolver-output (entity_uri non-null) make it to
+        # the unresolved-EU SELECT are excluded BY THE QUERY. We
+        # therefore only need to assert the handler doesn't somehow
+        # forward resolved entity_rows into the unresolved list.
+        resolved_eu_rows: list[tuple] = [
+            (
+                "32016R0679",
+                "https://data.riik.ee/ontology/estleg#EU-32016R0679",
+                0.95,
+                "eu_act",
+                json.dumps({}),
+                None,
+            ),
+        ]
+        report_data_json = self._run_with_rows(
+            unresolved_eu_rows=[],
+            entity_rows=resolved_eu_rows,
+        )
+        report_data = json.loads(report_data_json)
+        assert report_data.get("unresolved_eu_refs") == [], (
+            "Resolved rows must NOT appear in unresolved_eu_refs"
+        )
+
+    def test_blank_ref_text_rows_are_skipped(self):
+        """Defensive: a row with NULL/empty ref_text (unexpected, but
+        possible if the extractor wrote a sentinel) is silently
+        dropped from the warning list. The user gets nothing useful
+        from an empty ``<code></code>`` chip.
+        """
+        report_data_json = self._run_with_rows(
+            unresolved_eu_rows=[
+                ("", 0.5),
+                ("   ", 0.5),
+                ("32016R0679", 0.9),
+            ],
+        )
+        report_data = json.loads(report_data_json)
+        refs = report_data["unresolved_eu_refs"]
+        # Only the GDPR CELEX should survive — the empty/blank ones are filtered.
+        assert len(refs) == 1
+        assert refs[0]["ref_text"] == "32016R0679"
+
+    def test_unresolved_eu_select_uses_correct_filters(self):
+        """The unresolved-EU SELECT must filter on ref_type='eu_act'
+        AND entity_uri IS NULL AND partial_match IS NULL — these
+        together are the "draft mentioned an EU reference but we
+        couldn't map it" predicate.
+        """
+        draft = _make_draft()
+        load_conn = _make_load_conn(unresolved_eu_rows=[], entity_rows=[])
+        insert_conn = _make_insert_conn()
+        sync_conn = _make_sync_conn(None)
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = _findings(affected=0)
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.get_latest_version", return_value=_make_version()),
+            patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
+            patch("app.docs.analyze_handler.put_named_graph", return_value=True),
+            patch("app.docs.analyze_handler.write_doc_lineage", return_value=None),
+            patch("app.docs.analyze_handler.fetch_draft", return_value=None),
+            patch(
+                "app.docs.analyze_handler.ImpactAnalyzer",
+                return_value=mock_analyzer,
+            ),
+            patch(
+                "app.docs.analyze_handler.calculate_impact_score",
+                return_value=0,
+            ),
+        ):
+            mock_get_conn.side_effect = [
+                _ConnectCM(load_conn),
+                _ConnectCM(sync_conn),
+                _ConnectCM(insert_conn),
+            ]
+            analyze_impact({"draft_id": str(_DRAFT_ID)})
+
+        # Two SELECTs from draft_entities — one of them is the
+        # unresolved-EU query and must carry the three required
+        # WHERE-clause predicates.
+        drafts_selects = [
+            c.args[0]
+            for c in load_conn.execute.call_args_list
+            if "from draft_entities" in c.args[0].lower()
+        ]
+        # Identify by absence of "entity_uri" in the SELECT projection.
+        unresolved_select = next(
+            (
+                s
+                for s in drafts_selects
+                if "entity_uri" not in s.lower().split("from draft_entities")[0]
+            ),
+            None,
+        )
+        assert unresolved_select is not None, "No unresolved-EU SELECT found"
+        sql_lower = unresolved_select.lower()
+        # The three required predicates.
+        assert "ref_type" in sql_lower and "'eu_act'" in sql_lower, (
+            "unresolved-EU SELECT must filter on ref_type = 'eu_act'"
+        )
+        assert "entity_uri is null" in sql_lower, (
+            "unresolved-EU SELECT must filter on entity_uri IS NULL"
+        )
+        assert "partial_match is null" in sql_lower, (
+            "unresolved-EU SELECT must filter on partial_match IS NULL"
+        )
 
 
 class TestRegistration:

--- a/tests/test_docs_docx_export.py
+++ b/tests/test_docs_docx_export.py
@@ -420,3 +420,156 @@ class TestBuildImpactReportDocx:
         # phrasing — verify by counting occurrences of the partial
         # phrase (should equal 1 for the one partial row only).
         assert joined.count("Akt (sätet ei leitud)") == 1
+
+
+# ---------------------------------------------------------------------------
+# #815 — unresolved EU references warning section in DOCX
+# ---------------------------------------------------------------------------
+
+
+def _paragraph_texts(doc_mock: MagicMock) -> list[str]:
+    """Collect the text passed to every ``doc.add_paragraph`` call."""
+    out: list[str] = []
+    for call in doc_mock.add_paragraph.call_args_list:
+        if call.args:
+            out.append(call.args[0])
+    return out
+
+
+class TestUnresolvedEuRefsDocxSection:
+    """The DOCX export must surface the same warning the on-page
+    report does when ``report_data["unresolved_eu_refs"]`` is
+    non-empty.
+    """
+
+    def test_warning_section_rendered_with_celexes(self, tmp_export_dir: Path):
+        draft = _make_draft()
+        findings_with_unresolved = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [
+                {"ref_text": "32016R0679", "confidence": 0.95},
+                {"ref_text": "32019L1152", "confidence": 0.88},
+            ],
+        }
+        row = _build_report_row(
+            affected=0,
+            conflicts=0,
+            gaps=0,
+            findings=findings_with_unresolved,
+        )
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            mock_doc = MagicMock()
+            mock_doc.sections = []
+            mock_doc_cls.return_value = mock_doc
+
+            build_impact_report_docx(draft, row)
+
+        headings = _heading_calls(mock_doc)
+        assert "EL-i kaardistamata viited" in headings, (
+            "DOCX export must emit the 'kaardistamata viited' heading "
+            "when unresolved_eu_refs is non-empty"
+        )
+
+        # Collect every CELEX-bearing paragraph (the bullet list).
+        paragraphs = _paragraph_texts(mock_doc)
+        joined = " | ".join(paragraphs)
+        assert "32016R0679" in joined, "GDPR CELEX must appear in DOCX"
+        assert "32019L1152" in joined, "Working Conditions CELEX must appear in DOCX"
+        assert "2 CELEX-numbrit" in joined, "DOCX must mention the count of unresolved CELEXes"
+        assert "Kontrollige käsitsi" in joined
+
+    def test_warning_section_omitted_when_empty(self, tmp_export_dir: Path):
+        """No section, no heading, no extra paragraphs when the list is empty."""
+        draft = _make_draft()
+        findings_empty = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [],
+        }
+        row = _build_report_row(
+            affected=0,
+            conflicts=0,
+            gaps=0,
+            findings=findings_empty,
+        )
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            mock_doc = MagicMock()
+            mock_doc.sections = []
+            mock_doc_cls.return_value = mock_doc
+
+            build_impact_report_docx(draft, row)
+
+        headings = _heading_calls(mock_doc)
+        assert "EL-i kaardistamata viited" not in headings
+
+    def test_warning_section_omitted_when_key_missing(self, tmp_export_dir: Path):
+        """Legacy reports (pre-#815) have no key — must not crash, must
+        not render the section."""
+        draft = _make_draft()
+        # Note: NO ``unresolved_eu_refs`` key at all.
+        legacy_findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+        }
+        row = _build_report_row(
+            affected=0,
+            conflicts=0,
+            gaps=0,
+            findings=legacy_findings,
+        )
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            mock_doc = MagicMock()
+            mock_doc.sections = []
+            mock_doc_cls.return_value = mock_doc
+
+            build_impact_report_docx(draft, row)
+
+        headings = _heading_calls(mock_doc)
+        assert "EL-i kaardistamata viited" not in headings
+
+    def test_duplicate_celex_refs_are_deduplicated(self, tmp_export_dir: Path):
+        """Same CELEX in the JSON N times → one bullet in the .docx."""
+        draft = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [
+                {"ref_text": "32016R0679", "confidence": 0.95},
+                {"ref_text": "32016R0679", "confidence": 0.85},
+                {"ref_text": "32016R0679", "confidence": 0.75},
+            ],
+        }
+        row = _build_report_row(
+            affected=0,
+            conflicts=0,
+            gaps=0,
+            findings=findings,
+        )
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            mock_doc = MagicMock()
+            mock_doc.sections = []
+            mock_doc_cls.return_value = mock_doc
+
+            build_impact_report_docx(draft, row)
+
+        paragraphs = _paragraph_texts(mock_doc)
+        celex_bullets = [p for p in paragraphs if p == "32016R0679"]
+        assert len(celex_bullets) == 1, (
+            "Duplicate CELEX numbers must collapse to a single bullet — got " + repr(celex_bullets)
+        )
+        # The summary line shows the unique count.
+        joined = " | ".join(paragraphs)
+        assert "1 CELEX-numbrit" in joined

--- a/tests/test_docs_docx_export.py
+++ b/tests/test_docs_docx_export.py
@@ -479,7 +479,16 @@ class TestUnresolvedEuRefsDocxSection:
         joined = " | ".join(paragraphs)
         assert "32016R0679" in joined, "GDPR CELEX must appear in DOCX"
         assert "32019L1152" in joined, "Working Conditions CELEX must appear in DOCX"
-        assert "2 CELEX-numbrit" in joined, "DOCX must mention the count of unresolved CELEXes"
+        assert "2 EL viidet" in joined, (
+            "DOCX must mention the count of unresolved EU refs using the "
+            "inclusive 'EL viidet' wording — the extractor accepts both "
+            "CELEX numbers and title/acronym mentions like GDPR, so a "
+            "blanket 'CELEX-numbrit' claim is wrong (#821 P2)."
+        )
+        assert "CELEX-numbrit" not in joined, (
+            "Do not label the unresolved set as CELEX-only — some entries "
+            "may be acronyms or titles."
+        )
         assert "Kontrollige käsitsi" in joined
 
     def test_warning_section_omitted_when_empty(self, tmp_export_dir: Path):
@@ -570,6 +579,48 @@ class TestUnresolvedEuRefsDocxSection:
         assert len(celex_bullets) == 1, (
             "Duplicate CELEX numbers must collapse to a single bullet — got " + repr(celex_bullets)
         )
-        # The summary line shows the unique count.
+        # The summary line shows the unique count using the inclusive
+        # "EL viidet" wording.
         joined = " | ".join(paragraphs)
-        assert "1 CELEX-numbrit" in joined
+        assert "1 EL viidet" in joined
+
+    def test_title_acronym_refs_rendered_without_celex_claim(self, tmp_export_dir: Path):
+        """#821 P2 regression — same as the HTML renderer test: the
+        DOCX export must use the inclusive "EL viidet" wording when
+        unresolved_eu_refs contains title/acronym mentions (not only
+        CELEX numbers).
+        """
+        draft = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [
+                {"ref_text": "GDPR", "confidence": 0.92},
+                {"ref_text": "Working Conditions Directive", "confidence": 0.71},
+            ],
+        }
+        row = _build_report_row(
+            affected=0,
+            conflicts=0,
+            gaps=0,
+            findings=findings,
+        )
+
+        with patch("app.docs.docx_export.Document") as mock_doc_cls:
+            mock_doc = MagicMock()
+            mock_doc.sections = []
+            mock_doc_cls.return_value = mock_doc
+
+            build_impact_report_docx(draft, row)
+
+        paragraphs = _paragraph_texts(mock_doc)
+        joined = " | ".join(paragraphs)
+        # Inclusive wording, count is 2.
+        assert "2 EL viidet" in joined
+        # Acronym/title mentions must NOT be labelled "CELEX".
+        assert "CELEX-numbrit" not in joined
+        # Both refs appear as bullet entries.
+        assert "GDPR" in paragraphs
+        assert "Working Conditions Directive" in paragraphs

--- a/tests/test_docs_report_routes.py
+++ b/tests/test_docs_report_routes.py
@@ -377,6 +377,175 @@ class TestDraftReportPage:
 
 
 # ---------------------------------------------------------------------------
+# #815 — unresolved EU references warning block
+# ---------------------------------------------------------------------------
+#
+# The analyze_handler persists ``ref_type='eu_act'`` rows that the
+# resolver couldn't map into ``report_data["unresolved_eu_refs"]``.
+# When non-empty, the report page surfaces a warning alert near the
+# EL-i õigusaktide section so the user knows the analysis is missing
+# coverage rather than treating "no EU findings" as "no EU impact".
+
+
+class TestUnresolvedEuRefsSection:
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_warning_shown_when_unresolved_refs_present(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """A draft mentioning GDPR + Working Conditions whose CELEXes
+        weren't mapped must show a "kaardistamata viited" warning
+        listing both CELEX numbers as inline <code>.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [
+                {"ref_text": "32016R0679", "confidence": 0.95},
+                {"ref_text": "32019L1152", "confidence": 0.88},
+            ],
+        }
+        mock_fetch_report.return_value = _make_report_row(
+            affected=0, conflicts=0, gaps=0, findings=findings
+        )
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # Estonian alert title.
+        assert "EL-i kaardistamata viited" in body
+        # The summary line mentions the count.
+        assert "2 CELEX-numbrit" in body
+        assert "kaardistada" in body
+        # Both CELEX values are rendered inside <code> tags so they're
+        # visually distinct + copy-paste friendly.
+        assert "<code>32016R0679</code>" in body
+        assert "<code>32019L1152</code>" in body
+        # Action prompt.
+        assert "Kontrollige käsitsi" in body
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_warning_hidden_when_unresolved_refs_empty(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """No warning when every EU ref resolved cleanly (or there
+        were no EU refs at all). The existing "EL-i õigusaktide seoseid
+        ei tuvastatud" copy remains in the regular section.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [],
+        }
+        mock_fetch_report.return_value = _make_report_row(
+            affected=0, conflicts=0, gaps=0, findings=findings
+        )
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # The warning title must NOT appear.
+        assert "EL-i kaardistamata viited" not in body
+        # The regular "no EU findings" copy still shows in the
+        # eu_compliance section.
+        assert "EL-i õigusaktide seoseid ei tuvastatud" in body
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_legacy_report_without_unresolved_key_renders_cleanly(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """Reports written BEFORE #815 don't carry the
+        ``unresolved_eu_refs`` key. The renderer must treat this as
+        "nothing to warn about" rather than crashing or showing the
+        warning.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        # Legacy findings: no unresolved_eu_refs key at all.
+        legacy_findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+        }
+        mock_fetch_report.return_value = _make_report_row(
+            affected=0, conflicts=0, gaps=0, findings=legacy_findings
+        )
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "EL-i kaardistamata viited" not in body
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_duplicate_celex_refs_are_deduplicated(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """A long draft can mention the same CELEX many times. The
+        warning lists each CELEX once, not N times.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [
+                {"ref_text": "32016R0679", "confidence": 0.95},
+                {"ref_text": "32016R0679", "confidence": 0.85},
+                {"ref_text": "32016R0679", "confidence": 0.75},
+            ],
+        }
+        mock_fetch_report.return_value = _make_report_row(
+            affected=0, conflicts=0, gaps=0, findings=findings
+        )
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # Count reflects unique CELEXes, not row count.
+        assert "1 CELEX-numbrit" in body
+        # The CELEX is rendered exactly once.
+        assert body.count("<code>32016R0679</code>") == 1
+
+
+# ---------------------------------------------------------------------------
 # POST /drafts/{id}/export
 # ---------------------------------------------------------------------------
 

--- a/tests/test_docs_report_routes.py
+++ b/tests/test_docs_report_routes.py
@@ -424,8 +424,16 @@ class TestUnresolvedEuRefsSection:
         body = resp.text
         # Estonian alert title.
         assert "EL-i kaardistamata viited" in body
-        # The summary line mentions the count.
-        assert "2 CELEX-numbrit" in body
+        # The summary line mentions the count using the inclusive
+        # "EL viidet" wording (extractor's eu_act ref_type covers both
+        # CELEX numbers AND title/acronym mentions like GDPR — see #821
+        # P2 follow-up).
+        assert "2 EL viidet" in body
+        assert "CELEX-numbrit" not in body, (
+            "The summary line must not assert all refs are CELEX-shaped — "
+            "GDPR/title/acronym mentions are also persisted to "
+            "unresolved_eu_refs."
+        )
         assert "kaardistada" in body
         # Both CELEX values are rendered inside <code> tags so they're
         # visually distinct + copy-paste friendly.
@@ -539,10 +547,53 @@ class TestUnresolvedEuRefsSection:
 
         assert resp.status_code == 200
         body = resp.text
-        # Count reflects unique CELEXes, not row count.
-        assert "1 CELEX-numbrit" in body
-        # The CELEX is rendered exactly once.
+        # Count reflects unique refs, not row count.
+        assert "1 EL viidet" in body
+        # The ref is rendered exactly once.
         assert body.count("<code>32016R0679</code>") == 1
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_title_acronym_refs_rendered_without_celex_claim(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """#821 P2 regression: the extractor's ``eu_act`` ref_type covers
+        BOTH canonical CELEX numbers and title/acronym mentions like
+        ``GDPR``. The unresolved-EU section must NOT label acronym
+        mentions as "CELEX-numbrit" in the copy. The inclusive "EL
+        viidet" wording covers both shapes truthfully.
+        """
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        findings = {
+            "affected_entities": [],
+            "conflicts": [],
+            "eu_compliance": [],
+            "gaps": [],
+            "unresolved_eu_refs": [
+                {"ref_text": "GDPR", "confidence": 0.92},
+                {"ref_text": "Working Conditions Directive", "confidence": 0.71},
+            ],
+        }
+        mock_fetch_report.return_value = _make_report_row(
+            affected=0, conflicts=0, gaps=0, findings=findings
+        )
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "2 EL viidet" in body
+        # The acronym/title mentions must NOT be labelled "CELEX".
+        assert "CELEX-numbrit" not in body
+        # Both refs render inside <code> tags regardless of shape.
+        assert "<code>GDPR</code>" in body
+        assert "<code>Working Conditions Directive</code>" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#805 (EL ülevõtt route)**: when a user enters a canonical-shaped CELEX (e.g. `32016R0679` for GDPR) that isn't yet in our ontology snapshot, the unresolved page now names the specific CELEX in the warning copy (`"EL õigusakt CELEX-numbriga 32016R0679 ei ole veel ontoloogias kaardistatud. Kontrollige käsitsi või proovige akti pealkirja."`) so users know to verify manually instead of suspecting a typo. The generic `"Ei tuvastanud EL õigusakti"` copy stays for prose/garbage input.

- **#815 (uploaded draft impact report)**: `analyze_handler.analyze_impact` now queries `draft_entities` for fully-unresolved `ref_type='eu_act'` rows BEFORE the existing resolved-refs SELECT filters them out, persists them into `report_data["unresolved_eu_refs"]`, and the report renderer + `.docx` export surface them as an `"EL-i kaardistamata viited"` warning naming every unmapped CELEX as inline `<code>`. `ImpactAnalyzer` stays Postgres-free per its module docstring; the warning is assembled at the handler layer that already owns `draft_entities` access.

- **Future-proof**: when ontology coverage catches up (separate ontology-repo PR), no app change is needed — the resolver populates `entity_uri`, the unresolved list naturally empties, and the warning disappears.

## Files touched

**App:**
- `app/analyysikeskus/eu_lookup.py` — new `is_canonical_celex_shape()` helper (strict `^[1-9]\d{4}[RLDH...]\d{4}$`, excludes `X`/other rarely-used form letters per the acceptance criteria).
- `app/analyysikeskus/routes.py` — `_render_eu_unresolved` branches on shape (one ~20-line edit, no `_ANALYYSIKESKUS_INPUTS` changes per #814 parallelism plan).
- `app/docs/analyze_handler.py` — extra SELECT for unresolved EU refs; persists into `report_data["unresolved_eu_refs"]`. Constant-time addition, no analyzer changes.
- `app/docs/report_routes.py` — new `_unresolved_eu_refs_section` helper; wired between `_eu_compliance_section` and `_gaps_section` in `draft_report_page`.
- `app/docs/docx_export.py` — new `_add_unresolved_eu_refs` helper + 1-unit contribution to `_compute_progress_total` when non-empty; bullet-listed CELEX values in Courier New for visual parity with on-page `<code>`.

**Tests:**
- `tests/test_analyysikeskus_eu_lookup.py` (NEW) — 21 tests pinning the strict CELEX shape recognition + label-search degradation.
- `tests/test_analyysikeskus_routes.py` — 3 new tests for the canonical-CELEX warning branch (GDPR shows specific copy, `12abc34` shows generic, free-text shows generic).
- `tests/test_docs_analyze_handler.py` — `TestUnresolvedEuRefs` (5 tests) + updated `_make_load_conn` for the two-SELECT contract.
- `tests/test_docs_report_routes.py` — `TestUnresolvedEuRefsSection` (4 tests covering non-empty, empty, legacy-without-key, duplicate-dedup).
- `tests/test_docs_docx_export.py` — `TestUnresolvedEuRefsDocxSection` (4 tests mirroring the renderer scenarios).

**Not touched (per architectural constraint):**
- `app/docs/impact/analyzer.py` — stays Postgres-free.
- `app/analyysikeskus/eu_transposition.py` — dashboard widget, out of scope.
- `_ANALYYSIKESKUS_INPUTS` / new routes — reserved for #814.

## Test plan

- [x] `uv run pytest tests/test_analyysikeskus_eu_lookup.py` — 21 tests pass
- [x] `uv run pytest tests/test_analyysikeskus_routes.py -k el_ulevott` — 7 tests pass (existing + 3 new)
- [x] `uv run pytest tests/test_docs_analyze_handler.py` — 20 tests pass (existing + 5 new)
- [x] `uv run pytest tests/test_docs_report_routes.py` — 45 tests pass (existing + 4 new)
- [x] `uv run pytest tests/test_docs_docx_export.py` — 13 tests pass (existing + 4 new)
- [x] `uv run pytest` — 3153 passed, 37 skipped (full suite)
- [x] `uv run ruff check` — clean
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] End-to-end real `.docx` build verified — `EL-i kaardistamata viited` heading + both CELEX values rendered as bullets
- [x] Real renderer HTML verified — `<code>32016R0679</code>` inline, alert variant=warning with Estonian title
- [ ] Manual smoke on prod: `/analyysikeskus/el-ulevott?sisend=32016R0679` shows the canonical-CELEX-not-mapped warning
- [ ] Manual smoke on prod: upload a draft mentioning GDPR → impact report shows "EL-i kaardistamata viited" warning
- [ ] Manual smoke on prod: `.docx` export of the same report includes the unresolved-EU section

## Notes

- All user-visible copy is Estonian.
- No bool-True HTML attrs introduced (per #813 hardening).
- `ImpactAnalyzer` remains Postgres-free; the warning is assembled in `analyze_handler` (the only layer with `draft_entities` access pre-filter).
- `routes.py` discipline observed: only `_render_eu_unresolved` modified (~25 lines including docstring), no `_ANALYYSIKESKUS_INPUTS` touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)