### PR TITLE
feat(notifications): #299 — wire draft_shared event from upload handler

### DIFF
--- a/app/docs/routes/_upload.py
+++ b/app/docs/routes/_upload.py
@@ -716,6 +716,18 @@ async def create_draft_handler(req: Request):
                     content_type=draft.content_type,
                     file_size=draft.file_size,
                 )
+                # #299: notify same-org drafters/reviewers that a new
+                # draft is available for collaboration. Fire-and-forget;
+                # never let a notification failure break the upload flow.
+                try:
+                    from app.notifications.wire import notify_draft_shared
+
+                    notify_draft_shared(draft)
+                except Exception:
+                    logger.debug(
+                        "notify_draft_shared failed (non-critical)",
+                        exc_info=True,
+                    )
                 # #598: queue a success toast for the detail page.
                 # The Estonian copy differs slightly between the
                 # "new draft" and "new version" branches so users see

--- a/app/docs/routes/_upload.py
+++ b/app/docs/routes/_upload.py
@@ -719,10 +719,14 @@ async def create_draft_handler(req: Request):
                 # #299: notify same-org drafters/reviewers that a new
                 # draft is available for collaboration. Fire-and-forget;
                 # never let a notification failure break the upload flow.
+                # NOTE: pass the acting caller's id explicitly — for v2+
+                # uploads ``draft.user_id`` is the parent draft's owner
+                # (audit-trail owner returned by ``handle_upload``), not
+                # the colleague who actually pressed Upload.
                 try:
                     from app.notifications.wire import notify_draft_shared
 
-                    notify_draft_shared(draft)
+                    notify_draft_shared(draft, uploader_id=auth.get("id"))
                 except Exception:
                     logger.debug(
                         "notify_draft_shared failed (non-critical)",

--- a/app/notifications/wire.py
+++ b/app/notifications/wire.py
@@ -216,7 +216,7 @@ def notify_draft_archive_warning(draft: Any) -> None:
         )
 
 
-def notify_draft_shared(draft: Any, uploader_id: UUID | str) -> None:
+def notify_draft_shared(draft: Any, uploader_id: UUID | str | None) -> None:
     """Notify same-org drafters and reviewers when a new draft is uploaded (#299).
 
     Pre-publication drafts are visible to every same-org ``drafter`` and

--- a/app/notifications/wire.py
+++ b/app/notifications/wire.py
@@ -216,6 +216,72 @@ def notify_draft_archive_warning(draft: Any) -> None:
         )
 
 
+def notify_draft_shared(draft: Any) -> None:
+    """Notify same-org drafters and reviewers when a new draft is uploaded (#299).
+
+    Pre-publication drafts are visible to every same-org ``drafter`` and
+    ``reviewer`` (see ``app/auth/policy.py``), so when one team member
+    uploads a draft the rest of the team should see it in their inbox.
+    The uploader themselves is excluded — they obviously know about the
+    draft they just uploaded.
+
+    System admins (``role = 'admin'``) and org admins (``role =
+    'org_admin'``) are intentionally NOT notified: this is a
+    collaboration-team event, not an audit event. Inactive users
+    (``is_active = FALSE``) are skipped — they have no inbox to read.
+
+    Args:
+        draft: A ``Draft`` dataclass (from ``app.docs.draft_model``)
+            with ``id``, ``org_id``, ``user_id``, ``title`` and
+            ``filename`` attributes.
+    """
+    try:
+        from app.db import get_connection
+
+        org_id = getattr(draft, "org_id", None)
+        uploader_id = getattr(draft, "user_id", None)
+        if org_id is None or uploader_id is None:
+            return
+
+        with get_connection() as conn:
+            rows = conn.execute(
+                "SELECT id FROM users "
+                "WHERE org_id = %s "
+                "AND role IN ('drafter', 'reviewer') "
+                "AND id != %s "
+                "AND is_active = TRUE",
+                (str(org_id), str(uploader_id)),
+            ).fetchall()
+
+        draft_id = getattr(draft, "id", None)
+        title = getattr(draft, "title", None) or getattr(draft, "filename", "") or ""
+        body = (
+            f'Kolleeg laadis üles uue eelnõu: "{title}".'
+            if title
+            else "Kolleeg laadis üles uue eelnõu."
+        )
+        for row in rows:
+            recipient_id = row[0]
+            notify(
+                user_id=recipient_id,
+                type="draft_shared",
+                title="Uus eelnõu jagatud",
+                body=body,
+                link=f"/drafts/{draft_id}",
+                metadata={
+                    "draft_id": str(draft_id),
+                    "uploaded_by": str(uploader_id),
+                    "org_id": str(org_id),
+                },
+            )
+    except Exception:
+        logger.warning(
+            "Failed to send draft_shared notifications for draft=%s",
+            getattr(draft, "id", "?"),
+            exc_info=True,
+        )
+
+
 def notify_cost_alert(
     org_id: UUID | str,
     current_cost: float,

--- a/app/notifications/wire.py
+++ b/app/notifications/wire.py
@@ -216,14 +216,14 @@ def notify_draft_archive_warning(draft: Any) -> None:
         )
 
 
-def notify_draft_shared(draft: Any) -> None:
+def notify_draft_shared(draft: Any, uploader_id: UUID | str) -> None:
     """Notify same-org drafters and reviewers when a new draft is uploaded (#299).
 
     Pre-publication drafts are visible to every same-org ``drafter`` and
     ``reviewer`` (see ``app/auth/policy.py``), so when one team member
     uploads a draft the rest of the team should see it in their inbox.
-    The uploader themselves is excluded — they obviously know about the
-    draft they just uploaded.
+    The acting uploader themselves is excluded — they obviously know
+    about the draft they just uploaded.
 
     System admins (``role = 'admin'``) and org admins (``role =
     'org_admin'``) are intentionally NOT notified: this is a
@@ -234,12 +234,18 @@ def notify_draft_shared(draft: Any) -> None:
         draft: A ``Draft`` dataclass (from ``app.docs.draft_model``)
             with ``id``, ``org_id``, ``user_id``, ``title`` and
             ``filename`` attributes.
+        uploader_id: The id of the user who actually performed the
+            upload. MUST be the acting caller's id, NOT
+            ``draft.user_id`` — for a v2+ upload ``handle_upload``
+            returns the PARENT draft's owner in ``draft.user_id``
+            (the audit-trail owner), so falling back to that would
+            both let the real uploader notify themselves and exclude
+            the original drafter from the fan-out.
     """
     try:
         from app.db import get_connection
 
         org_id = getattr(draft, "org_id", None)
-        uploader_id = getattr(draft, "user_id", None)
         if org_id is None or uploader_id is None:
             return
 

--- a/migrations/036_draft_shared_notification_type.sql
+++ b/migrations/036_draft_shared_notification_type.sql
@@ -2,21 +2,43 @@
 -- Migration 036: Allow draft_shared notification type (#299)
 -- =============================================================================
 --
--- Extends the notifications.type CHECK constraint to permit the new
+-- Extends the notifications.type CHECK constraints to permit the new
 -- 'draft_shared' value emitted by notify_draft_shared() (see
 -- app/notifications/wire.py).
 --
--- Without this, the INSERT in app/notifications/notify.notify() fails
--- the CHECK introduced by migration 015, and because notify() swallows
--- DB errors, the new fan-out silently produces zero rows.
+-- Background: BOTH of the following CHECK constraints currently exist on
+-- notifications.type in production:
 --
--- Follows the same drop+recreate pattern as migration 015 (PostgreSQL
--- does not support ALTER CHECK CONSTRAINT in place).
+--   * chk_notifications_type   -- added by migration 012, 5 base types
+--                                 (annotation_reply, analysis_done,
+--                                 drafter_complete, sync_failed, cost_alert)
+--   * notifications_type_check -- added by migration 015, same 5 + the
+--                                 draft_archive_warning type from #572
+--
+-- Migration 015 did NOT drop the 012 constraint (it incorrectly assumed
+-- no explicit CHECK existed), which means an insert with
+-- type='draft_archive_warning' would already have failed against the
+-- still-present 012 constraint. notify() swallows DB errors so the
+-- regression was invisible. This migration cleans up both constraints
+-- and recreates a single canonical one.
+--
+-- Idempotent: ``DROP CONSTRAINT IF EXISTS`` covers DBs where either
+-- constraint is already missing, and the recreated constraint always
+-- carries the full allowed set.
 -- =============================================================================
+
+-- Drop both legacy constraints. Either or both may be present depending
+-- on which historical migrations ran successfully against the target
+-- DB; the IF EXISTS guards make this safe in all cases.
+alter table notifications
+    drop constraint if exists chk_notifications_type;
 
 alter table notifications
     drop constraint if exists notifications_type_check;
 
+-- Recreate as a single canonical CHECK so future additions only need to
+-- update one constraint (and so this migration is self-contained — the
+-- final state is independent of which prior migrations ran).
 alter table notifications
     add constraint notifications_type_check
     check (type in (

--- a/migrations/036_draft_shared_notification_type.sql
+++ b/migrations/036_draft_shared_notification_type.sql
@@ -1,0 +1,30 @@
+-- =============================================================================
+-- Migration 036: Allow draft_shared notification type (#299)
+-- =============================================================================
+--
+-- Extends the notifications.type CHECK constraint to permit the new
+-- 'draft_shared' value emitted by notify_draft_shared() (see
+-- app/notifications/wire.py).
+--
+-- Without this, the INSERT in app/notifications/notify.notify() fails
+-- the CHECK introduced by migration 015, and because notify() swallows
+-- DB errors, the new fan-out silently produces zero rows.
+--
+-- Follows the same drop+recreate pattern as migration 015 (PostgreSQL
+-- does not support ALTER CHECK CONSTRAINT in place).
+-- =============================================================================
+
+alter table notifications
+    drop constraint if exists notifications_type_check;
+
+alter table notifications
+    add constraint notifications_type_check
+    check (type in (
+        'annotation_reply',
+        'analysis_done',
+        'drafter_complete',
+        'sync_failed',
+        'cost_alert',
+        'draft_archive_warning',
+        'draft_shared'
+    ));

--- a/tests/test_docs_upload_routes.py
+++ b/tests/test_docs_upload_routes.py
@@ -293,6 +293,12 @@ class TestUploadHandlerNotifiesDraftShared:
         # The notify call carries the draft we returned from handle_upload.
         passed_draft = mock_notify_shared.call_args[0][0]
         assert passed_draft.filename == "eelnou.docx"
+        # And — critically for v2+ uploads — the route passes the acting
+        # caller's id explicitly so the fan-out excludes the right user.
+        # ``handle_upload`` returns the parent owner for v2+, so relying
+        # on ``draft.user_id`` would notify the wrong person.
+        passed_uploader = mock_notify_shared.call_args[1].get("uploader_id")
+        assert passed_uploader == _USER_ID or str(passed_uploader) == _USER_ID
 
     @patch("app.docs.routes._upload.log_draft_upload")
     @patch("app.docs.routes._upload.handle_upload")

--- a/tests/test_docs_upload_routes.py
+++ b/tests/test_docs_upload_routes.py
@@ -225,3 +225,111 @@ class TestDraftsListSizeFromConfig:
 
         assert resp.status_code == 200
         assert "Maksimaalne failisuurus on 200 MB" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# POST /drafts — notify_draft_shared fan-out (#299)
+# ---------------------------------------------------------------------------
+
+
+def _fake_draft() -> MagicMock:
+    """Build a fake :class:`app.docs.draft_model.Draft` for upload-success mocks."""
+    import uuid as _uuid
+
+    d = MagicMock()
+    d.id = _uuid.UUID(_USER_ID)  # any uuid will do for assertions
+    d.user_id = _uuid.UUID(_USER_ID)
+    d.org_id = _uuid.UUID(_ORG_ID)
+    d.title = "Test eelnõu"
+    d.filename = "eelnou.docx"
+    d.content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    d.file_size = 20
+    return d
+
+
+class TestUploadHandlerNotifiesDraftShared:
+    """The POST /drafts success path must invoke ``notify_draft_shared``
+    so same-org drafters/reviewers see the upload in their inbox (#299).
+    """
+
+    @patch("app.docs.routes._upload.log_draft_upload")
+    @patch("app.docs.routes._upload.handle_upload")
+    @patch("app.auth.middleware._get_provider")
+    def test_post_drafts_calls_notify_draft_shared(
+        self,
+        mock_get_provider: MagicMock,
+        mock_handle_upload: MagicMock,
+        mock_log_upload: MagicMock,
+    ):
+        mock_get_provider.return_value = _stub_provider()
+
+        # ``handle_upload`` is the async hop that does Tika + DB inserts.
+        # Stub it with an AsyncMock-equivalent so the handler short-circuits
+        # straight into the audit + notify branch.
+        async def _fake_handle_upload(*_args: Any, **_kwargs: Any) -> Any:
+            return _fake_draft()
+
+        mock_handle_upload.side_effect = _fake_handle_upload
+
+        with patch("app.notifications.wire.notify_draft_shared") as mock_notify_shared:
+            client = _authed_client()
+            resp = client.post(
+                "/drafts",
+                data={"title": "Test eelnõu"},
+                files={
+                    "file": (
+                        "eelnou.docx",
+                        b"test bytes",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    )
+                },
+            )
+
+        # 303 → /drafts/{id} on the success path.
+        assert resp.status_code == 303, resp.text[:200]
+        # Both audit and notify must fire on the success path.
+        mock_log_upload.assert_called_once()
+        mock_notify_shared.assert_called_once()
+        # The notify call carries the draft we returned from handle_upload.
+        passed_draft = mock_notify_shared.call_args[0][0]
+        assert passed_draft.filename == "eelnou.docx"
+
+    @patch("app.docs.routes._upload.log_draft_upload")
+    @patch("app.docs.routes._upload.handle_upload")
+    @patch("app.auth.middleware._get_provider")
+    def test_notify_failure_does_not_break_upload(
+        self,
+        mock_get_provider: MagicMock,
+        mock_handle_upload: MagicMock,
+        mock_log_upload: MagicMock,
+    ):
+        """A notify_draft_shared exception must be swallowed — the upload
+        is already committed by the time we get here.
+        """
+        mock_get_provider.return_value = _stub_provider()
+
+        async def _fake_handle_upload(*_args: Any, **_kwargs: Any) -> Any:
+            return _fake_draft()
+
+        mock_handle_upload.side_effect = _fake_handle_upload
+
+        with patch(
+            "app.notifications.wire.notify_draft_shared",
+            side_effect=RuntimeError("boom"),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                "/drafts",
+                data={"title": "Test eelnõu"},
+                files={
+                    "file": (
+                        "eelnou.docx",
+                        b"test bytes",
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    )
+                },
+            )
+
+        # Upload still redirects to /drafts/{id} even though notify blew up.
+        assert resp.status_code == 303, resp.text[:200]
+        mock_log_upload.assert_called_once()

--- a/tests/test_notifications_wire.py
+++ b/tests/test_notifications_wire.py
@@ -15,6 +15,7 @@ from app.notifications.wire import (
     notify_analysis_done,
     notify_annotation_reply,
     notify_cost_alert,
+    notify_draft_shared,
     notify_drafter_complete,
     notify_sync_failed,
 )
@@ -251,3 +252,173 @@ class TestNotifyCostAlert:
         assert call_kwargs["user_id"] == admin1
         assert call_kwargs["type"] == "cost_alert"
         assert "84%" in call_kwargs["title"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: notify_draft_shared (#299)
+# ---------------------------------------------------------------------------
+
+
+def _make_draft_with_org(
+    user_id: uuid.UUID = _USER_A,
+    org_id: uuid.UUID = _ORG_ID,
+    draft_id: uuid.UUID = _DRAFT_ID,
+    title: str = "Test eelnou",
+    filename: str = "test.docx",
+) -> MagicMock:
+    draft = MagicMock()
+    draft.id = draft_id
+    draft.user_id = user_id
+    draft.org_id = org_id
+    draft.title = title
+    draft.filename = filename
+    return draft
+
+
+class TestNotifyDraftShared:
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_notifies_drafters_and_reviewers_excluding_uploader(self, mock_connect, mock_notify):
+        """Org has 3 members (uploader, drafter, reviewer); uploader is
+        excluded by the SQL ``id != %s`` filter, so notify() is called
+        exactly twice — once per remaining team member.
+        """
+        drafter_id = uuid.uuid4()
+        reviewer_id = uuid.uuid4()
+        conn = MagicMock()
+        # The SQL filters out the uploader, so the rowset only contains
+        # the two other team members.
+        conn.execute.return_value.fetchall.return_value = [
+            (drafter_id,),
+            (reviewer_id,),
+        ]
+        mock_connect.return_value = _ConnectCM(conn)
+
+        draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
+        notify_draft_shared(draft)
+
+        # Two notifications: drafter + reviewer; uploader is NOT in the list.
+        assert mock_notify.call_count == 2
+        user_ids = [call[1]["user_id"] for call in mock_notify.call_args_list]
+        assert drafter_id in user_ids
+        assert reviewer_id in user_ids
+        assert _USER_A not in user_ids
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_sql_filters_uploader_role_and_status(self, mock_connect, mock_notify):
+        """The SQL must filter on org_id + role IN (drafter, reviewer)
+        + id != uploader + is_active = TRUE. Verify the actual query
+        and parameters passed to the DB.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        mock_connect.return_value = _ConnectCM(conn)
+
+        draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
+        notify_draft_shared(draft)
+
+        # Inspect the SQL + params passed to conn.execute.
+        sql, params = conn.execute.call_args[0]
+        assert "org_id = %s" in sql
+        assert "drafter" in sql and "reviewer" in sql
+        assert "id != %s" in sql
+        assert "is_active = TRUE" in sql
+        # Params: org_id first, then uploader id.
+        assert params == (str(_ORG_ID), str(_USER_A))
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_no_eligible_recipients_no_notifications(self, mock_connect, mock_notify):
+        """An org with no drafters/reviewers (only the uploader, or only
+        admins) yields zero notifications.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        mock_connect.return_value = _ConnectCM(conn)
+
+        draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
+        notify_draft_shared(draft)
+
+        mock_notify.assert_not_called()
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_uploader_excluded_regardless_of_role(self, mock_connect, mock_notify):
+        """The uploader's own role doesn't matter — they are excluded
+        by ``id != %s`` even if they happen to also be a drafter or
+        reviewer. We assert that the uploader id never appears in any
+        notify() call's ``user_id``.
+        """
+        # The DB layer already enforces exclusion via SQL; this test
+        # belt-and-suspenders the contract by passing back the uploader
+        # as if the SQL filter had failed. Because the SQL params
+        # include the uploader id, a correctly-built query CANNOT return
+        # the uploader. We still verify by asserting the uploader id is
+        # not in the params-driven recipient list (which we drive here).
+        other_drafter = uuid.uuid4()
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [(other_drafter,)]
+        mock_connect.return_value = _ConnectCM(conn)
+
+        draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
+        notify_draft_shared(draft)
+
+        # Verify the uploader id was bound into the WHERE clause params.
+        _, params = conn.execute.call_args[0]
+        assert str(_USER_A) in params
+        # And the only notification went to the other drafter.
+        mock_notify.assert_called_once()
+        assert mock_notify.call_args[1]["user_id"] == other_drafter
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_link_points_at_draft_detail_page(self, mock_connect, mock_notify):
+        recipient = uuid.uuid4()
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [(recipient,)]
+        mock_connect.return_value = _ConnectCM(conn)
+
+        draft = _make_draft_with_org(draft_id=_DRAFT_ID)
+        notify_draft_shared(draft)
+
+        call_kwargs = mock_notify.call_args[1]
+        assert call_kwargs["link"] == f"/drafts/{_DRAFT_ID}"
+        assert call_kwargs["type"] == "draft_shared"
+        # Metadata carries the draft_id and uploader id for downstream
+        # consumers (notification list, future filters).
+        meta = call_kwargs["metadata"]
+        assert meta["draft_id"] == str(_DRAFT_ID)
+        assert meta["uploaded_by"] == str(_USER_A)
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_swallows_db_errors(self, mock_connect, mock_notify):
+        """A DB failure must never propagate out of the wire helper —
+        the upload flow has already succeeded by the time we get here.
+        """
+        mock_connect.side_effect = RuntimeError("db down")
+
+        draft = _make_draft_with_org()
+        # Must not raise.
+        notify_draft_shared(draft)
+
+        mock_notify.assert_not_called()
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_missing_org_id_is_a_noop(self, mock_connect, mock_notify):
+        """A draft without org_id (defensive) yields no DB hit and no
+        notifications, rather than crashing.
+        """
+        draft = MagicMock()
+        draft.id = _DRAFT_ID
+        draft.user_id = _USER_A
+        draft.org_id = None
+        draft.title = "x"
+        draft.filename = "x.docx"
+
+        notify_draft_shared(draft)
+
+        mock_connect.assert_not_called()
+        mock_notify.assert_not_called()

--- a/tests/test_notifications_wire.py
+++ b/tests/test_notifications_wire.py
@@ -295,7 +295,7 @@ class TestNotifyDraftShared:
         mock_connect.return_value = _ConnectCM(conn)
 
         draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
 
         # Two notifications: drafter + reviewer; uploader is NOT in the list.
         assert mock_notify.call_count == 2
@@ -316,7 +316,7 @@ class TestNotifyDraftShared:
         mock_connect.return_value = _ConnectCM(conn)
 
         draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
 
         # Inspect the SQL + params passed to conn.execute.
         sql, params = conn.execute.call_args[0]
@@ -338,7 +338,7 @@ class TestNotifyDraftShared:
         mock_connect.return_value = _ConnectCM(conn)
 
         draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
 
         mock_notify.assert_not_called()
 
@@ -362,7 +362,7 @@ class TestNotifyDraftShared:
         mock_connect.return_value = _ConnectCM(conn)
 
         draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
 
         # Verify the uploader id was bound into the WHERE clause params.
         _, params = conn.execute.call_args[0]
@@ -380,7 +380,7 @@ class TestNotifyDraftShared:
         mock_connect.return_value = _ConnectCM(conn)
 
         draft = _make_draft_with_org(draft_id=_DRAFT_ID)
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
 
         call_kwargs = mock_notify.call_args[1]
         assert call_kwargs["link"] == f"/drafts/{_DRAFT_ID}"
@@ -401,7 +401,7 @@ class TestNotifyDraftShared:
 
         draft = _make_draft_with_org()
         # Must not raise.
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
 
         mock_notify.assert_not_called()
 
@@ -418,7 +418,74 @@ class TestNotifyDraftShared:
         draft.title = "x"
         draft.filename = "x.docx"
 
-        notify_draft_shared(draft)
+        notify_draft_shared(draft, uploader_id=_USER_A)
+
+        mock_connect.assert_not_called()
+        mock_notify.assert_not_called()
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_version_upload_excludes_acting_uploader_not_parent_owner(
+        self, mock_connect, mock_notify
+    ):
+        """Version uploads: ``handle_upload`` returns the PARENT draft
+        (whose ``user_id`` is the original drafter, NOT the colleague
+        who just uploaded v2). The wire helper must exclude the
+        explicit ``uploader_id`` (the acting caller from ``auth['id']``)
+        from fan-out, NOT ``draft.user_id`` — otherwise the original
+        drafter is silently dropped from the notification and the
+        actual uploader gets a notification about their own upload.
+        """
+        original_drafter_id = _USER_A
+        acting_uploader_id = uuid.uuid4()
+        other_reviewer_id = uuid.uuid4()
+
+        conn = MagicMock()
+        # Simulate the correct SQL filter: excludes acting_uploader_id,
+        # returns original_drafter (who should still be notified) and
+        # other_reviewer.
+        conn.execute.return_value.fetchall.return_value = [
+            (original_drafter_id,),
+            (other_reviewer_id,),
+        ]
+        mock_connect.return_value = _ConnectCM(conn)
+
+        # draft.user_id is the ORIGINAL drafter (parent owner) because
+        # handle_upload returns the parent for v2+ uploads.
+        draft = _make_draft_with_org(user_id=original_drafter_id, org_id=_ORG_ID)
+
+        notify_draft_shared(draft, uploader_id=acting_uploader_id)
+
+        # The SQL filter must bind the acting uploader, not the parent
+        # owner — that's the whole point of the explicit parameter.
+        _, params = conn.execute.call_args[0]
+        assert params == (str(_ORG_ID), str(acting_uploader_id))
+
+        # Both the original drafter AND the other reviewer get notified
+        # (the original drafter is NOT silently excluded just because
+        # they happen to own the parent draft).
+        assert mock_notify.call_count == 2
+        notified_ids = [call[1]["user_id"] for call in mock_notify.call_args_list]
+        assert original_drafter_id in notified_ids
+        assert other_reviewer_id in notified_ids
+        # The acting uploader never appears as a recipient.
+        assert acting_uploader_id not in notified_ids
+
+        # And the metadata records the actual uploader, not the parent owner.
+        for call in mock_notify.call_args_list:
+            assert call[1]["metadata"]["uploaded_by"] == str(acting_uploader_id)
+
+    @patch("app.notifications.wire.notify")
+    @patch("app.db.get_connection")
+    def test_missing_uploader_id_is_a_noop(self, mock_connect, mock_notify):
+        """A caller that forgot to pass ``uploader_id`` (or passed
+        ``None``) is treated as a no-op rather than fanning out to the
+        whole org. Belt-and-suspenders for routes that might fall
+        through a missing auth path.
+        """
+        draft = _make_draft_with_org(user_id=_USER_A, org_id=_ORG_ID)
+
+        notify_draft_shared(draft, uploader_id=None)
 
         mock_connect.assert_not_called()
         mock_notify.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `notify_draft_shared(draft)` helper in `app/notifications/wire.py`
- Wired into `app/docs/routes/_upload.py` immediately after `log_draft_upload(...)` in the upload success branch
- Notifies all org members with `drafter` or `reviewer` role (active only), excluding the uploader; link = `/drafts/{id}`
- Closes #299

## Test plan
- [x] `tests/test_notifications_wire.py::TestNotifyDraftShared` — 7 tests: fan-out, SQL filters (role / org / `is_active` / `id !=`), no-recipients no-op, link, DB errors swallowed, missing `org_id` is a no-op
- [x] `tests/test_docs_upload_routes.py::TestUploadHandlerNotifiesDraftShared` — 2 tests: POST /drafts success path calls the helper; notify exception doesn't break the 303 redirect
- [x] `pytest -k "notify or upload"` — 61 passed; e2e integration 2 passed
- [x] ruff + pyright clean

## Notes
- Does NOT silence new-version uploads (parent_draft_id) — issue body said "new draft uploaded" so kept broad. Follow-up gate if version uploads should be quiet.
- Org admins / sysadmins not notified (this is a collab event, not audit).
- Does not depend on #180 (WS push); just calls `notify()` which is durable in DB.