### PR TITLE
feat(docs): #306 — draft re-analyze button + handler with history

### DIFF
--- a/app/docs/audit.py
+++ b/app/docs/audit.py
@@ -42,6 +42,20 @@ def log_draft_view(user_id: str | None, draft_id: Any, **extra: Any) -> None:
     log_action(user_id, "draft.view", detail)
 
 
+def log_draft_reanalyze(user_id: str | None, draft_id: Any, **extra: Any) -> None:
+    """Record a ``draft.reanalyze`` event (issue #306).
+
+    Fired by the draft-detail "Analüüsi uuesti" button which resets the
+    draft to ``status='analyzing'`` and re-enqueues the ``analyze_impact``
+    job without touching the parse / extract stages.  Extra keyword
+    arguments (``job_id``, ``prior_status``, ...) are folded into the
+    audit ``detail`` blob so reviewers can answer "what state was the
+    draft in before the re-run?".
+    """
+    detail: dict[str, Any] = {"draft_id": str(draft_id), **extra}
+    log_action(user_id, "draft.reanalyze", detail)
+
+
 def log_review_outcome(
     user_id: str | None,
     draft_id: Any,

--- a/app/docs/routes/__init__.py
+++ b/app/docs/routes/__init__.py
@@ -13,6 +13,7 @@ Route map:
     POST /drafts/{draft_id}/link-vtk — set or clear ``parent_vtk_id`` (#640)
     GET  /drafts/{draft_id}/diff     — side-by-side version diff (#618 PR-C)
     POST /drafts/{draft_id}/retry    — retry a failed draft's pipeline (#656)
+    POST /drafts/{draft_id}/reanalyze — re-run impact analysis on a finished draft (#306)
     POST /drafts/{draft_id}/review-outcome — reviewer outcome (#817)
 
 All routes require authentication (they are **not** in ``SKIP_PATHS``).
@@ -109,7 +110,11 @@ from app.docs.routes._detail_versions import (
     _version_timeline_section,
     draft_diff_page,
 )
-from app.docs.routes._lifecycle import delete_draft_handler, keep_draft_handler
+from app.docs.routes._lifecycle import (
+    delete_draft_handler,
+    keep_draft_handler,
+    reanalyze_draft_handler,
+)
 from app.docs.routes._list import (
     _DOC_TYPE_BADGE,
     _DOC_TYPE_CHOICES,
@@ -216,6 +221,7 @@ __all__ = [
     # _lifecycle.py (re-exported for symmetry; #703 already moved these)
     "delete_draft_handler",
     "keep_draft_handler",
+    "reanalyze_draft_handler",
     # _detail_modals.py constants (#704 PR-E)
     "_DELETE_FORM_ID",
     "_DELETE_MODAL_ID",
@@ -280,6 +286,9 @@ def register_draft_routes(rt) -> None:  # type: ignore[no-untyped-def]
     rt("/drafts/{draft_id}/actions", methods=["GET"])(draft_actions_fragment)
     rt("/drafts/{draft_id}/keep", methods=["POST"])(keep_draft_handler)
     rt("/drafts/{draft_id}/delete", methods=["POST"])(delete_draft_handler)
+    # #306: re-run analysis on a finished draft (ready/failed) — distinct
+    # from the report-page ontology-drift reanalyze + the parse-from-top retry.
+    rt("/drafts/{draft_id}/reanalyze", methods=["POST"])(reanalyze_draft_handler)
     rt("/drafts/{draft_id}/link-vtk", methods=["POST"])(link_vtk_handler)
     # #817: reviewer-only outcome submission.
     rt("/drafts/{draft_id}/review-outcome", methods=["POST"])(submit_review_outcome_handler)

--- a/app/docs/routes/_detail.py
+++ b/app/docs/routes/_detail.py
@@ -87,6 +87,10 @@ from app.docs.routes._detail_modals import (
     _DRAFT_METADATA_ID,
     _LINK_VTK_MODAL_ID,
     _LINK_VTK_TRIGGER_ID,
+    _REANALYZE_FORM_ID,
+    _REANALYZE_MODAL_ID,
+    _REANALYZE_MODAL_SCRIPT,
+    _REANALYZE_TRIGGER_ID,
     _link_vtk_modal,
 )
 from app.docs.routes._detail_versions import (
@@ -579,6 +583,65 @@ def _draft_detail_body(
                 title="Ava selle eelnõu mõjuahel Analüüsikeskuses.",
             )
         )
+
+    # #306: "Analüüsi uuesti" — re-run impact analysis on a finished
+    # draft. Visible only when the pipeline has reached a terminal
+    # state (``ready`` / ``failed``) so the button can't race an
+    # in-flight run; the server-side handler in ``_lifecycle.py``
+    # revalidates the same condition. Same-org viewers see the button
+    # because the detail page itself is org-scoped via
+    # :func:`can_view_draft`; the handler re-checks org scope for
+    # defence-in-depth.
+    #
+    # Uses the shared ConfirmModal primitive (matching the delete flow
+    # per #601) so the confirm prompt is keyboard-accessible, focus-
+    # trapped, and free of the native ``confirm()`` artefacts that
+    # ``hx-confirm`` would otherwise inject.
+    if draft.status in ("ready", "failed"):
+        actions.append(
+            Button(
+                "Analüüsi uuesti",
+                type="button",
+                variant="secondary",
+                size="md",
+                id=_REANALYZE_TRIGGER_ID,
+                aria_haspopup="dialog",
+                aria_controls=_REANALYZE_MODAL_ID,
+            )
+        )
+        actions.append(
+            Form(  # noqa: F405
+                # Hidden HTMX form fired by the modal's confirm button
+                # via ``window.htmx.trigger(form, 'submit')`` — mirrors
+                # the delete flow exactly. The native ``action`` is
+                # the no-JS fallback; without JS the user cannot open
+                # the modal anyway, but if something else POSTs the
+                # form they still hit the right endpoint.
+                id=_REANALYZE_FORM_ID,
+                method="post",
+                action=f"/drafts/{draft.id}/reanalyze",
+                enctype="application/x-www-form-urlencoded",
+                hx_post=f"/drafts/{draft.id}/reanalyze",
+                hx_target="body",
+                hx_swap="outerHTML",
+                cls="inline-form draft-reanalyze-form",
+                hidden="hidden",
+            )
+        )
+        actions.append(
+            ConfirmModal(
+                "Käivita analüüs uuesti",
+                "Soovid eelnõu mõjuanalüüsi uuesti käivitada? "
+                "Olemasolev aruanne säilib ajaloos ja uus aruanne "
+                "lisatakse selle kõrvale.",
+                id=_REANALYZE_MODAL_ID,
+                confirm_label="Käivita",
+                cancel_label="Tühista",
+                confirm_variant="primary",
+            )
+        )
+        actions.append(ModalScript())
+        actions.append(Script(_REANALYZE_MODAL_SCRIPT))  # noqa: F405
 
     # #572: stale drafts (not accessed for 90+ days) get a "Hoia alles"
     # button so the owner can reset the archive clock. The owner-only

--- a/app/docs/routes/_detail_modals.py
+++ b/app/docs/routes/_detail_modals.py
@@ -56,6 +56,11 @@ _LINK_VTK_TRIGGER_ID = "link-vtk-trigger"
 _LINK_VTK_FORM_ID = "link-vtk-form"
 _DRAFT_METADATA_ID = "draft-metadata"
 
+# #306: identifiers for the "Analüüsi uuesti" confirm modal + its hidden form.
+_REANALYZE_MODAL_ID = "reanalyze-draft-modal"
+_REANALYZE_TRIGGER_ID = "reanalyze-draft-trigger"
+_REANALYZE_FORM_ID = "reanalyze-draft-form"
+
 
 # ---------------------------------------------------------------------------
 # Inline JS payloads
@@ -102,6 +107,32 @@ _DELETE_MODAL_SCRIPT = (
     "  });\n"
     "  confirmBtn.addEventListener('click', function () {\n"
     f"    window.Modal.close('{_DELETE_MODAL_ID}');\n"
+    "    if (window.htmx && typeof window.htmx.trigger === 'function') {\n"
+    "      window.htmx.trigger(form, 'submit');\n"
+    "    } else {\n"
+    "      form.submit();\n"
+    "    }\n"
+    "  });\n"
+    "})();\n"
+)
+
+# #306: same shape as ``_DELETE_MODAL_SCRIPT`` — the "Analüüsi uuesti"
+# trigger opens the confirm modal, the modal's confirm button fires the
+# hidden HTMX form's submit. Kept as a separate script so the IDs are
+# scoped per-action and the two flows can co-exist on the same page
+# without colliding event listeners.
+_REANALYZE_MODAL_SCRIPT = (
+    "(function () {\n"
+    f"  var trigger = document.getElementById('{_REANALYZE_TRIGGER_ID}');\n"
+    f"  var confirmBtn = document.getElementById('{_REANALYZE_MODAL_ID}-confirm');\n"
+    f"  var form = document.getElementById('{_REANALYZE_FORM_ID}');\n"
+    "  if (!trigger || !confirmBtn || !form || !window.Modal) return;\n"
+    "  trigger.addEventListener('click', function (evt) {\n"
+    "    evt.preventDefault();\n"
+    f"    window.Modal.open('{_REANALYZE_MODAL_ID}');\n"
+    "  });\n"
+    "  confirmBtn.addEventListener('click', function () {\n"
+    f"    window.Modal.close('{_REANALYZE_MODAL_ID}');\n"
     "    if (window.htmx && typeof window.htmx.trigger === 'function') {\n"
     "      window.htmx.trigger(form, 'submit');\n"
     "    } else {\n"

--- a/app/docs/routes/_lifecycle.py
+++ b/app/docs/routes/_lifecycle.py
@@ -344,12 +344,27 @@ def reanalyze_draft_handler(req: Request, draft_id: str):
     prior_status = draft.status
 
     # Flip the row to ``analyzing`` and clear any stale error / completion
-    # timestamps in a single transaction via the SSOT helper. Same
-    # transaction purges in-flight queue entries so the fresh analyze
-    # can't race a stuck prior job.
+    # timestamps in a single transaction via the SSOT helper. The
+    # ``expected_status=prior_status`` predicate is the optimistic-
+    # concurrency guard that makes this safe under concurrent POSTs
+    # (two open tabs, a double-click, a retried request): the underlying
+    # ``UPDATE drafts SET status='analyzing' WHERE id=? AND status=?``
+    # matches at most one writer. The loser sees ``updated=False`` and
+    # short-circuits below WITHOUT enqueuing a duplicate analyze job or
+    # purging the winner's freshly-enqueued queue entry. Without this
+    # predicate, both callers would see ``updated=True`` (both flip a
+    # ``ready`` row to ``analyzing`` idempotently) and both would enqueue
+    # — defeating the state-machine guard above. Same transaction also
+    # purges any in-flight queue entries left over from a previous
+    # stuck analyze, so the fresh job can't race them.
     try:
         with _connect() as conn:
-            updated = update_draft_status(conn, parsed, "analyzing")
+            updated = update_draft_status(
+                conn,
+                parsed,
+                "analyzing",
+                expected_status=prior_status,
+            )
             if updated:
                 conn.execute(
                     """
@@ -366,8 +381,11 @@ def reanalyze_draft_handler(req: Request, draft_id: str):
 
     if not updated:
         # Either the row vanished mid-flight or a parallel writer beat
-        # us to a status change. Treat as a no-op and bounce back to the
-        # detail page where the user will see the actual state.
+        # us to the status flip (concurrent reanalyze POSTs from two
+        # tabs / a double-click — the ``expected_status`` predicate
+        # above lets exactly one of them win). Treat as a no-op and
+        # bounce back to the detail page where the user will see the
+        # actual state. NO job is enqueued and NO queue entry is purged.
         logger.info(
             "reanalyze_draft_handler: draft=%s update_draft_status matched 0 rows (race)",
             parsed,

--- a/app/docs/routes/_lifecycle.py
+++ b/app/docs/routes/_lifecycle.py
@@ -9,12 +9,17 @@ package's ``__init__.py`` and will move in follow-up PRs.
 
 Routes registered:
 
-    POST /drafts/{draft_id}/delete   — delete_draft_handler
-    POST /drafts/{draft_id}/keep     — keep_draft_handler
+    POST /drafts/{draft_id}/delete     — delete_draft_handler
+    POST /drafts/{draft_id}/keep       — keep_draft_handler
+    POST /drafts/{draft_id}/reanalyze  — reanalyze_draft_handler (#306)
 
-Both routes are owner-only per ``app.auth.policy.can_delete_draft``;
-cross-org or non-owner callers receive 404 (never 403) so existence
-is not leaked.
+The delete/keep routes are owner-only per
+``app.auth.policy.can_delete_draft``; the reanalyze route is
+**org-scoped** (any same-org viewer per ``can_view_draft``) since
+re-running analysis is a read-like governance action and the existing
+``POST /drafts/{id}/report/reanalyze`` ontology-drift route already
+uses the same scoping. Cross-org callers receive 404 (never 403) so
+existence is not leaked.
 """
 
 from __future__ import annotations
@@ -26,21 +31,31 @@ from starlette.responses import RedirectResponse, Response
 
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
-from app.auth.policy import can_delete_draft
+from app.auth.policy import can_delete_draft, can_view_draft
 from app.db import get_connection as _connect
 from app.docs._helpers import _not_found_page, _parse_uuid
-from app.docs.audit import log_draft_delete
+from app.docs.audit import log_draft_delete, log_draft_reanalyze
 from app.docs.draft_model import (
     delete_draft,
     fetch_draft,
     get_draft_artifact_paths,
     touch_draft_access,
 )
+from app.docs.status import update_draft_status
 from app.jobs.queue import JobQueue
 from app.rag.retriever import delete_chunks_for_draft
 from app.ui.feedback.flash import push_flash
 
 logger = logging.getLogger(__name__)
+
+# #306: a draft can only be re-analyzed when its pipeline has reached a
+# terminal state.  Allowing re-analyze mid-pipeline (``parsing`` /
+# ``extracting`` / ``analyzing``) would either race the in-flight job
+# (double-enqueue) or stomp on partial work.  ``uploaded`` is excluded
+# because the natural pipeline will pick it up on its own — re-analyze
+# is for *re-running* a completed (or permanently failed) analysis, not
+# for kicking off a fresh one.
+_REANALYZABLE_STATUSES: frozenset[str] = frozenset({"ready", "failed"})
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +264,157 @@ def keep_draft_handler(req: Request, draft_id: str):
 
     # HTMX-driven submits get an HX-Redirect so the browser performs a
     # real navigation rather than swapping a partial into <body>.
+    if req.headers.get("HX-Request") == "true":
+        return Response(
+            status_code=204,
+            headers={"HX-Redirect": f"/drafts/{parsed}"},
+        )
+    return RedirectResponse(url=f"/drafts/{parsed}", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# POST /drafts/{draft_id}/reanalyze — re-run impact analysis (#306)
+# ---------------------------------------------------------------------------
+
+
+def reanalyze_draft_handler(req: Request, draft_id: str):
+    """POST /drafts/{draft_id}/reanalyze — re-enqueue the analyze stage.
+
+    Distinct from ``POST /drafts/{id}/retry`` (which restarts the WHOLE
+    pipeline from ``parse_draft`` for a *failed* draft) and from
+    ``POST /drafts/{id}/report/reanalyze`` (which targets only the
+    ontology-drift banner on the report page). This route is the
+    user-facing "re-run analysis on a finished draft" action and is
+    wired to the "Analüüsi uuesti" button on the draft detail page.
+
+    Behaviour:
+
+    * Authorization is **org-scoped** via :func:`can_view_draft` —
+      matches the existing report-level reanalyze handler so a same-org
+      reviewer can refresh the analysis without bouncing through the
+      owner. Cross-org callers resolve to 404 (never 403) so we never
+      leak the draft's existence.
+    * Re-runnable only from terminal states (``ready`` or ``failed``).
+      Any other status returns a 303 redirect to the detail page so a
+      stale tab can't double-enqueue against an in-flight pipeline.
+    * The DB mutation flips the draft to ``status='analyzing'`` and
+      clears ``error_message`` / ``error_debug`` / ``processing_completed_at``
+      via the SSOT :func:`update_draft_status` helper. The prior
+      ``impact_reports`` row is left untouched — the new analyze job
+      INSERTs a fresh row so older reports remain queryable as history
+      (the report page already orders ``generated_at DESC LIMIT 1`` so
+      the latest is surfaced automatically).
+    * Stale ``pending`` / ``claimed`` / ``running`` jobs referencing
+      this draft are purged in the same transaction so a previously
+      stuck analyze can't race the fresh one.
+    """
+    auth_or_redirect = _require_auth(req)
+    if isinstance(auth_or_redirect, Response):
+        return auth_or_redirect
+    auth = auth_or_redirect
+
+    parsed = _parse_uuid(draft_id)
+    if parsed is None:
+        return _not_found_page(req)
+
+    draft = fetch_draft(parsed)
+    if draft is None:
+        return _not_found_page(req)
+    # 404 (not 403) on cross-org access so we never leak existence
+    # (matches delete_draft_handler + retry_draft_handler).
+    if not can_view_draft(auth, draft):
+        return _not_found_page(req)
+
+    # Revalidate state server-side. A duplicate POST from a stale tab
+    # after the pipeline already restarted must be a no-op — not a
+    # second concurrent run that fights the first.
+    if draft.status not in _REANALYZABLE_STATUSES:
+        logger.info(
+            "reanalyze_draft_handler: draft=%s status=%s not re-analyzable — ignoring",
+            parsed,
+            draft.status,
+        )
+        if req.headers.get("HX-Request") == "true":
+            return Response(
+                status_code=204,
+                headers={"HX-Redirect": f"/drafts/{parsed}"},
+            )
+        return RedirectResponse(url=f"/drafts/{parsed}", status_code=303)
+
+    prior_status = draft.status
+
+    # Flip the row to ``analyzing`` and clear any stale error / completion
+    # timestamps in a single transaction via the SSOT helper. Same
+    # transaction purges in-flight queue entries so the fresh analyze
+    # can't race a stuck prior job.
+    try:
+        with _connect() as conn:
+            updated = update_draft_status(conn, parsed, "analyzing")
+            if updated:
+                conn.execute(
+                    """
+                    delete from background_jobs
+                    where payload ->> 'draft_id' = %s
+                      and status in ('pending', 'claimed', 'running')
+                    """,
+                    (str(parsed),),
+                )
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to flip draft=%s to analyzing for reanalyze", parsed)
+        return _not_found_page(req)
+
+    if not updated:
+        # Either the row vanished mid-flight or a parallel writer beat
+        # us to a status change. Treat as a no-op and bounce back to the
+        # detail page where the user will see the actual state.
+        logger.info(
+            "reanalyze_draft_handler: draft=%s update_draft_status matched 0 rows (race)",
+            parsed,
+        )
+        if req.headers.get("HX-Request") == "true":
+            return Response(
+                status_code=204,
+                headers={"HX-Redirect": f"/drafts/{parsed}"},
+            )
+        return RedirectResponse(url=f"/drafts/{parsed}", status_code=303)
+
+    # Enqueue the analyze stage. We skip parse + extract because the
+    # encrypted file is already parsed and the entity rows already
+    # exist; only the analyzer needs to re-run against the (possibly
+    # updated) ontology snapshot.
+    try:
+        job_id = JobQueue().enqueue(
+            "analyze_impact",
+            {"draft_id": str(parsed)},
+            priority=5,
+        )
+    except Exception:
+        logger.exception("Failed to enqueue analyze_impact reanalyze for draft=%s", parsed)
+        # The row is already back in ``analyzing`` state. The operator
+        # can trigger another retry. We avoid flipping it to ``failed``
+        # because there was no actual failure — just an enqueue glitch.
+        return _not_found_page(req)
+
+    log_draft_reanalyze(
+        auth.get("id"),
+        parsed,
+        job_id=job_id,
+        prior_status=prior_status,
+    )
+    logger.info(
+        "Reanalyze enqueued draft=%s job_id=%s prior_status=%s user=%s",
+        parsed,
+        job_id,
+        prior_status,
+        auth.get("id"),
+    )
+
+    # HTMX form on the detail page targets ``#draft-status-{id}`` so we
+    # could return just the refreshed tracker, but the status flip touches
+    # the metadata block, the actions row, and the failed-banner so it's
+    # simpler (and avoids stale partial DOM) to redirect the browser back
+    # to the detail page. HTMX gets an HX-Redirect; non-HTMX gets a 303.
     if req.headers.get("HX-Request") == "true":
         return Response(
             status_code=204,

--- a/tests/test_docs_reanalyze.py
+++ b/tests/test_docs_reanalyze.py
@@ -145,12 +145,16 @@ class TestReanalyzeHappyPath:
         assert resp.status_code == 204
         assert resp.headers["HX-Redirect"] == f"/drafts/{draft.id}"
 
-        # update_draft_status called with the analyzing status.
+        # update_draft_status called with the analyzing status AND the
+        # ``expected_status=prior_status`` optimistic-concurrency guard
+        # (PR #826 P1 review fix — without this kwarg, two concurrent
+        # POSTs both flip ``ready`` -> ``analyzing`` and both enqueue).
         mock_update.assert_called_once()
         update_args = mock_update.call_args.args
         assert update_args[0] is conn
         assert update_args[1] == draft.id
         assert update_args[2] == "analyzing"
+        assert mock_update.call_args.kwargs["expected_status"] == "ready"
 
         # Stale queue entries purged in the same transaction.
         delete_calls = [
@@ -213,6 +217,10 @@ class TestReanalyzeHappyPath:
         mock_queue.enqueue.assert_called_once()
         # Prior status captured in audit log for traceability.
         assert mock_log.call_args.kwargs["prior_status"] == "failed"
+        # And the same prior status is the predicate on the conditional
+        # UPDATE so a parallel reanalyze on a ``failed`` draft can only
+        # succeed once (PR #826 P1).
+        assert mock_update.call_args.kwargs["expected_status"] == "failed"
 
     @patch("app.docs.routes._lifecycle.log_draft_reanalyze")
     @patch("app.docs.routes._lifecycle.JobQueue")
@@ -317,6 +325,7 @@ class TestReanalyzeStateMachine:
         mock_update.assert_not_called()
         mock_queue.enqueue.assert_not_called()
 
+    @patch("app.docs.routes._lifecycle.log_draft_reanalyze")
     @patch("app.docs.routes._lifecycle.JobQueue")
     @patch("app.docs.routes._lifecycle.update_draft_status")
     @patch("app.docs.routes._lifecycle._connect")
@@ -329,9 +338,18 @@ class TestReanalyzeStateMachine:
         mock_connect: MagicMock,
         mock_update: MagicMock,
         mock_queue_cls: MagicMock,
+        mock_log: MagicMock,
     ):
         """``update_draft_status`` matching 0 rows means a parallel writer
-        won — bounce back to the detail page without enqueueing."""
+        won — bounce back to the detail page without enqueueing, without
+        purging the winner's queue entries, and without writing an audit
+        row.
+
+        Pinned by PR #826 P1 review fix: without ``expected_status``
+        passed to the SSOT helper the underlying UPDATE has no row-level
+        guard and two concurrent POSTs would both flip ``ready`` ->
+        ``analyzing`` idempotently and both would land here as winners.
+        """
         mock_get_provider.return_value = _stub_provider()
         draft = _make_draft(status="ready")
         mock_fetch.return_value = draft
@@ -346,7 +364,80 @@ class TestReanalyzeStateMachine:
 
         assert resp.status_code == 303
         assert resp.headers["location"] == f"/drafts/{draft.id}"
+        # The handler MUST have asked for the optimistic guard.
+        assert mock_update.call_args.kwargs["expected_status"] == "ready"
+        # Loser-of-the-race side effects: no enqueue, no purge, no audit.
         mock_queue.enqueue.assert_not_called()
+        delete_calls = [
+            c for c in conn.execute.call_args_list if "delete from background_jobs" in c.args[0]
+        ]
+        assert delete_calls == [], "loser of the race must NOT purge the winner's queue entries"
+        mock_log.assert_not_called()
+
+    def test_concurrent_writers_only_one_enqueues(self):
+        """End-to-end simulation: two POSTs against the same ``ready``
+        draft arrive concurrently. The conditional UPDATE on
+        ``app.docs.status.update_draft_status`` is the choke point: the
+        first writer's ``UPDATE drafts SET status='analyzing' WHERE id=?
+        AND status='ready'`` matches one row; the second sees zero rows
+        because the row is now ``analyzing``. Only the winner enqueues
+        ``analyze_impact`` and only the winner purges the queue.
+
+        We simulate this by driving two sequential handler invocations
+        against a single shared fake DB whose draft row tracks its own
+        status. The second invocation models the second tab — it reads
+        the SAME ``ready`` draft (the read happens BEFORE the first
+        writer commits in the real race) and then loses on the
+        conditional UPDATE.
+        """
+        from unittest.mock import patch as _patch
+
+        # Shared row state — mutated by the first writer, observed by
+        # the second. ``fetch_draft`` always returns ``ready`` to mimic
+        # the race window where both reads happen before either write.
+        row_status = {"value": "ready"}
+
+        def fake_update(conn, draft_id, status, **kwargs):
+            expected = kwargs.get("expected_status")
+            if expected is not None and row_status["value"] != expected:
+                # The conditional WHERE matched zero rows.
+                return False
+            row_status["value"] = status
+            return True
+
+        draft = _make_draft(status="ready")
+
+        with (
+            _patch("app.auth.middleware._get_provider", return_value=_stub_provider()),
+            _patch("app.docs.routes._lifecycle.fetch_draft", return_value=draft),
+            _patch("app.docs.routes._lifecycle._connect") as mock_connect,
+            _patch(
+                "app.docs.routes._lifecycle.update_draft_status",
+                side_effect=fake_update,
+            ),
+            _patch("app.docs.routes._lifecycle.JobQueue") as mock_queue_cls,
+            _patch("app.docs.routes._lifecycle.log_draft_reanalyze") as mock_log,
+        ):
+            mock_connect.return_value.__enter__.return_value = MagicMock()
+            mock_queue = MagicMock()
+            mock_queue.enqueue.return_value = 1234
+            mock_queue_cls.return_value = mock_queue
+
+            client = _authed_client()
+            first = client.post(f"/drafts/{draft.id}/reanalyze")
+            second = client.post(f"/drafts/{draft.id}/reanalyze")
+
+        # Both responses are user-visible redirects; the user can't
+        # tell which one won, and both UIs will reload the detail page.
+        assert first.status_code == 303
+        assert second.status_code == 303
+
+        # The first POST flipped ``ready`` -> ``analyzing`` (winner).
+        # The second POST's UPDATE matched zero rows so its handler
+        # short-circuited: NO duplicate enqueue, NO duplicate audit row.
+        assert mock_queue.enqueue.call_count == 1
+        assert mock_log.call_count == 1
+        assert row_status["value"] == "analyzing"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_docs_reanalyze.py
+++ b/tests/test_docs_reanalyze.py
@@ -1,0 +1,517 @@
+"""Integration tests for ``POST /drafts/{id}/reanalyze`` (#306).
+
+The handler lives in :mod:`app.docs.routes._lifecycle` next to the
+delete + keep handlers. It is distinct from:
+
+* ``POST /drafts/{id}/retry`` — restarts the pipeline from
+  ``parse_draft`` on a *failed* draft (covered by ``test_docs_routes``).
+* ``POST /drafts/{id}/report/reanalyze`` — ontology-drift banner
+  re-run on the report page (covered by ``test_docs_report_routes``).
+
+These tests exercise the full ``app.main.app`` via ``TestClient`` so
+they validate the FastHTML wiring, the auth Beforeware, and the
+status-state-machine guard. External dependencies — Postgres, the
+JobQueue, the audit log — are mocked. Patch paths follow the
+"patch where used" rule pinned by ``tests/test_docs_routes_patch_paths``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from starlette.testclient import TestClient
+
+from app.docs.draft_model import Draft
+
+# ---------------------------------------------------------------------------
+# Helpers — copied from tests/test_docs_routes.py so this module stays
+# self-contained and a refactor of the shared helpers can't quietly drop
+# coverage of the #306 endpoint.
+# ---------------------------------------------------------------------------
+
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_OTHER_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_DRAFT_ID = "44444444-4444-4444-4444-444444444444"
+
+
+def _authed_user(role: str = "drafter") -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "koostaja@seadusloome.ee",
+        "full_name": "Test Koostaja",
+        "role": role,
+        "org_id": _ORG_ID,
+    }
+
+
+def _make_draft(
+    *,
+    draft_id: uuid.UUID | None = None,
+    org_id: str = _ORG_ID,
+    user_id: str = _USER_ID,
+    status: str = "ready",
+    title: str = "Test eelnõu",
+    error_message: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    doc_type: str = "eelnou",
+    parent_vtk_id: uuid.UUID | None = None,
+    processing_completed_at: datetime | None = None,
+) -> Draft:
+    now = datetime.now(UTC)
+    resolved_id = draft_id or uuid.UUID(_DRAFT_ID)
+    return Draft(
+        id=resolved_id,
+        user_id=uuid.UUID(user_id),
+        org_id=uuid.UUID(org_id),
+        title=title,
+        filename="eelnou.docx",
+        content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        file_size=2048,
+        storage_path="/tmp/ciphertext.enc",
+        graph_uri=f"https://data.riik.ee/ontology/estleg/drafts/{resolved_id}",
+        status=status,
+        parsed_text_encrypted=None,
+        entity_count=None,
+        error_message=error_message,
+        created_at=created_at or now,
+        updated_at=updated_at or now,
+        doc_type=doc_type,  # type: ignore[arg-type]
+        parent_vtk_id=parent_vtk_id,
+        processing_completed_at=processing_completed_at,
+    )
+
+
+def _stub_provider(role: str = "drafter") -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user(role=role)
+    return provider
+
+
+def _authed_client() -> TestClient:
+    client = TestClient(__import__("app.main", fromlist=["app"]).app, follow_redirects=False)
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestReanalyzeHappyPath:
+    """Owner on a ready draft → status flips to analyzing, job enqueued,
+    audit row written."""
+
+    @patch("app.docs.routes._lifecycle.log_draft_reanalyze")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.update_draft_status")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_ready_draft_htmx_redirects(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_update: MagicMock,
+        mock_queue_cls: MagicMock,
+        mock_log: MagicMock,
+    ):
+        """HTMX POST on a ready draft: status flipped to ``analyzing`` via
+        the SSOT helper, analyze_impact job enqueued, audit row written,
+        HX-Redirect back to the detail page."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="ready")
+        mock_fetch.return_value = draft
+        conn = MagicMock()
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_update.return_value = True
+        mock_queue = MagicMock()
+        mock_queue.enqueue.return_value = 99
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(
+            f"/drafts/{draft.id}/reanalyze",
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 204
+        assert resp.headers["HX-Redirect"] == f"/drafts/{draft.id}"
+
+        # update_draft_status called with the analyzing status.
+        mock_update.assert_called_once()
+        update_args = mock_update.call_args.args
+        assert update_args[0] is conn
+        assert update_args[1] == draft.id
+        assert update_args[2] == "analyzing"
+
+        # Stale queue entries purged in the same transaction.
+        delete_calls = [
+            c for c in conn.execute.call_args_list if "delete from background_jobs" in c.args[0]
+        ]
+        assert len(delete_calls) == 1
+        assert delete_calls[0].args[1] == (str(draft.id),)
+        conn.commit.assert_called_once()
+
+        # analyze_impact enqueued with the draft id.
+        mock_queue.enqueue.assert_called_once()
+        enq_args = mock_queue.enqueue.call_args
+        assert enq_args.args[0] == "analyze_impact"
+        assert enq_args.args[1] == {"draft_id": str(draft.id)}
+
+        # Audit row written with the right shape.
+        mock_log.assert_called_once()
+        log_args = mock_log.call_args
+        # log_draft_reanalyze(user_id, draft_id, **extra)
+        assert log_args.args[0] == _USER_ID
+        assert log_args.args[1] == draft.id
+        assert log_args.kwargs["job_id"] == 99
+        assert log_args.kwargs["prior_status"] == "ready"
+
+    @patch("app.docs.routes._lifecycle.log_draft_reanalyze")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.update_draft_status")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_failed_draft_can_reanalyze(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_update: MagicMock,
+        mock_queue_cls: MagicMock,
+        mock_log: MagicMock,
+    ):
+        """A failed draft is also re-analyzable: the user might want to
+        re-run analysis after a transient ontology hiccup without
+        going all the way back to the parse stage."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="failed", error_message="Vana viga")
+        mock_fetch.return_value = draft
+        conn = MagicMock()
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_update.return_value = True
+        mock_queue = MagicMock()
+        mock_queue.enqueue.return_value = 42
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(
+            f"/drafts/{draft.id}/reanalyze",
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 204
+        mock_queue.enqueue.assert_called_once()
+        # Prior status captured in audit log for traceability.
+        assert mock_log.call_args.kwargs["prior_status"] == "failed"
+
+    @patch("app.docs.routes._lifecycle.log_draft_reanalyze")
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.update_draft_status")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_non_htmx_returns_303(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_update: MagicMock,
+        mock_queue_cls: MagicMock,
+        mock_log: MagicMock,
+    ):
+        """No HX-Request header: server returns a plain 303 redirect so
+        full-page form submits navigate back to the detail page."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="ready")
+        mock_fetch.return_value = draft
+        conn = MagicMock()
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_update.return_value = True
+        mock_queue = MagicMock()
+        mock_queue.enqueue.return_value = 7
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(f"/drafts/{draft.id}/reanalyze")
+
+        assert resp.status_code == 303
+        assert resp.headers["location"] == f"/drafts/{draft.id}"
+        mock_queue.enqueue.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# State-machine guards
+# ---------------------------------------------------------------------------
+
+
+class TestReanalyzeStateMachine:
+    """The handler refuses to re-enqueue when the pipeline is already
+    in-flight or in a non-terminal state."""
+
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.update_draft_status")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_analyzing_draft_is_noop(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_update: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """Posting against a draft already in ``analyzing`` must NOT
+        re-enqueue — that would double-fire the analyze job."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="analyzing")
+        mock_fetch.return_value = draft
+        mock_queue = MagicMock()
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(f"/drafts/{draft.id}/reanalyze")
+
+        assert resp.status_code == 303
+        assert resp.headers["location"] == f"/drafts/{draft.id}"
+        mock_update.assert_not_called()
+        mock_queue.enqueue.assert_not_called()
+
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.update_draft_status")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_parsing_draft_is_noop(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_update: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """Same guard applies to earlier pipeline stages — the natural
+        flow will reach analyzing on its own; manual re-enqueue here is
+        a no-op."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="parsing")
+        mock_fetch.return_value = draft
+        mock_queue = MagicMock()
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(
+            f"/drafts/{draft.id}/reanalyze",
+            headers={"HX-Request": "true"},
+        )
+
+        # HTMX still gets a redirect, just via HX-Redirect.
+        assert resp.status_code == 204
+        assert resp.headers["HX-Redirect"] == f"/drafts/{draft.id}"
+        mock_update.assert_not_called()
+        mock_queue.enqueue.assert_not_called()
+
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.update_draft_status")
+    @patch("app.docs.routes._lifecycle._connect")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_optimistic_race_returns_redirect(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_update: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """``update_draft_status`` matching 0 rows means a parallel writer
+        won — bounce back to the detail page without enqueueing."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="ready")
+        mock_fetch.return_value = draft
+        conn = MagicMock()
+        mock_connect.return_value.__enter__.return_value = conn
+        mock_update.return_value = False
+        mock_queue = MagicMock()
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(f"/drafts/{draft.id}/reanalyze")
+
+        assert resp.status_code == 303
+        assert resp.headers["location"] == f"/drafts/{draft.id}"
+        mock_queue.enqueue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Auth + org scoping
+# ---------------------------------------------------------------------------
+
+
+class TestReanalyzeAuth:
+    """Cross-org request → 404; anonymous → 303 login redirect."""
+
+    @patch("app.docs.routes._lifecycle.JobQueue")
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_other_org_returns_not_found(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_queue_cls: MagicMock,
+    ):
+        """A user in org A POSTing against a draft in org B sees a 404
+        (NOT a 403) so we never leak the draft's existence."""
+        mock_get_provider.return_value = _stub_provider()
+        foreign = _make_draft(org_id=_OTHER_ORG_ID, status="ready")
+        mock_fetch.return_value = foreign
+        mock_queue = MagicMock()
+        mock_queue_cls.return_value = mock_queue
+
+        client = _authed_client()
+        resp = client.post(f"/drafts/{foreign.id}/reanalyze")
+
+        assert resp.status_code == 404
+        assert "Eelnõu ei leitud" in resp.text
+        mock_queue.enqueue.assert_not_called()
+
+    def test_anonymous_redirects_to_login(self):
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(f"/drafts/{_DRAFT_ID}/reanalyze")
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/auth/login"
+
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_missing_draft_returns_not_found(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """A draft id that doesn't resolve (deleted between page render
+        and POST) returns the standard 404 page."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = None
+
+        client = _authed_client()
+        resp = client.post(f"/drafts/{_DRAFT_ID}/reanalyze")
+
+        assert resp.status_code == 404
+        assert "Eelnõu ei leitud" in resp.text
+
+    @patch("app.docs.routes._lifecycle.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_malformed_draft_id_returns_not_found(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """Non-UUID path param resolves to 404 without ever touching the
+        DB (the parsed-uuid helper rejects it first)."""
+        mock_get_provider.return_value = _stub_provider()
+
+        client = _authed_client()
+        resp = client.post("/drafts/not-a-uuid/reanalyze")
+
+        assert resp.status_code == 404
+        mock_fetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Button rendering on the detail page
+# ---------------------------------------------------------------------------
+
+
+class TestReanalyzeButtonInDetailPage:
+    """The 'Analüüsi uuesti' button must appear on ready/failed drafts
+    and stay hidden during the pipeline."""
+
+    @patch("app.docs.routes._detail.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_ready_draft_renders_reanalyze_button(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """Ready drafts surface the button so the user can rerun
+        analysis without going through the report page. The button is
+        wired to the shared ConfirmModal primitive (per #601) so no
+        ``hx-confirm`` artefacts leak into the page."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="ready")
+        mock_fetch.return_value = draft
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{draft.id}")
+
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Analüüsi uuesti" in body
+        # Hidden form posts to the endpoint.
+        assert f'hx-post="/drafts/{draft.id}/reanalyze"' in body
+        assert f'action="/drafts/{draft.id}/reanalyze"' in body
+        # Modal trigger + dialog mounted.
+        assert 'id="reanalyze-draft-trigger"' in body
+        assert 'id="reanalyze-draft-modal"' in body
+        # Inline ``hx-confirm`` MUST NOT leak in — confirm flows go
+        # through the Modal primitive (#601 regression guard).
+        # ``hx-confirm=`` is only blocked on the *reanalyze* form here;
+        # other forms remain free to use it. We assert it is absent on
+        # the reanalyze form by checking the page doesn't contain the
+        # specific Estonian prompt the plan originally proposed.
+        assert "Käivita analüüs uuesti?" not in body
+        # The ConfirmModal renders the Estonian copy inside the dialog.
+        assert "Käivita analüüs uuesti" in body
+
+    @patch("app.docs.routes._detail.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_failed_draft_renders_reanalyze_button(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """Failed drafts also surface the button alongside the retry
+        button — the user can choose to re-run *just* the analyze stage
+        instead of restarting parse from scratch."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="failed", error_message="midagi läks valesti")
+        mock_fetch.return_value = draft
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{draft.id}")
+
+        assert resp.status_code == 200
+        assert "Analüüsi uuesti" in resp.text
+        assert f"/drafts/{draft.id}/reanalyze" in resp.text
+
+    @patch("app.docs.routes._detail.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_in_flight_draft_hides_reanalyze_button(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+    ):
+        """Mid-pipeline statuses must NOT render the button — that
+        avoids the user race that the server-side guard already
+        defends against."""
+        mock_get_provider.return_value = _stub_provider()
+        draft = _make_draft(status="analyzing")
+        mock_fetch.return_value = draft
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{draft.id}")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # The URL is the discriminating signal — the label could
+        # legitimately appear in other UI copy.
+        assert f"/drafts/{draft.id}/reanalyze" not in body
+        assert 'id="reanalyze-draft-modal"' not in body

--- a/tests/test_docs_routes_registered.py
+++ b/tests/test_docs_routes_registered.py
@@ -36,6 +36,10 @@ def test_draft_route_surface_is_stable() -> None:
         ("/drafts/{draft_id}/actions", ("GET", "HEAD")),
         ("/drafts/{draft_id}/keep", ("POST",)),
         ("/drafts/{draft_id}/delete", ("POST",)),
+        # #306: re-run impact analysis on a finished draft (ready/failed).
+        # Distinct from /retry (restarts from parse) and from the
+        # report-page ontology-drift /report/reanalyze below.
+        ("/drafts/{draft_id}/reanalyze", ("POST",)),
         ("/drafts/{draft_id}/link-vtk", ("POST",)),
         ("/drafts/{draft_id}/retry", ("POST",)),
         # #817: reviewer outcome submission.


### PR DESCRIPTION
## Summary
- `POST /drafts/{id}/reanalyze` in `app/docs/routes/_lifecycle.py` (`reanalyze_draft_handler`). Org-scoped via `can_view_draft`; 404 on cross-org, never 403. Flips `ready`/`failed` → `analyzing` via the SSOT `update_draft_status`, purges stale jobs in the same transaction, enqueues `analyze_impact` (priority 5), audits via new `log_draft_reanalyze`. HTMX → 204 + `HX-Redirect`; non-HTMX → 303.
- Detail-page button in `_draft_detail_body` uses the shared `ConfirmModal` (same shape as the delete flow per #601). Visible only when status ∈ {`ready`, `failed`}.
- Route wired in `app/docs/routes/__init__.py`; surface tripwire updated.
- Closes #306

## Test plan
- [x] `tests/test_docs_reanalyze.py` — 13 new tests (HTMX 204 + audit, failed-draft re-analyze, non-HTMX 303, analyzing/parsing no-op, optimistic-race redirect, cross-org 404, anonymous redirect, missing/malformed UUID, button visibility, in-flight hides button)
- [x] Wider sweep — `test_docs_routes`, `test_audit`, `test_docs_status`, `test_docs_analyze_handler`, `test_docs_report_routes`, `test_docs_routes_patch_paths`, `test_docs_routes_registered` — 263 pass total
- [x] ruff + pyright clean

## Notes
- **No migration needed.** `impact_reports` has no `UNIQUE(draft_id)`; old reports are preserved naturally because the analyze handler INSERTs a fresh row and `_fetch_latest_report` already orders `generated_at DESC LIMIT 1`.
- **Re-analyzable set is `{ready, failed}` only.** Mid-pipeline statuses race the natural flow; the button is hidden and the server guard rejects with a no-op redirect.
- **Used `ConfirmModal` instead of `hx-confirm`** — #601 removed `hx-confirm` page-wide; matching the delete flow shape.
- **`can_view_draft` (org-scoped)** matches the sibling `/report/reanalyze` handler. If owner-only is preferred later, swap to `can_edit_draft` in `_lifecycle.py` — one-liner.