### PR TITLE
feat(analyysikeskus): #814 Phase 2b — wire intent-analysis routes + flip capability live

### DIFF
--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -6458,31 +6458,30 @@ async def moju_poliitikamottest_extract(req: Request):
 
     # Run the LLM-driven extractor (cost-tracked with
     # ``feature="intent_analysis"``).
-    candidates = extract_candidates(
+    llm_candidates = extract_candidates(
         intent_text,
         user_id=user_id,
         org_id=org_id,
     )
 
-    # Augment the LLM candidates with the user's manually entered
-    # known refs — split on commas, treat each as a literal ``ref_text``
-    # for the resolver. ``ref_type`` defaults to ``provision`` since
-    # most known-ref entries from the usability tests are §-shaped; the
-    # resolver tolerates the guess (a law name still resolves cleanly
-    # through ``_resolve_provision`` because the act-only branch fires
-    # on partial matches).
+    # Collect the user's manually entered known refs — split on commas,
+    # treat each as a literal ``ref_text`` for the resolver. ``ref_type``
+    # defaults to ``provision`` since most known-ref entries from the
+    # usability tests are §-shaped; the resolver tolerates the guess (a
+    # law name still resolves cleanly through ``_resolve_provision``
+    # because the act-only branch fires on partial matches).
     #
     # Cap to ``_MAX_INTENT_KNOWN_REFS`` so a comma-bomb POST can't
     # trigger an unbounded number of resolver SPARQL lookups.
+    manual_candidates: list[IntentCandidate] = []
     if known_refs_raw:
-        known_count = 0
         for raw_ref in known_refs_raw.split(","):
-            if known_count >= _MAX_INTENT_KNOWN_REFS:
+            if len(manual_candidates) >= _MAX_INTENT_KNOWN_REFS:
                 break
             ref_text = raw_ref.strip()
             if not ref_text:
                 continue
-            candidates.append(
+            manual_candidates.append(
                 IntentCandidate(
                     ref_text=ref_text,
                     ref_type="provision",
@@ -6490,14 +6489,23 @@ async def moju_poliitikamottest_extract(req: Request):
                     reasoning="Kasutaja sisestatud käsitsi teadaolev viide.",
                 )
             )
-            known_count += 1
 
-    # Defence in depth: clamp the combined LLM + manual candidate list to
-    # ``_MAX_INTENT_CANDIDATES`` before resolving, so a misbehaving extractor
-    # (or future prompt drift that returns more than the documented 3-8)
-    # can't fan out into the resolver beyond what the UI can render.
-    if len(candidates) > _MAX_INTENT_CANDIDATES:
-        candidates = candidates[:_MAX_INTENT_CANDIDATES]
+    # Merge with manual refs winning over LLM. A previous revision of
+    # this handler appended manual refs after the LLM list and then
+    # truncated to ``_MAX_INTENT_CANDIDATES`` from the front — which
+    # silently dropped every manual ref whenever the LLM filled the cap
+    # (#822 PR review P2). Explicit user input outranks inferred
+    # candidates, so manual refs go in first; LLM rows then fill the
+    # remaining slots in confidence order, highest first.
+    candidates: list[IntentCandidate] = list(manual_candidates)
+    llm_slots_remaining = _MAX_INTENT_CANDIDATES - len(candidates)
+    if llm_slots_remaining > 0:
+        sorted_llm = sorted(
+            llm_candidates,
+            key=lambda c: c.confidence,
+            reverse=True,
+        )
+        candidates.extend(sorted_llm[:llm_slots_remaining])
 
     # Resolve every candidate to a URI (or ``None`` for unresolvable).
     resolved = resolve_candidates(candidates)

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -84,6 +84,15 @@ from app.analyysikeskus.court_practice import (
 from app.analyysikeskus.eu_lookup import is_canonical_celex_shape, search_eu_acts_by_label
 from app.analyysikeskus.history import get_history_bundle, temporal_status_label
 from app.analyysikeskus.input_parser import parse_user_reference
+from app.analyysikeskus.intent_analysis import (
+    AggregatedResult,
+    ResolvedCandidate,
+    extract_candidates,
+    prepare_intent_form_context,
+    resolve_candidates,
+    run_aggregated_analysis,
+)
+from app.analyysikeskus.intent_extractor import IntentCandidate
 from app.analyysikeskus.result_shell import analysis_result_shell
 from app.analyysikeskus.sanctions import (
     SanctionRow,
@@ -112,7 +121,7 @@ from app.ui.data.data_table import Column, DataTable
 from app.ui.layout import PageShell
 from app.ui.primitives.badge import Badge, BadgeVariant  # noqa: E402  (re-import after wildcard)
 from app.ui.primitives.button import Button  # noqa: E402  (re-import after wildcard)
-from app.ui.primitives.input import Checkbox, Input, Select
+from app.ui.primitives.input import Checkbox, Input, Select, Textarea
 from app.ui.surfaces.alert import Alert
 from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.theme import get_theme_from_request
@@ -371,6 +380,17 @@ def _recent_analyses_card(items: list[dict[str, Any]]) -> Any:
 # (most consumers don't need it). When a planned workflow ships, its entry
 # is added here at the same time its ``status`` flips to ``"live"``.
 _ANALYYSIKESKUS_INPUTS: dict[str, dict[str, str]] = {
+    "moju-poliitikamottest": {
+        "placeholder": (
+            "Kirjelda poliitilist kavatsust vabas vormis — nt «Soovin lihtsustada "
+            "puudega inimese toetuse taotlemist…»"
+        ),
+        "aria_label": "Poliitiline kavatsus vabas vormis",
+        "examples": (
+            "Näited: «Soovin lihtsustada puudega inimese toetuse taotlemist nii, "
+            "et osa andmeid liiguks automaatselt Tervisekassast ja Töötukassast.»"
+        ),
+    },
     "normi-mojuahel": {
         "placeholder": (
             "Nt: AvTS § 35 · CELEX-number · eelnõu pealkiri · või kirjeldage muudatust"
@@ -445,6 +465,29 @@ def _planned_workflow_card(cap: Capability) -> Any:
     )
 
 
+def _intent_workflow_card(cap: Capability, *, examples: str) -> Any:
+    """Directory entry for the policy-intent workflow (#814 Phase 2b).
+
+    The intent flow's intake form needs a *multi-line* textarea plus chip
+    selectors, which don't fit the single-``sisend`` GET form the other
+    workflow cards use. Render a compact link-style card instead — the
+    primary action navigates to ``/analyysikeskus/moju-poliitikamottest``
+    where the full intake form lives.
+    """
+    return Card(
+        CardHeader(H3(cap.canonical_name_et, cls="card-title")),  # noqa: F405
+        CardBody(
+            P(cap.one_line_description_et),  # noqa: F405
+            A(  # noqa: F405
+                "Alusta analüüsi →",
+                href=cap.target_url,
+                cls="btn btn-primary",
+            ),
+            Small(examples, cls="muted-text"),  # noqa: F405
+        ),
+    )
+
+
 def _capability_card(cap: Capability) -> Any:
     """Render a Capability as a directory entry — full card or "Tulekul" card."""
     if cap.status != "live":
@@ -455,6 +498,12 @@ def _capability_card(cap: Capability) -> Any:
         # back to the planned-card layout so the user can still see it (and the
         # developer notices the missing entry).
         return _planned_workflow_card(cap)
+    # The policy-intent workflow has a richer intake form (textarea + chip
+    # selectors) than the single ``sisend`` text input every other workflow
+    # uses — render a link-style card that hands the user straight to the
+    # full intake form instead of trying to cram everything onto the card.
+    if cap.slug == "moju-poliitikamottest":
+        return _intent_workflow_card(cap, examples=inputs["examples"])
     return _workflow_card(
         title=cap.canonical_name_et,
         purpose=cap.one_line_description_et,
@@ -5913,6 +5962,734 @@ def sarnasus_page(req: Request):
     )
 
 
+# ---------------------------------------------------------------------------
+# Analüüsi poliitikamõttest (#814 Phase 2b)
+# ---------------------------------------------------------------------------
+#
+# Three-step HTMX-driven flow that bridges plain-language policy intent to
+# the proven per-URI impact analyser:
+#
+#   GET  /analyysikeskus/moju-poliitikamottest
+#                                       — Koostaja-style intake form with
+#                                         intent textarea + target-group
+#                                         and affected-area chip selectors
+#                                         + optional known-refs text.
+#   POST /analyysikeskus/moju-poliitikamottest/extract
+#                                       — LLM-driven semantic-inference
+#                                         extractor; renders the candidate-
+#                                         confirmation panel (HTMX swap).
+#   POST /analyysikeskus/moju-poliitikamottest/analyze
+#                                       — runs the per-URI impact analyser
+#                                         over the confirmed URIs and
+#                                         swaps in the full result shell
+#                                         with per-source traceability.
+#
+# Design contract: LLM hallucination is *expected and managed* — the
+# confirmation step is the non-negotiable guardrail. Per-URI calls into
+# ``run_adhoc_impact_analysis`` (the proven path) — strictly NO composite
+# ephemeral graph, per the user's explicit MVP direction.
+#
+# Cost tracking: every LLM call flows through
+# :func:`extract_candidates` -> :func:`extract_intent_candidates`, which
+# pins ``feature="intent_analysis"`` via the module-level constant in
+# :mod:`app.analyysikeskus.intent_extractor`.
+
+# The HTMX target — both POST handlers swap their fragment into this
+# container so the user never sees a full page reload between steps.
+_INTENT_RESULT_REGION_ID = "moju-poliitikamottest-result"
+
+# Cap how many candidates the LLM can return before we trim to keep the
+# confirmation panel scannable. Matches the prompt's "3-8 candidates" hint.
+_MAX_INTENT_CANDIDATES = 12
+
+# Confidence threshold above which a candidate is pre-checked in the
+# confirmation panel. Below this the row is still rendered but unchecked
+# so the user opts in.
+_INTENT_CONFIDENCE_PRE_CHECK = 0.7
+
+# Hard cap on the policy-intent free-text length — defensive bound so a
+# pathological input can't bloat the LLM call.
+_MAX_INTENT_LEN = 5000
+
+
+def _intent_back_link() -> Any:
+    """The shared "← Analüüsikeskus" back link rendered above the intake form."""
+    return A(  # noqa: F405
+        "← Analüüsikeskus",
+        href="/analyysikeskus",
+        cls="back-link",
+    )
+
+
+def _intent_chip_group(
+    *,
+    name: str,
+    label: str,
+    chips: tuple[str, ...] | list[str],
+    selected: list[str] | None = None,
+) -> Any:
+    """Render a multi-select chip group as a fieldset of checkboxes.
+
+    Each chip is a labelled checkbox; visually styled by CSS to read as a
+    chip via the ``.chip-checkbox`` / ``.chip-group`` classes (already in
+    the design system for tag-style multi-selects). Checkboxes are the
+    accessible primitive — they announce "checked/not checked" to screen
+    readers, ride through GET/POST form bodies without JS, and degrade
+    cleanly when CSS fails to load.
+    """
+    selected_set = set(selected or [])
+    items = [
+        Checkbox(
+            name=name,
+            value=chip,
+            checked=chip in selected_set,
+            label=chip,
+            cls="chip-checkbox",
+        )
+        for chip in chips
+    ]
+    return Fieldset(  # noqa: F405
+        Legend(label),  # noqa: F405
+        Div(*items, cls="chip-group"),  # noqa: F405
+        cls="form-field",
+    )
+
+
+def _intent_intake_form() -> Any:
+    """Render the policy-intent intake form (the Step-1 surface)."""
+    ctx = prepare_intent_form_context()
+    return Form(  # noqa: F405
+        # Intent textarea — required, multiline, captures the policy idea.
+        Div(  # noqa: F405
+            Label(  # noqa: F405
+                "Mida soovid muuta või lisada?",
+                fr="moju-poliitikamottest-intent",
+            ),
+            Textarea(
+                "intent",
+                placeholder=(
+                    "Kirjelda poliitilist kavatsust vabas vormis. Nt: «Soovin "
+                    "lihtsustada puudega inimese toetuse taotlemist nii, et "
+                    "osa andmeid liiguks automaatselt Tervisekassast ja "
+                    "Töötukassast.»"
+                ),
+                rows=6,
+                required=True,
+                id="moju-poliitikamottest-intent",
+                aria_label="Poliitiline kavatsus vabas vormis",
+            ),
+            cls="form-field",
+        ),
+        # Target-group chip group — optional.
+        _intent_chip_group(
+            name="target_groups",
+            label="Sihtrühm (valikuline)",
+            chips=ctx.target_groups,
+        ),
+        # Affected-area chip group — optional.
+        _intent_chip_group(
+            name="affected_areas",
+            label="Mõjutatud valdkonnad (valikuline)",
+            chips=ctx.affected_areas,
+        ),
+        # Optional known-refs free-text input.
+        Div(  # noqa: F405
+            Label(  # noqa: F405
+                "Teadaolevad õiguslikud viited (valikuline)",
+                fr="moju-poliitikamottest-known-refs",
+            ),
+            Input(
+                "known_refs",
+                type="text",
+                placeholder=(
+                    "Kui tead juba mõnda sätet või seadust, lisa siia (nt AvTS § 35, KarS § 121)"
+                ),
+                id="moju-poliitikamottest-known-refs",
+                aria_label="Teadaolevad õiguslikud viited",
+            ),
+            cls="form-field",
+        ),
+        Button(
+            "Otsi mõjutatud sätteid",
+            type="submit",
+            variant="primary",
+        ),
+        method="post",
+        action="/analyysikeskus/moju-poliitikamottest/extract",
+        hx_post="/analyysikeskus/moju-poliitikamottest/extract",
+        hx_target=f"#{_INTENT_RESULT_REGION_ID}",
+        hx_swap="innerHTML",
+        cls="moju-poliitikamottest-intake-form",
+    )
+
+
+def _intent_result_region(*children: Any) -> Any:
+    """Wrap content in the HTMX target region the POST handlers swap into."""
+    return Div(*children, id=_INTENT_RESULT_REGION_ID)  # noqa: F405
+
+
+def _intent_intake_page(req: Request) -> Any:
+    """Render the GET intake page (Step 1).
+
+    Reuses :func:`analysis_result_shell` for the standard chrome but
+    keeps the heavy lifting in two custom cards: the intake form sits in
+    the ``Sisend`` block, and an empty ``#moju-poliitikamottest-result``
+    div sits in the ``Tulemused`` block — both POST handlers swap their
+    fragments into the latter so the user never leaves the page.
+    """
+    auth = req.scope.get("auth") or None
+    theme = get_theme_from_request(req)
+
+    return analysis_result_shell(
+        workflow_title="Analüüsi poliitikamõttest",
+        input_summary=_intent_intake_form(),
+        results_block=_intent_result_region(
+            P(  # noqa: F405
+                "Esita ülal poliitiline kavatsus. Süsteem pakub välja "
+                "kandidaadid mõjutatud õigusaktidest, mida saad kinnitada "
+                "või eemaldada enne mõjuanalüüsi käivitamist.",
+                cls="muted-text",
+            )
+        ),
+        evidence_block=_missing_row("Tõendid ilmuvad pärast mõjuanalüüsi käivitamist."),
+        actions=[
+            {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
+        ],
+        user=auth,
+        theme=theme,
+        scope_block=Span(  # noqa: F405
+            "Ulatuse seaded ilmuvad pärast mõjuanalüüsi käivitamist.",
+            cls="muted-text",
+        ),
+    )
+
+
+async def moju_poliitikamottest_page(req: Request):
+    """GET /analyysikeskus/moju-poliitikamottest — the intake form.
+
+    Step 1 of the three-step intent → impact flow. Renders the Koostaja-
+    style intake form (intent textarea + target-group/affected-area chip
+    groups + optional known-refs input). The form posts to
+    ``/extract``, which HTMX-swaps the candidate-confirmation panel into
+    the ``#moju-poliitikamottest-result`` region without a page reload.
+    """
+    return _intent_intake_page(req)
+
+
+# ---------------------------------------------------------------------------
+# Intent — Step 2: extract candidates + render confirmation panel
+# ---------------------------------------------------------------------------
+
+
+def _intent_row_label(cand: IntentCandidate) -> str:
+    """Estonian label for the candidate's ref_type chip."""
+    return {
+        "law": "seadus",
+        "provision": "säte",
+        "eu_act": "EL õigusakt",
+        "court_decision": "kohtulahend",
+        "concept": "õigusmõiste",
+    }.get(cand.ref_type, cand.ref_type)
+
+
+def _intent_candidate_row(
+    rc: ResolvedCandidate,
+    *,
+    index: int,
+) -> Any:
+    """Render one row of the candidate-confirmation panel.
+
+    The user toggles inclusion via a checkbox; multiple resolver matches
+    surface as a radio-group (so the user picks which URI to analyse).
+    A single resolver match becomes a hidden input. Fully-unresolved
+    candidates show a muted "ei tuvastatud ontoloogias" badge — the
+    user can still toggle them to keep them visible but the per-URI
+    analyser cannot run on a None URI, so they're filtered out at
+    submit time.
+    """
+    cand = rc.candidate
+    resolved = rc.resolved
+    pre_checked = cand.confidence >= _INTENT_CONFIDENCE_PRE_CHECK
+
+    label = (resolved.matched_label or cand.ref_text).strip()
+    type_label = _intent_row_label(cand)
+    confidence_pct = int(round(cand.confidence * 100))
+
+    # The URI(s) that this row could resolve to. The resolver returns one
+    # URI per ExtractedRef today, so we treat it as a single hidden value
+    # rather than a radio. Defensive: if entity_uri is missing, no hidden
+    # input is rendered and the row is treated as unresolvable.
+    uri = (resolved.entity_uri or "").strip()
+    label_id = f"intent-candidate-{index}"
+
+    uri_marker: Any
+    if uri:
+        # Carry the chosen URI through as a hidden input keyed on the
+        # candidate's row index. The /analyze handler reads every
+        # ``confirmed_uri`` value off the form.
+        uri_marker = Hidden(name=f"uri_{index}", value=uri)  # noqa: F405
+    else:
+        uri_marker = Span(  # noqa: F405
+            Badge(
+                "Ei tuvastatud ontoloogias",
+                variant="warning",
+            ),
+            cls="muted-text",
+        )
+
+    # Label snapshot — needed by /analyze so the result page can render
+    # "Mõjuahel sätte X analüüsist" headings without re-resolving.
+    label_marker = Hidden(  # noqa: F405
+        name=f"label_{index}",
+        value=label,
+    )
+
+    # The checkbox controls inclusion. Defensive ``value`` carries the
+    # row index back so the handler knows which ``uri_N`` / ``label_N``
+    # pair to read.
+    checkbox = Checkbox(
+        name="confirmed",
+        value=str(index),
+        checked=pre_checked and bool(uri),
+        disabled=not uri,
+        label=None,
+    )
+
+    return Div(  # noqa: F405
+        Div(  # noqa: F405
+            checkbox,
+            cls="moju-poliitikamottest-candidate-checkbox",
+        ),
+        Div(  # noqa: F405
+            P(  # noqa: F405
+                Strong(label),  # noqa: F405
+                " ",
+                Badge(type_label, variant="default"),
+                " ",
+                Span(f"({confidence_pct}%)", cls="muted-text"),  # noqa: F405
+            ),
+            P(cand.reasoning or "—", cls="muted-text small-text"),  # noqa: F405
+            uri_marker,
+            label_marker,
+            cls="moju-poliitikamottest-candidate-body",
+        ),
+        cls="moju-poliitikamottest-candidate-row",
+        id=label_id,
+    )
+
+
+def _intent_chip_summary(*, target_groups: list[str], affected_areas: list[str]) -> Any:
+    """Render a compact "applied chips" summary above the candidate list."""
+    parts: list[Any] = []
+    if target_groups:
+        parts.append(
+            P(  # noqa: F405
+                Strong("Sihtrühm: "),  # noqa: F405
+                ", ".join(target_groups),
+            )
+        )
+    if affected_areas:
+        parts.append(
+            P(  # noqa: F405
+                Strong("Valdkonnad: "),  # noqa: F405
+                ", ".join(affected_areas),
+            )
+        )
+    if not parts:
+        return ""
+    return Div(*parts, cls="moju-poliitikamottest-chip-summary")  # noqa: F405
+
+
+def _intent_confirmation_panel(
+    *,
+    intent_text: str,
+    target_groups: list[str],
+    affected_areas: list[str],
+    resolved: list[ResolvedCandidate],
+) -> Any:
+    """Render the candidate-confirmation panel (Step-2 surface)."""
+    if not resolved:
+        return Div(  # noqa: F405
+            Alert(
+                "Süsteem ei suutnud sellest kavatsusest kandidaate välja "
+                "pakkuda. Proovige sõnastust täpsustada või lisada teadaolevaid "
+                "viiteid (nt «AvTS § 35»).",
+                variant="warning",
+            ),
+            A(  # noqa: F405
+                "← Tagasi sisestuse juurde",
+                href="/analyysikeskus/moju-poliitikamottest",
+                cls="back-link",
+            ),
+        )
+
+    # Cap rendered rows so a runaway LLM can't bloat the page.
+    trimmed = resolved[:_MAX_INTENT_CANDIDATES]
+
+    rows = [_intent_candidate_row(rc, index=i) for i, rc in enumerate(trimmed)]
+
+    # Count how many rows are pre-checked + resolvable — drives the
+    # initial submit-button label ("Käivita mõjuanalüüs ({N} kinnitatud
+    # sätet)"). Live counts are JS work; this is the deterministic
+    # server-side estimate.
+    initial_checked = sum(
+        1
+        for rc in trimmed
+        if rc.candidate.confidence >= _INTENT_CONFIDENCE_PRE_CHECK
+        and (rc.resolved.entity_uri or "").strip()
+    )
+
+    return Div(  # noqa: F405
+        H3(  # noqa: F405
+            "Süsteem leidis järgmised kandidaadid",
+            cls="card-title",
+        ),
+        P(  # noqa: F405
+            "Kinnitage, eemaldage või lisage kandidaate. Iga kinnitatud säte saab oma mõjuahela.",
+            cls="muted-text",
+        ),
+        _intent_chip_summary(
+            target_groups=target_groups,
+            affected_areas=affected_areas,
+        ),
+        Form(  # noqa: F405
+            # Carry the intent text + chip selections through so the
+            # /analyze handler can render the Sisend block honestly.
+            Hidden(name="intent", value=intent_text),  # noqa: F405
+            *[
+                Hidden(name="target_groups", value=tg)  # noqa: F405
+                for tg in target_groups
+            ],
+            *[
+                Hidden(name="affected_areas", value=aa)  # noqa: F405
+                for aa in affected_areas
+            ],
+            Div(*rows, cls="moju-poliitikamottest-candidate-list"),  # noqa: F405
+            Button(
+                f"Käivita mõjuanalüüs ({initial_checked} kinnitatud sätet)",
+                type="submit",
+                variant="primary",
+            ),
+            A(  # noqa: F405
+                "Tagasi sisestuse juurde",
+                href="/analyysikeskus/moju-poliitikamottest",
+                cls="btn btn-secondary",
+            ),
+            method="post",
+            action="/analyysikeskus/moju-poliitikamottest/analyze",
+            hx_post="/analyysikeskus/moju-poliitikamottest/analyze",
+            hx_target=f"#{_INTENT_RESULT_REGION_ID}",
+            hx_swap="innerHTML",
+            cls="moju-poliitikamottest-confirm-form",
+        ),
+    )
+
+
+async def moju_poliitikamottest_extract(req: Request):
+    """POST /analyysikeskus/moju-poliitikamottest/extract — Step 2.
+
+    Reads the intake form, runs the semantic-inference extractor over
+    the policy intent, resolves each candidate to a URI, and returns
+    the candidate-confirmation panel as an HTMX fragment.
+    """
+    auth = req.scope.get("auth") or None
+    user_id = auth.get("id") if auth else None
+    org_id = auth.get("org_id") if auth else None
+
+    try:
+        form = await req.form()
+    except Exception:
+        logger.warning("moju_poliitikamottest_extract: failed to read form", exc_info=True)
+        return Alert(
+            "Vormi lugemine ebaõnnestus. Proovige uuesti.",
+            variant="danger",
+        )
+
+    intent_text = str(form.get("intent") or "").strip()[:_MAX_INTENT_LEN]
+    target_groups = [str(v) for v in form.getlist("target_groups")]
+    affected_areas = [str(v) for v in form.getlist("affected_areas")]
+    known_refs_raw = str(form.get("known_refs") or "").strip()
+
+    # Empty intent → friendly validation, NO LLM call.
+    if not intent_text:
+        return Alert(
+            "Palun sisesta poliitiline kavatsus enne kandidaatide otsimist.",
+            variant="warning",
+        )
+
+    # Run the LLM-driven extractor (cost-tracked with
+    # ``feature="intent_analysis"``).
+    candidates = extract_candidates(
+        intent_text,
+        user_id=user_id,
+        org_id=org_id,
+    )
+
+    # Augment the LLM candidates with the user's manually entered
+    # known refs — split on commas, treat each as a literal ``ref_text``
+    # for the resolver. ``ref_type`` defaults to ``provision`` since
+    # most known-ref entries from the usability tests are §-shaped; the
+    # resolver tolerates the guess (a law name still resolves cleanly
+    # through ``_resolve_provision`` because the act-only branch fires
+    # on partial matches).
+    if known_refs_raw:
+        for raw_ref in known_refs_raw.split(","):
+            ref_text = raw_ref.strip()
+            if not ref_text:
+                continue
+            candidates.append(
+                IntentCandidate(
+                    ref_text=ref_text,
+                    ref_type="provision",
+                    confidence=1.0,
+                    reasoning="Kasutaja sisestatud käsitsi teadaolev viide.",
+                )
+            )
+
+    # Resolve every candidate to a URI (or ``None`` for unresolvable).
+    resolved = resolve_candidates(candidates)
+
+    return _intent_confirmation_panel(
+        intent_text=intent_text,
+        target_groups=target_groups,
+        affected_areas=affected_areas,
+        resolved=resolved,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Intent — Step 3: per-URI analysis + render aggregated results
+# ---------------------------------------------------------------------------
+
+
+def _intent_result_input_summary(
+    *,
+    intent_text: str,
+    confirmed_labels: list[str],
+) -> Any:
+    """Render the ``Sisend`` block content for the result page."""
+    return Div(  # noqa: F405
+        P(  # noqa: F405
+            Strong("Poliitiline kavatsus: "),  # noqa: F405
+            intent_text,
+        ),
+        P(  # noqa: F405
+            Strong("Kinnitatud viited: "),  # noqa: F405
+            ", ".join(confirmed_labels) if confirmed_labels else "—",
+        ),
+    )
+
+
+def _intent_per_uri_section(per_uri: Any, *, scope: _Scope) -> Any:
+    """Render one per-URI result group.
+
+    The sub-heading carries the per-URI attribution ("Mõjuahel sätte X
+    analüüsist") so the user can always trace a finding back to exactly
+    one confirmed input. The underlying findings are laid out via the
+    same :func:`_build_results_block` the Normi mõjuahel page uses, so
+    the visual language is identical across workflows.
+    """
+    heading = f"Mõjuahel sätte {per_uri.source_label} analüüsist"
+    inner_block = _build_results_block(per_uri.adhoc.findings, per_uri.adhoc.score, scope)
+    return Div(  # noqa: F405
+        H3(heading, cls="card-title"),  # noqa: F405
+        *inner_block,
+        cls="moju-poliitikamottest-per-uri-section",
+    )
+
+
+def _intent_results_block(agg: AggregatedResult, *, scope: _Scope) -> list[Any]:
+    """Assemble the ``Tulemused`` block from the aggregated result."""
+    summary = P(  # noqa: F405
+        Strong(  # noqa: F405
+            f"Kokku: {agg.total_affected} mõjutatud üksust, "
+            f"{agg.total_conflicts} konflikti, {agg.total_gaps} lünka "
+            f"(üle {len(agg.per_uri)} kinnitatud sätte)."
+        )
+    )
+    sections: list[Any] = [summary]
+    sections.extend(_intent_per_uri_section(per, scope=scope) for per in agg.per_uri)
+    return sections
+
+
+def _intent_evidence_block(agg: AggregatedResult) -> Any:
+    """Render the ``Tõendid`` block — a flat list of (source → finding) links."""
+    items: list[Any] = []
+    for per in agg.per_uri:
+        # Per-URI evidence: an entry-point link to the source on
+        # Õiguskaart so the user can drill into context.
+        items.append(
+            Li(  # noqa: F405
+                Strong(per.source_label),  # noqa: F405
+                " — ",
+                A(  # noqa: F405
+                    "Ava õiguskaardil →",
+                    href=explorer_focus_url(per.entity_uri),
+                    cls="data-table-link",
+                ),
+                " · ",
+                Span(  # noqa: F405
+                    f"{per.adhoc.findings.affected_count} mõjutatud, "
+                    f"{per.adhoc.findings.conflict_count} konflikti, "
+                    f"{per.adhoc.findings.gap_count} lünka",
+                    cls="muted-text",
+                ),
+            )
+        )
+    if not items:
+        return _missing_row("Tõendeid ei leitud.")
+    return Ul(*items, cls="moju-poliitikamottest-evidence-list")  # noqa: F405
+
+
+def _intent_result_actions() -> list[dict[str, str]]:
+    """Static recommended actions for the intent result page."""
+    return [
+        {"label": "Küsi nõustajalt", "href": "/chat/new"},
+        {"label": "Ava õiguskaart", "href": "/explorer"},
+        {"label": "Ava Koostaja", "href": "/drafter/new"},
+        {"label": "Laadi üles eelnõu", "href": "/drafts/new"},
+        {"label": "Tagasi analüüsikeskusesse", "href": "/analyysikeskus"},
+    ]
+
+
+def _intent_empty_state() -> Any:
+    """Render the empty-confirmation friendly state (Step 3 with 0 URIs)."""
+    return Div(  # noqa: F405
+        Alert(
+            "Mõjuanalüüsi käivitamiseks kinnita vähemalt üks säte. "
+            "Mine tagasi ja vali vähemalt üks kandidaat.",
+            variant="info",
+        ),
+        A(  # noqa: F405
+            "← Tagasi sisestuse juurde",
+            href="/analyysikeskus/moju-poliitikamottest",
+            cls="back-link",
+        ),
+    )
+
+
+async def moju_poliitikamottest_analyze(req: Request):
+    """POST /analyysikeskus/moju-poliitikamottest/analyze — Step 3.
+
+    Reads the confirmation form, runs the per-URI aggregated impact
+    analysis over the confirmed URIs, and returns the full result
+    layout (Sisend / Ulatus / Tulemused / Tõendid / Soovitatud
+    tegevused) as an HTMX fragment swapped into the result region.
+    """
+    try:
+        form = await req.form()
+    except Exception:
+        logger.warning("moju_poliitikamottest_analyze: failed to read form", exc_info=True)
+        return Alert(
+            "Vormi lugemine ebaõnnestus. Proovige uuesti.",
+            variant="danger",
+        )
+
+    intent_text = str(form.get("intent") or "").strip()[:_MAX_INTENT_LEN]
+    target_groups = [str(v) for v in form.getlist("target_groups")]
+    affected_areas = [str(v) for v in form.getlist("affected_areas")]
+
+    # Read the confirmed-row indices, then pull the URI + label per row.
+    confirmed_indices: list[int] = []
+    for raw in form.getlist("confirmed"):
+        try:
+            idx = int(str(raw).strip())
+        except ValueError:
+            continue
+        confirmed_indices.append(idx)
+
+    confirmed_uris: list[str] = []
+    confirmed_labels: list[str] = []
+    source_labels: dict[str, str] = {}
+    for idx in confirmed_indices:
+        uri = str(form.get(f"uri_{idx}") or "").strip()
+        label = str(form.get(f"label_{idx}") or "").strip()
+        if not uri:
+            continue
+        confirmed_uris.append(uri)
+        confirmed_labels.append(label or uri)
+        if label:
+            source_labels[uri] = label
+
+    # Empty-confirmation friendly state.
+    if not confirmed_uris:
+        return _intent_empty_state()
+
+    # Run the per-URI aggregated analysis (each URI runs in its own
+    # ephemeral synthetic graph; the orchestrator sums the counts).
+    agg = run_aggregated_analysis(
+        confirmed_uris,
+        source_labels=source_labels,
+    )
+
+    # ``_build_results_block`` needs a Normi-style scope; the intent
+    # workflow doesn't expose scope toggles in this MVP, so we use the
+    # defaults (EU on, court practice on, org-wide drafts off).
+    scope = _Scope({})
+
+    input_summary = _intent_result_input_summary(
+        intent_text=intent_text,
+        confirmed_labels=confirmed_labels,
+    )
+    results_block = _intent_results_block(agg, scope=scope)
+    evidence_block = _intent_evidence_block(agg)
+
+    # Render the *full* result layout (5-block shell) as an HTMX
+    # fragment — the swap target is the result region, so we wrap the
+    # content in fresh ``Sisend`` / ``Ulatus`` / ... cards rather than
+    # re-rendering the full ``PageShell``.
+    chips_summary = _intent_chip_summary(
+        target_groups=target_groups, affected_areas=affected_areas
+    )
+    scope_block = (
+        chips_summary
+        if chips_summary
+        else Span(  # noqa: F405
+            "Vaikimisi ulatus: kehtiv õigus + EL õigus + Riigikohtu praktika.",
+            cls="muted-text",
+        )
+    )
+
+    # The result region only carries the inner blocks — the surrounding
+    # PageShell + back-link + workflow H1 stay in place from Step 1.
+    # We render each block as a Card so the visual rhythm matches.
+    return Div(  # noqa: F405
+        Card(
+            CardHeader(H3("Sisend", cls="card-title")),  # noqa: F405
+            CardBody(input_summary),
+        ),
+        Card(
+            CardHeader(H3("Ulatus", cls="card-title")),  # noqa: F405
+            CardBody(scope_block),
+        ),
+        Card(
+            CardHeader(H3("Tulemused", cls="card-title")),  # noqa: F405
+            CardBody(*results_block),
+        ),
+        Card(
+            CardHeader(H3("Tõendid", cls="card-title")),  # noqa: F405
+            CardBody(evidence_block),
+        ),
+        Card(
+            CardHeader(H3("Soovitatud tegevused", cls="card-title")),  # noqa: F405
+            CardBody(
+                Div(  # noqa: F405
+                    *[
+                        A(  # noqa: F405
+                            str(a["label"]),
+                            href=str(a["href"]),
+                            cls="btn btn-secondary btn-md",
+                        )
+                        for a in _intent_result_actions()
+                    ],
+                    cls="analyysikeskus-actions",
+                )
+            ),
+        ),
+        cls="moju-poliitikamottest-result",
+    )
+
+
 def register_analyysikeskus_routes(rt) -> None:  # type: ignore[no-untyped-def]
     """Register Analüüsikeskus routes on the FastHTML route decorator *rt*."""
     rt("/analyysikeskus", methods=["GET"])(analyysikeskus_page)
@@ -5924,3 +6701,11 @@ def register_analyysikeskus_routes(rt) -> None:  # type: ignore[no-untyped-def]
     rt("/analyysikeskus/padevused", methods=["GET"])(padevused_page)
     rt("/analyysikeskus/ajalugu", methods=["GET"])(ajalugu_page)
     rt("/analyysikeskus/sarnasus", methods=["GET"])(sarnasus_page)
+    # #814 Phase 2b — policy-intent → impact flow (three-step HTMX).
+    rt("/analyysikeskus/moju-poliitikamottest", methods=["GET"])(moju_poliitikamottest_page)
+    rt("/analyysikeskus/moju-poliitikamottest/extract", methods=["POST"])(
+        moju_poliitikamottest_extract
+    )
+    rt("/analyysikeskus/moju-poliitikamottest/analyze", methods=["POST"])(
+        moju_poliitikamottest_analyze
+    )

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -6011,6 +6011,20 @@ _INTENT_CONFIDENCE_PRE_CHECK = 0.7
 # pathological input can't bloat the LLM call.
 _MAX_INTENT_LEN = 5000
 
+# Cap manually entered ``known_refs`` rows before the resolver runs.
+# Without this, a comma-separated list of N items would trigger N
+# resolver lookups (each a SPARQL roundtrip) — easy to weaponise from
+# a single authenticated POST. 10 is well above the realistic 1-3 refs
+# a ministry lawyer adds manually.
+_MAX_INTENT_KNOWN_REFS = 10
+
+# Cap how many confirmed URIs the ``/analyze`` handler will run a per-URI
+# impact analysis for. Each URI triggers a Jena-backed ``run_adhoc_impact_analysis``
+# call, so an unbounded confirmed list is an easy fan-out vector. 10 is
+# generous for the realistic VTK workflow (3-8 candidates from the
+# extractor + 1-2 manual additions = ~10 max).
+_MAX_INTENT_CONFIRMED_URIS = 10
+
 
 def _intent_back_link() -> Any:
     """The shared "← Analüüsikeskus" back link rendered above the intake form."""
@@ -6055,8 +6069,14 @@ def _intent_chip_group(
     )
 
 
-def _intent_intake_form() -> Any:
-    """Render the policy-intent intake form (the Step-1 surface)."""
+def _intent_intake_form(prefill: str = "") -> Any:
+    """Render the policy-intent intake form (the Step-1 surface).
+
+    ``prefill`` is the value to seed the intent textarea with — typically
+    the capability example carried in via ``?sisend=`` (so the dashboard
+    "Näide:" affordance + global-search row land the user on a populated
+    form, not a blank one).
+    """
     ctx = prepare_intent_form_context()
     return Form(  # noqa: F405
         # Intent textarea — required, multiline, captures the policy idea.
@@ -6067,6 +6087,7 @@ def _intent_intake_form() -> Any:
             ),
             Textarea(
                 "intent",
+                value=prefill or None,
                 placeholder=(
                     "Kirjelda poliitilist kavatsust vabas vormis. Nt: «Soovin "
                     "lihtsustada puudega inimese toetuse taotlemist nii, et "
@@ -6080,16 +6101,24 @@ def _intent_intake_form() -> Any:
             ),
             cls="form-field",
         ),
-        # Target-group chip group — optional.
+        # Scope-metadata chips below. These currently DO NOT influence
+        # the LLM extractor — they're captured as user-visible context
+        # and echoed back in the result page's Ulatus block so the user
+        # has a record of their stated scope. Chip-driven extraction is
+        # a future enhancement (would require passing them into
+        # ``extract_candidates`` and tuning the prompt). The label copy
+        # makes this expectation explicit so users don't think a chip
+        # selection silently changed the suggestions.
         _intent_chip_group(
             name="target_groups",
-            label="Sihtrühm (valikuline)",
+            label="Sihtrühm (kuvatakse tulemustes — ei mõjuta kandidaatide otsingut)",
             chips=ctx.target_groups,
         ),
-        # Affected-area chip group — optional.
         _intent_chip_group(
             name="affected_areas",
-            label="Mõjutatud valdkonnad (valikuline)",
+            label=(
+                "Mõjutatud valdkonnad (kuvatakse tulemustes — ei mõjuta kandidaatide otsingut)"
+            ),
             chips=ctx.affected_areas,
         ),
         # Optional known-refs free-text input.
@@ -6136,13 +6165,23 @@ def _intent_intake_page(req: Request) -> Any:
     the ``Sisend`` block, and an empty ``#moju-poliitikamottest-result``
     div sits in the ``Tulemused`` block — both POST handlers swap their
     fragments into the latter so the user never leaves the page.
+
+    Reads ``?sisend=`` from the query string and pre-fills the intent
+    textarea — this is the same param the capability-card / global-
+    search helpers already weave into deep-links for any
+    ``/analyysikeskus/*`` workflow, so landing from the dashboard's
+    "Näide:" affordance puts the example policy intent into the form
+    automatically. Length-capped to ``_MAX_INTENT_LEN`` for parity with
+    the POST handler.
     """
     auth = req.scope.get("auth") or None
     theme = get_theme_from_request(req)
 
+    prefill = str(req.query_params.get("sisend") or "").strip()[:_MAX_INTENT_LEN]
+
     return analysis_result_shell(
         workflow_title="Analüüsi poliitikamõttest",
-        input_summary=_intent_intake_form(),
+        input_summary=_intent_intake_form(prefill=prefill),
         results_block=_intent_result_region(
             P(  # noqa: F405
                 "Esita ülal poliitiline kavatsus. Süsteem pakub välja "
@@ -6432,8 +6471,14 @@ async def moju_poliitikamottest_extract(req: Request):
     # resolver tolerates the guess (a law name still resolves cleanly
     # through ``_resolve_provision`` because the act-only branch fires
     # on partial matches).
+    #
+    # Cap to ``_MAX_INTENT_KNOWN_REFS`` so a comma-bomb POST can't
+    # trigger an unbounded number of resolver SPARQL lookups.
     if known_refs_raw:
+        known_count = 0
         for raw_ref in known_refs_raw.split(","):
+            if known_count >= _MAX_INTENT_KNOWN_REFS:
+                break
             ref_text = raw_ref.strip()
             if not ref_text:
                 continue
@@ -6445,6 +6490,14 @@ async def moju_poliitikamottest_extract(req: Request):
                     reasoning="Kasutaja sisestatud käsitsi teadaolev viide.",
                 )
             )
+            known_count += 1
+
+    # Defence in depth: clamp the combined LLM + manual candidate list to
+    # ``_MAX_INTENT_CANDIDATES`` before resolving, so a misbehaving extractor
+    # (or future prompt drift that returns more than the documented 3-8)
+    # can't fan out into the resolver beyond what the UI can render.
+    if len(candidates) > _MAX_INTENT_CANDIDATES:
+        candidates = candidates[:_MAX_INTENT_CANDIDATES]
 
     # Resolve every candidate to a URI (or ``None`` for unresolvable).
     resolved = resolve_candidates(candidates)
@@ -6614,6 +6667,18 @@ async def moju_poliitikamottest_analyze(req: Request):
     # Empty-confirmation friendly state.
     if not confirmed_uris:
         return _intent_empty_state()
+
+    # Cap fan-out before running per-URI Jena impact: each URI triggers
+    # a ``run_adhoc_impact_analysis`` SPARQL roundtrip, so an unbounded
+    # confirmed list is an easy DOS vector from an authenticated POST.
+    # The cap aligns with ``_MAX_INTENT_CANDIDATES`` (12) — anything
+    # above is suspicious for a single-intent workflow.
+    if len(confirmed_uris) > _MAX_INTENT_CONFIRMED_URIS:
+        confirmed_uris = confirmed_uris[:_MAX_INTENT_CONFIRMED_URIS]
+        confirmed_labels = confirmed_labels[:_MAX_INTENT_CONFIRMED_URIS]
+        # Drop matching ``source_labels`` keys so the result page doesn't
+        # carry stale attribution for URIs we trimmed.
+        source_labels = {uri: source_labels[uri] for uri in confirmed_uris if uri in source_labels}
 
     # Run the per-URI aggregated analysis (each URI runs in its own
     # ephemeral synthetic graph; the orchestrator sums the counts).

--- a/app/ui/capabilities.py
+++ b/app/ui/capabilities.py
@@ -154,21 +154,16 @@ CAPABILITIES: list[Capability] = [
             "ja teostab mõjuanalüüsi kinnitatud sätete kohta."
         ),
         icon="lightbulb",
-        # ``target_url`` points to the Analüüsikeskus directory while the
-        # real route is wired by #814 Phase 2b (held until #805/#815 lands
-        # to avoid routes.py merge contention). The convention used by
-        # the other ``status="planned"`` entries above is to link to a
-        # related, already-live landing surface so a curious click goes
-        # somewhere useful instead of 404-ing. When Phase 2b lands, this
-        # entry flips to ``target_url="/analyysikeskus/moju-poliitikamottest"``
-        # + ``status="live"``.
-        target_url="/analyysikeskus",
+        # Wired by #814 Phase 2b. The handler lives at
+        # :func:`app.analyysikeskus.routes.moju_poliitikamottest_page` and
+        # registers the three-step flow (GET intake form, POST extract,
+        # POST analyze) on the FastHTML route decorator.
+        target_url="/analyysikeskus/moju-poliitikamottest",
         example_input=(
             "Soovin lihtsustada puudega inimese toetuse taotlemist nii, "
             "et osa andmeid liiguks automaatselt Tervisekassast ja Töötukassast."
         ),
         use_case_from_section_2=3,
-        status="planned",
     ),
     Capability(
         slug="normi-mojuahel",

--- a/tests/test_analyysikeskus_intent_routes.py
+++ b/tests/test_analyysikeskus_intent_routes.py
@@ -680,6 +680,146 @@ def test_extract_caps_manual_known_refs_to_max_intent_known_refs(
 
 
 @patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_extract_manual_refs_win_when_llm_fills_the_cap(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    """#822 PR review P2 (round 2): if the LLM returns _MAX_INTENT_CANDIDATES
+    rows, a previous revision truncated post-append and silently dropped
+    every manual known_ref. Explicit user input must reach the resolver
+    even when the LLM list is full — manual refs win over inferred ones.
+    """
+    from app.analyysikeskus.intent_extractor import IntentCandidate
+    from app.analyysikeskus.routes import _MAX_INTENT_CANDIDATES
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    mock_provider.return_value = _stub_provider()
+
+    # LLM returns exactly _MAX_INTENT_CANDIDATES candidates (12) — would
+    # have completely displaced the manual ref under the old behaviour.
+    mock_extract.return_value = [
+        IntentCandidate(
+            ref_text=f"LLM{n}",
+            ref_type="provision",
+            confidence=0.5 + (n * 0.01),  # ascending confidence
+            reasoning=f"LLM kandidaat #{n}.",
+        )
+        for n in range(_MAX_INTENT_CANDIDATES)
+    ]
+
+    captured: list[ExtractedRef] = []
+
+    def _capture(refs: list[ExtractedRef]) -> list[ResolvedRef]:
+        captured.extend(refs)
+        return [
+            ResolvedRef(
+                extracted=r,
+                entity_uri=f"uri-{r.ref_text}",
+                matched_label=r.ref_text,
+                match_score=1.0,
+            )
+            for r in refs
+        ]
+
+    mock_resolve.side_effect = _capture
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={
+            "intent": "mingi kavatsus",
+            "known_refs": "Manual § 1, Manual § 2",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    ref_texts = {r.ref_text for r in captured}
+    # The manual refs MUST have reached the resolver.
+    assert "Manual § 1" in ref_texts, f"Manual ref 1 dropped — captured: {sorted(ref_texts)}"
+    assert "Manual § 2" in ref_texts, f"Manual ref 2 dropped — captured: {sorted(ref_texts)}"
+    # Combined count still respects the overall cap.
+    assert len(captured) <= _MAX_INTENT_CANDIDATES
+    # The lowest-confidence LLM rows are the ones that got squeezed out.
+    assert "LLM0" not in ref_texts  # lowest confidence — bumped by manual
+    # Highest-confidence LLM rows survive.
+    assert f"LLM{_MAX_INTENT_CANDIDATES - 1}" in ref_texts
+    # The confirmation panel renders the manual refs so the user can see them.
+    assert "Manual § 1" in body
+    assert "Manual § 2" in body
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_extract_manual_refs_capped_when_overflowing_total(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    """Manual refs are themselves capped at _MAX_INTENT_KNOWN_REFS (10).
+    If the user crams more than the cap into the comma list, only the
+    first 10 reach the resolver (no LLM rows fit at all in this case
+    because the manual list already meets the global cap)."""
+    from app.analyysikeskus.intent_extractor import IntentCandidate
+    from app.analyysikeskus.routes import _MAX_INTENT_KNOWN_REFS
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    mock_provider.return_value = _stub_provider()
+    mock_extract.return_value = [
+        IntentCandidate(
+            ref_text="LLM_extra",
+            ref_type="law",
+            confidence=0.9,
+            reasoning="LLM kandidaat.",
+        )
+    ]
+
+    captured: list[ExtractedRef] = []
+
+    def _capture(refs: list[ExtractedRef]) -> list[ResolvedRef]:
+        captured.extend(refs)
+        return [
+            ResolvedRef(
+                extracted=r,
+                entity_uri=f"uri-{r.ref_text}",
+                matched_label=r.ref_text,
+                match_score=1.0,
+            )
+            for r in refs
+        ]
+
+    mock_resolve.side_effect = _capture
+
+    # 15 manual refs > _MAX_INTENT_KNOWN_REFS (10).
+    flood = ", ".join(f"Manual{n}" for n in range(15))
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={"intent": "mingi kavatsus", "known_refs": flood},
+    )
+    assert resp.status_code == 200
+
+    manual_in_captured = [r for r in captured if r.ref_text.startswith("Manual")]
+    assert len(manual_in_captured) <= _MAX_INTENT_KNOWN_REFS
+    # The first N manual entries are taken in order (split-on-comma order).
+    captured_texts = {r.ref_text for r in manual_in_captured}
+    assert "Manual0" in captured_texts
+    assert "Manual9" in captured_texts
+    assert "Manual10" not in captured_texts  # past the cap
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
 @patch("app.analyysikeskus.intent_analysis.run_adhoc_impact_analysis")
 @patch("app.auth.middleware._get_provider")
 def test_analyze_caps_confirmed_uris_to_max_intent_confirmed_uris(

--- a/tests/test_analyysikeskus_intent_routes.py
+++ b/tests/test_analyysikeskus_intent_routes.py
@@ -164,12 +164,15 @@ def test_intent_intake_form_renders(mock_provider: MagicMock, mock_recent: Magic
     assert 'name="intent"' in body
     # Intent is a textarea, not a single-line input.
     assert "<textarea" in body
-    # Target-group chips — chip group label + at least one canonical chip.
-    assert "Sihtrühm (valikuline)" in body
+    # Target-group chips — chip group label includes the explicit
+    # "scope metadata only, doesn't influence search" disclaimer so users
+    # don't expect chip selection to silently shape candidates (#822 P2-2).
+    assert "Sihtrühm" in body
+    assert "ei mõjuta kandidaatide otsingut" in body
     assert "Lapsed" in body
     assert "Puuetega inimesed" in body
-    # Affected-area chips.
-    assert "Mõjutatud valdkonnad (valikuline)" in body
+    # Affected-area chips with the same disclaimer.
+    assert "Mõjutatud valdkonnad" in body
     assert "Sotsiaalhoolekanne" in body
     # Known-refs optional text input.
     assert "Teadaolevad õiguslikud viited (valikuline)" in body
@@ -588,3 +591,131 @@ def test_intent_analyze_drops_confirmed_rows_without_uri(
     # The unresolved label does NOT appear as a "Mõjuahel sätte ..." heading.
     assert "Mõjuahel sätte Unresolved ref analüüsist" not in body
     assert "Mõjuahel sätte KarS § 121 analüüsist" in body
+
+
+# ---------------------------------------------------------------------------
+# #822 review follow-ups (P2 caps + P3 prefill)
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_intake_form_prefills_intent_from_sisend_query_param(
+    mock_provider: MagicMock,
+    mock_recent: MagicMock,
+):
+    """#822 P3: the capability-card / global-search helpers append
+    ?sisend=<example> to /analyysikeskus/* deep-links. The intake page
+    must read it and prefill the textarea, otherwise clicking the
+    dashboard "Näide:" affordance lands on a blank form."""
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    sisend = "Soovin lihtsustada puudega inimese toetuse taotlemist."
+    resp = client.get(
+        "/analyysikeskus/moju-poliitikamottest",
+        params={"sisend": sisend},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    # The textarea value attribute carries the prefill.
+    assert sisend in body
+    # Belt-and-braces: an empty sisend doesn't crash + renders blank textarea.
+    resp_blank = client.get(
+        "/analyysikeskus/moju-poliitikamottest",
+        params={"sisend": ""},
+    )
+    assert resp_blank.status_code == 200
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_extract_caps_manual_known_refs_to_max_intent_known_refs(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    """#822 P2-1: an unbounded comma-separated known_refs list would
+    fan out into N resolver SPARQL lookups. Cap at
+    ``_MAX_INTENT_KNOWN_REFS`` (10)."""
+    from app.analyysikeskus.routes import _MAX_INTENT_KNOWN_REFS
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    mock_provider.return_value = _stub_provider()
+    mock_extract.return_value = []  # No LLM candidates.
+
+    captured: list[ExtractedRef] = []
+
+    def _capture(refs: list[ExtractedRef]) -> list[ResolvedRef]:
+        captured.extend(refs)
+        return [
+            ResolvedRef(
+                extracted=r,
+                entity_uri=f"uri-{i}",
+                matched_label=r.ref_text,
+                match_score=1.0,
+            )
+            for i, r in enumerate(refs)
+        ]
+
+    mock_resolve.side_effect = _capture
+
+    # 25 manually entered refs — well above the cap.
+    flood = ", ".join(f"REF{n}" for n in range(25))
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={"intent": "mingi kavatsus", "known_refs": flood},
+    )
+    assert resp.status_code == 200
+    # Resolver received at most the cap, not all 25.
+    assert len(captured) <= _MAX_INTENT_KNOWN_REFS, (
+        f"Expected at most {_MAX_INTENT_KNOWN_REFS} refs to reach the "
+        f"resolver, got {len(captured)}"
+    )
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.run_adhoc_impact_analysis")
+@patch("app.auth.middleware._get_provider")
+def test_analyze_caps_confirmed_uris_to_max_intent_confirmed_uris(
+    mock_provider: MagicMock,
+    mock_adhoc: MagicMock,
+    mock_recent: MagicMock,
+):
+    """#822 P2-1: each confirmed URI triggers a per-URI Jena impact
+    run. An unbounded POST would fan out N Jena roundtrips. Cap at
+    ``_MAX_INTENT_CONFIRMED_URIS`` (10)."""
+    from app.analyysikeskus.adhoc_analysis import AdhocAnalysisResult
+    from app.analyysikeskus.routes import _MAX_INTENT_CONFIRMED_URIS
+
+    mock_provider.return_value = _stub_provider()
+    mock_adhoc.return_value = AdhocAnalysisResult(
+        findings=_canned_findings(),
+        score=50,
+        graph_uri="g",
+    )
+
+    # 25 confirmed rows posted — well above the cap.
+    data: dict[str, Any] = {
+        "intent": "midagi",
+        "confirmed": [str(i) for i in range(25)],
+    }
+    for i in range(25):
+        data[f"uri_{i}"] = f"uri-{i}"
+        data[f"label_{i}"] = f"label-{i}"
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/analyze",
+        data=data,
+    )
+    assert resp.status_code == 200
+    # The analyser was invoked at most the cap, not all 25.
+    assert mock_adhoc.call_count <= _MAX_INTENT_CONFIRMED_URIS, (
+        f"Expected at most {_MAX_INTENT_CONFIRMED_URIS} per-URI runs, got {mock_adhoc.call_count}"
+    )

--- a/tests/test_analyysikeskus_intent_routes.py
+++ b/tests/test_analyysikeskus_intent_routes.py
@@ -1,0 +1,590 @@
+"""Route-level integration tests for the intent → impact flow (#814 Phase 2b).
+
+Exercises the three new endpoints end-to-end via :class:`TestClient`:
+
+    GET  /analyysikeskus/moju-poliitikamottest          — intake form
+    POST /analyysikeskus/moju-poliitikamottest/extract  — confirmation panel
+    POST /analyysikeskus/moju-poliitikamottest/analyze  — aggregated result
+
+The LLM extractor, reference resolver, and Jena layer are all patched
+*where used* (the patch-path contract — patch where the symbol is
+imported, not where it's defined). No real network calls; deterministic
+canned responses drive every code path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": "11111111-1111-1111-1111-111111111111",
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client(*, raise_server_exceptions: bool = True):
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+        raise_server_exceptions=raise_server_exceptions,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Canned LLM + resolver responses
+# ---------------------------------------------------------------------------
+
+
+def _canned_intent_candidates():
+    """Two canned :class:`IntentCandidate` rows the route handler renders."""
+    from app.analyysikeskus.intent_extractor import IntentCandidate
+
+    return [
+        IntentCandidate(
+            ref_text="PISTS § 4",
+            ref_type="provision",
+            confidence=0.9,
+            reasoning="Põhinorm puudega inimese toetuse maksmise kohta.",
+        ),
+        IntentCandidate(
+            ref_text="sotsiaalhoolekande seadus",
+            ref_type="law",
+            confidence=0.5,
+            reasoning="Seos sotsiaaltoetuste üldise raamistikuga.",
+        ),
+    ]
+
+
+_PISTS_URI = "https://data.riik.ee/ontology/estleg#PISTS_Par_4"
+_SHS_URI = "https://data.riik.ee/ontology/estleg#sotsiaalhoolekande-seadus"
+
+
+def _canned_resolved_refs():
+    """Canned resolver output for the two candidates above."""
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    return [
+        ResolvedRef(
+            extracted=ExtractedRef(
+                ref_text="PISTS § 4",
+                ref_type="provision",
+                confidence=0.9,
+            ),
+            entity_uri=_PISTS_URI,
+            matched_label="PISTS § 4",
+            match_score=1.0,
+        ),
+        ResolvedRef(
+            extracted=ExtractedRef(
+                ref_text="sotsiaalhoolekande seadus",
+                ref_type="law",
+                confidence=0.5,
+            ),
+            entity_uri=_SHS_URI,
+            matched_label="Sotsiaalhoolekande seadus",
+            match_score=0.9,
+        ),
+    ]
+
+
+def _canned_findings(affected: int = 2, conflicts: int = 1, gaps: int = 0):
+    from app.docs.impact.analyzer import ImpactFindings
+
+    return ImpactFindings(
+        affected_entities=[
+            {"uri": f"e-{i}", "label": f"Üksus {i}", "type": "Provision"} for i in range(affected)
+        ],
+        conflicts=[
+            {"conflicting_entity": f"c-{i}", "conflicting_label": f"Konflikt {i}", "reason": "x"}
+            for i in range(conflicts)
+        ],
+        gaps=[{"label": f"gap-{i}"} for i in range(gaps)],
+        affected_count=affected,
+        conflict_count=conflicts,
+        gap_count=gaps,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unauthenticated requests redirect to login
+# ---------------------------------------------------------------------------
+
+
+def test_intent_routes_redirect_unauthenticated():
+    from starlette.testclient import TestClient
+
+    from app.main import app
+
+    client = TestClient(app, follow_redirects=False)
+    for path in (
+        "/analyysikeskus/moju-poliitikamottest",
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        "/analyysikeskus/moju-poliitikamottest/analyze",
+    ):
+        resp = client.get(path) if path.endswith("moju-poliitikamottest") else client.post(path)
+        assert resp.status_code == 303, path
+        assert resp.headers["location"] == "/auth/login", path
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — GET intake form
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_intent_intake_form_renders(mock_provider: MagicMock, mock_recent: MagicMock):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus/moju-poliitikamottest")
+    assert resp.status_code == 200
+    body = resp.text
+
+    # The page chrome / workflow title.
+    assert "Analüüsi poliitikamõttest" in body
+    # The four intake form fields are present.
+    assert "Mida soovid muuta või lisada?" in body
+    assert 'name="intent"' in body
+    # Intent is a textarea, not a single-line input.
+    assert "<textarea" in body
+    # Target-group chips — chip group label + at least one canonical chip.
+    assert "Sihtrühm (valikuline)" in body
+    assert "Lapsed" in body
+    assert "Puuetega inimesed" in body
+    # Affected-area chips.
+    assert "Mõjutatud valdkonnad (valikuline)" in body
+    assert "Sotsiaalhoolekanne" in body
+    # Known-refs optional text input.
+    assert "Teadaolevad õiguslikud viited (valikuline)" in body
+    assert 'name="known_refs"' in body
+    # The submit button copy.
+    assert "Otsi mõjutatud sätteid" in body
+    # The HTMX target wiring.
+    assert "moju-poliitikamottest-result" in body
+    assert 'hx-post="/analyysikeskus/moju-poliitikamottest/extract"' in body
+    # Estonian copy throughout — no raw English placeholder leaks.
+    assert "Poliitiline kavatsus" in body
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — capability card uses the new route
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.auth.middleware._get_provider")
+def test_analyysikeskus_directory_links_to_new_intent_route(
+    mock_provider: MagicMock, mock_recent: MagicMock
+):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.get("/analyysikeskus")
+    assert resp.status_code == 200
+    body = resp.text
+
+    # The capability card is visible and links to the new route — NOT to
+    # the directory page anymore.
+    assert "Analüüsi poliitikamõttest" in body
+    assert 'href="/analyysikeskus/moju-poliitikamottest"' in body
+    # The "Tulekul" badge is gone for this card (the entry is live now).
+    # We can't assert the badge absence globally (other planned entries
+    # use it) — but we can assert this card's link is "Alusta analüüsi →"
+    # which only the live intent card renders.
+    assert "Alusta analüüsi →" in body
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — POST /extract — happy path
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_intent_extract_renders_confirmation_panel(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    mock_provider.return_value = _stub_provider()
+    mock_extract.return_value = _canned_intent_candidates()
+    mock_resolve.return_value = _canned_resolved_refs()
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={
+            "intent": "Soovin lihtsustada puudega inimese toetuse taotlemist.",
+            "target_groups": ["Puuetega inimesed", "Eakad"],
+            "affected_areas": ["Sotsiaalhoolekanne"],
+            "known_refs": "",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # The confirmation panel headline.
+    assert "Süsteem leidis järgmised kandidaadid" in body
+    # The applied chip selections surface in the summary.
+    assert "Puuetega inimesed" in body
+    assert "Sotsiaalhoolekanne" in body
+    # Each candidate's resolved label + ref_type + confidence shows.
+    assert "PISTS § 4" in body
+    assert "säte" in body
+    # The reasoning text (smaller font).
+    assert "Põhinorm puudega inimese toetuse" in body
+    # The high-confidence row (>= 0.7) is pre-checked; the low one is not.
+    # Pre-check is shown via the "checked" attribute on the checkbox.
+    assert 'checked="checked"' in body
+    # The submit button copy includes the count of pre-checked rows
+    # (PISTS § 4 with confidence 0.9 is the only one above the threshold).
+    assert "Käivita mõjuanalüüs (1 kinnitatud sätet)" in body
+    # The form posts to /analyze.
+    assert 'hx-post="/analyysikeskus/moju-poliitikamottest/analyze"' in body
+    # The URI hidden inputs carry the resolved URI per candidate.
+    assert _PISTS_URI in body
+    # Each candidate row carries a label hidden input.
+    assert "label_0" in body
+    assert "label_1" in body
+    # The LLM was called exactly once with the full intent.
+    mock_extract.assert_called_once()
+    args, kwargs = mock_extract.call_args
+    assert "puudega inimese" in args[0]
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — empty intent skips the LLM
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.auth.middleware._get_provider")
+def test_intent_extract_empty_intent_shows_validation_no_llm(
+    mock_provider: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={"intent": "   "},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Friendly Estonian validation message.
+    assert "Palun sisesta poliitiline kavatsus" in body
+    # The LLM extractor was NOT called.
+    mock_extract.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — zero LLM candidates → empty-state warning + back link
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_intent_extract_zero_candidates_shows_empty_state(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    mock_provider.return_value = _stub_provider()
+    mock_extract.return_value = []
+    mock_resolve.return_value = []
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={"intent": "midagi ebamäärast"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Empty-state messaging + back-link affordance.
+    assert "ei suutnud sellest kavatsusest kandidaate" in body
+    assert "Tagasi sisestuse juurde" in body
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — known refs from the manual input get added as candidates
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.extract_intent_candidates")
+@patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+@patch("app.auth.middleware._get_provider")
+def test_intent_extract_includes_manual_known_refs(
+    mock_provider: MagicMock,
+    mock_resolve: MagicMock,
+    mock_extract: MagicMock,
+    mock_recent: MagicMock,
+):
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    mock_provider.return_value = _stub_provider()
+    mock_extract.return_value = []  # No LLM candidates.
+
+    # Capture what the resolver receives.
+    captured: list[ExtractedRef] = []
+
+    def _capture(refs: list[ExtractedRef]) -> list[ResolvedRef]:
+        captured.extend(refs)
+        return [
+            ResolvedRef(
+                extracted=r,
+                entity_uri=f"https://data.riik.ee/ontology/estleg#{r.ref_text.replace(' ', '_')}",
+                matched_label=r.ref_text,
+                match_score=1.0,
+            )
+            for r in refs
+        ]
+
+    mock_resolve.side_effect = _capture
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/extract",
+        data={
+            "intent": "mingi kavatsus",
+            "known_refs": "AvTS § 35, KarS § 121",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # The two manually entered refs were passed through to the resolver.
+    ref_texts = {r.ref_text for r in captured}
+    assert "AvTS § 35" in ref_texts
+    assert "KarS § 121" in ref_texts
+    # Both surface in the confirmation panel.
+    assert "AvTS § 35" in body
+    assert "KarS § 121" in body
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — POST /analyze with 0 confirmed URIs returns empty state
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.run_adhoc_impact_analysis")
+@patch("app.auth.middleware._get_provider")
+def test_intent_analyze_zero_confirmed_returns_empty_state(
+    mock_provider: MagicMock,
+    mock_adhoc: MagicMock,
+    mock_recent: MagicMock,
+):
+    mock_provider.return_value = _stub_provider()
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/analyze",
+        data={"intent": "midagi", "confirmed": []},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Friendly empty state with the back link.
+    assert "Mõjuanalüüsi käivitamiseks kinnita vähemalt üks säte" in body
+    assert "Tagasi sisestuse juurde" in body
+    # The per-URI analyser was never called.
+    mock_adhoc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — POST /analyze with N confirmed URIs renders the full result
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.run_adhoc_impact_analysis")
+@patch("app.auth.middleware._get_provider")
+def test_intent_analyze_runs_per_uri_and_renders_result(
+    mock_provider: MagicMock,
+    mock_adhoc: MagicMock,
+    mock_recent: MagicMock,
+):
+    from app.analyysikeskus.adhoc_analysis import AdhocAnalysisResult
+
+    mock_provider.return_value = _stub_provider()
+
+    # Each URI returns its own canned result.
+    results = {
+        _PISTS_URI: AdhocAnalysisResult(
+            findings=_canned_findings(affected=3, conflicts=1, gaps=0),
+            score=70,
+            graph_uri="g-pists",
+        ),
+        _SHS_URI: AdhocAnalysisResult(
+            findings=_canned_findings(affected=2, conflicts=0, gaps=1),
+            score=40,
+            graph_uri="g-shs",
+        ),
+    }
+    mock_adhoc.side_effect = lambda uri, **_: results[uri]
+
+    client = _authed_client()
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/analyze",
+        data={
+            "intent": "Soovin lihtsustada puudega toetuse taotlemist.",
+            "target_groups": ["Puuetega inimesed"],
+            "affected_areas": ["Sotsiaalhoolekanne"],
+            "confirmed": ["0", "1"],
+            "uri_0": _PISTS_URI,
+            "label_0": "PISTS § 4",
+            "uri_1": _SHS_URI,
+            "label_1": "Sotsiaalhoolekande seadus",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # The five result-shell cards are present in the fragment.
+    for heading in ("Sisend", "Ulatus", "Tulemused", "Tõendid", "Soovitatud tegevused"):
+        assert heading in body, heading
+    # The Sisend block echoes the intent + confirmed labels.
+    assert "Soovin lihtsustada" in body
+    assert "PISTS § 4" in body
+    assert "Sotsiaalhoolekande seadus" in body
+    # The Ulatus block lists the applied chips.
+    assert "Puuetega inimesed" in body
+    assert "Sotsiaalhoolekanne" in body
+    # Per-URI traceability: each confirmed URI has its own "Mõjuahel
+    # sätte X analüüsist" sub-heading.
+    assert "Mõjuahel sätte PISTS § 4 analüüsist" in body
+    assert "Mõjuahel sätte Sotsiaalhoolekande seadus analüüsist" in body
+    # The headline totals sum across URIs.
+    assert "5 mõjutatud üksust" in body  # 3 + 2
+    assert "1 konflikti" in body
+    assert "1 lünka" in body
+    assert "üle 2 kinnitatud sätte" in body
+    # Recommended actions include the cross-links the design doc names.
+    assert "Küsi nõustajalt" in body
+    assert "/chat/new" in body
+    assert "Ava õiguskaart" in body
+    assert "Ava Koostaja" in body
+    assert "Laadi üles eelnõu" in body
+    # The per-URI analyser was called once per confirmed URI.
+    assert mock_adhoc.call_count == 2
+    called_uris = {c.args[0] for c in mock_adhoc.call_args_list}
+    assert called_uris == {_PISTS_URI, _SHS_URI}
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — per-URI traceability headings include every confirmed source
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.run_adhoc_impact_analysis")
+@patch("app.auth.middleware._get_provider")
+def test_intent_analyze_traceability_per_source(
+    mock_provider: MagicMock,
+    mock_adhoc: MagicMock,
+    mock_recent: MagicMock,
+):
+    from app.analyysikeskus.adhoc_analysis import AdhocAnalysisResult
+
+    mock_provider.return_value = _stub_provider()
+    mock_adhoc.return_value = AdhocAnalysisResult(
+        findings=_canned_findings(),
+        score=50,
+        graph_uri="g",
+    )
+
+    client = _authed_client()
+    # Three confirmed sources — every one gets its own heading.
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/analyze",
+        data={
+            "intent": "midagi",
+            "confirmed": ["0", "1", "2"],
+            "uri_0": "uri-A",
+            "label_0": "AvTS § 35",
+            "uri_1": "uri-B",
+            "label_1": "KarS § 121",
+            "uri_2": "uri-C",
+            "label_2": "TLS § 12",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Each confirmed source maps to a "Mõjuahel sätte X analüüsist" sub-heading.
+    for label in ("AvTS § 35", "KarS § 121", "TLS § 12"):
+        assert f"Mõjuahel sätte {label} analüüsist" in body
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — confirmed row with no URI is silently dropped
+# ---------------------------------------------------------------------------
+
+
+@patch("app.analyysikeskus.routes._get_recent_analyses", return_value=[])
+@patch("app.analyysikeskus.intent_analysis.run_adhoc_impact_analysis")
+@patch("app.auth.middleware._get_provider")
+def test_intent_analyze_drops_confirmed_rows_without_uri(
+    mock_provider: MagicMock,
+    mock_adhoc: MagicMock,
+    mock_recent: MagicMock,
+):
+    from app.analyysikeskus.adhoc_analysis import AdhocAnalysisResult
+
+    mock_provider.return_value = _stub_provider()
+    mock_adhoc.return_value = AdhocAnalysisResult(
+        findings=_canned_findings(),
+        score=50,
+        graph_uri="g",
+    )
+
+    client = _authed_client()
+    # Row 0 is confirmed but has no uri_0 hidden input (e.g. unresolved).
+    # Row 1 is confirmed with a URI.
+    resp = client.post(
+        "/analyysikeskus/moju-poliitikamottest/analyze",
+        data={
+            "intent": "midagi",
+            "confirmed": ["0", "1"],
+            # uri_0 deliberately omitted.
+            "label_0": "Unresolved ref",
+            "uri_1": "uri-B",
+            "label_1": "KarS § 121",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Only the row with a real URI was sent to the analyser.
+    assert mock_adhoc.call_count == 1
+    assert mock_adhoc.call_args_list[0].args[0] == "uri-B"
+    # The unresolved label does NOT appear as a "Mõjuahel sätte ..." heading.
+    assert "Mõjuahel sätte Unresolved ref analüüsist" not in body
+    assert "Mõjuahel sätte KarS § 121 analüüsist" in body


### PR DESCRIPTION
## Summary

Wires the three-step HTMX flow for the policy-intent → impact workflow on top of the merged #819 extractor + orchestration. The capability `moju-poliitikamottest` flips from `status="planned"` → `"live"`, and its `target_url` now points at the new route handler instead of the placeholder directory link.

Builds on top of #819 (intent extractor + orchestration helpers) and assumes #821 (#805/#815 unresolved-EU warnings) has already landed in `routes.py`. Phase 2b's mandate was explicitly to **only add** new routes / inputs entries — no edits to `_render_eu_unresolved` or any other existing handler.

### New routes

- `GET /analyysikeskus/moju-poliitikamottest` — Koostaja-style intake form (intent textarea + target-group chips + affected-area chips + optional known-refs text).
- `POST /analyysikeskus/moju-poliitikamottest/extract` — LLM-driven semantic-inference candidate proposal + URI resolution → renders the candidate-confirmation panel as an HTMX fragment.
- `POST /analyysikeskus/moju-poliitikamottest/analyze` — runs `run_aggregated_analysis` per confirmed URI and HTMX-swaps the full result shell (Sisend / Ulatus / Tulemused / Tõendid / Soovitatud tegevused) with per-source traceability headings (`Mõjuahel sätte X analüüsist`).

### Design contract preserved

- LLM hallucination is *expected and managed* — the confirmation step is the non-negotiable guardrail before any analysis runs.
- All LLM calls flow through `extract_candidates` → `extract_intent_candidates`, which pins `feature="intent_analysis"` via the `INTENT_FEATURE_LABEL` module constant.
- Strictly per-URI calls into `run_adhoc_impact_analysis` (the proven path) — NO composite ephemeral graph, per the user's explicit MVP direction.
- All HTMX swaps target the result region (`#moju-poliitikamottest-result`) — no full-page reload between steps.
- `_render_eu_unresolved` and all other existing handlers untouched.

## Test plan

- [x] `uv run pyright` clean (0 errors, 0 warnings)
- [x] `uv run ruff check` clean
- [x] `uv run pytest` — 3257 passed, 37 skipped (no regressions)
- [x] New `tests/test_analyysikeskus_intent_routes.py` — 11 route-level integration tests covering:
  - GET intake form renders all four fields + HTMX wiring
  - Directory card now links to the new route (no longer redirects to `/analyysikeskus`)
  - POST `/extract` with valid intent → confirmation panel with reasoning + URI hidden inputs + pre-checked rows for confidence ≥ 0.7
  - POST `/extract` with empty intent → validation message, LLM NOT called
  - POST `/extract` with zero LLM candidates → friendly empty state + back link
  - POST `/extract` with manual known refs → merged into resolver input
  - POST `/analyze` with 0 confirmed URIs → friendly empty state + back link
  - POST `/analyze` with N confirmed URIs → full 5-card result with per-URI traceability headings + summed totals
  - POST `/analyze` with 3 sources → all three sub-headings rendered
  - POST `/analyze` with row missing URI → silently dropped (analyser called only on resolvable rows)
  - Unauthenticated requests redirect to `/auth/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)