### PR TITLE
feat(annotations): #176 — @mention autocomplete typeahead

### DIFF
--- a/app/annotations/models.py
+++ b/app/annotations/models.py
@@ -438,8 +438,11 @@ def list_replies(
 
 # Regex for @mention tokens.  Estonian usernames / display names may contain
 # dots and hyphens; we stop at whitespace and punctuation that cannot be part
-# of an identifier.
-_MENTION_RE = re.compile(r"@([\w.\-]+)")
+# of an identifier.  The optional ``@<domain>`` suffix is what lets the
+# typeahead widget round-trip a full email address (e.g. ``@andres@min.ee``)
+# as a single token so the server resolves it unambiguously even when two
+# users in different orgs share the same email local-part.
+_MENTION_RE = re.compile(r"@([\w.\-]+(?:@[\w.\-]+)?)")
 
 
 def parse_mentions(
@@ -454,12 +457,22 @@ def parse_mentions(
     matches are silently dropped.  Duplicate mentions of the same user are
     deduplicated in the returned list.
 
-    The token captured by ``_MENTION_RE`` is whitespace-free, matching the
-    token the typeahead widget inserts (``@<email-local-part>``).  The lookup
-    accepts four forms so both typed and typeahead-inserted mentions resolve:
+    The token captured by ``_MENTION_RE`` is whitespace-free and may include
+    a single ``@<domain>`` suffix; the typeahead widget inserts the full email
+    (``@andres@min.ee``) so we resolve the exact user even when two orgs
+    share an email local-part (``andres@min.ee`` vs ``andres@agency.ee``).
+    The lookup accepts four forms so typed, typeahead-inserted, and legacy
+    mentions all resolve:
 
-    1. Full email address (``@peeter@min.ee`` — typed form).
-    2. Email local-part prefix (``@peeter`` → matches ``peeter@…``).
+    1. Full email address (``@andres@min.ee`` — preferred, typeahead form).
+       Globally unique via the ``users.email`` UNIQUE constraint, so this is
+       the *only* arm used when the token contains ``@`` — the local-part
+       LIKE fallback is suppressed to avoid the cross-org ambiguity that
+       motivated this disambiguation.
+    2. Email local-part prefix (``@andres`` → matches ``andres@…``). Best-
+       effort fallback for users who type ``@andres`` by hand; LIMIT 1 means
+       any local-part collision across orgs is non-deterministic, but the
+       ``org_id = %s`` filter still scopes it inside the user's own org.
     3. Exact ``full_name`` (handles ``@Peeter`` for single-word names,
        and any underscore-joined form like ``@Peeter_Pärn``).
     4. Underscore-to-space variant (``@eesnimi_perenimi`` →
@@ -476,40 +489,67 @@ def parse_mentions(
     result: list[uuid.UUID] = []
 
     for token in tokens:
+        # Tokens that contain ``@`` are treated as a full email address: the
+        # ``users.email`` UNIQUE constraint disambiguates across orgs, so we
+        # skip every name / local-part fallback to avoid resolving the wrong
+        # user (#825 review follow-up). For bare tokens we keep the legacy
+        # name + local-part arms for back-compat.
+        token_has_at = "@" in token
         # Normalise: treat underscores as spaces so @eesnimi_perenimi works too.
-        name_variant = token.replace("_", " ")
-        # Local-part prefix match: ``peeter`` should resolve ``peeter@min.ee``.
-        # Skip when the token already contains ``@`` (i.e. a literal email
-        # was typed) to avoid double-matching and to keep the LIKE pattern
-        # well-formed.
-        email_local_pattern = f"{token.lower()}@%" if "@" not in token else None
-        try:
-            row = conn.execute(
-                """
-                SELECT id FROM users
-                WHERE org_id = %s
-                  AND (
-                      email = %s
-                      OR email = %s
-                      OR (%s IS NOT NULL AND lower(email) LIKE %s)
-                      OR full_name ILIKE %s
-                      OR full_name ILIKE %s
-                  )
-                LIMIT 1
-                """,
-                (
-                    str(org_id),
-                    token,  # exact email match e.g. peeter@min.ee
-                    token.lower(),  # case-insensitive email
-                    email_local_pattern,  # NULL when token has @
-                    email_local_pattern,  # local-part LIKE pattern
-                    token,  # exact full_name
-                    name_variant,  # space-variant full_name
-                ),
-            ).fetchone()
-        except Exception:
-            logger.exception("parse_mentions: DB error resolving token %r", token)
-            continue
+        # Only relevant for bare tokens — emails never contain spaces.
+        name_variant = None if token_has_at else token.replace("_", " ")
+        # Local-part prefix match: ``andres`` should resolve ``andres@min.ee``.
+        # Suppressed when the token already contains ``@`` so the well-formed
+        # exact-email arm wins unambiguously.
+        email_local_pattern = None if token_has_at else f"{token.lower()}@%"
+        # Bare tokens use the legacy multi-arm OR; full-email tokens go through
+        # the single exact-email arm so a local-part collision in another row
+        # cannot win the LIMIT 1.
+        if token_has_at:
+            try:
+                row = conn.execute(
+                    """
+                    SELECT id FROM users
+                    WHERE org_id = %s
+                      AND (email = %s OR email = %s)
+                    LIMIT 1
+                    """,
+                    (
+                        str(org_id),
+                        token,  # exact email match e.g. andres@min.ee
+                        token.lower(),  # case-insensitive email
+                    ),
+                ).fetchone()
+            except Exception:
+                logger.exception("parse_mentions: DB error resolving token %r", token)
+                continue
+        else:
+            try:
+                row = conn.execute(
+                    """
+                    SELECT id FROM users
+                    WHERE org_id = %s
+                      AND (
+                          email = %s
+                          OR email = %s
+                          OR lower(email) LIKE %s
+                          OR full_name ILIKE %s
+                          OR full_name ILIKE %s
+                      )
+                    LIMIT 1
+                    """,
+                    (
+                        str(org_id),
+                        token,  # exact email (rare for bare tokens, kept for parity)
+                        token.lower(),
+                        email_local_pattern,  # local-part LIKE pattern
+                        token,  # exact full_name
+                        name_variant,  # space-variant full_name
+                    ),
+                ).fetchone()
+            except Exception:
+                logger.exception("parse_mentions: DB error resolving token %r", token)
+                continue
 
         if row is None:
             continue

--- a/app/annotations/models.py
+++ b/app/annotations/models.py
@@ -454,10 +454,16 @@ def parse_mentions(
     matches are silently dropped.  Duplicate mentions of the same user are
     deduplicated in the returned list.
 
-    The lookup checks both ``email`` and ``full_name`` columns so that
-    ``@peeter.pärn`` and ``@Peeter Pärn`` both resolve (space replaced by
-    ``_`` is a common convention in Estonian government systems, but both
-    the raw token and the underscore-replaced form are tried).
+    The token captured by ``_MENTION_RE`` is whitespace-free, matching the
+    token the typeahead widget inserts (``@<email-local-part>``).  The lookup
+    accepts four forms so both typed and typeahead-inserted mentions resolve:
+
+    1. Full email address (``@peeter@min.ee`` — typed form).
+    2. Email local-part prefix (``@peeter`` → matches ``peeter@…``).
+    3. Exact ``full_name`` (handles ``@Peeter`` for single-word names,
+       and any underscore-joined form like ``@Peeter_Pärn``).
+    4. Underscore-to-space variant (``@eesnimi_perenimi`` →
+       ``Eesnimi Perenimi``).
 
     Returns an empty list when *content* contains no ``@`` tokens, or when no
     tokens resolve to users in the given org.
@@ -472,6 +478,11 @@ def parse_mentions(
     for token in tokens:
         # Normalise: treat underscores as spaces so @eesnimi_perenimi works too.
         name_variant = token.replace("_", " ")
+        # Local-part prefix match: ``peeter`` should resolve ``peeter@min.ee``.
+        # Skip when the token already contains ``@`` (i.e. a literal email
+        # was typed) to avoid double-matching and to keep the LIKE pattern
+        # well-formed.
+        email_local_pattern = f"{token.lower()}@%" if "@" not in token else None
         try:
             row = conn.execute(
                 """
@@ -480,6 +491,7 @@ def parse_mentions(
                   AND (
                       email = %s
                       OR email = %s
+                      OR (%s IS NOT NULL AND lower(email) LIKE %s)
                       OR full_name ILIKE %s
                       OR full_name ILIKE %s
                   )
@@ -489,6 +501,8 @@ def parse_mentions(
                     str(org_id),
                     token,  # exact email match e.g. peeter@min.ee
                     token.lower(),  # case-insensitive email
+                    email_local_pattern,  # NULL when token has @
+                    email_local_pattern,  # local-part LIKE pattern
                     token,  # exact full_name
                     name_variant,  # space-variant full_name
                 ),

--- a/app/annotations/routes.py
+++ b/app/annotations/routes.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from app.annotations.audit import (
     log_annotation_create,
@@ -52,7 +52,7 @@ from app.auth.helpers import require_auth as _require_auth
 from app.auth.provider import UserDict
 from app.auth.users import get_user
 from app.db import get_connection as _connect
-from app.notifications.wire import notify_annotation_reply
+from app.notifications.wire import notify_annotation_mention, notify_annotation_reply
 from app.ui.primitives.badge import Badge
 from app.ui.primitives.button import Button as UiButton
 from app.ui.surfaces.alert import Alert
@@ -220,11 +220,13 @@ def _annotation_item(
     reply_form = Form(  # noqa: F405
         Textarea(  # noqa: F405
             name="content",
-            placeholder="Kirjutage vastus...",
+            placeholder="Kirjutage vastus... Kasuta @nimi mainimiseks.",
             rows="2",
             cls="annotation-reply-input",
             # #813: HTML4 string form survives FastHTML's HTTP renderer.
             required="required",
+            # #176: hook for the @mention typeahead JS widget.
+            data_annotation_textarea="1",
         ),
         Button(  # noqa: F405
             "Vasta",
@@ -279,6 +281,87 @@ def _annotation_list_fragment(
         annotations=items,
         auth=auth,
     )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/annotations/mentions/search — #176 @mention typeahead backend
+# ---------------------------------------------------------------------------
+#
+# Returns up to 10 org-scoped users whose ``full_name`` OR ``email`` matches
+# the prefix ``q``.  Empty / whitespace-only queries return an empty list
+# (so the JS widget can clear gracefully); the result is always wrapped in
+# ``{"results": [...]}`` so future fields (e.g. has_more) can extend without
+# breaking clients.
+#
+# Security: results are filtered by ``org_id = auth['org_id']`` so a caller
+# cannot probe for users in other organisations.
+# ---------------------------------------------------------------------------
+
+
+def mentions_search_handler(req: Request):
+    """GET /api/annotations/mentions/search?q=<prefix> — typeahead candidates."""
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    org_id = auth.get("org_id")
+    if not org_id:
+        return JSONResponse({"results": []}, status_code=200)
+
+    raw_q = req.query_params.get("q", "")
+    q = raw_q.strip()
+    if not q:
+        return JSONResponse({"results": []}, status_code=200)
+
+    # ``LIKE`` pattern: prefix match on the front of the field plus
+    # substring match anywhere — matches both "And…" and "…and…" so the
+    # typeahead surfaces partial-name candidates from the start.
+    pattern = f"%{q}%"
+
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, full_name, email
+                FROM users
+                WHERE org_id = %s
+                  AND is_active = TRUE
+                  AND (
+                      lower(full_name) LIKE lower(%s)
+                      OR lower(email)  LIKE lower(%s)
+                  )
+                ORDER BY full_name
+                LIMIT 10
+                """,
+                (str(org_id), pattern, pattern),
+            ).fetchall()
+    except Exception:
+        logger.exception("mentions_search_handler: DB error q=%r", q)
+        # Never 500: a typeahead failure must degrade gracefully on the
+        # client, not surface a stack-trace popup.
+        return JSONResponse({"results": []}, status_code=200)
+
+    results = []
+    for row in rows:
+        user_id = row[0]
+        full_name = row[1] or ""
+        email = row[2] or ""
+        # ``label`` is what the JS widget injects into the textarea after
+        # the ``@`` prefix; ``parse_mentions`` strips a leading ``@`` and
+        # looks the label up against ``full_name`` / ``email``, so either
+        # works as a round-trip key. Prefer full_name for readability.
+        label = full_name or email
+        results.append(
+            {
+                "id": str(user_id),
+                "label": label,
+                "full_name": full_name,
+                "email": email,
+            }
+        )
+
+    return JSONResponse({"results": results}, status_code=200)
 
 
 # ---------------------------------------------------------------------------
@@ -858,6 +941,10 @@ def _row_panel_fragment(
             # #813: HTML4 string form survives FastHTML's HTTP renderer.
             required="required",
             disabled="disabled" if is_resolved else None,
+            # #176: hook for the @mention typeahead JS widget. Only bind
+            # when the thread is editable — a disabled textarea can't
+            # produce mentions anyway and binding would be wasted work.
+            data_annotation_textarea=None if is_resolved else "1",
         ),
         UiButton(
             "Saada",
@@ -1037,6 +1124,16 @@ async def post_row_message_handler(
     else:
         log_row_annotation_message(auth["id"], annotation.id, version_uuid, row_kind, row_key)
 
+    # #176: fan out "you were mentioned" notifications to every in-org
+    # user resolved from the ``@token`` syntax in the message body. The
+    # author is excluded so self-mentions don't ping yourself.
+    if annotation.mentions:
+        notify_annotation_mention(
+            annotation=annotation,
+            mentioned_user_ids=annotation.mentions,
+            mentioner_user_id=auth["id"],
+        )
+
     # Reload the thread so the fragment shows the message we just inserted
     # plus everything that was already there.
     messages = _load_panel_messages(version_uuid, row_kind, row_key)
@@ -1153,6 +1250,11 @@ def post_row_reopen_handler(
 
 def register_annotation_routes(rt) -> None:  # type: ignore[no-untyped-def]
     """Mount annotation API routes on the FastHTML route decorator *rt*."""
+    # #176: typeahead must be registered BEFORE ``/api/annotations`` so the
+    # static ``/mentions/search`` segment is matched ahead of any greedier
+    # sibling. Both are unambiguous on path, but keeping fixed-prefix
+    # routes above parameterised ones matches the rest of the codebase.
+    rt("/api/annotations/mentions/search", methods=["GET"])(mentions_search_handler)
     rt("/api/annotations", methods=["GET"])(list_annotations_handler)
     rt("/api/annotations", methods=["POST"])(create_annotation_handler)
     rt("/api/annotations/{id}/reply", methods=["POST"])(reply_annotation_handler)

--- a/app/main.py
+++ b/app/main.py
@@ -162,6 +162,11 @@ _HDRS = (
     # bar renders on every PageShell page. Defer so it doesn't block first paint;
     # the script binds on DOMContentLoaded.
     Script(src="/static/js/global_search.js", defer=True),
+    # #176 annotation @mention typeahead — loaded globally because the
+    # annotation popover is injected via HTMX swap at runtime, so we
+    # cannot scope the script to a single page. The widget binds itself
+    # on DOMContentLoaded and re-binds on every ``htmx:afterSwap``.
+    Script(src="/static/js/annotation_mentions.js", defer=True),
 )
 
 # Initialize Sentry before the ASGI app is created so that the Starlette

--- a/app/notifications/wire.py
+++ b/app/notifications/wire.py
@@ -86,6 +86,52 @@ def notify_annotation_reply(annotation: Any, reply: Any) -> None:
         )
 
 
+def notify_annotation_mention(
+    annotation: Any,
+    mentioned_user_ids: list[UUID] | list[str],
+    mentioner_user_id: UUID | str,
+) -> None:
+    """Notify every user mentioned in an annotation body (#176).
+
+    The annotation must already have its ``mentions`` array resolved
+    (see :func:`app.annotations.models.parse_mentions`). Self-mentions
+    are silently skipped so an author writing ``@iseennast`` doesn't
+    ping their own inbox.
+
+    Args:
+        annotation: The freshly-created ``Annotation`` row.
+        mentioned_user_ids: The resolved in-org user UUIDs to notify.
+        mentioner_user_id: The author of the message (excluded from fan-out).
+    """
+    try:
+        mentioner_str = str(mentioner_user_id)
+        body_preview = annotation.content[:200] if getattr(annotation, "content", None) else None
+        link = _annotation_target_link(annotation)
+        for target_id in mentioned_user_ids:
+            if str(target_id) == mentioner_str:
+                # Self-mention: nothing to notify.
+                continue
+            notify(
+                user_id=target_id,
+                type="annotation_mention",
+                title="Sind mainiti märkuses",
+                body=body_preview,
+                link=link,
+                metadata={
+                    "annotation_id": str(getattr(annotation, "id", "")),
+                    "mentioner_user_id": mentioner_str,
+                    "target_type": getattr(annotation, "target_type", None),
+                    "target_id": getattr(annotation, "target_id", None),
+                },
+            )
+    except Exception:
+        logger.warning(
+            "Failed to send annotation_mention notifications for annotation=%s",
+            getattr(annotation, "id", "?"),
+            exc_info=True,
+        )
+
+
 def notify_analysis_done(draft: Any) -> None:
     """Notify the draft owner when impact analysis completes.
 

--- a/app/static/css/ui.css
+++ b/app/static/css/ui.css
@@ -2720,6 +2720,48 @@
   box-shadow: 0 0 0 2px var(--color-primary-alpha);
 }
 
+/* ---- #176 @mention typeahead popup ---- */
+.mention-typeahead {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-1);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.mention-typeahead[hidden] {
+  display: none;
+}
+
+.mention-typeahead-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-2);
+  border-radius: var(--radius-xs, 4px);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+}
+
+.mention-typeahead-item:hover,
+.mention-typeahead-item--active {
+  background: var(--color-primary-alpha);
+}
+
+.mention-typeahead-name {
+  font-weight: 500;
+}
+
+.mention-typeahead-email {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
 /* ===========================================================================
    Disclosure cells in admin / dashboard tables
    ---------------------------------------------------------------------------

--- a/app/static/js/annotation_mentions.js
+++ b/app/static/js/annotation_mentions.js
@@ -16,15 +16,17 @@
  *    Returns {"results": [{id, label, full_name, email}, ...]}.
  *
  *  - On select, the ``@<query>`` substring is replaced with a
- *    whitespace-free, resolvable token: ``@<email-local-part> ``
- *    (the part before ``@`` in the user's email). ``parse_mentions``
- *    server-side resolves it by matching against ``users.email``'s
- *    local part. The readable display name still shows in the
- *    typeahead UI; we only insert the stable token because the
- *    server-side _MENTION_RE stops at whitespace and would otherwise
- *    truncate ``@Andres Tamm`` to ``@Andres``. If the user has no
- *    email we fall back to the full_name with spaces stripped, or
- *    the user id as a last resort — all whitespace-free.
+ *    whitespace-free, resolvable token: ``@<full-email> `` (e.g.
+ *    ``@andres@min.ee ``). The full email is globally unique in
+ *    ``users.email``, so ``parse_mentions`` server-side resolves it
+ *    unambiguously even when two orgs share the same local-part
+ *    (``andres@min.ee`` vs ``andres@agency.ee``). The readable display
+ *    name still shows in the typeahead UI; we only insert the stable
+ *    token because the server-side _MENTION_RE stops at whitespace and
+ *    would otherwise truncate ``@Andres Tamm`` to ``@Andres``. If the
+ *    user has no email we fall back to the email local-part, then the
+ *    full_name with spaces stripped, then the user id — all
+ *    whitespace-free.
  *
  *  - Keyboard: Down/Up navigate, Enter/Tab select, Escape closes.
  *
@@ -45,12 +47,17 @@
   // Debounce delay between the user typing and the fetch firing.
   const DEBOUNCE_MS = 150;
 
-  // Word-char regex for what counts as part of an @token. Matches the
-  // server-side _MENTION_RE in app/annotations/models.py:
-  //     re.compile(r"@([\w.\-]+)")
+  // Word-char regex for what counts as part of an *in-flight* @token (the
+  // chars the user is currently typing before they accept a suggestion).
+  // Mirrors the local-part character class of the server-side _MENTION_RE
+  // in app/annotations/models.py:
+  //     re.compile(r"@([\w.\-]+(?:@[\w.\-]+)?)")
   // \w in Python without re.ASCII includes Unicode letters (Estonian
   // diacritics). JS \w is ASCII-only by default, so we use Unicode
-  // property escapes for letters + digits.
+  // property escapes for letters + digits. We deliberately do NOT include
+  // ``@`` here: the user types ``@andres``, and on accept we *replace*
+  // that span with the full ``@andres@min.ee`` token — the typeahead
+  // never has to detect a literal ``@`` inside an in-flight token.
   const WORD_CHAR_RE = /[\p{L}\p{N}_.\-]/u;
 
   // Track widget instances by textarea so we don't double-bind.
@@ -63,26 +70,47 @@
 
   /**
    * Compute the whitespace-free token to insert after ``@`` for a
-   * suggestion. Prefer the email local-part (everything before ``@``),
-   * fall back to a space-stripped full_name, then the user id.
+   * suggestion. Prefer the full email address (e.g. ``andres@min.ee``)
+   * so the server-side resolver matches the exact user — even when two
+   * users in different orgs share the same email local-part. Fall back
+   * to the email local-part, then a space-stripped full_name, then the
+   * user id, so we always emit *something* the parser can match.
    *
-   * Only emits chars that match the server-side _MENTION_RE
-   * (``[\w.\-]+`` — Unicode letters/digits, underscore, dot, hyphen);
-   * any other char in the source is stripped so the token round-trips
-   * cleanly through the parser.
+   * The full-email path emits chars that match the expanded server-side
+   * _MENTION_RE (``[\w.\-]+(?:@[\w.\-]+)?`` — Unicode letters/digits,
+   * underscore, dot, hyphen, plus an optional ``@domain`` suffix). The
+   * fallback paths emit only ``[\w.\-]+`` chars. Any other char in the
+   * source is stripped so the token round-trips cleanly through the
+   * parser.
    */
   function mentionToken(choice) {
-    const safe = (s) =>
+    // Strict local-part safe (no ``@`` allowed).
+    const safeLocal = (s) =>
       String(s || "").replace(/[^\p{L}\p{N}_.\-]/gu, "");
+    // Full-email safe — keeps a single ``@`` between local-part and domain
+    // and strips any other ``@`` chars so the token always matches the
+    // server regex's optional ``@domain`` suffix exactly once.
+    const safeEmail = (s) => {
+      const cleaned = String(s || "").replace(/[^\p{L}\p{N}_.\-@]/gu, "");
+      const at = cleaned.indexOf("@");
+      if (at < 0) return cleaned;
+      const local = cleaned.slice(0, at).replace(/@/g, "");
+      const domain = cleaned.slice(at + 1).replace(/@/g, "");
+      if (!local || !domain) return local;
+      return `${local}@${domain}`;
+    };
     const email = String(choice.email || "");
-    const atIdx = email.indexOf("@");
-    if (atIdx > 0) {
-      const local = safe(email.slice(0, atIdx));
+    if (email.includes("@")) {
+      const fullEmail = safeEmail(email);
+      // Only accept when both local + domain survived sanitisation; this
+      // disambiguates two users who share a local-part in different orgs.
+      if (fullEmail.includes("@")) return fullEmail;
+      const local = safeLocal(email.split("@")[0]);
       if (local) return local;
     }
-    const fromName = safe(choice.full_name || choice.label);
+    const fromName = safeLocal(choice.full_name || choice.label);
     if (fromName) return fromName;
-    return safe(choice.id);
+    return safeLocal(choice.id);
   }
 
   /**
@@ -296,10 +324,12 @@
       const after = value.slice(textarea.selectionStart);
       // Insert a whitespace-free token so the server-side _MENTION_RE
       // (which stops at whitespace) captures the full identifier.
-      // Preferred form: ``@<email-local-part>``; fall back to
-      // ``@<full_name-without-spaces>`` and finally ``@<id>`` so we
-      // always insert something the resolver can match. The readable
-      // display label only appears in the typeahead UI itself.
+      // Preferred form: ``@<full-email>`` (globally unique, immune to
+      // local-part collisions across orgs); fall back to
+      // ``@<email-local-part>``, then ``@<full_name-without-spaces>``,
+      // then ``@<id>`` so we always insert something the resolver can
+      // match. The readable display label only appears in the typeahead
+      // UI itself.
       const token = mentionToken(choice);
       const insertion = `@${token} `;
       const newValue = before + insertion + after;

--- a/app/static/js/annotation_mentions.js
+++ b/app/static/js/annotation_mentions.js
@@ -15,9 +15,16 @@
  *  - Backend: GET /api/annotations/mentions/search?q=<prefix>
  *    Returns {"results": [{id, label, full_name, email}, ...]}.
  *
- *  - On select, the ``@<query>`` substring is replaced with
- *    ``@<full_name> `` (trailing space) so ``parse_mentions`` on the
- *    server side picks it up by name match against the users table.
+ *  - On select, the ``@<query>`` substring is replaced with a
+ *    whitespace-free, resolvable token: ``@<email-local-part> ``
+ *    (the part before ``@`` in the user's email). ``parse_mentions``
+ *    server-side resolves it by matching against ``users.email``'s
+ *    local part. The readable display name still shows in the
+ *    typeahead UI; we only insert the stable token because the
+ *    server-side _MENTION_RE stops at whitespace and would otherwise
+ *    truncate ``@Andres Tamm`` to ``@Andres``. If the user has no
+ *    email we fall back to the full_name with spaces stripped, or
+ *    the user id as a last resort — all whitespace-free.
  *
  *  - Keyboard: Down/Up navigate, Enter/Tab select, Escape closes.
  *
@@ -52,6 +59,30 @@
   /** Remove every child of an element without using innerHTML. */
   function clearChildren(el) {
     while (el.firstChild) el.removeChild(el.firstChild);
+  }
+
+  /**
+   * Compute the whitespace-free token to insert after ``@`` for a
+   * suggestion. Prefer the email local-part (everything before ``@``),
+   * fall back to a space-stripped full_name, then the user id.
+   *
+   * Only emits chars that match the server-side _MENTION_RE
+   * (``[\w.\-]+`` — Unicode letters/digits, underscore, dot, hyphen);
+   * any other char in the source is stripped so the token round-trips
+   * cleanly through the parser.
+   */
+  function mentionToken(choice) {
+    const safe = (s) =>
+      String(s || "").replace(/[^\p{L}\p{N}_.\-]/gu, "");
+    const email = String(choice.email || "");
+    const atIdx = email.indexOf("@");
+    if (atIdx > 0) {
+      const local = safe(email.slice(0, atIdx));
+      if (local) return local;
+    }
+    const fromName = safe(choice.full_name || choice.label);
+    if (fromName) return fromName;
+    return safe(choice.id);
   }
 
   /**
@@ -263,13 +294,14 @@
       const value = textarea.value;
       const before = value.slice(0, state.tokenStart);
       const after = value.slice(textarea.selectionStart);
-      // Insert @<full_name> followed by a single space. parse_mentions
-      // server-side handles ``@Full Name`` (matches users.full_name
-      // verbatim) and tolerates underscores → spaces; either form works.
-      const label = (choice.label || choice.full_name || choice.email || "")
-        .replace(/\s+/g, " ")
-        .trim();
-      const insertion = `@${label} `;
+      // Insert a whitespace-free token so the server-side _MENTION_RE
+      // (which stops at whitespace) captures the full identifier.
+      // Preferred form: ``@<email-local-part>``; fall back to
+      // ``@<full_name-without-spaces>`` and finally ``@<id>`` so we
+      // always insert something the resolver can match. The readable
+      // display label only appears in the typeahead UI itself.
+      const token = mentionToken(choice);
+      const insertion = `@${token} `;
       const newValue = before + insertion + after;
       const newCaret = before.length + insertion.length;
 

--- a/app/static/js/annotation_mentions.js
+++ b/app/static/js/annotation_mentions.js
@@ -1,0 +1,397 @@
+/**
+ * Annotation @mention typeahead — Issue #176.
+ *
+ * Lightweight vanilla JS widget that binds to any textarea carrying
+ * the ``data-annotation-textarea`` attribute and pops up a floating
+ * list of org-scoped user candidates when the caret is in the middle
+ * of an ``@token`` typed by the user.
+ *
+ * Wire pattern:
+ *   - This script is loaded globally from app/main.py _HDRS, so it
+ *     attaches itself to every textarea on the page on DOMContentLoaded
+ *     AND on every HTMX swap (so freshly-rendered annotation popovers
+ *     get the same behaviour without re-loading the script).
+ *
+ *  - Backend: GET /api/annotations/mentions/search?q=<prefix>
+ *    Returns {"results": [{id, label, full_name, email}, ...]}.
+ *
+ *  - On select, the ``@<query>`` substring is replaced with
+ *    ``@<full_name> `` (trailing space) so ``parse_mentions`` on the
+ *    server side picks it up by name match against the users table.
+ *
+ *  - Keyboard: Down/Up navigate, Enter/Tab select, Escape closes.
+ *
+ *  - Accessibility: textarea sets aria-expanded, aria-controls,
+ *    aria-activedescendant; the list has role="listbox" and each
+ *    option role="option".
+ *
+ * Security: every list item is built with textContent / DOM APIs only —
+ * no innerHTML on untrusted strings — so a malicious display name
+ * cannot inject markup.
+ */
+(function () {
+  "use strict";
+
+  // CSS selector for textareas we should hook into.
+  const TARGET_SELECTOR = "textarea[data-annotation-textarea]";
+
+  // Debounce delay between the user typing and the fetch firing.
+  const DEBOUNCE_MS = 150;
+
+  // Word-char regex for what counts as part of an @token. Matches the
+  // server-side _MENTION_RE in app/annotations/models.py:
+  //     re.compile(r"@([\w.\-]+)")
+  // \w in Python without re.ASCII includes Unicode letters (Estonian
+  // diacritics). JS \w is ASCII-only by default, so we use Unicode
+  // property escapes for letters + digits.
+  const WORD_CHAR_RE = /[\p{L}\p{N}_.\-]/u;
+
+  // Track widget instances by textarea so we don't double-bind.
+  const INSTANCES = new WeakMap();
+
+  /** Remove every child of an element without using innerHTML. */
+  function clearChildren(el) {
+    while (el.firstChild) el.removeChild(el.firstChild);
+  }
+
+  /**
+   * Wrap a single textarea with a mention-typeahead widget.
+   * Idempotent: returns the existing instance if the textarea is
+   * already wired up.
+   */
+  function attach(textarea) {
+    if (INSTANCES.has(textarea)) {
+      return INSTANCES.get(textarea);
+    }
+
+    // Floating result list element.
+    const list = document.createElement("ul");
+    list.className = "mention-typeahead";
+    list.setAttribute("role", "listbox");
+    list.hidden = true;
+    document.body.appendChild(list);
+
+    // ARIA wiring on the textarea.
+    const listId = `mention-typeahead-${Math.random().toString(36).slice(2, 8)}`;
+    list.id = listId;
+    textarea.setAttribute("aria-controls", listId);
+    textarea.setAttribute("aria-expanded", "false");
+    textarea.setAttribute("aria-autocomplete", "list");
+
+    const state = {
+      // Index of the ``@`` that started the active token, or -1 when no
+      // active token (closed).
+      tokenStart: -1,
+      // Current query string (chars after ``@``).
+      query: "",
+      // Search results list.
+      results: [],
+      // Active item index (for keyboard nav).
+      activeIndex: -1,
+      // Debounce timer.
+      debounceTimer: null,
+      // Last query we fetched, so we don't re-fetch identical strings.
+      lastFetched: null,
+    };
+
+    function close() {
+      state.tokenStart = -1;
+      state.query = "";
+      state.results = [];
+      state.activeIndex = -1;
+      list.hidden = true;
+      clearChildren(list);
+      textarea.setAttribute("aria-expanded", "false");
+      textarea.removeAttribute("aria-activedescendant");
+    }
+
+    function renderList() {
+      clearChildren(list);
+      if (!state.results.length) {
+        list.hidden = true;
+        textarea.setAttribute("aria-expanded", "false");
+        textarea.removeAttribute("aria-activedescendant");
+        return;
+      }
+      state.results.forEach((r, idx) => {
+        const li = document.createElement("li");
+        li.className =
+          "mention-typeahead-item" +
+          (idx === state.activeIndex ? " mention-typeahead-item--active" : "");
+        li.setAttribute("role", "option");
+        li.id = `${listId}-opt-${idx}`;
+        li.dataset.index = String(idx);
+        li.setAttribute(
+          "aria-selected",
+          idx === state.activeIndex ? "true" : "false",
+        );
+
+        const nameSpan = document.createElement("span");
+        nameSpan.className = "mention-typeahead-name";
+        nameSpan.textContent = r.label || r.full_name || r.email || "";
+        li.appendChild(nameSpan);
+
+        if (r.email && r.email !== (r.label || r.full_name)) {
+          const emailSpan = document.createElement("span");
+          emailSpan.className = "mention-typeahead-email";
+          emailSpan.textContent = r.email;
+          li.appendChild(emailSpan);
+        }
+
+        // Click selects. Use mousedown so the textarea's blur doesn't
+        // close the list before the click registers.
+        li.addEventListener("mousedown", (ev) => {
+          ev.preventDefault();
+          select(idx);
+        });
+        list.appendChild(li);
+      });
+
+      positionList();
+      list.hidden = false;
+      textarea.setAttribute("aria-expanded", "true");
+      if (state.activeIndex >= 0) {
+        textarea.setAttribute(
+          "aria-activedescendant",
+          `${listId}-opt-${state.activeIndex}`,
+        );
+      }
+    }
+
+    function positionList() {
+      // Position the list under the textarea. A caret-precise position
+      // would require a mirror element; for an MVP the bottom of the
+      // textarea is good enough and keeps the code small.
+      const rect = textarea.getBoundingClientRect();
+      list.style.position = "absolute";
+      list.style.left = `${window.scrollX + rect.left}px`;
+      list.style.top = `${window.scrollY + rect.bottom}px`;
+      list.style.minWidth = `${Math.max(rect.width, 220)}px`;
+      list.style.zIndex = "9999";
+    }
+
+    function detectToken() {
+      const value = textarea.value;
+      const caret = textarea.selectionStart;
+      if (caret === null || caret === undefined) {
+        close();
+        return;
+      }
+      // Walk backwards from caret to find ``@`` preceded by start-of-string
+      // or whitespace.
+      let i = caret - 1;
+      while (i >= 0) {
+        const ch = value[i];
+        if (ch === "@") {
+          // Validate the char before ``@`` is whitespace or string start.
+          if (i === 0 || /\s/.test(value[i - 1])) {
+            // Validate every char between i+1..caret-1 is a word char.
+            const between = value.slice(i + 1, caret);
+            if (between === "" || isAllWordChars(between)) {
+              state.tokenStart = i;
+              state.query = between;
+              scheduleFetch();
+              return;
+            }
+          }
+          break;
+        }
+        if (!WORD_CHAR_RE.test(ch)) {
+          break;
+        }
+        i -= 1;
+      }
+      close();
+    }
+
+    function isAllWordChars(str) {
+      for (const ch of str) {
+        if (!WORD_CHAR_RE.test(ch)) return false;
+      }
+      return true;
+    }
+
+    function scheduleFetch() {
+      if (state.debounceTimer) clearTimeout(state.debounceTimer);
+      state.debounceTimer = setTimeout(runFetch, DEBOUNCE_MS);
+    }
+
+    async function runFetch() {
+      const q = state.query;
+      if (q === state.lastFetched) {
+        // Same query as last time — nothing to do.
+        return;
+      }
+      state.lastFetched = q;
+      if (q.length === 0) {
+        // Empty query → no results, but keep tokenStart so further typing
+        // re-enters the loop.
+        state.results = [];
+        state.activeIndex = -1;
+        renderList();
+        return;
+      }
+      try {
+        const resp = await fetch(
+          `/api/annotations/mentions/search?q=${encodeURIComponent(q)}`,
+          {
+            headers: { Accept: "application/json" },
+            credentials: "same-origin",
+          },
+        );
+        if (!resp.ok) {
+          state.results = [];
+          state.activeIndex = -1;
+          renderList();
+          return;
+        }
+        const data = await resp.json();
+        state.results = Array.isArray(data.results) ? data.results : [];
+        state.activeIndex = state.results.length ? 0 : -1;
+        renderList();
+      } catch (e) {
+        // Network failure: silently degrade.
+        state.results = [];
+        state.activeIndex = -1;
+        renderList();
+      }
+    }
+
+    function select(idx) {
+      const choice = state.results[idx];
+      if (!choice) return;
+      const value = textarea.value;
+      const before = value.slice(0, state.tokenStart);
+      const after = value.slice(textarea.selectionStart);
+      // Insert @<full_name> followed by a single space. parse_mentions
+      // server-side handles ``@Full Name`` (matches users.full_name
+      // verbatim) and tolerates underscores → spaces; either form works.
+      const label = (choice.label || choice.full_name || choice.email || "")
+        .replace(/\s+/g, " ")
+        .trim();
+      const insertion = `@${label} `;
+      const newValue = before + insertion + after;
+      const newCaret = before.length + insertion.length;
+
+      // Stash the resolved user id for future use (e.g. richer client
+      // metadata); parse_mentions still re-resolves by name on submit, so
+      // this is purely informational.
+      const ids = (textarea.dataset.mentions || "")
+        .split(",")
+        .filter(Boolean);
+      if (!ids.includes(choice.id)) ids.push(choice.id);
+      textarea.dataset.mentions = ids.join(",");
+
+      textarea.value = newValue;
+      textarea.setSelectionRange(newCaret, newCaret);
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      close();
+      textarea.focus();
+    }
+
+    function moveActive(delta) {
+      if (!state.results.length) return;
+      const n = state.results.length;
+      state.activeIndex = (state.activeIndex + delta + n) % n;
+      renderList();
+    }
+
+    // --- event handlers -----------------------------------------------------
+
+    function onInput() {
+      detectToken();
+    }
+
+    function onKeyDown(ev) {
+      if (list.hidden || state.results.length === 0) {
+        if (state.tokenStart >= 0 && ev.key === "Escape") {
+          close();
+        }
+        return;
+      }
+      switch (ev.key) {
+        case "ArrowDown":
+          ev.preventDefault();
+          moveActive(1);
+          break;
+        case "ArrowUp":
+          ev.preventDefault();
+          moveActive(-1);
+          break;
+        case "Enter":
+        case "Tab":
+          if (state.activeIndex >= 0) {
+            ev.preventDefault();
+            select(state.activeIndex);
+          }
+          break;
+        case "Escape":
+          ev.preventDefault();
+          close();
+          break;
+        default:
+          break;
+      }
+    }
+
+    function onBlur() {
+      // Delay so a click on the list resolves first.
+      setTimeout(() => {
+        if (!list.contains(document.activeElement)) close();
+      }, 150);
+    }
+
+    function onDocClick(ev) {
+      if (ev.target === textarea || list.contains(ev.target)) return;
+      close();
+    }
+
+    function onScrollOrResize() {
+      if (!list.hidden) positionList();
+    }
+
+    textarea.addEventListener("input", onInput);
+    textarea.addEventListener("keydown", onKeyDown);
+    textarea.addEventListener("blur", onBlur);
+    document.addEventListener("click", onDocClick);
+    window.addEventListener("resize", onScrollOrResize);
+    window.addEventListener("scroll", onScrollOrResize, true);
+
+    const instance = {
+      textarea,
+      list,
+      destroy() {
+        textarea.removeEventListener("input", onInput);
+        textarea.removeEventListener("keydown", onKeyDown);
+        textarea.removeEventListener("blur", onBlur);
+        document.removeEventListener("click", onDocClick);
+        window.removeEventListener("resize", onScrollOrResize);
+        window.removeEventListener("scroll", onScrollOrResize, true);
+        list.remove();
+        INSTANCES.delete(textarea);
+      },
+    };
+    INSTANCES.set(textarea, instance);
+    return instance;
+  }
+
+  function attachAll(root) {
+    const scope = root && root.querySelectorAll ? root : document;
+    scope.querySelectorAll(TARGET_SELECTOR).forEach(attach);
+  }
+
+  // Initial pass.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => attachAll(document));
+  } else {
+    attachAll(document);
+  }
+
+  // Re-scan after every HTMX swap so newly-rendered popovers get bound.
+  document.body.addEventListener("htmx:afterSwap", (ev) => {
+    attachAll(ev.target || document);
+  });
+
+  // Expose for manual rebinds / debugging.
+  window.AnnotationMentions = { attach, attachAll };
+})();

--- a/app/ui/surfaces/annotation_popover.py
+++ b/app/ui/surfaces/annotation_popover.py
@@ -71,11 +71,13 @@ def AnnotationPopover(
         Input(type="hidden", name="target_id", value=target_id),  # noqa: F405
         Textarea(  # noqa: F405
             name="content",
-            placeholder="Lisa markus...",
+            placeholder="Lisa markus... Kasuta @nimi mainimiseks.",
             rows="3",
             cls="annotation-form-input",
             # #813: HTML4 string form survives FastHTML's HTTP renderer.
             required="required",
+            # #176: hook for the @mention typeahead JS widget.
+            data_annotation_textarea="1",
         ),
         Button(  # noqa: F405
             "Lisa markus",

--- a/tests/test_annotation_mentions.py
+++ b/tests/test_annotation_mentions.py
@@ -1,0 +1,310 @@
+"""Tests for the #176 @mention typeahead feature.
+
+Covers:
+    - GET /api/annotations/mentions/search — org-scoped user lookup
+    - Auth gate (303 redirect when unauthenticated)
+    - Empty query returns empty results
+    - notify_annotation_mention fan-out + self-exclusion
+
+Mocks the Postgres layer; same patterns as ``tests/test_annotations_routes.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from starlette.testclient import TestClient
+
+from app.annotations.models import Annotation
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_OTHER_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_OTHER_USER_ID = "44444444-4444-4444-4444-444444444444"
+_MENTIONED_USER_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+_ANOTHER_MENTIONED_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+
+
+def _authed_user(
+    user_id: str = _USER_ID,
+    org_id: str = _ORG_ID,
+) -> dict[str, Any]:
+    return {
+        "id": user_id,
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": org_id,
+    }
+
+
+def _stub_provider(user: dict[str, Any] | None = None) -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = user or _authed_user()
+    return provider
+
+
+def _authed_client() -> TestClient:
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+def _mock_db_conn(rows: list[tuple[Any, ...]] | None = None) -> MagicMock:
+    """Build a mock psycopg connection whose ``execute().fetchall()`` returns *rows*."""
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows or []
+    db = MagicMock()
+    db.execute.return_value = cursor
+    return db
+
+
+def _mock_conn_factory(db: MagicMock) -> MagicMock:
+    """Build a mock for ``_connect`` (a context-manager factory)."""
+    mock_conn = MagicMock()
+    mock_conn.return_value.__enter__ = MagicMock(return_value=db)
+    mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn
+
+
+# ---------------------------------------------------------------------------
+# GET /api/annotations/mentions/search — auth
+# ---------------------------------------------------------------------------
+
+
+class TestMentionsSearchAuth:
+    def test_unauth_redirects_to_login(self):
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get("/api/annotations/mentions/search?q=an")
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/auth/login"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/annotations/mentions/search — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestMentionsSearchResults:
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_returns_matching_users(self, mock_prov, mock_conn):
+        mock_prov.return_value = _stub_provider()
+
+        db = _mock_db_conn(
+            rows=[
+                (str(_MENTIONED_USER_ID), "Andres Tamm", "andres@min.ee"),
+                (str(_ANOTHER_MENTIONED_ID), "Anna Saar", "anna@min.ee"),
+            ]
+        )
+        # Replace the _connect symbol's context-manager return.
+        mock_conn.return_value.__enter__ = MagicMock(return_value=db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.get("/api/annotations/mentions/search?q=an")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert "results" in payload
+        assert len(payload["results"]) == 2
+        labels = {r["label"] for r in payload["results"]}
+        assert labels == {"Andres Tamm", "Anna Saar"}
+        # Each result carries id + label + full_name + email.
+        for r in payload["results"]:
+            assert set(r.keys()) >= {"id", "label", "full_name", "email"}
+
+        # Verify the SQL query was org-scoped.
+        call_args = db.execute.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "org_id = %s" in sql
+        assert "is_active = TRUE" in sql
+        assert params[0] == _ORG_ID  # first param is the caller's org_id
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_empty_query_returns_empty_results(self, mock_prov, mock_conn):
+        """A blank/whitespace q must short-circuit before hitting the DB."""
+        mock_prov.return_value = _stub_provider()
+
+        db = _mock_db_conn(rows=[])
+        mock_conn.return_value.__enter__ = MagicMock(return_value=db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+
+        # Missing q
+        resp = client.get("/api/annotations/mentions/search")
+        assert resp.status_code == 200
+        assert resp.json() == {"results": []}
+
+        # Whitespace-only q
+        resp = client.get("/api/annotations/mentions/search?q=%20%20")
+        assert resp.status_code == 200
+        assert resp.json() == {"results": []}
+
+        # No DB call should have happened.
+        db.execute.assert_not_called()
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_matches_returns_empty_list(self, mock_prov, mock_conn):
+        mock_prov.return_value = _stub_provider()
+
+        db = _mock_db_conn(rows=[])
+        mock_conn.return_value.__enter__ = MagicMock(return_value=db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.get("/api/annotations/mentions/search?q=zzzz")
+        assert resp.status_code == 200
+        assert resp.json() == {"results": []}
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_db_error_degrades_to_empty_list(self, mock_prov, mock_conn):
+        """A DB failure must never 500 the typeahead — degrade silently."""
+        mock_prov.return_value = _stub_provider()
+
+        db = MagicMock()
+        db.execute.side_effect = RuntimeError("DB exploded")
+        mock_conn.return_value.__enter__ = MagicMock(return_value=db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.get("/api/annotations/mentions/search?q=an")
+        assert resp.status_code == 200
+        assert resp.json() == {"results": []}
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_cross_org_isolation_via_sql_params(self, mock_prov, mock_conn):
+        """User in org1 must not see org2 users — verified via SQL param."""
+        mock_prov.return_value = _stub_provider(user=_authed_user(org_id=_OTHER_ORG_ID))
+
+        db = _mock_db_conn(rows=[])
+        mock_conn.return_value.__enter__ = MagicMock(return_value=db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.get("/api/annotations/mentions/search?q=an")
+        assert resp.status_code == 200
+
+        # The query must have been parameterised with the caller's org_id.
+        params = db.execute.call_args[0][1]
+        assert params[0] == _OTHER_ORG_ID
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_missing_org_returns_empty_list(self, mock_prov, mock_conn):
+        """An authed user with no org_id (edge case) gets an empty list."""
+        mock_prov.return_value = _stub_provider(user=_authed_user(org_id=""))
+
+        client = _authed_client()
+        resp = client.get("/api/annotations/mentions/search?q=an")
+        assert resp.status_code == 200
+        assert resp.json() == {"results": []}
+
+
+# ---------------------------------------------------------------------------
+# notify_annotation_mention — fan-out + self-exclusion
+# ---------------------------------------------------------------------------
+
+
+def _make_annotation_with_mentions(
+    *,
+    mentions: list[uuid.UUID],
+) -> Annotation:
+    now = datetime.now(UTC)
+    return Annotation(
+        id=uuid.UUID("99999999-9999-9999-9999-999999999999"),
+        user_id=uuid.UUID(_USER_ID),
+        org_id=uuid.UUID(_ORG_ID),
+        target_type="impact_report_item",
+        target_id="conflict:abc123",
+        target_metadata=None,
+        content="Tere @Andres ja @Anna — vaadake palun üle.",
+        resolved=False,
+        resolved_by=None,
+        resolved_at=None,
+        created_at=now,
+        updated_at=now,
+        mentions=mentions,
+    )
+
+
+class TestNotifyAnnotationMention:
+    @patch("app.notifications.wire.notify")
+    def test_notifies_every_mentioned_user_except_self(self, mock_notify):
+        """Each mentioned user gets one notify() call; self is skipped."""
+        from app.notifications.wire import notify_annotation_mention
+
+        # Author is _USER_ID; they appear in the mention list along with
+        # two genuine targets.
+        mentions = [
+            uuid.UUID(_USER_ID),  # self → must be skipped
+            _MENTIONED_USER_ID,
+            _ANOTHER_MENTIONED_ID,
+        ]
+        annotation = _make_annotation_with_mentions(mentions=mentions)
+
+        notify_annotation_mention(
+            annotation=annotation,
+            mentioned_user_ids=mentions,
+            mentioner_user_id=uuid.UUID(_USER_ID),
+        )
+
+        # Exactly two notify() calls: one per non-self mention.
+        assert mock_notify.call_count == 2
+        called_user_ids = {call.kwargs["user_id"] for call in mock_notify.call_args_list}
+        assert called_user_ids == {_MENTIONED_USER_ID, _ANOTHER_MENTIONED_ID}
+
+        # Type / title checks.
+        for call in mock_notify.call_args_list:
+            assert call.kwargs["type"] == "annotation_mention"
+            assert call.kwargs["title"] == "Sind mainiti märkuses"
+            # Metadata carries annotation_id + mentioner_user_id.
+            md = call.kwargs["metadata"]
+            assert md["annotation_id"] == str(annotation.id)
+            assert md["mentioner_user_id"] == _USER_ID
+
+    @patch("app.notifications.wire.notify")
+    def test_empty_mentions_no_notifications(self, mock_notify):
+        from app.notifications.wire import notify_annotation_mention
+
+        annotation = _make_annotation_with_mentions(mentions=[])
+        notify_annotation_mention(
+            annotation=annotation,
+            mentioned_user_ids=[],
+            mentioner_user_id=uuid.UUID(_USER_ID),
+        )
+        mock_notify.assert_not_called()
+
+    @patch("app.notifications.wire.notify")
+    def test_swallows_exceptions(self, mock_notify):
+        """notify_annotation_mention is fire-and-forget — must not raise."""
+        from app.notifications.wire import notify_annotation_mention
+
+        mock_notify.side_effect = RuntimeError("DB exploded")
+
+        annotation = _make_annotation_with_mentions(
+            mentions=[_MENTIONED_USER_ID],
+        )
+        # Should not raise.
+        notify_annotation_mention(
+            annotation=annotation,
+            mentioned_user_ids=[_MENTIONED_USER_ID],
+            mentioner_user_id=uuid.UUID(_USER_ID),
+        )

--- a/tests/test_annotations_models.py
+++ b/tests/test_annotations_models.py
@@ -753,6 +753,49 @@ class TestRowAnnotationExtensions:
         result = parse_mentions(conn, "@kasutaja kommenteerib.", _ORG_ID)
         assert result == []
 
+    def test_parse_mentions_resolves_email_local_part_for_multi_word_name(self):
+        """End-to-end: typeahead inserts @<email-local-part> for a multi-word
+        display name (e.g. ``Andres Tamm`` → ``@andres``). The resolver must
+        match the user via the ``email LIKE 'andres@%'`` arm — without this,
+        the original bug truncated ``@Andres Tamm`` to ``@Andres`` and never
+        resolved.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        # Simulate what annotation_mentions.js now inserts for a user whose
+        # display name is "Andres Tamm" and whose email is "andres@min.ee".
+        content = "Palun vaata üle @andres — see vajab kommentaari."
+        result = parse_mentions(conn, content, _ORG_ID)
+
+        assert result == [_USER_ID]
+        # The local-part LIKE parameter must be passed and shaped correctly.
+        params = conn.execute.call_args.args[1]
+        # token (lowercase) is "andres"; the email-local-part LIKE pattern
+        # must be "andres@%". The same pattern appears twice (once for the
+        # IS NOT NULL guard, once for the LIKE).
+        assert "andres@%" in params
+
+    def test_parse_mentions_literal_email_still_resolves(self):
+        """A typed ``@user@domain`` form skips the local-part LIKE arm and
+        resolves via the exact-email arm — ``@`` in the token would otherwise
+        produce a malformed LIKE pattern.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        # NB: ``_MENTION_RE`` stops at ``@`` because ``@`` isn't a word char,
+        # so the captured token is just the local-part. This exercises the
+        # safe fallback path where the SQL is still well-formed even if the
+        # local-part pattern happens to coincide with someone's email prefix.
+        content = "@peeter on autor."
+        result = parse_mentions(conn, content, _ORG_ID)
+        assert result == [_USER_ID]
+        params = conn.execute.call_args.args[1]
+        # Local-part LIKE is populated (token has no @), and it must be the
+        # well-formed "peeter@%" pattern, never None or empty.
+        assert params[3] == "peeter@%"
+
     # ------------------------------------------------------------------
     # list_annotations_for_version_row
     # ------------------------------------------------------------------

--- a/tests/test_annotations_models.py
+++ b/tests/test_annotations_models.py
@@ -772,22 +772,24 @@ class TestRowAnnotationExtensions:
         # The local-part LIKE parameter must be passed and shaped correctly.
         params = conn.execute.call_args.args[1]
         # token (lowercase) is "andres"; the email-local-part LIKE pattern
-        # must be "andres@%". The same pattern appears twice (once for the
-        # IS NOT NULL guard, once for the LIKE).
+        # must be "andres@%". This is back-compat for users who manually type
+        # ``@andres`` — the typeahead now inserts the full email instead so
+        # the cross-org LIMIT 1 ambiguity is avoided when accepting a
+        # suggestion (#825 P2 follow-up).
         assert "andres@%" in params
 
     def test_parse_mentions_literal_email_still_resolves(self):
-        """A typed ``@user@domain`` form skips the local-part LIKE arm and
-        resolves via the exact-email arm — ``@`` in the token would otherwise
-        produce a malformed LIKE pattern.
+        """A bare ``@local-part`` form (no ``@domain`` suffix) is captured by
+        ``_MENTION_RE`` as just the local-part. The bare-token branch must
+        produce a well-formed ``local@%`` LIKE pattern at index 3, never
+        None or empty.
         """
         conn = MagicMock()
         conn.execute.return_value.fetchone.return_value = (_USER_ID,)
 
-        # NB: ``_MENTION_RE`` stops at ``@`` because ``@`` isn't a word char,
-        # so the captured token is just the local-part. This exercises the
-        # safe fallback path where the SQL is still well-formed even if the
-        # local-part pattern happens to coincide with someone's email prefix.
+        # NB: this input has NO ``@domain`` suffix, so the captured token is
+        # just the local-part. Exercises the bare-token branch and asserts
+        # the LIKE param is well-formed.
         content = "@peeter on autor."
         result = parse_mentions(conn, content, _ORG_ID)
         assert result == [_USER_ID]
@@ -795,6 +797,134 @@ class TestRowAnnotationExtensions:
         # Local-part LIKE is populated (token has no @), and it must be the
         # well-formed "peeter@%" pattern, never None or empty.
         assert params[3] == "peeter@%"
+
+    # ------------------------------------------------------------------
+    # parse_mentions — full-email disambiguation (#825 P2 follow-up)
+    # ------------------------------------------------------------------
+
+    def test_parse_mentions_full_email_is_captured_as_one_token(self):
+        """``_MENTION_RE`` must capture ``andres@min.ee`` as a single token
+        (local-part + ``@domain``) so the resolver can do an exact-email
+        match instead of a cross-org-ambiguous local-part LIKE.
+        """
+        from app.annotations.models import _MENTION_RE
+
+        tokens = _MENTION_RE.findall("Tere @andres@min.ee, palun vaata.")
+        assert tokens == ["andres@min.ee"]
+
+    def test_parse_mentions_full_email_uses_exact_arm_only(self):
+        """A token with ``@`` (full email) must hit the 2-arm exact-email SQL
+        path and NOT pass a local-part LIKE pattern that could collide with
+        another user in a different org sharing the same local-part.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        content = "Palun vaata @andres@min.ee — see vajab kommentaari."
+        result = parse_mentions(conn, content, _ORG_ID)
+
+        assert result == [_USER_ID]
+        sql, params = conn.execute.call_args.args
+        # The full-email SQL is the 2-arm variant: only org_id + 2 emails.
+        assert "lower(email) LIKE" not in sql
+        assert "full_name ILIKE" not in sql
+        # Params: (org_id, exact-email, lowercase-email) — exactly 3 entries.
+        assert params == (str(_ORG_ID), "andres@min.ee", "andres@min.ee")
+
+    def test_parse_mentions_full_email_with_uppercase_domain(self):
+        """Case-insensitive resolution: ``@Andres@MIN.ee`` lowercased in the
+        second exact-email param so DB rows stored lower still match.
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        content = "@Andres@MIN.ee siin."
+        result = parse_mentions(conn, content, _ORG_ID)
+
+        assert result == [_USER_ID]
+        params = conn.execute.call_args.args[1]
+        # exact arm uses the raw token; case-insensitive arm uses .lower().
+        assert params[1] == "Andres@MIN.ee"
+        assert params[2] == "andres@min.ee"
+
+    def test_parse_mentions_full_email_disambiguates_cross_org_collision(self):
+        """Collision case: two users named ``andres`` exist in different orgs
+        (``andres@min.ee`` in org A, ``andres@agency.ee`` in org B). When
+        a mention by full email is parsed for org A, only the org-A row is
+        returned even though the local-part is shared.
+
+        The org_id WHERE filter does the heavy lifting; the test asserts
+        that the typeahead-inserted full-email token round-trips correctly
+        for *each* org independently.
+        """
+        org_a = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        org_b = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        user_a = uuid.UUID("aaaa1111-aaaa-1111-aaaa-aaaa11111111")
+        user_b = uuid.UUID("bbbb2222-bbbb-2222-bbbb-bbbb22222222")
+
+        # Org A lookup: DB returns user_a's row.
+        conn_a = MagicMock()
+        conn_a.execute.return_value.fetchone.return_value = (user_a,)
+        result_a = parse_mentions(conn_a, "@andres@min.ee", org_a)
+        assert result_a == [user_a]
+        params_a = conn_a.execute.call_args.args[1]
+        assert params_a[0] == str(org_a)
+        assert params_a[1] == "andres@min.ee"
+
+        # Org B lookup: same local-part, different domain → different user.
+        conn_b = MagicMock()
+        conn_b.execute.return_value.fetchone.return_value = (user_b,)
+        result_b = parse_mentions(conn_b, "@andres@agency.ee", org_b)
+        assert result_b == [user_b]
+        params_b = conn_b.execute.call_args.args[1]
+        assert params_b[0] == str(org_b)
+        assert params_b[1] == "andres@agency.ee"
+
+    def test_parse_mentions_mixed_full_email_and_bare_local(self):
+        """A single content string may contain both a full-email mention and
+        a bare-local mention; both must resolve via their respective SQL
+        branches without one branch's params bleeding into the other.
+        """
+        conn = MagicMock()
+        # Two execute() calls → return distinct users in order.
+        user2 = uuid.UUID("c0c0c0c0-c0c0-c0c0-c0c0-c0c0c0c0c0c0")
+        conn.execute.return_value.fetchone.side_effect = [(_USER_ID,), (user2,)]
+
+        # NB: trailing whitespace + punctuation (NOT . / -) so the bare
+        # token is captured cleanly as "peeter" — both . and - are word
+        # chars in _MENTION_RE's [\w.\-] class.
+        content = "Tere @andres@min.ee ja @peeter aitäh"
+        result = parse_mentions(conn, content, _ORG_ID)
+
+        assert result == [_USER_ID, user2]
+        assert conn.execute.call_count == 2
+
+        # First call (full email) → 2-arm SQL, 3 params.
+        first_sql, first_params = conn.execute.call_args_list[0].args
+        assert "full_name ILIKE" not in first_sql
+        assert len(first_params) == 3
+        assert first_params[1] == "andres@min.ee"
+
+        # Second call (bare local-part) → 5-arm SQL with the LIKE pattern.
+        second_sql, second_params = conn.execute.call_args_list[1].args
+        assert "full_name ILIKE" in second_sql
+        assert second_params[3] == "peeter@%"
+
+    def test_parse_mentions_full_email_with_dotted_local_part(self):
+        """Dotted local-parts (``@john.doe@min.ee``) survive ``_MENTION_RE``
+        as one token and resolve via exact-email.
+        """
+        from app.annotations.models import _MENTION_RE
+
+        tokens = _MENTION_RE.findall("cc @john.doe@min.ee siin")
+        assert tokens == ["john.doe@min.ee"]
+
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+        result = parse_mentions(conn, "@john.doe@min.ee", _ORG_ID)
+        assert result == [_USER_ID]
+        params = conn.execute.call_args.args[1]
+        assert params[1] == "john.doe@min.ee"
 
     # ------------------------------------------------------------------
     # list_annotations_for_version_row


### PR DESCRIPTION
## Summary
- Backend: `GET /api/annotations/mentions/search?q=<prefix>` — auth-gated, org-scoped, 10-row LIMIT, returns `{"results": [{id, label, full_name, email}]}`. Empty/whitespace `q`, missing org, and DB errors degrade to `{"results": []}`.
- Frontend: `app/static/js/annotation_mentions.js` — vanilla JS typeahead bound to `textarea[data-annotation-textarea]`. Debounced 150ms fetch, role=listbox + aria-activedescendant, keyboard nav (Down/Up/Enter/Tab/Esc), click-outside close, `htmx:afterSwap` re-scan. All DOM built with `textContent` (no innerHTML XSS).
- Three textareas wired: popover form, thread reply, row-panel compose. Estonian placeholder "Kasuta @nimi mainimiseks."
- New `notify_annotation_mention(annotation, mentioned_user_ids, mentioner_user_id)` in `app/notifications/wire.py` — fires from `post_row_message_handler`, excludes self-mentions, type=`annotation_mention`, title "Sind mainiti märkuses".
- Closes #176

## Test plan
- [x] `tests/test_annotation_mentions.py` — 10 new tests (auth redirect, SQL params, empty q short-circuit, no-match, DB error degradation, cross-org isolation, mention fan-out, self-exclusion, exception swallowing)
- [x] Full annotation suite (169 tests) green
- [x] Notification suite (36 tests) green
- [x] ruff + pyright clean
- [ ] Manual: type @ in popover and verify dropdown (staging)

## Notes
- `create_annotation` and `create_reply` paths don't yet persist `mentions` on the model — fan-out only fires from the row-panel write path, which already resolves mentions. Generalizing to the other paths is out of scope here.