### PR TITLE
feat(docs): #307 — HMAC-signed expiring URL for report .docx + .pdf downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ SECRET_KEY=REPLACE_WITH_RANDOM_64_CHAR_HEX
 # Set to 1 in production (cookies only sent over HTTPS)
 COOKIE_SECURE=0
 
+# HMAC key for signed expiring impact-report download URLs (issue #307).
+# Optional: when unset, falls back to SECRET_KEY so a single rotation
+# rotates both. Generate with: openssl rand -hex 32
+DOWNLOAD_TOKEN_SECRET=
+
 # Phase 2: Document Upload + Impact Analysis
 # -------------------------------------------
 

--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import TYPE_CHECKING, Any
+from urllib.parse import parse_qsl
 
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
@@ -213,10 +214,18 @@ def auth_before(req: Request) -> Response | None:
     raw_path = scope.get("path") if scope else None
     if isinstance(raw_path, str):
         path = raw_path
+    # Real key check, not substring — ``?notoken=1`` no longer matches.
+    # Parse with parse_qsl using ``latin-1`` because ASGI query strings are
+    # URL-encoded bytes (every byte is a valid latin-1 codepoint, so the
+    # round-trip is loss-free; parse_qsl still URL-decodes percent escapes).
     query_string = scope.get("query_string") if scope else None
     has_token_param = False
-    if isinstance(query_string, bytes) and b"token=" in query_string:
-        has_token_param = True
+    if isinstance(query_string, bytes) and query_string:
+        try:
+            params = parse_qsl(query_string.decode("latin-1"), keep_blank_values=True)
+            has_token_param = any(k == "token" for k, _ in params)
+        except (UnicodeDecodeError, ValueError):
+            has_token_param = False
     if path and has_token_param:
         for pattern in _TOKEN_BEARER_PATHS:
             if re.fullmatch(pattern, path):

--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -55,6 +55,19 @@ SKIP_PATHS: list[str] = [
     r"/api/validate/.*",
 ]
 
+
+# #307: paths that carry their own bearer credential in a ``?token=``
+# query param and therefore must reach the handler even when the
+# session cookie is missing. The handler is responsible for validating
+# the token and returning 403 on failure — middleware only checks that
+# the param is present (no validation here) so we don't duplicate the
+# HMAC logic. When the token param is absent, the path falls through
+# to the normal cookie-auth flow.
+_TOKEN_BEARER_PATHS: list[str] = [
+    r"/drafts/[^/]+/report/full\.docx",
+    r"/drafts/[^/]+/report/full\.pdf",
+]
+
 # Paths an authenticated user with ``must_change_password=True`` may
 # still reach without being bounced to ``/profile/password``. Anything
 # else gets a 303 to ``/profile/password``. Matched with ``re.fullmatch``
@@ -180,7 +193,35 @@ def auth_before(req: Request) -> Response | None:
       healthchecks, redirects to ``/profile/password``.
     - Returns ``None`` when the user is authenticated (lets the request through).
     - Returns a ``RedirectResponse`` to ``/auth/login`` when unauthenticated.
+
+    #307: paths in ``_TOKEN_BEARER_PATHS`` that present a ``?token=``
+    query param bypass cookie-auth and are forwarded straight to the
+    handler, which validates the token and returns 403 on any failure.
+    Token presence alone is the trigger — invalid tokens are still
+    rejected by the handler, not silently treated as anonymous.
     """
+    # #307: short-circuit signed-URL downloads before any cookie work
+    # so an unauthenticated caller with a valid token never hits the
+    # /auth/login redirect. The path is read from ``req.scope["path"]``
+    # rather than ``req.url.path`` because the existing
+    # test_auth_middleware fixtures stub ``req.url`` as a plain string;
+    # ``scope["path"]`` is the canonical ASGI path string and works for
+    # both real Starlette requests and those test mocks (the scope
+    # comes from the fixtures' ``req.scope = {}``).
+    path: str = ""
+    scope = req.scope if isinstance(req.scope, dict) else {}
+    raw_path = scope.get("path") if scope else None
+    if isinstance(raw_path, str):
+        path = raw_path
+    query_string = scope.get("query_string") if scope else None
+    has_token_param = False
+    if isinstance(query_string, bytes) and b"token=" in query_string:
+        has_token_param = True
+    if path and has_token_param:
+        for pattern in _TOKEN_BEARER_PATHS:
+            if re.fullmatch(pattern, path):
+                return None
+
     access_token: str | None = req.cookies.get("access_token")
     refresh_token: str | None = req.cookies.get("refresh_token")
 

--- a/app/docs/audit.py
+++ b/app/docs/audit.py
@@ -56,6 +56,33 @@ def log_draft_reanalyze(user_id: str | None, draft_id: Any, **extra: Any) -> Non
     log_action(user_id, "draft.reanalyze", detail)
 
 
+def log_draft_download(
+    user_id: str | None,
+    draft_id: Any,
+    *,
+    via_token: bool,
+    **extra: Any,
+) -> None:
+    """Record a ``draft.report.download`` event (issue #307).
+
+    Captured every time the impact-report .docx/.pdf is downloaded —
+    whether the caller authenticated via session cookie (the legacy
+    path) or via an HMAC-signed expiring URL token. The ``via_token``
+    flag lets ops distinguish the two paths in the audit timeline so
+    a leaked token can be traced back to its mint event.
+
+    Sensitive fields (the token itself, the file bytes) are NEVER
+    logged. Only the draft id + the boolean + any caller-supplied
+    ``extra`` keyword args (format, filename, transport mode).
+    """
+    detail: dict[str, Any] = {
+        "draft_id": str(draft_id),
+        "via_token": bool(via_token),
+        **extra,
+    }
+    log_action(user_id, "draft.report.download", detail)
+
+
 def log_review_outcome(
     user_id: str | None,
     draft_id: Any,

--- a/app/docs/report_routes.py
+++ b/app/docs/report_routes.py
@@ -61,8 +61,10 @@ from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_view_draft
 from app.db import get_connection as _connect
+from app.docs.audit import log_draft_download
 from app.docs.draft_model import Draft, fetch_draft, touch_draft_access_conn
 from app.docs.labels import TYPE_LABELS_ET as _TYPE_LABELS_ET
+from app.docs.signed_urls import make_download_token, validate_download_token
 from app.jobs.queue import JobQueue
 from app.ontology.relations import legal_phrase
 from app.ui.data.data_table import Column, DataTable
@@ -1381,8 +1383,15 @@ def _print_summary_button(draft: Draft) -> Any:
     )
 
 
-def _export_button(draft: Draft, *, fmt: str, label: str, variant: ButtonVariant) -> Any:
-    """Render one export-trigger anchor for a single output format (#613, #811).
+def _export_button(
+    draft: Draft,
+    *,
+    fmt: str,
+    label: str,
+    variant: ButtonVariant,
+    user_id: str | None = None,
+) -> Any:
+    """Render one export-trigger anchor for a single output format (#613, #811, #307).
 
     Both the .docx and .pdf controls are plain ``<a href download>``
     GETs pointing at the synchronous ``/drafts/<id>/report/full.<fmt>``
@@ -1396,12 +1405,25 @@ def _export_button(draft: Draft, *, fmt: str, label: str, variant: ButtonVariant
     The ``download`` attribute pre-populates Safari's "Save As" dialog
     with a slugified filename derived from the draft title (mirrors the
     existing ``Prindi kokkuvõte`` link a few lines above, which works
-    cross-browser for exactly this reason)."""
+    cross-browser for exactly this reason).
+
+    #307: when ``user_id`` is provided, the href is suffixed with a
+    short-lived ``?token=...`` HMAC signed for that draft+user. The
+    download endpoint accepts the token in lieu of a session cookie so
+    the link is safe to share / cache for the token TTL (1 hour). The
+    legacy session-auth path stays in place for callers that omit the
+    token (admin tools, scripted exports), so this is an additive
+    hardening, not a breaking change.
+    """
     suffix = "pdf" if fmt == "pdf" else "docx"
     filename = f"impact_report_{_slugify(draft.title)}.{suffix}"
+    href = f"/drafts/{draft.id}/report/full.{suffix}"
+    if user_id:
+        token = make_download_token(str(draft.id), str(user_id))
+        href = f"{href}?token={token}"
     return LinkButton(
         label,
-        href=f"/drafts/{draft.id}/report/full.{suffix}",
+        href=href,
         variant=variant,
         # ``download`` hints to the browser to treat this as a file
         # download rather than navigating to the URL. Safari respects
@@ -1411,15 +1433,20 @@ def _export_button(draft: Draft, *, fmt: str, label: str, variant: ButtonVariant
     )
 
 
-def _export_section(draft: Draft) -> Any:
-    """Build the export action card (#613, #811).
+def _export_section(draft: Draft, *, user_id: str | None = None) -> Any:
+    """Build the export action card (#613, #811, #307).
 
     Two anchors: .docx (primary, default) and .pdf (secondary). Both
     are plain ``<a href download>`` GETs hitting the synchronous
     ``/report/full.<fmt>`` routes — the response streams the file with
     ``Content-Disposition: attachment``, which Safari handles natively
     (the prior HTMX form-post + async-job flow did not produce a
-    Safari download — #811)."""
+    Safari download — #811).
+
+    #307: the user-id is forwarded to ``_export_button`` so each
+    button mints its own short-lived HMAC token. Re-rendering the
+    page rotates the token (a fresh token is minted every time the
+    report page is built)."""
     return Card(
         CardHeader(H3("Eksport", cls="card-title")),  # noqa: F405
         CardBody(
@@ -1428,8 +1455,20 @@ def _export_section(draft: Draft) -> Any:
                 cls="muted-text",
             ),
             Div(  # noqa: F405
-                _export_button(draft, fmt="docx", label="Laadi alla .docx", variant="primary"),
-                _export_button(draft, fmt="pdf", label="Laadi alla .pdf", variant="secondary"),
+                _export_button(
+                    draft,
+                    fmt="docx",
+                    label="Laadi alla .docx",
+                    variant="primary",
+                    user_id=user_id,
+                ),
+                _export_button(
+                    draft,
+                    fmt="pdf",
+                    label="Laadi alla .pdf",
+                    variant="secondary",
+                    user_id=user_id,
+                ),
                 cls="export-actions",
             ),
         ),
@@ -1631,7 +1670,7 @@ def draft_report_page(req: Request, draft_id: str):
             draft_version_id=draft_version_id,
             counts=unresolved_counts,
         ),
-        _export_section(draft),
+        _export_section(draft, user_id=str(auth.get("id")) if auth.get("id") else None),
         # C6 (#791): print stylesheet expands collapsibles in print
         # media so a browser-native print of the page shows full
         # content. The localStorage script persists user choice on
@@ -2320,7 +2359,7 @@ def executive_summary_download_handler(req: Request, draft_id: str):
 
 
 def report_full_download_handler(req: Request, draft_id: str, fmt: str):
-    """GET /drafts/{draft_id}/report/full.{docx,pdf} — synchronous download (#811).
+    """GET /drafts/{draft_id}/report/full.{docx,pdf} — synchronous download (#811, #307).
 
     Renders the full impact-report .docx (and optionally converts to
     PDF) on the fly and streams the file with ``Content-Disposition:
@@ -2329,8 +2368,21 @@ def report_full_download_handler(req: Request, draft_id: str, fmt: str):
     GET that Safari treats as a native file download (the prior async
     HTMX-form pipeline silently failed in Safari — #811).
 
-    Auth + org-scoping mirror :func:`draft_report_page`: a missing /
-    cross-org draft resolves to the 404 page.
+    Two authentication paths are supported (#307):
+
+    * **Signed-URL path** — when ``?token=...`` is present, the token
+      is HMAC-validated against the draft id. A valid token bypasses
+      session auth (the token IS the bearer credential). Invalid or
+      expired tokens return 403 — never 200, never 404 (the latter
+      would let an attacker probe draft existence).
+    * **Legacy session path** — when no token is present, the handler
+      falls through to the original session-auth + org-scope check.
+      A missing or cross-org draft returns 404 so we don't leak the
+      existence of other orgs' reports.
+
+    Both paths audit the download via :func:`log_draft_download`
+    with a ``via_token`` flag so ops can trace whether a download came
+    through a shared signed URL or the original logged-in session.
 
     DOCX rendering is well within request-timeout territory (matches the
     summary path). PDF conversion shells out to headless LibreOffice
@@ -2338,11 +2390,6 @@ def report_full_download_handler(req: Request, draft_id: str, fmt: str):
     (:data:`app.docs.docx_export._SOFFICE_TIMEOUT_SECONDS` caps it at
     60 s).
     """
-    auth_or_redirect = _require_auth(req)
-    if isinstance(auth_or_redirect, Response):
-        return auth_or_redirect
-    auth = auth_or_redirect
-
     fmt_normalised = (fmt or "").lower()
     if fmt_normalised not in _VALID_EXPORT_FORMATS:
         return _not_found_page(req)
@@ -2351,12 +2398,54 @@ def report_full_download_handler(req: Request, draft_id: str, fmt: str):
     if parsed is None:
         return _not_found_page(req)
 
+    # ----- #307 token branch ------------------------------------------------
+    # If a token is supplied, validate it FIRST and bypass session-auth
+    # on success. A supplied-but-invalid token is an explicit 403 — not
+    # 404 — because the caller deliberately presented a credential. The
+    # legacy 404-for-cross-org path stays reserved for the
+    # session-cookie-only callers below.
+    token = req.query_params.get("token")
+    via_token = False
+    auth_user_id: str | None = None
+    if token is not None:
+        payload = validate_download_token(token, str(parsed))
+        if payload is None:
+            return Response(
+                "Allalaadimise link on aegunud või vigane.",
+                status_code=403,
+                media_type="text/plain; charset=utf-8",
+            )
+        via_token = True
+        # The minter's id is in the payload; that's the user we attribute
+        # the audit row to (handy when the URL is shared — the audit
+        # trail still points at the user who originally requested it).
+        auth_user_id = str(payload.get("user_id") or "") or None
+    else:
+        # ----- Legacy session-auth branch -----------------------------------
+        auth_or_redirect = _require_auth(req)
+        if isinstance(auth_or_redirect, Response):
+            return auth_or_redirect
+        auth = auth_or_redirect
+        auth_user_id = str(auth.get("id")) if auth.get("id") else None
+
     draft = fetch_draft(parsed)
-    if draft is None or not can_view_draft(auth, draft):
+    if draft is None:
         return _not_found_page(req)
+    if not via_token:
+        # Legacy callers must satisfy the org-scope policy. Token
+        # callers already proved authorisation via the HMAC.
+        # ``auth`` is in scope only on this branch — guarded by the
+        # else-arm above. We re-pull it from the request scope for
+        # type narrowing.
+        legacy_auth = req.scope.get("auth")
+        if not can_view_draft(legacy_auth, draft):
+            return _not_found_page(req)
 
     report_row = _fetch_latest_report(parsed)
     if report_row is None:
+        # Token holders see 404 here too — the token claim was valid but
+        # the report has since been deleted. There's no information leak
+        # because a token holder already proved they know the draft id.
         return _not_found_page(req)
 
     # Lazy import keeps the top-level module light and avoids a cycle
@@ -2389,8 +2478,10 @@ def report_full_download_handler(req: Request, draft_id: str, fmt: str):
         suffix = "docx"
 
     filename = f"impact_report_{_slugify(draft.title)}.{suffix}"
+    # Legacy audit event preserved verbatim for back-compat with the
+    # existing audit-log dashboards. Both paths emit it.
     log_action(
-        auth.get("id"),
+        auth_user_id,
         "draft.report.export.download",
         {
             "draft_id": str(parsed),
@@ -2398,7 +2489,19 @@ def report_full_download_handler(req: Request, draft_id: str, fmt: str):
             "filename": filename,
             "format": suffix,
             "transport": "sync",
+            "via_token": via_token,
         },
+    )
+    # #307: dedicated audit hook with structured ``via_token`` flag so
+    # ops dashboards can pivot directly on the auth path used. Mirrors
+    # the existing log_draft_view / log_draft_delete shape.
+    log_draft_download(
+        auth_user_id,
+        parsed,
+        via_token=via_token,
+        report_id=str(report_row[0]),
+        format=suffix,
+        transport="sync",
     )
     # #572: download counts as access; reset the archive clock.
     touch_draft_access_conn(parsed)

--- a/app/docs/signed_urls.py
+++ b/app/docs/signed_urls.py
@@ -1,0 +1,208 @@
+"""HMAC-signed expiring URLs for impact-report downloads (issue #307).
+
+Plain session-auth gating ties a download link to the user's browser
+session: the moment the user copies the URL into another tab, shares it
+with a colleague, or hands it to a curl call from a build script, the
+link becomes either useless (no session cookie) or a backdoor that lives
+as long as the session does. Short-lived signed URLs flip that picture:
+the URL itself encodes the authorisation, so it can be safely shared
+inside a 1-hour window and is dead after.
+
+The token format is intentionally JWT-flavoured but home-grown so we
+don't pull in the `jwt` dependency at the download layer (the auth
+module already does, but keeping the report module dependency-free
+keeps the surface tight):
+
+    <base64url(payload_json)>.<base64url(hmac_sha256)>
+
+Payload fields:
+
+    draft_id : str  — the impact-report draft this token authorises
+    user_id  : str  — who minted the token (audit trail)
+    exp      : int  — unix timestamp; rejected when expired
+    nonce    : str  — 16 random bytes hex; prevents accidental dedupe
+
+Validation is strict: payload must round-trip cleanly through JSON, the
+HMAC must be byte-identical (constant-time compare), the token must not
+be expired, and the embedded ``draft_id`` must match the expected one
+the route handler is serving. Any mismatch returns ``None`` so handlers
+can collapse every failure mode into a single 403 response without
+leaking which check failed.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import time
+from typing import Any
+
+from app.config import is_stub_allowed
+
+logger = logging.getLogger(__name__)
+
+
+# Env var name carrying the HMAC key. Operators set this alongside the
+# other secrets (SECRET_KEY, STORAGE_ENCRYPTION_KEY) in production.
+_DOWNLOAD_TOKEN_SECRET_ENV = "DOWNLOAD_TOKEN_SECRET"
+
+# Dev sentinel — see ``_load_signing_key`` for the production fallback
+# rules. Never used in production: the loader raises before reaching it.
+_DEV_SIGNING_KEY = b"dev-only-download-token-secret-do-not-use-in-production"
+
+# Default lifetime per the issue spec — 1 hour. Callers may override
+# with a shorter TTL for one-shot links if that ever becomes useful.
+DEFAULT_TOKEN_TTL_SECONDS = 3600
+
+
+def _load_signing_key() -> bytes:
+    """Return the HMAC signing key, enforcing an explicit value off-dev.
+
+    Resolution order:
+
+    1. ``DOWNLOAD_TOKEN_SECRET`` env var if set — always preferred.
+    2. ``SECRET_KEY`` env var if set — re-use the JWT signing key so a
+       single rotation rotates both. This is a deliberate convenience
+       for operators who don't want to manage one more secret in their
+       Coolify env editor.
+    3. Dev sentinel — only outside production (mirrors the
+       :mod:`app.docs.reference_resolver` pattern). Raises in production
+       so a misconfigured deploy can't silently sign tokens with a
+       well-known value.
+    """
+    explicit = os.environ.get(_DOWNLOAD_TOKEN_SECRET_ENV)
+    if explicit:
+        return explicit.encode("utf-8")
+    jwt_secret = os.environ.get("SECRET_KEY")
+    if jwt_secret:
+        return jwt_secret.encode("utf-8")
+    if not is_stub_allowed():  # production
+        raise RuntimeError(
+            f"{_DOWNLOAD_TOKEN_SECRET_ENV} (or SECRET_KEY) must be set in production "
+            "to sign report-download URLs."
+        )
+    return _DEV_SIGNING_KEY
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Encode *data* as base64url WITHOUT padding (=, /, + are URL-hostile).
+
+    The trailing ``=`` padding chars are stripped because some web
+    frameworks/browsers treat them as significant inside query strings;
+    the decoder re-pads at parse time so the round-trip is exact.
+    """
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(value: str) -> bytes:
+    """Decode a base64url payload that may be missing padding.
+
+    Raises ``ValueError`` (or anything ``binascii`` raises wrapped as
+    such) on malformed input — callers must treat that as an invalid
+    token. Pad length is computed from the input length mod 4.
+    """
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def make_download_token(
+    draft_id: str,
+    user_id: str,
+    ttl_seconds: int = DEFAULT_TOKEN_TTL_SECONDS,
+) -> str:
+    """Mint a short-lived HMAC-signed download token for *draft_id*.
+
+    Parameters
+    ----------
+    draft_id:
+        The impact-report draft id the token authorises. Must match
+        exactly when the download endpoint validates.
+    user_id:
+        The UUID of the user minting the token. Carried in the payload
+        so the audit log records who originally requested the link
+        (even if the URL is later shared and used by someone else).
+    ttl_seconds:
+        Token lifetime in seconds. Defaults to 1 hour per the issue.
+
+    Returns the token as ``<payload_b64>.<sig_b64>``. Callers embed it
+    in the download URL as ``?token=...``.
+    """
+    payload: dict[str, Any] = {
+        "draft_id": str(draft_id),
+        "user_id": str(user_id),
+        "exp": int(time.time()) + int(ttl_seconds),
+        # 16 random bytes → 32 hex chars; nonce makes two tokens minted
+        # in the same second distinct (handy for invalidating one
+        # leaked link without rotating the whole secret).
+        "nonce": secrets.token_hex(16),
+    }
+    payload_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    sig = hmac.new(_load_signing_key(), payload_bytes, hashlib.sha256).digest()
+    return f"{_b64url_encode(payload_bytes)}.{_b64url_encode(sig)}"
+
+
+def validate_download_token(token: str, expected_draft_id: str) -> dict[str, Any] | None:
+    """Verify *token* and return its payload, or ``None`` on any failure.
+
+    Failure modes (all collapse to ``None``):
+
+    * Malformed shape (missing ``.`` separator, non-base64url chars).
+    * Tampered HMAC (constant-time compare via
+      :func:`hmac.compare_digest`).
+    * Expired ``exp`` claim.
+    * Payload ``draft_id`` does not match ``expected_draft_id``.
+    * Payload missing required fields.
+    * JSON decode failure.
+
+    Returning ``None`` for every error case lets handlers collapse all
+    of them into a single 403 response, which means an attacker cannot
+    distinguish "expired" from "wrong draft" from "tampered" via the
+    response — every invalid token looks the same from outside.
+    """
+    if not token or not isinstance(token, str):
+        return None
+    parts = token.split(".")
+    if len(parts) != 2:
+        return None
+    payload_b64, sig_b64 = parts
+    try:
+        payload_bytes = _b64url_decode(payload_b64)
+        sig_bytes = _b64url_decode(sig_b64)
+    except (ValueError, TypeError):
+        return None
+    if not payload_bytes or not sig_bytes:
+        return None
+
+    # Constant-time HMAC compare — never short-circuit on a mismatched
+    # prefix because that leaks the matching-byte count to a timing
+    # attacker (CWE-208).
+    expected_sig = hmac.new(_load_signing_key(), payload_bytes, hashlib.sha256).digest()
+    if not hmac.compare_digest(sig_bytes, expected_sig):
+        return None
+
+    try:
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    # Required claim check — missing fields are treated as tampered.
+    draft_id = payload.get("draft_id")
+    user_id = payload.get("user_id")
+    exp = payload.get("exp")
+    if not isinstance(draft_id, str) or not isinstance(user_id, str):
+        return None
+    if not isinstance(exp, int):
+        return None
+
+    if str(draft_id) != str(expected_draft_id):
+        return None
+    if int(time.time()) >= exp:
+        return None
+    return payload

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -77,12 +77,20 @@ def test_protected_path_is_not_skipped(path: str):
 def _make_request(
     cookies: dict[str, str] | None = None,
     path: str = "/dashboard",
+    query_string: bytes | None = None,
 ) -> MagicMock:
-    """Return a Starlette-Request-like mock carrying ``cookies`` and a url."""
+    """Return a Starlette-Request-like mock carrying ``cookies`` and a url.
+
+    ``query_string`` (bytes, ASGI shape) and ``path`` are surfaced through
+    ``req.scope`` so the #307 signed-URL bypass check can read them.
+    """
     req = MagicMock()
     req.cookies = cookies or {}
     req.url = f"http://testserver{path}"
-    req.scope = {}
+    scope: dict[str, Any] = {"path": path}
+    if query_string is not None:
+        scope["query_string"] = query_string
+    req.scope = scope
     return req
 
 
@@ -184,3 +192,80 @@ def test_only_refresh_cookie_still_refreshes(stub_provider: MagicMock):
     assert result.status_code == 307
     stub_provider.get_current_user.assert_not_called()
     stub_provider.verify_refresh_token.assert_called_once_with("ok")
+
+
+# ---------------------------------------------------------------------------
+# #307 signed-URL bypass — happy path and substring-false-positive regressions
+# ---------------------------------------------------------------------------
+
+
+_SIGNED_DOWNLOAD_PATH = "/drafts/00000000-0000-0000-0000-000000000001/report/full.docx"
+
+
+def test_signed_download_with_real_token_param_bypasses_auth(
+    stub_provider: MagicMock,
+):
+    """Happy path: a real ``?token=...`` on a signed-download path
+    short-circuits cookie-auth and is forwarded to the handler."""
+    req = _make_request(
+        cookies={},
+        path=_SIGNED_DOWNLOAD_PATH,
+        query_string=b"token=abc123",
+    )
+
+    result = auth_before(req)
+
+    # None == "let the request through" (middleware deferred to handler).
+    assert result is None
+    # Provider was never consulted because the bypass triggered first.
+    stub_provider.get_current_user.assert_not_called()
+    stub_provider.verify_refresh_token.assert_not_called()
+
+
+def test_signed_download_with_notoken_param_does_not_bypass(
+    stub_provider: MagicMock,
+):
+    """Regression: ``?notoken=abc`` must NOT trigger the bypass.
+
+    Before the fix the substring ``b"token="`` inside ``b"notoken=abc"``
+    matched, short-circuited cookie-auth, and the request fell through
+    to a 403/login redirect even for authenticated users.
+    """
+    stub_provider.get_current_user.return_value = None
+    stub_provider.verify_refresh_token.return_value = None
+
+    req = _make_request(
+        cookies={},
+        path=_SIGNED_DOWNLOAD_PATH,
+        query_string=b"notoken=abc",
+    )
+    result = auth_before(req)
+
+    # Cookie-auth ran and produced the normal "no creds" redirect.
+    assert isinstance(result, RedirectResponse)
+    assert result.status_code == 303
+    assert result.headers["location"] == "/auth/login"
+
+
+def test_signed_download_with_token_substring_in_other_param_does_not_bypass(
+    stub_provider: MagicMock,
+):
+    """Regression: ``?next=x-token=y`` must NOT trigger the bypass either.
+
+    The substring ``token=`` appears inside the value of the ``next``
+    param but there is no real ``token`` query key, so cookie-auth must
+    run as normal.
+    """
+    stub_provider.get_current_user.return_value = None
+    stub_provider.verify_refresh_token.return_value = None
+
+    req = _make_request(
+        cookies={},
+        path=_SIGNED_DOWNLOAD_PATH,
+        query_string=b"next=x-token=y",
+    )
+    result = auth_before(req)
+
+    assert isinstance(result, RedirectResponse)
+    assert result.status_code == 303
+    assert result.headers["location"] == "/auth/login"

--- a/tests/test_docs_signed_urls.py
+++ b/tests/test_docs_signed_urls.py
@@ -1,0 +1,414 @@
+"""Tests for the signed-URL download flow (issue #307).
+
+Two layers:
+
+1. Unit tests for ``make_download_token`` / ``validate_download_token``
+   — round-trip, expiry, draft-id mismatch, HMAC tampering, malformed
+   input. These run with no DB / no FastHTML test client.
+2. Integration tests for ``GET /drafts/{id}/report/full.docx?token=...``
+   — valid token returns the file with the right audit row, expired /
+   invalid tokens return 403, the legacy session-auth path still works
+   without a token.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from starlette.testclient import TestClient
+
+from app.docs.draft_model import Draft
+from app.docs.signed_urls import (
+    DEFAULT_TOKEN_TTL_SECONDS,
+    make_download_token,
+    validate_download_token,
+)
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_OTHER_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_DRAFT_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+_OTHER_DRAFT_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+_REPORT_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures shared with the integration tests
+# ---------------------------------------------------------------------------
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "koostaja@seadusloome.ee",
+        "full_name": "Test Koostaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _make_draft(*, org_id: str = _ORG_ID, title: str = "Test eelnõu") -> Draft:
+    now = datetime.now(UTC)
+    return Draft(
+        id=_DRAFT_ID,
+        user_id=uuid.UUID(_USER_ID),
+        org_id=uuid.UUID(org_id),
+        title=title,
+        filename="eelnou.docx",
+        content_type=("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        file_size=2048,
+        storage_path="/tmp/cipher.enc",
+        graph_uri=f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}",
+        status="ready",
+        parsed_text_encrypted=None,
+        entity_count=None,
+        error_message=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_report_row() -> tuple:
+    findings = {
+        "affected_entities": [],
+        "conflicts": [],
+        "eu_compliance": [],
+        "gaps": [],
+    }
+    return (
+        _REPORT_ID,
+        _DRAFT_ID,
+        0,
+        0,
+        0,
+        0,
+        findings,
+        "2026-04-09T12:00+00:00@1061123",
+        datetime(2026, 4, 9, 12, 0, tzinfo=UTC),
+    )
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client() -> TestClient:
+    client = TestClient(__import__("app.main", fromlist=["app"]).app, follow_redirects=False)
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: token helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenHelperRoundtrip:
+    def test_valid_token_roundtrip_returns_payload(self):
+        token = make_download_token(str(_DRAFT_ID), _USER_ID)
+        payload = validate_download_token(token, str(_DRAFT_ID))
+        assert payload is not None
+        assert payload["draft_id"] == str(_DRAFT_ID)
+        assert payload["user_id"] == _USER_ID
+        # ``exp`` is in the future and within the TTL window.
+        assert payload["exp"] > int(time.time())
+        assert payload["exp"] <= int(time.time()) + DEFAULT_TOKEN_TTL_SECONDS + 1
+        # Nonce is a 16-byte hex string (token_hex(16) == 32 chars).
+        assert isinstance(payload["nonce"], str)
+        assert len(payload["nonce"]) == 32
+
+    def test_token_format_is_two_base64url_parts(self):
+        token = make_download_token(str(_DRAFT_ID), _USER_ID)
+        # ``<payload>.<sig>`` — exactly two segments.
+        assert token.count(".") == 1
+        parts = token.split(".")
+        assert len(parts) == 2
+        # Both segments are base64url chars only (no '+', '/', '=').
+        for part in parts:
+            assert all(c.isalnum() or c in {"-", "_"} for c in part), part
+
+    def test_two_tokens_for_same_draft_have_distinct_nonces(self):
+        """A fresh nonce per mint means token churn doesn't accidentally
+        collide — useful when invalidating one leaked link without
+        rotating the whole secret."""
+        t1 = make_download_token(str(_DRAFT_ID), _USER_ID)
+        t2 = make_download_token(str(_DRAFT_ID), _USER_ID)
+        assert t1 != t2
+
+
+class TestTokenHelperRejectsBadInput:
+    def test_expired_token_returns_none(self):
+        # TTL=0 → exp is "now"; one tick later validate must reject.
+        token = make_download_token(str(_DRAFT_ID), _USER_ID, ttl_seconds=0)
+        time.sleep(0.05)
+        assert validate_download_token(token, str(_DRAFT_ID)) is None
+
+    def test_wrong_draft_id_returns_none(self):
+        token = make_download_token(str(_DRAFT_ID), _USER_ID)
+        assert validate_download_token(token, str(_OTHER_DRAFT_ID)) is None
+
+    def test_tampered_hmac_returns_none(self):
+        """Flipping one byte of the signature segment must fail the
+        constant-time HMAC compare."""
+        token = make_download_token(str(_DRAFT_ID), _USER_ID)
+        payload_b64, sig_b64 = token.split(".")
+        # Flip the first sig byte to something that's still a valid
+        # base64url char but produces a different decoded value.
+        tampered_sig = ("A" if sig_b64[0] != "A" else "B") + sig_b64[1:]
+        tampered = f"{payload_b64}.{tampered_sig}"
+        assert validate_download_token(tampered, str(_DRAFT_ID)) is None
+
+    def test_tampered_payload_returns_none(self):
+        """Editing the payload (e.g. to bump ``exp``) without re-signing
+        is rejected — the HMAC won't match."""
+        token = make_download_token(str(_DRAFT_ID), _USER_ID, ttl_seconds=10)
+        payload_b64, sig_b64 = token.split(".")
+        # Rebuild a payload with a far-future exp but keep the original sig.
+        tampered_payload = {
+            "draft_id": str(_DRAFT_ID),
+            "user_id": _USER_ID,
+            "exp": int(time.time()) + 365 * 24 * 3600,
+            "nonce": "0" * 32,
+        }
+        tampered_bytes = json.dumps(
+            tampered_payload, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        tampered_b64 = base64.urlsafe_b64encode(tampered_bytes).rstrip(b"=").decode("ascii")
+        tampered_token = f"{tampered_b64}.{sig_b64}"
+        assert validate_download_token(tampered_token, str(_DRAFT_ID)) is None
+
+    def test_empty_string_returns_none(self):
+        assert validate_download_token("", str(_DRAFT_ID)) is None
+
+    def test_missing_separator_returns_none(self):
+        assert validate_download_token("nodot", str(_DRAFT_ID)) is None
+
+    def test_three_segments_returns_none(self):
+        assert validate_download_token("a.b.c", str(_DRAFT_ID)) is None
+
+    def test_non_base64_payload_returns_none(self):
+        # Star ('*') is not a base64url character so decoding throws.
+        assert validate_download_token("***.***", str(_DRAFT_ID)) is None
+
+    def test_non_string_token_returns_none(self):
+        # Defensive: callers might pass None / bytes from a query parser.
+        assert validate_download_token(None, str(_DRAFT_ID)) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: integration tests against the report download route
+# ---------------------------------------------------------------------------
+
+
+class TestReportDownloadWithToken:
+    @patch("app.docs.report_routes.log_draft_download")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    def test_valid_token_returns_file_without_session_auth(
+        self,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+        mock_log: MagicMock,
+        tmp_path: Any,
+    ):
+        """A request with a valid ``?token=`` and NO session cookie
+        must still stream the file — the token IS the credential."""
+        mock_fetch.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+
+        docx_file = tmp_path / "report.docx"
+        docx_file.write_bytes(b"PK\x03\x04 fake docx bytes")
+        import app.docs.docx_export as _docx_export
+
+        original = _docx_export.build_impact_report_docx
+        _docx_export.build_impact_report_docx = lambda *a, **kw: docx_file
+        try:
+            from app.main import app
+
+            # No cookie set — proves token alone is sufficient.
+            client = TestClient(app, follow_redirects=False)
+            token = make_download_token(str(_DRAFT_ID), _USER_ID)
+            resp = client.get(
+                f"/drafts/{_DRAFT_ID}/report/full.docx",
+                params={"token": token},
+            )
+        finally:
+            _docx_export.build_impact_report_docx = original
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        # Audit row written with via_token=True and the minter's id.
+        assert mock_log.called, "log_draft_download must be called on success"
+        call_kwargs = mock_log.call_args.kwargs
+        # signature: log_draft_download(user_id, draft_id, *, via_token=, ...)
+        assert mock_log.call_args.args[0] == _USER_ID
+        assert str(mock_log.call_args.args[1]) == str(_DRAFT_ID)
+        assert call_kwargs.get("via_token") is True
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    def test_expired_token_returns_403(
+        self,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        mock_fetch.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        token = make_download_token(str(_DRAFT_ID), _USER_ID, ttl_seconds=0)
+        time.sleep(0.05)
+        resp = client.get(
+            f"/drafts/{_DRAFT_ID}/report/full.docx",
+            params={"token": token},
+        )
+
+        assert resp.status_code == 403
+        # Body is Estonian and does NOT leak the failure mode.
+        assert "aegunud" in resp.text or "vigane" in resp.text
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    def test_malformed_token_returns_403(
+        self,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        mock_fetch.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get(
+            f"/drafts/{_DRAFT_ID}/report/full.docx",
+            params={"token": "not-a-real-token"},
+        )
+
+        assert resp.status_code == 403
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    def test_token_for_other_draft_returns_403(
+        self,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """A token signed for draft B cannot download draft A."""
+        mock_fetch.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        # Mint a token for _OTHER_DRAFT_ID and present it on the
+        # _DRAFT_ID download URL.
+        token = make_download_token(str(_OTHER_DRAFT_ID), _USER_ID)
+        resp = client.get(
+            f"/drafts/{_DRAFT_ID}/report/full.docx",
+            params={"token": token},
+        )
+
+        assert resp.status_code == 403
+
+
+class TestLegacySessionAuthStillWorks:
+    @patch("app.docs.report_routes.log_draft_download")
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_token_with_session_succeeds(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+        mock_log: MagicMock,
+        tmp_path: Any,
+    ):
+        """The pre-#307 contract must keep working: an authenticated
+        user with no ``?token=`` still downloads the file."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+
+        docx_file = tmp_path / "report.docx"
+        docx_file.write_bytes(b"PK\x03\x04 fake docx bytes")
+        import app.docs.docx_export as _docx_export
+
+        original = _docx_export.build_impact_report_docx
+        _docx_export.build_impact_report_docx = lambda *a, **kw: docx_file
+        try:
+            client = _authed_client()
+            resp = client.get(f"/drafts/{_DRAFT_ID}/report/full.docx")
+        finally:
+            _docx_export.build_impact_report_docx = original
+
+        assert resp.status_code == 200
+        # Audit row written with via_token=False (legacy path).
+        assert mock_log.called
+        call_kwargs = mock_log.call_args.kwargs
+        assert call_kwargs.get("via_token") is False
+
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_token_cross_org_returns_404(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        """The legacy 404-instead-of-403 contract for cross-org callers
+        (we don't leak the existence of other orgs' drafts) is
+        preserved unchanged when no token is supplied."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft(org_id=_OTHER_ORG_ID)
+        mock_fetch_report.return_value = _make_report_row()
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report/full.docx")
+
+        # 404 (NOT 403) — matches the pre-#307 behaviour exactly.
+        assert resp.status_code == 404
+        assert "Eelnõu ei leitud" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Report page renders the download anchor with a fresh token (#307)
+# ---------------------------------------------------------------------------
+
+
+class TestReportPageEmitsTokenInDownloadAnchor:
+    @patch("app.docs.report_routes._fetch_latest_report")
+    @patch("app.docs.report_routes.fetch_draft")
+    @patch("app.auth.middleware._get_provider")
+    def test_report_page_anchor_has_token_query_param(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_fetch_report: MagicMock,
+    ):
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_draft()
+        mock_fetch_report.return_value = _make_report_row()
+
+        client = _authed_client()
+        resp = client.get(f"/drafts/{_DRAFT_ID}/report")
+
+        assert resp.status_code == 200
+        body = resp.text
+        # Two download anchors (docx + pdf), each with a ``?token=`` suffix.
+        assert f"/drafts/{_DRAFT_ID}/report/full.docx?token=" in body
+        assert f"/drafts/{_DRAFT_ID}/report/full.pdf?token=" in body


### PR DESCRIPTION
## Summary
- New `app/docs/signed_urls.py`: `make_download_token(draft_id, user_id, ttl=3600)` mints `<b64url(payload)>.<b64url(hmac)>` with payload `{draft_id, user_id, exp, nonce}`. `validate_download_token` collapses every failure (malformed, tampered HMAC, expired, wrong draft_id, missing fields) to `None` via `hmac.compare_digest`.
- `report_routes.py`: `_export_button` / `_export_section` thread `user_id` through and append `?token=...` to the `<a href download>`. Handler validates `?token=` first → 403 on failure; if absent, falls through to the existing `_require_auth` + `can_view_draft` path (still 404 cross-org).
- New `log_draft_download(user_id, draft_id, *, via_token, **extra)` audit hook fires on both paths.
- `app/auth/middleware.py`: short-circuits `auth_before` for `/drafts/{id}/report/full.{docx,pdf}` when `token=` query param is present — required so unauthenticated callers (e.g. an email link forwarded after session expiry) reach the handler. Cookie-bearing requests follow the legacy path unchanged.
- `.env.example`: documents optional `DOWNLOAD_TOKEN_SECRET` (falls back to `SECRET_KEY`).
- Closes #307

## Test plan
- [x] `tests/test_docs_signed_urls.py` — 19 new tests (roundtrip, expired, tampered, wrong draft_id, malformed, valid 200 with audit row, no-token legacy path, cross-org 404, audit `via_token` flag)
- [x] Full suite 3281 passed / 37 skipped
- [x] ruff + pyright clean

## Security review notes
- **Auth middleware change is the sensitive piece.** It short-circuits ONLY when `path` matches `/drafts/<uuid>/report/full.(docx|pdf)` AND `token=` is present. Anything else still requires session auth.
- Token failure → 403 (no enumeration of valid drafts).
- HMAC compare uses `hmac.compare_digest` (constant-time).
- 1h TTL; nonce in payload prevents replay coordination but tokens are intentionally single-secret bearer auth — treat them like email magic links.
- Production refuses to mint tokens when neither `DOWNLOAD_TOKEN_SECRET` nor `SECRET_KEY` is set.

## Notes
- The original plan pointed at `_detail.py` for the download anchor; anchors actually live in `report_routes.py::_export_button` (the report page). Agent corrected the file scope.