### PR TITLE
feat(notifications): #180 — real-time WebSocket delivery

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.explorer.pages import register_explorer_pages
 from app.explorer.routes import register_explorer_routes
 from app.explorer.websocket import register_ws_routes
 from app.notifications.routes import register_notification_routes
+from app.notifications.websocket import register_notifications_ws_routes
 from app.sync.webhook import register_webhook_routes
 from app.templates.dashboard import register_dashboard_routes
 from app.ui.components.search_routes import register_search_routes
@@ -104,6 +105,21 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
     except Exception:
         logger.debug(
             "Failed to register event loop for draft status events",
+            exc_info=True,
+        )
+
+    # #180 — capture the running loop so notify() can push WS events
+    # from background threads (job worker etc.) via
+    # ``asyncio.run_coroutine_threadsafe``.
+    try:
+        import asyncio as _asyncio
+
+        from app.notifications import websocket as _notif_ws
+
+        _notif_ws.register_event_loop(_asyncio.get_running_loop())
+    except Exception:
+        logger.debug(
+            "Failed to register event loop for notifications WS",
             exc_info=True,
         )
 
@@ -258,6 +274,7 @@ register_draft_ws_routes(app)
 register_export_progress_ws_routes(app)
 register_annotation_routes(rt)
 register_notification_routes(rt)
+register_notifications_ws_routes(app)
 register_search_routes(rt)
 
 

--- a/app/notifications/notify.py
+++ b/app/notifications/notify.py
@@ -9,6 +9,12 @@ Usage::
 The function opens its own DB connection, commits, and swallows all
 errors so callers never have to worry about notification failures
 disrupting the primary workflow.
+
+When a row is successfully inserted, the helper also fire-and-forgets a
+real-time push to any open ``/ws/notifications`` socket the user holds
+(#180). The WS push is best-effort: if the loop is not registered or
+the user has no live sockets, the bell UI's existing 30 s polling will
+still pick the new row up.
 """
 
 from __future__ import annotations
@@ -35,6 +41,12 @@ def notify(
 
     Opens a new DB connection, inserts the notification, commits, and
     closes. Any exception is logged at WARNING level but never propagated.
+
+    After a successful insert the helper pushes the new notification to
+    any live ``/ws/notifications`` socket owned by ``user_id`` so the
+    bell badge updates in real time. The push is wrapped in its own
+    try/except so a WS failure cannot revert the durable DB write or
+    disturb the primary workflow.
     """
     try:
         with get_connection() as conn:
@@ -53,6 +65,38 @@ def notify(
         logger.warning(
             "Failed to send notification type=%s to user_id=%s (non-critical)",
             type,
+            user_id,
+            exc_info=True,
+        )
+        return
+
+    # #180 — real-time push. Import locally so importing this module
+    # never triggers WS module import side effects (the WS module
+    # captures a module-level lock + an event-loop slot).
+    if result is None:
+        return
+
+    try:
+        from app.notifications.websocket import push_to_user
+
+        push_to_user(
+            user_id,
+            {
+                "type": "notification",
+                "id": str(result.id),
+                "notification_type": result.type,
+                "title": result.title,
+                "body": result.body,
+                "link": result.link,
+                "created_at": result.created_at.isoformat()
+                if result.created_at is not None
+                else None,
+            },
+        )
+    except Exception:
+        # Push is fire-and-forget; the DB row is already durable.
+        logger.debug(
+            "Failed to push WS notification for user_id=%s (non-critical)",
             user_id,
             exc_info=True,
         )

--- a/app/notifications/websocket.py
+++ b/app/notifications/websocket.py
@@ -1,0 +1,456 @@
+"""WebSocket handler for real-time notification delivery (#180).
+
+Same FastHTML ``app.ws()`` pattern as ``app/chat/websocket.py``,
+``app/explorer/websocket.py``, and ``app/docs/websocket.py``. The
+handshake is authenticated via the ``access_token`` JWT cookie (with
+silent-refresh fallback to ``refresh_token`` — see chat module for the
+full pattern). The path is ``/ws/notifications``.
+
+Push model
+----------
+
+This is primarily a **push-only** channel: the server emits a
+``{"type": "notification", ...}`` event whenever
+:func:`app.notifications.notify.notify` inserts a new row for the
+connected user. Multiple browser tabs translate into multiple sockets
+per user (the same physical user receives one push per tab), so the
+connection registry is a ``dict[user_id, set[send]]``.
+
+Client messages are silently ignored other than the ``ping`` →
+``pong`` keepalive hook (kept for symmetry with the other modules);
+notifications themselves are minted by domain code, not by the WS
+client.
+
+Reconnect / heartbeat
+---------------------
+
+The server emits a periodic ``{"type": "ping"}`` so NAT / proxy idle
+timeouts cannot silently kill the socket. On the client side, the
+bell UI in :mod:`app.ui.layout.top_bar` reconnects with a 5-second
+backoff on close. The existing 30 s polling endpoint
+(``/api/notifications/unread-count``) is retained as a fallback so a
+WS-disconnect-storm does not leave the bell stale.
+
+FastHTML param-resolver discipline (root cause of #802)
+-------------------------------------------------------
+
+* ``send`` / ``scope`` MUST NOT be annotated on FastHTML WS
+  connect/disconnect/receive hooks. ``_find_p`` only resolves these
+  special WS names in its ``if anno is empty:`` branch.
+* ``msg`` is declared ``dict`` in source for static analysis, and the
+  ``__annotations__['msg'] = dict`` override below makes FastHTML's
+  identity-based ``if anno is dict`` check pass at runtime (PEP-563
+  would otherwise stringify the annotation and break the resolver).
+
+See ``docs/2026-05-18-bugfix-plan.md`` Wave 3 for the full story.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+from http.cookies import SimpleCookie
+from typing import Any
+
+from app.auth.jwt_provider import JWTAuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat (same shape as chat/draft-status WS handlers — see #684 review)
+# ---------------------------------------------------------------------------
+
+_WS_HEARTBEAT_INTERVAL_SECONDS = 25.0
+_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS = 5.0
+
+
+def _start_heartbeat(send: Any) -> asyncio.Task[None]:
+    """Spawn a periodic ``{"type": "ping"}`` task for the lifetime of the
+    WS handler invocation. Self-terminates on the first send failure."""
+
+    async def _beat() -> None:
+        while True:
+            try:
+                await asyncio.sleep(_WS_HEARTBEAT_INTERVAL_SECONDS)
+                await asyncio.wait_for(
+                    send(json.dumps({"type": "ping"})),
+                    timeout=_WS_HEARTBEAT_SEND_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug(
+                    "notifications WS heartbeat send failed; terminating",
+                    exc_info=True,
+                )
+                return
+
+    return asyncio.create_task(_beat())
+
+
+# ---------------------------------------------------------------------------
+# Connection registry — module-level so notify() can push from anywhere
+# ---------------------------------------------------------------------------
+
+# ``user_id (str)`` → set of bound ``send`` callables. Multiple tabs for
+# the same user produce multiple entries. The registry is protected by
+# ``_registry_lock`` because :func:`push_to_user` may be invoked from a
+# background worker thread (notify is called fire-and-forget from job
+# handlers and synchronous domain code), so we need thread-safe access
+# to the set.
+_connections: dict[str, set[Any]] = {}
+_registry_lock = threading.Lock()
+
+# The event loop running the FastHTML ASGI app. Captured by
+# :func:`register_event_loop` from the lifespan hook so background-thread
+# callers of :func:`push_to_user` can schedule a coroutine on the right
+# loop via ``asyncio.run_coroutine_threadsafe``.
+_event_loop: asyncio.AbstractEventLoop | None = None
+
+
+def register_event_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Remember the FastHTML ASGI event loop.
+
+    Called once from the lifespan hook so :func:`push_to_user` can
+    schedule pushes from a non-async background thread (notify() is
+    fire-and-forget and may run inside the job worker).
+    """
+    global _event_loop
+    _event_loop = loop
+
+
+def _add_connection(user_id: str, send: Any) -> None:
+    """Register *send* as an active socket for *user_id*."""
+    with _registry_lock:
+        _connections.setdefault(user_id, set()).add(send)
+
+
+def _remove_connection(user_id: str, send: Any) -> None:
+    """Drop *send* from *user_id*'s socket set; drop the entry when empty."""
+    with _registry_lock:
+        sends = _connections.get(user_id)
+        if sends is None:
+            return
+        sends.discard(send)
+        if not sends:
+            _connections.pop(user_id, None)
+
+
+def _snapshot_connections(user_id: str) -> list[Any]:
+    """Return a snapshot of *user_id*'s current sockets.
+
+    Snapshotting under the lock lets the caller iterate without
+    blocking other connect/disconnect mutations.
+    """
+    with _registry_lock:
+        sends = _connections.get(user_id)
+        if not sends:
+            return []
+        return list(sends)
+
+
+async def _broadcast_async(user_id: str, payload: dict[str, Any]) -> None:
+    """Send *payload* to every live socket for *user_id*.
+
+    Dead sockets are removed from the registry on send failure so the
+    next broadcast does not re-attempt them.
+    """
+    sends = _snapshot_connections(user_id)
+    if not sends:
+        return
+
+    serialised = json.dumps(payload, default=str)
+    for send in sends:
+        try:
+            await send(serialised)
+        except Exception:
+            logger.debug(
+                "notifications WS send failed for user=%s; dropping socket",
+                user_id,
+                exc_info=True,
+            )
+            _remove_connection(user_id, send)
+
+
+def push_to_user(user_id: Any, payload: dict[str, Any]) -> None:
+    """Fire-and-forget push of *payload* to every socket owned by *user_id*.
+
+    Safe to call from sync code (e.g. ``notify()`` running in a
+    background worker thread) — if the FastHTML event loop has been
+    registered via :func:`register_event_loop` we schedule the
+    broadcast coroutine on it via
+    ``asyncio.run_coroutine_threadsafe``. If we are already inside an
+    async task on that loop we use ``create_task`` instead.
+
+    Never raises: errors are logged at DEBUG so notification creation
+    stays unobtrusive. The DB row has already been written by the
+    time the caller reaches this function — the push is a courtesy
+    on top of the durable record, not a substitute for it.
+    """
+    user_id_str = str(user_id)
+
+    # Fast path: nothing to do if nobody is connected.
+    if not _snapshot_connections(user_id_str):
+        return
+
+    try:
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+
+        if running is not None:
+            # We are on an event loop already — schedule directly.
+            running.create_task(_broadcast_async(user_id_str, payload))
+            return
+
+        # We are on a thread with no running loop. Hop onto the
+        # registered FastHTML loop if we have one.
+        if _event_loop is not None and not _event_loop.is_closed():
+            asyncio.run_coroutine_threadsafe(
+                _broadcast_async(user_id_str, payload),
+                _event_loop,
+            )
+            return
+
+        # Nothing to schedule against — log and drop. The DB row is
+        # still there, so the next poll / page load will pick it up.
+        logger.debug(
+            "notifications WS push: no event loop registered; "
+            "user=%s will rely on polling fallback",
+            user_id_str,
+        )
+    except Exception:
+        logger.debug(
+            "notifications WS push failed for user=%s",
+            user_id_str,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cookie helpers (same shape as chat/draft-status WS)
+# ---------------------------------------------------------------------------
+
+
+def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) -> str | None:
+    """Parse the ``Cookie`` header from raw ASGI *headers* and return the value for *name*."""
+    for hdr_name, hdr_value in headers:
+        if hdr_name.lower() == b"cookie":
+            cookie: SimpleCookie = SimpleCookie()
+            cookie.load(hdr_value.decode("latin-1"))
+            morsel = cookie.get(name)
+            if morsel is not None:
+                return morsel.value
+    return None
+
+
+async def _ws_close(send: Any, code: int, reason: str) -> None:
+    """Best-effort WS close. Mirrors the chat module's helper."""
+    try:
+        await send({"type": "websocket.close", "code": code, "reason": reason})
+    except Exception:
+        try:
+            await send(json.dumps({"type": "error", "message": reason, "code": code}))
+        except Exception:
+            logger.debug("notifications WS close fallback failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Inner message handler — exposed for unit tests
+# ---------------------------------------------------------------------------
+
+
+async def ws_notifications(
+    msg: str,
+    send: Any,
+    scope: dict[str, Any] | None = None,
+) -> None:
+    """Handle one client message on ``/ws/notifications``.
+
+    This is largely a push-only channel: the server emits events when
+    :func:`push_to_user` runs. The only meaningful client message is
+    an optional ``{"type": "ping"}`` keepalive that the handler replies
+    to with ``{"type": "pong"}``. Any other (or invalid) message is
+    silently ignored — keeping the channel forwards-compatible if we
+    later add ``ack`` or ``mark_read`` events.
+
+    Auth is extracted by the wrapper in
+    :func:`register_notifications_ws_routes`; this handler trusts
+    ``scope['auth']`` to be set on success.
+    """
+    try:
+        data = json.loads(msg)
+    except (json.JSONDecodeError, TypeError):
+        # Silently ignore malformed input — push-only channel; client
+        # never *needs* to send anything.
+        return
+
+    if not isinstance(data, dict):
+        return
+
+    if data.get("type") == "ping":
+        try:
+            await send(json.dumps({"type": "pong"}))
+        except Exception:
+            logger.debug("notifications WS pong send failed", exc_info=True)
+        return
+
+    # Unknown message types are silently ignored.
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_notifications_ws_routes(app: Any) -> None:
+    """Mount the notifications WS at ``/ws/notifications``.
+
+    Mirrors :func:`app.chat.websocket.register_chat_ws_routes`: a
+    wrapper does cookie-based JWT auth on each invocation, then
+    delegates the message body to :func:`ws_notifications`. The
+    per-connection registry entry is added in the ``conn`` hook and
+    removed in the ``disconn`` hook so that pushes from
+    :func:`push_to_user` reach every live tab the user has open.
+
+    Note: ``/ws/notifications`` is deliberately **not** added to
+    ``SKIP_PATHS`` — the WS handshake does not go through the HTTP
+    Beforeware. Auth is handled inline by extracting the
+    ``access_token`` cookie from the raw ASGI headers below.
+    """
+    _jwt_provider: list[JWTAuthProvider | None] = [None]
+
+    def _get_jwt_provider() -> JWTAuthProvider | None:
+        """Lazily construct the shared JWT provider.
+
+        Returns ``None`` on construction failure so callers can
+        fail-closed (#594.4).
+        """
+        if _jwt_provider[0] is None:
+            try:
+                _jwt_provider[0] = JWTAuthProvider()
+            except Exception:
+                logger.error(
+                    "notifications WS: failed to construct JWTAuthProvider",
+                    exc_info=True,
+                )
+                return None
+        return _jwt_provider[0]
+
+    def _auth_from_scope(scope: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Verify the JWT cookie carried on the WS handshake.
+
+        Returns the user dict on success, ``None`` when the request
+        is unauthenticated. Mirrors the silent-refresh contract used
+        by ``/ws/chat`` (see #637).
+        """
+        if scope is None:
+            return None
+        raw_headers: list[tuple[bytes, bytes]] = scope.get("headers", [])
+        access_token = _extract_cookie_from_headers(raw_headers, "access_token")
+        refresh_token = _extract_cookie_from_headers(raw_headers, "refresh_token")
+
+        if not (access_token or refresh_token):
+            return None
+
+        provider = _get_jwt_provider()
+        if provider is None:
+            return None
+
+        user: dict[str, Any] | None = None
+        if access_token:
+            verified = provider.get_current_user(access_token)
+            if verified is not None:
+                user = dict(verified)
+
+        if user is None and refresh_token:
+            # Verify-only refresh — same shape as chat/draft-status
+            # (#637). The WS upgrade response cannot persist rotated
+            # cookies; the next HTTP request will rotate atomically.
+            from app.auth.middleware import verify_refresh_token_user
+
+            refreshed_user = verify_refresh_token_user(refresh_token, provider=provider)
+            if refreshed_user is not None:
+                user = refreshed_user
+
+        return user
+
+    # IMPORTANT: do NOT annotate ``send``. See #802 / chat module for
+    # the FastHTML ``_find_p`` trap that motivates the missing
+    # annotation on the WS lifecycle hooks.
+    async def _on_connect(send, scope=None) -> None:
+        """Register the socket in the per-user pool on handshake.
+
+        The ``scope`` parameter is FastHTML-supplied; we pass it
+        through ``_auth_from_scope`` to identify the user. An
+        unauthenticated handshake is closed with code 1008 so the
+        client knows to redirect to login rather than silently
+        retrying.
+        """
+        user = _auth_from_scope(scope)
+        if user is None or not user.get("id"):
+            await _ws_close(send, 1008, "authentication required")
+            return
+
+        user_id = str(user["id"])
+        _add_connection(user_id, send)
+        try:
+            await send(json.dumps({"type": "connected"}))
+        except Exception:
+            # Failed to emit the greet event — drop the freshly-added
+            # socket so we don't leak it in the registry.
+            _remove_connection(user_id, send)
+            logger.debug("notifications WS greet send failed", exc_info=True)
+
+    async def _on_disconnect(send) -> None:
+        """Remove the socket from every user pool it might belong to.
+
+        We don't have direct access to the user_id at disconnect time
+        (FastHTML's disconnect hook only receives ``send``), so we
+        scan the registry for any entry containing this ``send``.
+        With at most a few hundred concurrent users this is
+        negligible; if the user count grows we can swap in a
+        reverse index (``send -> user_id``) without changing the
+        wire protocol.
+        """
+        with _registry_lock:
+            empty_users: list[str] = []
+            for user_id, sends in _connections.items():
+                if send in sends:
+                    sends.discard(send)
+                    if not sends:
+                        empty_users.append(user_id)
+            for user_id in empty_users:
+                _connections.pop(user_id, None)
+
+    # IMPORTANT — FastHTML param resolution:
+    #   * ``send`` / ``scope`` MUST be unannotated (see chat module).
+    #   * ``msg`` is declared ``dict`` for readability + static
+    #     analysis; the ``__annotations__['msg'] = dict`` override
+    #     below makes FastHTML's identity-based resolver inject the
+    #     parsed payload (PEP-563 otherwise stringifies the
+    #     annotation and breaks the check).
+    async def _ws_handler(msg: dict, send, scope=None) -> None:
+        # Heartbeat scoped to one handler invocation, mirroring the
+        # chat/draft-status pattern (#684 review).
+        heartbeat = _start_heartbeat(send)
+        try:
+            msg_str = json.dumps(msg) if isinstance(msg, dict) else msg
+            await ws_notifications(msg_str, send, scope)
+        finally:
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    # See chat module: PEP-563 stringifies ``msg: dict`` at runtime;
+    # FastHTML's ``_find_p`` does ``if anno is dict`` (identity), so
+    # we have to set the *real* type at runtime.
+    _ws_handler.__annotations__["msg"] = dict
+
+    app.ws("/ws/notifications", conn=_on_connect, disconn=_on_disconnect)(_ws_handler)

--- a/app/notifications/websocket.py
+++ b/app/notifications/websocket.py
@@ -248,15 +248,59 @@ def _extract_cookie_from_headers(headers: list[tuple[bytes, bytes]], name: str) 
     return None
 
 
-async def _ws_close(send: Any, code: int, reason: str) -> None:
-    """Best-effort WS close. Mirrors the chat module's helper."""
+async def _ws_close(ws: Any, code: int, reason: str) -> None:
+    """Best-effort WS close that actually closes the underlying ASGI socket.
+
+    FastHTML's ``send`` parameter exposed to WS hooks is
+    ``partial(_send_ws, conn)`` — i.e. the dict gets fed through
+    ``to_xml`` and ultimately ``ws.send_text``. Trying to close by
+    sending ``{"type": "websocket.close", ...}`` through ``send``
+    therefore produces a regular text frame and leaves the connection
+    open. We have to call ``ws.close()`` on the raw Starlette
+    WebSocket conn (exposed by FastHTML via the unannotated ``ws``
+    parameter on WS hooks).
+    """
+    if ws is None:
+        # Defensive: the caller forgot to pass the conn. Nothing we can
+        # do here other than log so a future regression is visible.
+        logger.debug("notifications WS close requested without ws conn")
+        return
     try:
-        await send({"type": "websocket.close", "code": code, "reason": reason})
+        await ws.close(code=code, reason=reason)
     except Exception:
-        try:
-            await send(json.dumps({"type": "error", "message": reason, "code": code}))
-        except Exception:
-            logger.debug("notifications WS close fallback failed", exc_info=True)
+        logger.debug("notifications WS close failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Per-connection heartbeat registry
+# ---------------------------------------------------------------------------
+# We key by ``id(ws)`` (the Starlette WebSocket conn) rather than
+# ``id(send)`` because FastHTML rebuilds the ``send`` partial on every
+# WS hook invocation (``partial(_send_ws, conn)`` inside ``_find_p``),
+# so ``id(send)`` differs between ``_on_connect`` and ``_on_disconnect``
+# even though the underlying physical connection is the same. The
+# ``ws`` (conn) IS the same object across all hooks for one socket
+# (see Starlette's ``WebSocketEndpoint.dispatch`` which forwards the
+# same ``WebSocket`` to ``on_connect``/``on_disconnect``/``on_receive``).
+
+_heartbeats: dict[int, asyncio.Task[None]] = {}
+_heartbeats_lock = threading.Lock()
+
+
+def _register_heartbeat(ws_id: int, task: asyncio.Task[None]) -> None:
+    with _heartbeats_lock:
+        # Cancel any pre-existing task under this key (defensive — a
+        # mis-ordered conn/disconn could leave a stale task).
+        old = _heartbeats.pop(ws_id, None)
+    if old is not None and not old.done():
+        old.cancel()
+    with _heartbeats_lock:
+        _heartbeats[ws_id] = task
+
+
+def _pop_heartbeat(ws_id: int) -> asyncio.Task[None] | None:
+    with _heartbeats_lock:
+        return _heartbeats.pop(ws_id, None)
 
 
 # ---------------------------------------------------------------------------
@@ -379,21 +423,30 @@ def register_notifications_ws_routes(app: Any) -> None:
 
         return user
 
-    # IMPORTANT: do NOT annotate ``send``. See #802 / chat module for
-    # the FastHTML ``_find_p`` trap that motivates the missing
-    # annotation on the WS lifecycle hooks.
-    async def _on_connect(send, scope=None) -> None:
-        """Register the socket in the per-user pool on handshake.
+    # IMPORTANT: do NOT annotate ``send``/``scope``/``ws``. See #802
+    # / chat module for the FastHTML ``_find_p`` trap — only the
+    # empty-annotation branch resolves these special WS parameter
+    # names. ``ws`` binds to the raw Starlette WebSocket conn (see
+    # ``fasthtml/core.py``: ``if arg.lower()=='ws' … return conn``).
+    async def _on_connect(send, scope=None, ws=None) -> None:
+        """Authenticate the handshake, register the socket, send the
+        greet event, and start the heartbeat.
 
-        The ``scope`` parameter is FastHTML-supplied; we pass it
-        through ``_auth_from_scope`` to identify the user. An
-        unauthenticated handshake is closed with code 1008 so the
-        client knows to redirect to login rather than silently
-        retrying.
+        Auth + heartbeat live HERE rather than in ``_ws_handler``
+        because this is a **push-only** channel: the top-bar bell
+        only opens the socket and listens for server-side
+        ``notification`` events, so ``_ws_handler`` (called on
+        inbound messages) never runs in production. If we deferred
+        auth or heartbeat to that path, neither would ever execute.
+
+        An unauthenticated handshake is closed with code 1008. The
+        close MUST go through ``ws.close()`` (not ``send`` — see
+        :func:`_ws_close` for why) so the underlying ASGI socket is
+        actually terminated rather than receiving a stray text frame.
         """
         user = _auth_from_scope(scope)
         if user is None or not user.get("id"):
-            await _ws_close(send, 1008, "authentication required")
+            await _ws_close(ws, 1008, "authentication required")
             return
 
         user_id = str(user["id"])
@@ -405,18 +458,37 @@ def register_notifications_ws_routes(app: Any) -> None:
             # socket so we don't leak it in the registry.
             _remove_connection(user_id, send)
             logger.debug("notifications WS greet send failed", exc_info=True)
+            return
 
-    async def _on_disconnect(send) -> None:
-        """Remove the socket from every user pool it might belong to.
+        # Heartbeat scoped to the WS lifetime. Push-only channel, so
+        # ``_ws_handler`` (the only place a per-message heartbeat
+        # could live) never runs — without spawning here the 25 s
+        # NAT-keepalive contract documented in the module header
+        # would silently never fire.
+        if ws is not None:
+            task = _start_heartbeat(send)
+            _register_heartbeat(id(ws), task)
 
-        We don't have direct access to the user_id at disconnect time
-        (FastHTML's disconnect hook only receives ``send``), so we
-        scan the registry for any entry containing this ``send``.
-        With at most a few hundred concurrent users this is
-        negligible; if the user count grows we can swap in a
-        reverse index (``send -> user_id``) without changing the
+    async def _on_disconnect(send, ws=None) -> None:
+        """Cancel the heartbeat and remove the socket from every
+        user pool it might belong to.
+
+        We don't have direct access to the user_id at disconnect
+        time (FastHTML's disconnect hook only receives ``send`` and
+        ``ws``), so we scan the registry for any entry containing
+        this ``send``. With at most a few hundred concurrent users
+        this is negligible; if the user count grows we can swap in
+        a reverse index (``send -> user_id``) without changing the
         wire protocol.
         """
+        if ws is not None:
+            task = _pop_heartbeat(id(ws))
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
         with _registry_lock:
             empty_users: list[str] = []
             for user_id, sends in _connections.items():
@@ -435,18 +507,12 @@ def register_notifications_ws_routes(app: Any) -> None:
     #     parsed payload (PEP-563 otherwise stringifies the
     #     annotation and breaks the check).
     async def _ws_handler(msg: dict, send, scope=None) -> None:
-        # Heartbeat scoped to one handler invocation, mirroring the
-        # chat/draft-status pattern (#684 review).
-        heartbeat = _start_heartbeat(send)
-        try:
-            msg_str = json.dumps(msg) if isinstance(msg, dict) else msg
-            await ws_notifications(msg_str, send, scope)
-        finally:
-            heartbeat.cancel()
-            try:
-                await heartbeat
-            except (asyncio.CancelledError, Exception):
-                pass
+        # NOTE: heartbeat lives in ``_on_connect`` for the lifetime
+        # of the WS, NOT here. This handler only runs when the
+        # client sends a message (e.g. a ``ping`` keepalive), which
+        # is the rare case for this push-only channel.
+        msg_str = json.dumps(msg) if isinstance(msg, dict) else msg
+        await ws_notifications(msg_str, send, scope)
 
     # See chat module: PEP-563 stringifies ``msg: dict`` at runtime;
     # FastHTML's ``_find_p`` does ``if anno is dict`` (identity), so

--- a/app/ui/layout/top_bar.py
+++ b/app/ui/layout/top_bar.py
@@ -24,6 +24,70 @@ from app.auth.provider import UserDict
 from app.ui.components.global_search import GlobalSearchBar, GlobalSearchMobileButton
 from app.ui.forms.app_form import AppForm
 
+# Inline JS for the notification bell. Extracted to a module-level
+# constant so the FT component stays readable. The script runs once on
+# DOM ready and opens a WebSocket to ``/ws/notifications`` for
+# real-time badge updates (#180); the existing 30 s polling endpoint is
+# kept as a fallback. The dropdown toggle is handled here too because
+# it depends on the same DOM subtree.
+_NOTIFICATION_BELL_JS = """
+document.addEventListener('click', function (e) {
+    var bell = document.querySelector('.notification-bell');
+    var dropdown = document.getElementById('notification-dropdown');
+    if (dropdown && bell && !bell.contains(e.target)) {
+        dropdown.replaceChildren();
+        dropdown.classList.remove('notification-dropdown--open');
+    }
+    if (dropdown && bell && bell.contains(e.target)) {
+        dropdown.classList.toggle('notification-dropdown--open');
+    }
+});
+
+(function () {
+    if (typeof window === 'undefined' || !('WebSocket' in window)) return;
+    var reconnectDelay = 5000;
+    var ws = null;
+    function bumpBadge() {
+        var badge = document.getElementById('bell-badge');
+        if (!badge) return;
+        var current = parseInt(badge.textContent || '0', 10);
+        if (isNaN(current)) current = 0;
+        var next = current + 1;
+        badge.textContent = next < 100 ? String(next) : '99+';
+        badge.classList.remove('bell-badge--hidden');
+    }
+    function connect() {
+        var proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        try {
+            ws = new WebSocket(proto + '//' + window.location.host + '/ws/notifications');
+        } catch (e) {
+            setTimeout(connect, reconnectDelay);
+            return;
+        }
+        ws.addEventListener('message', function (ev) {
+            var data;
+            try { data = JSON.parse(ev.data); } catch (e) { return; }
+            if (!data || data.type !== 'notification') return;
+            bumpBadge();
+            var poll = document.getElementById('bell-poll');
+            if (poll && window.htmx) { window.htmx.trigger(poll, 'refresh'); }
+        });
+        ws.addEventListener('close', function () {
+            ws = null;
+            setTimeout(connect, reconnectDelay);
+        });
+        ws.addEventListener('error', function () {
+            try { if (ws) ws.close(); } catch (e) {}
+        });
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', connect);
+    } else {
+        connect();
+    }
+})();
+"""
+
 
 def UserMenu(user: UserDict | None):  # noqa: ANN201
     """User dropdown menu in the topbar."""
@@ -67,7 +131,9 @@ def _bell_badge(unread_count: int):  # noqa: ANN201
 def NotificationBell(unread_count: int = 0):  # noqa: ANN201
     """Bell icon with unread count badge and HTMX-powered dropdown.
 
-    - Polls ``/api/notifications/unread-count`` every 30s to update the badge.
+    - Opens ``/ws/notifications`` for real-time badge updates (#180).
+    - Polls ``/api/notifications/unread-count`` every 30s as a fallback
+      so a dropped WS does not leave the badge stale.
     - Click toggles a dropdown loaded via ``hx_get="/api/notifications?limit=5"``.
     """
     return Div(  # noqa: F405
@@ -84,31 +150,19 @@ def NotificationBell(unread_count: int = 0):  # noqa: ANN201
             hx_trigger="click",
         ),
         Div(id="notification-dropdown", cls="notification-dropdown"),  # noqa: F405
-        # Badge poll: swap just the badge span every 30 seconds.
+        # Badge poll: swap just the badge span every 30 seconds. Kept
+        # as a fallback so a dropped or proxied-down WebSocket does
+        # not leave the badge stale (#180).
         Span(  # noqa: F405
             hx_get="/api/notifications/unread-count",
-            hx_trigger="load, every 30s",
+            hx_trigger="load, every 30s, refresh",
             hx_swap="none",
             # The endpoint returns an OOB-swapped badge span that
             # replaces #bell-badge in-place regardless of hx_swap.
             id="bell-poll",
             cls="hidden",
         ),
-        Script(  # noqa: F405
-            """
-            document.addEventListener('click', function(e) {
-                var bell = document.querySelector('.notification-bell');
-                var dropdown = document.getElementById('notification-dropdown');
-                if (dropdown && bell && !bell.contains(e.target)) {
-                    dropdown.innerHTML = '';
-                    dropdown.classList.remove('notification-dropdown--open');
-                }
-                if (dropdown && bell && bell.contains(e.target)) {
-                    dropdown.classList.toggle('notification-dropdown--open');
-                }
-            });
-            """
-        ),
+        Script(_NOTIFICATION_BELL_JS),  # noqa: F405
         cls="notification-bell",
     )
 

--- a/tests/test_notifications_websocket.py
+++ b/tests/test_notifications_websocket.py
@@ -45,6 +45,21 @@ class _Collector:
         self.sent.append(data)
 
 
+class _FakeWs:
+    """Minimal stand-in for the Starlette WebSocket conn that
+    FastHTML hands to WS hooks via the ``ws`` parameter. Only
+    ``close(code, reason)`` is exercised by the lifecycle code."""
+
+    def __init__(self) -> None:
+        self.close_calls: list[tuple[int, str]] = []
+        self.close_raises: BaseException | None = None
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        if self.close_raises is not None:
+            raise self.close_raises
+        self.close_calls.append((code, reason))
+
+
 def _build_user(user_id: str = _USER_A) -> dict[str, Any]:
     return {
         "id": user_id,
@@ -82,12 +97,20 @@ def _scope_with_cookie(token: str = "access-token-value") -> dict[str, Any]:
 
 @pytest.fixture(autouse=True)
 def _reset_registry():
-    """Wipe the module-level connection registry between tests."""
+    """Wipe the module-level connection + heartbeat registries between tests."""
     with notif_ws._registry_lock:
         notif_ws._connections.clear()
+    with notif_ws._heartbeats_lock:
+        for task in list(notif_ws._heartbeats.values()):
+            task.cancel()
+        notif_ws._heartbeats.clear()
     yield
     with notif_ws._registry_lock:
         notif_ws._connections.clear()
+    with notif_ws._heartbeats_lock:
+        for task in list(notif_ws._heartbeats.values()):
+            task.cancel()
+        notif_ws._heartbeats.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -345,13 +368,14 @@ class TestConnectLifecycle:
     def test_authenticated_connect_registers_socket(self):
         on_conn, _on_disconn, _handler = _capture_handlers()
         collector = _Collector()
+        ws = _FakeWs()
 
         with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
             mock_jwt = MagicMock()
             mock_jwt.get_current_user.return_value = _build_user(_USER_A)
             mock_jwt_cls.return_value = mock_jwt
 
-            asyncio.run(on_conn(collector, _scope_with_cookie()))
+            asyncio.run(on_conn(collector, _scope_with_cookie(), ws))
 
         # Socket is registered under the authenticated user.
         with notif_ws._registry_lock:
@@ -363,28 +387,80 @@ class TestConnectLifecycle:
             isinstance(s, str) and json.loads(s).get("type") == "connected" for s in collector.sent
         )
 
+        # And we do NOT close the socket on a successful auth.
+        assert ws.close_calls == []
+
+    def test_authenticated_connect_starts_heartbeat_for_push_only_channel(self):
+        """The bell UI is push-only — _ws_handler never runs in
+        production because the client doesn't send messages. The
+        heartbeat MUST therefore be started from _on_connect (keyed
+        by id(ws)) or NAT idle timeouts silently kill the socket.
+        """
+        on_conn, _on_disconn, _handler = _capture_handlers()
+        collector = _Collector()
+        ws = _FakeWs()
+
+        # Capture the task state *inside* the event loop — asyncio.run
+        # cancels all pending tasks when the loop closes, so checking
+        # done()/cancelled() from outside would always look cancelled.
+        captured: dict[str, Any] = {}
+
+        async def _run() -> None:
+            await on_conn(collector, _scope_with_cookie(), ws)
+            with notif_ws._heartbeats_lock:
+                captured["registered_id"] = id(ws) in notif_ws._heartbeats
+                captured["task"] = notif_ws._heartbeats.get(id(ws))
+
+        with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
+            mock_jwt = MagicMock()
+            mock_jwt.get_current_user.return_value = _build_user(_USER_A)
+            mock_jwt_cls.return_value = mock_jwt
+
+            asyncio.run(_run())
+
+        assert captured["registered_id"] is True
+        # The task was alive when we captured it (the lifetime check
+        # happens inside the loop where asyncio.run hasn't yet
+        # cancelled outstanding tasks).
+        task = captured["task"]
+        assert task is not None
+        assert isinstance(task, asyncio.Task)
+
     def test_unauthenticated_connect_closes_socket_with_1008(self):
+        """The unauthenticated handshake MUST actually close the
+        underlying WebSocket (via ws.close), not just send a
+        ``{"type": "websocket.close"}`` dict through FastHTML's
+        ``send`` wrapper — that wrapper routes through to_xml +
+        ws.send_text and leaves the connection open in production.
+        """
         on_conn, _on_disconn, _handler = _capture_handlers()
         sent: list[Any] = []
+        ws = _FakeWs()
 
         async def raw_send(data: Any) -> None:
             sent.append(data)
 
         # Empty scope = no cookie = no auth.
-        asyncio.run(on_conn(raw_send, {"headers": []}))
+        asyncio.run(on_conn(raw_send, {"headers": []}, ws))
 
-        close_frames = [
+        # Verify the close went through ws.close() with code 1008.
+        assert ws.close_calls == [(1008, "authentication required")]
+        # And NOT through `send` as a text frame.
+        close_frames_via_send = [
             d for d in sent if isinstance(d, dict) and d.get("type") == "websocket.close"
         ]
-        assert len(close_frames) == 1
-        assert close_frames[0]["code"] == 1008
-        # No connection was registered.
+        assert close_frames_via_send == []
+
+        # No connection was registered and no heartbeat was spawned.
         with notif_ws._registry_lock:
             assert notif_ws._connections == {}
+        with notif_ws._heartbeats_lock:
+            assert id(ws) not in notif_ws._heartbeats
 
     def test_invalid_jwt_closes_socket_and_skips_registration(self):
         on_conn, _on_disconn, _handler = _capture_handlers()
         sent: list[Any] = []
+        ws = _FakeWs()
 
         async def raw_send(data: Any) -> None:
             sent.append(data)
@@ -394,12 +470,10 @@ class TestConnectLifecycle:
             mock_jwt.get_current_user.return_value = None  # invalid token
             mock_jwt_cls.return_value = mock_jwt
 
-            asyncio.run(on_conn(raw_send, _scope_with_cookie("bad-token")))
+            asyncio.run(on_conn(raw_send, _scope_with_cookie("bad-token"), ws))
 
-        close_frames = [
-            d for d in sent if isinstance(d, dict) and d.get("type") == "websocket.close"
-        ]
-        assert len(close_frames) == 1
+        # Real ASGI close via ws.close, not a text frame masquerade.
+        assert ws.close_calls == [(1008, "authentication required")]
         with notif_ws._registry_lock:
             assert notif_ws._connections == {}
 
@@ -408,23 +482,50 @@ class TestDisconnectLifecycle:
     def test_disconnect_removes_socket_from_user_pool(self):
         on_conn, on_disconn, _handler = _capture_handlers()
         collector = _Collector()
+        ws = _FakeWs()
 
         with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
             mock_jwt = MagicMock()
             mock_jwt.get_current_user.return_value = _build_user(_USER_A)
             mock_jwt_cls.return_value = mock_jwt
 
-            asyncio.run(on_conn(collector, _scope_with_cookie()))
+            asyncio.run(on_conn(collector, _scope_with_cookie(), ws))
 
         with notif_ws._registry_lock:
             assert collector in notif_ws._connections[_USER_A]
 
-        # Now disconnect.
-        asyncio.run(on_disconn(collector))
+        # Now disconnect — pass the same ws so the heartbeat lookup hits.
+        asyncio.run(on_disconn(collector, ws))
 
         # The user's entry should be gone entirely (it was the only tab).
         with notif_ws._registry_lock:
             assert _USER_A not in notif_ws._connections
+
+    def test_disconnect_cancels_heartbeat_task(self):
+        """Disconnect must cancel the heartbeat that _on_connect spawned,
+        otherwise the task leaks past the connection lifetime."""
+        on_conn, on_disconn, _handler = _capture_handlers()
+        collector = _Collector()
+        ws = _FakeWs()
+
+        with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
+            mock_jwt = MagicMock()
+            mock_jwt.get_current_user.return_value = _build_user(_USER_A)
+            mock_jwt_cls.return_value = mock_jwt
+
+            async def _run() -> asyncio.Task[None]:
+                await on_conn(collector, _scope_with_cookie(), ws)
+                with notif_ws._heartbeats_lock:
+                    task = notif_ws._heartbeats[id(ws)]
+                await on_disconn(collector, ws)
+                return task
+
+            task = asyncio.run(_run())
+
+        # The heartbeat task was cancelled and removed from the registry.
+        assert task.cancelled() or task.done()
+        with notif_ws._heartbeats_lock:
+            assert id(ws) not in notif_ws._heartbeats
 
     def test_disconnect_only_removes_the_specific_tab(self):
         """When the user has two tabs and one disconnects, the other
@@ -433,22 +534,29 @@ class TestDisconnectLifecycle:
 
         tab1 = _Collector()
         tab2 = _Collector()
+        ws1 = _FakeWs()
+        ws2 = _FakeWs()
 
         with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
             mock_jwt = MagicMock()
             mock_jwt.get_current_user.return_value = _build_user(_USER_A)
             mock_jwt_cls.return_value = mock_jwt
 
-            asyncio.run(on_conn(tab1, _scope_with_cookie()))
-            asyncio.run(on_conn(tab2, _scope_with_cookie()))
+            asyncio.run(on_conn(tab1, _scope_with_cookie(), ws1))
+            asyncio.run(on_conn(tab2, _scope_with_cookie(), ws2))
 
         # Disconnect only tab1.
-        asyncio.run(on_disconn(tab1))
+        asyncio.run(on_disconn(tab1, ws1))
 
         with notif_ws._registry_lock:
             assert _USER_A in notif_ws._connections
             assert tab1 not in notif_ws._connections[_USER_A]
             assert tab2 in notif_ws._connections[_USER_A]
+
+        # Tab2's heartbeat is still alive.
+        with notif_ws._heartbeats_lock:
+            assert id(ws2) in notif_ws._heartbeats
+            assert id(ws1) not in notif_ws._heartbeats
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notifications_websocket.py
+++ b/tests/test_notifications_websocket.py
@@ -1,0 +1,499 @@
+"""Tests for ``app.notifications.websocket`` (#180).
+
+Covers the four DoD scenarios:
+
+1. ``push_to_user`` reaches every live socket for the target user.
+2. ``notify()`` inserts the row AND triggers a WS push for the user.
+3. Cross-user isolation — user A's notification does not push to user B.
+4. Disconnect cleanly drops the socket from the per-user pool.
+
+Same direct-handler test style as ``tests/test_chat_websocket.py`` and
+``tests/test_docs_websocket.py``: we drive ``_on_connect`` /
+``_on_disconnect`` / ``_ws_handler`` directly with a stub ``send`` and
+explicit ``scope`` instead of spinning up a full ASGI fixture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.notifications import websocket as notif_ws
+from app.notifications.models import Notification
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_USER_A = "11111111-1111-1111-1111-111111111111"
+_USER_B = "22222222-2222-2222-2222-222222222222"
+
+
+class _Collector:
+    """Async-compatible send collector with a ``close`` hook surrogate."""
+
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def __call__(self, data: Any) -> None:
+        self.sent.append(data)
+
+
+def _build_user(user_id: str = _USER_A) -> dict[str, Any]:
+    return {
+        "id": user_id,
+        "email": "test@riik.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": "33333333-3333-3333-3333-333333333333",
+    }
+
+
+def _capture_handlers() -> tuple[Any, Any, Any]:
+    """Drive ``register_notifications_ws_routes`` against a fake app and
+    capture the connect / disconnect / message handlers."""
+    mock_app = MagicMock()
+    captured: dict[str, Any] = {}
+
+    def capture_ws(path, conn=None, disconn=None):
+        captured["conn"] = conn
+        captured["disconn"] = disconn
+
+        def decorator(fn):
+            captured["handler"] = fn
+            return fn
+
+        return decorator
+
+    mock_app.ws = capture_ws
+    notif_ws.register_notifications_ws_routes(mock_app)
+    return captured["conn"], captured["disconn"], captured["handler"]
+
+
+def _scope_with_cookie(token: str = "access-token-value") -> dict[str, Any]:
+    return {"headers": [(b"cookie", f"access_token={token}".encode())]}
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Wipe the module-level connection registry between tests."""
+    with notif_ws._registry_lock:
+        notif_ws._connections.clear()
+    yield
+    with notif_ws._registry_lock:
+        notif_ws._connections.clear()
+
+
+# ---------------------------------------------------------------------------
+# push_to_user — direct API (no scope / cookie required)
+# ---------------------------------------------------------------------------
+
+
+class TestPushToUser:
+    def test_push_reaches_single_registered_socket(self):
+        collector = _Collector()
+        notif_ws._add_connection(_USER_A, collector)
+
+        async def _run() -> None:
+            await notif_ws._broadcast_async(
+                _USER_A,
+                {"type": "notification", "id": "abc", "title": "Tere"},
+            )
+
+        asyncio.run(_run())
+
+        assert len(collector.sent) == 1
+        payload = json.loads(collector.sent[0])
+        assert payload["type"] == "notification"
+        assert payload["title"] == "Tere"
+
+    def test_push_reaches_multiple_tabs_for_same_user(self):
+        """Multiple tabs translate into multiple ``send`` callables in
+        the same user's pool. Every tab must receive the push."""
+        tab1 = _Collector()
+        tab2 = _Collector()
+        notif_ws._add_connection(_USER_A, tab1)
+        notif_ws._add_connection(_USER_A, tab2)
+
+        async def _run() -> None:
+            await notif_ws._broadcast_async(
+                _USER_A,
+                {"type": "notification", "id": "n1", "title": "Hei"},
+            )
+
+        asyncio.run(_run())
+
+        assert len(tab1.sent) == 1
+        assert len(tab2.sent) == 1
+
+    def test_push_to_user_handles_uuid_input(self):
+        """``push_to_user`` accepts UUID and string IDs interchangeably."""
+        collector = _Collector()
+        user_uuid = uuid.UUID(_USER_A)
+        notif_ws._add_connection(str(user_uuid), collector)
+
+        async def _run() -> None:
+            await notif_ws._broadcast_async(
+                str(user_uuid),
+                {"type": "notification", "id": "n1"},
+            )
+
+        asyncio.run(_run())
+        assert len(collector.sent) == 1
+
+    def test_dead_socket_is_pruned_on_send_failure(self):
+        """A ``send`` that raises is dropped from the registry so the
+        next broadcast does not re-attempt it."""
+
+        class _ExplodingSend:
+            calls = 0
+
+            async def __call__(self, data: Any) -> None:
+                _ExplodingSend.calls += 1
+                raise RuntimeError("socket dead")
+
+        bomb = _ExplodingSend()
+        notif_ws._add_connection(_USER_A, bomb)
+
+        async def _run() -> None:
+            await notif_ws._broadcast_async(_USER_A, {"type": "notification"})
+
+        asyncio.run(_run())
+        # The dead socket was removed from the user's pool.
+        with notif_ws._registry_lock:
+            assert _USER_A not in notif_ws._connections
+
+    def test_push_to_empty_pool_is_noop(self):
+        """``push_to_user`` for an unknown user is a no-op (no raise)."""
+        notif_ws.push_to_user(_USER_A, {"type": "notification"})
+
+
+# ---------------------------------------------------------------------------
+# Cross-user isolation
+# ---------------------------------------------------------------------------
+
+
+class TestCrossUserIsolation:
+    def test_push_to_user_a_does_not_reach_user_b(self):
+        socket_a = _Collector()
+        socket_b = _Collector()
+        notif_ws._add_connection(_USER_A, socket_a)
+        notif_ws._add_connection(_USER_B, socket_b)
+
+        async def _run() -> None:
+            await notif_ws._broadcast_async(
+                _USER_A,
+                {"type": "notification", "title": "Ainult A-le"},
+            )
+
+        asyncio.run(_run())
+
+        assert len(socket_a.sent) == 1
+        # User B sees nothing.
+        assert socket_b.sent == []
+
+
+# ---------------------------------------------------------------------------
+# notify() integration — DB insert + WS push
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyIntegration:
+    def test_notify_inserts_row_and_pushes_to_socket(self):
+        """A successful ``notify()`` call must do TWO things:
+        1. Insert + commit the row.
+        2. Push the payload to every live socket for the user.
+        """
+        socket = _Collector()
+        notif_ws._add_connection(_USER_A, socket)
+
+        fake_notification = Notification(
+            id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            user_id=uuid.UUID(_USER_A),
+            type="analysis_done",
+            title="Mõjuanalüüs valmis",
+            body="Eelnõu mõjuanalüüs on valmis.",
+            link="/drafts/123/report",
+            metadata=None,
+            read=False,
+            created_at=datetime.now(UTC),
+        )
+
+        # ``push_to_user`` schedules the broadcast on the running loop
+        # via ``create_task``. We need to wait for that task to finish
+        # before asserting on the socket — so wrap the whole call in
+        # an async runner and add a short sleep.
+        async def _run() -> None:
+            from app.notifications.notify import notify as notify_fn
+
+            mock_conn = MagicMock()
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+            mock_ctx.__exit__ = MagicMock(return_value=None)
+
+            with (
+                patch("app.notifications.notify.get_connection", return_value=mock_ctx),
+                patch(
+                    "app.notifications.notify.create_notification",
+                    return_value=fake_notification,
+                ),
+            ):
+                notify_fn(
+                    user_id=_USER_A,
+                    type="analysis_done",
+                    title="Mõjuanalüüs valmis",
+                    body="Eelnõu mõjuanalüüs on valmis.",
+                    link="/drafts/123/report",
+                )
+                # Give the create_task() scheduled by push_to_user a
+                # chance to run before we assert.
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+            mock_conn.commit.assert_called_once()
+
+        asyncio.run(_run())
+
+        # WS push landed on the connected socket.
+        assert len(socket.sent) == 1, f"Expected 1 WS push, got: {socket.sent}"
+        payload = json.loads(socket.sent[0])
+        assert payload["type"] == "notification"
+        assert payload["title"] == "Mõjuanalüüs valmis"
+        assert payload["link"] == "/drafts/123/report"
+        assert payload["notification_type"] == "analysis_done"
+        assert payload["id"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+    def test_notify_to_user_a_does_not_push_to_user_b(self):
+        """End-to-end cross-user isolation through ``notify()``."""
+        socket_a = _Collector()
+        socket_b = _Collector()
+        notif_ws._add_connection(_USER_A, socket_a)
+        notif_ws._add_connection(_USER_B, socket_b)
+
+        fake = Notification(
+            id=uuid.uuid4(),
+            user_id=uuid.UUID(_USER_A),
+            type="analysis_done",
+            title="Privaatne",
+            body=None,
+            link=None,
+            metadata=None,
+            read=False,
+            created_at=datetime.now(UTC),
+        )
+
+        async def _run() -> None:
+            from app.notifications.notify import notify as notify_fn
+
+            mock_conn = MagicMock()
+            mock_ctx = MagicMock()
+            mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+            mock_ctx.__exit__ = MagicMock(return_value=None)
+
+            with (
+                patch("app.notifications.notify.get_connection", return_value=mock_ctx),
+                patch("app.notifications.notify.create_notification", return_value=fake),
+            ):
+                notify_fn(
+                    user_id=_USER_A,
+                    type="analysis_done",
+                    title="Privaatne",
+                )
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+        asyncio.run(_run())
+
+        assert len(socket_a.sent) == 1
+        assert socket_b.sent == []
+
+    def test_notify_db_failure_skips_push(self):
+        """When the DB write fails we must not push anything."""
+        socket = _Collector()
+        notif_ws._add_connection(_USER_A, socket)
+
+        async def _run() -> None:
+            from app.notifications.notify import notify as notify_fn
+
+            with patch(
+                "app.notifications.notify.get_connection",
+                side_effect=RuntimeError("db down"),
+            ):
+                notify_fn(
+                    user_id=_USER_A,
+                    type="analysis_done",
+                    title="Anyhow",
+                )
+                await asyncio.sleep(0)
+
+        asyncio.run(_run())
+        assert socket.sent == []
+
+
+# ---------------------------------------------------------------------------
+# Connect / disconnect lifecycle (via the FastHTML wrapper handlers)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectLifecycle:
+    def test_authenticated_connect_registers_socket(self):
+        on_conn, _on_disconn, _handler = _capture_handlers()
+        collector = _Collector()
+
+        with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
+            mock_jwt = MagicMock()
+            mock_jwt.get_current_user.return_value = _build_user(_USER_A)
+            mock_jwt_cls.return_value = mock_jwt
+
+            asyncio.run(on_conn(collector, _scope_with_cookie()))
+
+        # Socket is registered under the authenticated user.
+        with notif_ws._registry_lock:
+            assert _USER_A in notif_ws._connections
+            assert collector in notif_ws._connections[_USER_A]
+
+        # The greet event was sent.
+        assert any(
+            isinstance(s, str) and json.loads(s).get("type") == "connected" for s in collector.sent
+        )
+
+    def test_unauthenticated_connect_closes_socket_with_1008(self):
+        on_conn, _on_disconn, _handler = _capture_handlers()
+        sent: list[Any] = []
+
+        async def raw_send(data: Any) -> None:
+            sent.append(data)
+
+        # Empty scope = no cookie = no auth.
+        asyncio.run(on_conn(raw_send, {"headers": []}))
+
+        close_frames = [
+            d for d in sent if isinstance(d, dict) and d.get("type") == "websocket.close"
+        ]
+        assert len(close_frames) == 1
+        assert close_frames[0]["code"] == 1008
+        # No connection was registered.
+        with notif_ws._registry_lock:
+            assert notif_ws._connections == {}
+
+    def test_invalid_jwt_closes_socket_and_skips_registration(self):
+        on_conn, _on_disconn, _handler = _capture_handlers()
+        sent: list[Any] = []
+
+        async def raw_send(data: Any) -> None:
+            sent.append(data)
+
+        with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
+            mock_jwt = MagicMock()
+            mock_jwt.get_current_user.return_value = None  # invalid token
+            mock_jwt_cls.return_value = mock_jwt
+
+            asyncio.run(on_conn(raw_send, _scope_with_cookie("bad-token")))
+
+        close_frames = [
+            d for d in sent if isinstance(d, dict) and d.get("type") == "websocket.close"
+        ]
+        assert len(close_frames) == 1
+        with notif_ws._registry_lock:
+            assert notif_ws._connections == {}
+
+
+class TestDisconnectLifecycle:
+    def test_disconnect_removes_socket_from_user_pool(self):
+        on_conn, on_disconn, _handler = _capture_handlers()
+        collector = _Collector()
+
+        with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
+            mock_jwt = MagicMock()
+            mock_jwt.get_current_user.return_value = _build_user(_USER_A)
+            mock_jwt_cls.return_value = mock_jwt
+
+            asyncio.run(on_conn(collector, _scope_with_cookie()))
+
+        with notif_ws._registry_lock:
+            assert collector in notif_ws._connections[_USER_A]
+
+        # Now disconnect.
+        asyncio.run(on_disconn(collector))
+
+        # The user's entry should be gone entirely (it was the only tab).
+        with notif_ws._registry_lock:
+            assert _USER_A not in notif_ws._connections
+
+    def test_disconnect_only_removes_the_specific_tab(self):
+        """When the user has two tabs and one disconnects, the other
+        must remain registered."""
+        on_conn, on_disconn, _handler = _capture_handlers()
+
+        tab1 = _Collector()
+        tab2 = _Collector()
+
+        with patch("app.notifications.websocket.JWTAuthProvider") as mock_jwt_cls:
+            mock_jwt = MagicMock()
+            mock_jwt.get_current_user.return_value = _build_user(_USER_A)
+            mock_jwt_cls.return_value = mock_jwt
+
+            asyncio.run(on_conn(tab1, _scope_with_cookie()))
+            asyncio.run(on_conn(tab2, _scope_with_cookie()))
+
+        # Disconnect only tab1.
+        asyncio.run(on_disconn(tab1))
+
+        with notif_ws._registry_lock:
+            assert _USER_A in notif_ws._connections
+            assert tab1 not in notif_ws._connections[_USER_A]
+            assert tab2 in notif_ws._connections[_USER_A]
+
+
+# ---------------------------------------------------------------------------
+# Message handler (ping/pong + silent-ignore for unknown messages)
+# ---------------------------------------------------------------------------
+
+
+class TestWsNotificationsHandler:
+    def test_ping_message_yields_pong(self):
+        collector = _Collector()
+        asyncio.run(notif_ws.ws_notifications(json.dumps({"type": "ping"}), collector))
+        assert len(collector.sent) == 1
+        payload = json.loads(collector.sent[0])
+        assert payload["type"] == "pong"
+
+    def test_unknown_message_silently_ignored(self):
+        collector = _Collector()
+        asyncio.run(notif_ws.ws_notifications(json.dumps({"type": "future-thing"}), collector))
+        assert collector.sent == []
+
+    def test_invalid_json_silently_ignored(self):
+        collector = _Collector()
+        asyncio.run(notif_ws.ws_notifications("not-json{", collector))
+        assert collector.sent == []
+
+    def test_non_dict_payload_silently_ignored(self):
+        collector = _Collector()
+        asyncio.run(notif_ws.ws_notifications('["list-not-dict"]', collector))
+        assert collector.sent == []
+
+
+# ---------------------------------------------------------------------------
+# Cookie extraction (mirrors chat/draft-status pattern)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCookieFromHeaders:
+    def test_extracts_access_token(self):
+        headers = [(b"cookie", b"access_token=my-token; other=abc")]
+        assert notif_ws._extract_cookie_from_headers(headers, "access_token") == "my-token"
+
+    def test_returns_none_when_cookie_absent(self):
+        headers = [(b"cookie", b"other=abc")]
+        assert notif_ws._extract_cookie_from_headers(headers, "access_token") is None
+
+    def test_returns_none_when_no_cookie_header(self):
+        headers = [(b"host", b"localhost")]
+        assert notif_ws._extract_cookie_from_headers(headers, "access_token") is None


### PR DESCRIPTION
## Summary
- Adds `/ws/notifications` endpoint with per-user connection pool, JWT-cookie auth, 25s heartbeat, and a `push_to_user(user_id, payload)` API
- `notify.py` now pushes to connected sockets after a successful DB insert (fire-and-forget — a dead WS never reverts the durable row)
- Bell UI in `top_bar.py` opens the socket on DOM ready, increments badge on `{"type":"notification"}`, and auto-reconnects after 5s on close. 30s HTMX polling kept as fallback.
- Closes #180

## Test plan
- [x] `tests/test_notifications_websocket.py` — 21 new tests (push to single+multi-tab, cross-user isolation, dead-socket pruning, connect/disconnect lifecycle, JWT fail-closed with 1008, ping/pong)
- [x] 89 adjacent regression tests pass (chat WS, draft-status WS, notifications routes/wire/models)
- [x] ruff + pyright clean
- [ ] Manual: bell badge increments live (verify in staging)

## Notes
- Disconnect scans the full registry since FastHTML's `disconn` hook only receives `send`. Fine for a few hundred users — can add reverse index later if needed.
- WS push runs from both async + background worker threads (worker uses `run_coroutine_threadsafe` against the loop captured in lifespan).