### PR TITLE
feat(jobs): #348 — standalone worker entrypoint + WORKER_MODE env

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,17 @@ uv run scripts/sync.py
 uv run app/main.py
 ```
 
+### Background worker modes
+
+By default the background job worker runs as a daemon thread inside the
+FastHTML app container (`WORKER_MODE=inproc`). For scaled production
+deployments you can run it in a separate container by setting
+`WORKER_MODE=standalone` and launching `scripts/run_worker.py` (or the
+`seadusloome-worker` console script) in a second Coolify resource. The
+commented-out `worker:` service in `docker/docker-compose.yml` shows the
+shape locally. Full details in
+[`docs/operations/worker-modes.md`](docs/operations/worker-modes.md).
+
 ## Data Sources
 
 - **Ontology:** [github.com/henrikaavik/estonian-legal-ontology](https://github.com/henrikaavik/estonian-legal-ontology)

--- a/app/config.py
+++ b/app/config.py
@@ -55,3 +55,42 @@ def is_chat_auto_title_enabled() -> bool:
     if raw is None:
         return True
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+# ---------------------------------------------------------------------------
+# Worker mode (#348)
+# ---------------------------------------------------------------------------
+#
+# The background job worker can run in two modes:
+#
+#   ``inproc`` (default) — workers spawn as a daemon thread inside the
+#       FastHTML app process via the ASGI lifespan hook. Simplest for
+#       local dev and single-container production deployments.
+#
+#   ``standalone`` — workers run in a separate process (typically a
+#       second Coolify container) launched via ``scripts/run_worker.py``.
+#       The web container's lifespan SKIPS its inproc worker. Use when
+#       worker load grows beyond what one container can handle, or when
+#       you want to scale web and worker capacity independently.
+#
+# Both modes share the same handler registry (``app.jobs.registry``)
+# and read/write the same ``background_jobs`` Postgres table. You can
+# mix-and-match (one inproc + N standalone) without any other change.
+
+_VALID_WORKER_MODES = frozenset({"inproc", "standalone"})
+
+
+def get_worker_mode() -> str:
+    """Return the configured worker mode (``"inproc"`` | ``"standalone"``).
+
+    Defaults to ``"inproc"`` to preserve the historical single-container
+    behaviour. Unknown values raise ``ValueError`` so a typo in Coolify
+    env vars surfaces loudly at startup instead of silently disabling
+    the worker.
+    """
+    raw = os.environ.get("WORKER_MODE", "inproc").strip().lower()
+    if raw not in _VALID_WORKER_MODES:
+        raise ValueError(
+            f"WORKER_MODE={raw!r} is invalid; expected one of {sorted(_VALID_WORKER_MODES)}"
+        )
+    return raw

--- a/app/docs/__init__.py
+++ b/app/docs/__init__.py
@@ -1,14 +1,25 @@
 """Document Upload subsystem for Phase 2.
 
-Exposes the ``drafts`` CRUD helpers, the ``handle_upload`` pipeline, and
-the FastHTML route registration. The package is named ``docs`` (not
-``drafts``) because it will grow to host the impact-report and export
-handlers alongside the upload flow in later Phase 2 batches.
+Exposes the ``drafts`` CRUD helpers and the ``handle_upload`` pipeline.
+The package is named ``docs`` (not ``drafts``) because it hosts the
+impact-report and export handlers alongside the upload flow.
+
+Importing this package must NOT pull in any FastHTML / Starlette
+route module. The standalone worker (``scripts/run_worker.py``, #348)
+imports ``app.docs`` via :func:`app.jobs.registry.register_all_handlers`
+to trigger the ``@register_handler`` side effects of each handler
+module, and the whole point of the standalone container is that it
+stays framework-free. Route registration helpers (``register_draft_routes``,
+``register_report_routes``, ``register_draft_ws_routes``,
+``register_export_progress_ws_routes``) therefore live ONLY in their
+submodules — callers must import them from
+:mod:`app.docs.routes`/:mod:`app.docs.report_routes` directly. The
+canonical importer is ``app/main.py``.
 """
 
 # Import handlers for side effects — they register themselves via
-# @register_handler on import. The worker imports ``app.docs`` at
-# startup (see app/main.py), so by the time the worker claims any
+# @register_handler on import. ``app.jobs.registry.register_all_handlers``
+# imports ``app.docs`` at startup so by the time the worker claims any
 # job, the real handlers have overridden the fallback stubs in
 # app/jobs/worker.py.
 from app.docs import analyze_handler as _analyze_handler  # noqa: F401,E402
@@ -25,8 +36,6 @@ from app.docs.draft_model import (
     list_drafts_for_org,
     update_draft_status,
 )
-from app.docs.report_routes import register_report_routes
-from app.docs.routes import register_draft_routes
 from app.docs.upload import DraftUploadError, handle_upload
 
 __all__ = [
@@ -38,7 +47,5 @@ __all__ = [
     "get_draft",
     "handle_upload",
     "list_drafts_for_org",
-    "register_draft_routes",
-    "register_report_routes",
     "update_draft_status",
 ]

--- a/app/jobs/registry.py
+++ b/app/jobs/registry.py
@@ -1,0 +1,60 @@
+"""Shared handler wiring for inproc and standalone worker modes (#348).
+
+Background job handlers live in :mod:`app.docs` and :mod:`app.drafter`
+and register themselves via the ``@register_handler`` decorator as a
+side effect of import. The FastHTML app currently triggers those
+imports transitively through its route-registration imports
+(``from app.docs.routes import ...`` etc), which is fine for the
+in-process worker mode but leaves the standalone worker
+(:mod:`scripts.run_worker`) without an obvious place to do the same
+wiring — and we explicitly do NOT want the standalone worker pulling
+in FastHTML / Starlette to get the side effects.
+
+This module is the single, framework-free entry point both modes
+call to ensure the handler registry is populated. It must NOT import
+``app.main`` or any FastHTML/Starlette module.
+
+Adding a new handler family
+---------------------------
+1. Write the handler module (e.g. ``app/foo/bar_handler.py``) and add
+   ``register_handler("bar_job")(bar)`` at module bottom.
+2. Add the import to :func:`register_all_handlers` below. The import
+   alone is what triggers registration — no further wiring needed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def register_all_handlers() -> None:
+    """Import every handler module so its ``@register_handler`` runs.
+
+    Idempotent: re-importing a module re-runs the decorator, which
+    overwrites the existing registry entry with the same function
+    object. Safe to call from both the FastHTML lifespan hook (inproc
+    mode) and :mod:`scripts.run_worker` (standalone mode).
+
+    The function returns nothing; callers can introspect the result
+    via :data:`app.jobs.worker._HANDLERS` if they need to assert
+    coverage in tests.
+    """
+    # Document upload pipeline handlers: parse_draft, extract_entities,
+    # analyze_impact, export_report, draft_cleanup. Each handler module
+    # has a ``register_handler(...)`` call at the bottom; importing the
+    # package re-exports those side effects.
+    from app.docs import (  # noqa: F401  -- side-effect import
+        analyze_handler,
+        cleanup_handler,
+        export_handler,
+        extract_handler,
+        parse_handler,
+    )
+
+    # AI Law Drafter handlers: drafter_clarify, drafter_research,
+    # drafter_structure, drafter_draft, drafter_regenerate_clause.
+    from app.drafter import handlers  # noqa: F401  -- side-effect import
+
+    logger.debug("register_all_handlers: imported app.docs handlers and app.drafter handlers")

--- a/app/main.py
+++ b/app/main.py
@@ -112,12 +112,27 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
         yield
         return
 
+    # Draft archive-warning scheduler (issue #572): a daily background
+    # scan that emits notifications for drafts older than 90 days. This
+    # MUST run regardless of WORKER_MODE because the web process is the
+    # canonical singleton host for it — ``scripts/run_worker.py`` does
+    # NOT start the scheduler (see the "Why not also start the
+    # archive-warning scheduler here?" docstring there: a single daily
+    # scan must not run on multiple worker processes at once). So the
+    # scheduler starts before the WORKER_MODE gate, otherwise a
+    # web+standalone split deployment would silently lose the 90-day
+    # auto-archive warning — a compliance feature for draft sensitivity
+    # (see CLAUDE.md "Draft sensitivity"). (#348 review fix.)
+    from app.jobs.archive_warning import start_archive_warning_scheduler
+
+    _stop_archive_scheduler.clear()
+    _archive_thread = start_archive_warning_scheduler(_stop_archive_scheduler)
+    logger.info("Draft archive-warning scheduler started")
+
     # WORKER_MODE gate (#348): in 'standalone' mode the worker runs in
     # a separate Coolify container launched via ``scripts/run_worker.py``,
     # so the web container's lifespan must NOT spawn its own worker
     # thread (otherwise jobs get double-claimed at low priority load).
-    # The archive-warning scheduler is co-located with whichever
-    # process is acting as the worker, so it follows the same gate.
     from app.config import get_worker_mode
 
     worker_mode = get_worker_mode()
@@ -126,12 +141,18 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
             "WORKER_MODE=standalone — skipping in-process worker startup; "
             "expecting a separate worker process (scripts/run_worker.py)"
         )
-        yield
+        try:
+            yield
+        finally:
+            logger.info("Stopping draft archive-warning scheduler...")
+            _stop_archive_scheduler.set()
+            if _archive_thread is not None:
+                _archive_thread.join(timeout=5.0)
+                _archive_thread = None
         return
 
     # Local import so tests that patch app.jobs.worker see the module
     # freshly re-imported if they reload after setting env vars.
-    from app.jobs.archive_warning import start_archive_warning_scheduler
     from app.jobs.registry import register_all_handlers
     from app.jobs.worker import start_worker_thread
 
@@ -146,10 +167,6 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
     _stop_worker.clear()
     _worker_thread = start_worker_thread(_stop_worker)
     logger.info("Background worker started (WORKER_MODE=inproc)")
-
-    _stop_archive_scheduler.clear()
-    _archive_thread = start_archive_warning_scheduler(_stop_archive_scheduler)
-    logger.info("Draft archive-warning scheduler started")
 
     try:
         yield

--- a/app/main.py
+++ b/app/main.py
@@ -112,14 +112,40 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
         yield
         return
 
+    # WORKER_MODE gate (#348): in 'standalone' mode the worker runs in
+    # a separate Coolify container launched via ``scripts/run_worker.py``,
+    # so the web container's lifespan must NOT spawn its own worker
+    # thread (otherwise jobs get double-claimed at low priority load).
+    # The archive-warning scheduler is co-located with whichever
+    # process is acting as the worker, so it follows the same gate.
+    from app.config import get_worker_mode
+
+    worker_mode = get_worker_mode()
+    if worker_mode == "standalone":
+        logger.info(
+            "WORKER_MODE=standalone — skipping in-process worker startup; "
+            "expecting a separate worker process (scripts/run_worker.py)"
+        )
+        yield
+        return
+
     # Local import so tests that patch app.jobs.worker see the module
     # freshly re-imported if they reload after setting env vars.
     from app.jobs.archive_warning import start_archive_warning_scheduler
+    from app.jobs.registry import register_all_handlers
     from app.jobs.worker import start_worker_thread
+
+    # Ensure the handler registry is populated before the worker thread
+    # claims its first job. The route-registration imports at module top
+    # transitively import ``app.docs`` and ``app.drafter`` (which trigger
+    # @register_handler as a side effect), but we call this explicitly so
+    # the wiring is identical to standalone mode and any future refactor
+    # of the route imports cannot accidentally drop a handler.
+    register_all_handlers()
 
     _stop_worker.clear()
     _worker_thread = start_worker_thread(_stop_worker)
-    logger.info("Background worker started")
+    logger.info("Background worker started (WORKER_MODE=inproc)")
 
     _stop_archive_scheduler.clear()
     _archive_thread = start_archive_warning_scheduler(_stop_archive_scheduler)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,6 +31,55 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Standalone background-job worker (#348) — OPT-IN.
+  # ---------------------------------------------------------------------------
+  #
+  # By default the FastHTML `app` container runs the worker in-process via
+  # its ASGI lifespan hook (WORKER_MODE=inproc, the historical behaviour).
+  # That's the right choice for local dev and small deployments.
+  #
+  # UNCOMMENT this block when:
+  #   * scaling the web tier beyond a single container (otherwise each
+  #     web replica would spawn its own worker thread, doubling the
+  #     dispatch concurrency without any rate-limiting),
+  #   * background job latency or CPU is dominating the web container,
+  #   * or you want to deploy worker code without bouncing the web tier.
+  #
+  # When uncommented, ALSO set `WORKER_MODE=standalone` on the `app:`
+  # service so its lifespan hook skips spawning the in-process worker.
+  # Mixing modes (one inproc + N standalone) works but is rarely useful
+  # — pick one and stay consistent.
+  #
+  # The worker reuses the same image, .env, and Postgres connection as
+  # `app:`. It does NOT need draftsdata/exportsdata volumes mounted
+  # unless your handlers read/write those paths (parse/extract/export
+  # do; they share STORAGE_DIR/EXPORT_DIR with the web tier in prod).
+  #
+  # worker:
+  #   build:
+  #     context: ..
+  #     dockerfile: docker/Dockerfile
+  #   env_file:
+  #     - ../.env
+  #   environment:
+  #     WORKER_MODE: standalone
+  #     TIKA_URL: http://tika:9998
+  #     STORAGE_DIR: /var/seadusloome/drafts
+  #     EXPORT_DIR: /var/seadusloome/exports
+  #   command: ["python", "scripts/run_worker.py"]
+  #   volumes:
+  #     - draftsdata:/var/seadusloome/drafts
+  #     - exportsdata:/var/seadusloome/exports
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #     jena:
+  #       condition: service_healthy
+  #     tika:
+  #       condition: service_healthy
+  #   restart: unless-stopped
+
   postgres:
     image: pgvector/pgvector:pg18
     ports:

--- a/docs/operations/worker-modes.md
+++ b/docs/operations/worker-modes.md
@@ -1,0 +1,98 @@
+# Background worker modes (`WORKER_MODE`)
+
+Issue [#348](https://github.com/henrikaavik/seadusloome/issues/348). Lets the
+`JobWorker` that drains the `background_jobs` Postgres table run either in
+the FastHTML web container (default) or in a separate container.
+
+## Modes
+
+### `inproc` — default
+
+Workers run as a daemon thread inside the FastHTML app process, spawned
+by the ASGI lifespan hook in `app/main.py`.
+
+- Simplest to operate. Nothing extra to deploy.
+- The right choice for local dev (`uv run app/main.py`), CI, and any
+  production deployment where one web container is enough.
+- Set explicitly via `WORKER_MODE=inproc` or leave unset.
+
+### `standalone`
+
+Workers run in a separate process (typically a second Coolify container)
+launched via `scripts/run_worker.py`. The web container's lifespan
+recognises `WORKER_MODE=standalone` and **skips** spawning the in-process
+worker, so jobs are not double-claimed.
+
+Use this mode when:
+
+- Scaling the web tier beyond a single container (each replica would
+  otherwise spawn its own worker thread).
+- Background job CPU / memory is dominating the web container's
+  resource envelope.
+- You want to deploy worker code without bouncing the web tier (or
+  vice versa).
+
+## Switching modes
+
+### Local dev (docker-compose)
+
+The `worker` service block in `docker/docker-compose.yml` is commented
+out by default. To enable standalone mode locally:
+
+1. Uncomment the `worker:` block in `docker/docker-compose.yml`.
+2. Add `WORKER_MODE=standalone` to the `app:` service environment (so
+   the web container's lifespan skips its in-process worker).
+3. `docker compose -f docker/docker-compose.yml up -d`.
+
+### Production (Coolify)
+
+1. On the existing `seadusloome-app` resource, set
+   `WORKER_MODE=standalone` under Environment Variables → Production.
+2. Add a second Coolify application using the same image:
+   - Source: same Git repo / image as `seadusloome-app`.
+   - Start command: `python scripts/run_worker.py` (or
+     `seadusloome-worker` via the console script — see
+     `pyproject.toml [project.scripts]`).
+   - Environment: copy the `seadusloome-app` env vars (`DATABASE_URL`,
+     `JENA_URL`, `STORAGE_ENCRYPTION_KEY`, `ANTHROPIC_API_KEY`,
+     `VOYAGE_API_KEY`, `TIKA_URL`, `STORAGE_DIR`, `EXPORT_DIR`, …) plus
+     `WORKER_MODE=standalone`.
+   - Persistent storage: mount the same `drafts` and `exports` named
+     volumes as `seadusloome-app` so parse/extract/export handlers can
+     read/write the encrypted files.
+   - Health: no HTTP endpoint — Coolify will only know the container
+     is alive if it stays up. Container logs and the
+     `background_jobs.claimed_by` column are the source of truth for
+     "is the worker actually processing jobs".
+3. Redeploy both applications.
+
+To roll back, set `WORKER_MODE` back to `inproc` (or unset) on
+`seadusloome-app`, redeploy, and stop / delete the worker resource.
+
+## Shared internals
+
+Both modes import the same handler modules via
+`app.jobs.registry.register_all_handlers()` and read/write the same
+`background_jobs` table with `FOR UPDATE SKIP LOCKED`. That means you
+can mix-and-match (one `inproc` web + N `standalone` workers) without
+any code change — the dispatch contention is handled at the DB row
+level. In practice picking one mode and staying consistent keeps the
+operational model simpler.
+
+## Graceful shutdown
+
+`scripts/run_worker.py` installs `SIGTERM` and `SIGINT` handlers that
+set the worker's stop event. The worker finishes its in-flight job
+(if any), exits the dispatch loop, and the process terminates with
+exit code 0. Coolify / Docker delivers `SIGTERM` on container stop, so
+no further configuration is required.
+
+## Archive-warning scheduler
+
+The 90-day draft auto-archive warning scheduler (`#572`,
+`app/jobs/archive_warning.py`) **always runs in the web container's
+lifespan**, never in the standalone worker. A daily scan must happen
+exactly once per deployment; co-locating it with the singleton web
+process is the simplest way to guarantee that. If you ever scale the
+web tier to N replicas, you will need a dedicated cron container — out
+of scope for #348.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ dependencies = [
     "postmarker>=1.0",
 ]
 
+[project.scripts]
+# Standalone background-job worker entrypoint (#348).
+# Usage: `WORKER_MODE=standalone seadusloome-worker`
+seadusloome-worker = "scripts.run_worker:main"
+
 [dependency-groups]
 dev = [
     "ruff",

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,7 @@
+"""Operational CLI scripts (migrations, sync, standalone worker, etc.).
+
+These modules are deliberately kept free of FastHTML / Starlette
+imports so they can run in lightweight containers (e.g. the
+``WORKER_MODE=standalone`` worker container introduced in #348) without
+dragging in the full web framework dependency graph.
+"""

--- a/scripts/run_worker.py
+++ b/scripts/run_worker.py
@@ -1,0 +1,152 @@
+"""Standalone background worker entrypoint (#348).
+
+Runs the same :class:`app.jobs.worker.JobWorker` that the in-process
+mode uses, but without importing FastHTML / Starlette. Intended for
+deployment as a second Coolify container that scales independently
+from the web container.
+
+Usage:
+    WORKER_MODE=standalone python scripts/run_worker.py
+
+Or via the console-script entrypoint declared in ``pyproject.toml``:
+
+    WORKER_MODE=standalone seadusloome-worker
+
+Lifecycle:
+    - Set up logging (stdlib only — no structlog dependency).
+    - Validate ``WORKER_MODE=standalone``; refuse to start in any other
+      mode so an operator who forgot to flip the env var on the new
+      container does not silently end up double-running with inproc.
+    - Import every handler module via
+      :func:`app.jobs.registry.register_all_handlers` so the dispatch
+      registry is populated before the first job is claimed.
+    - Install SIGTERM / SIGINT handlers that set the shared stop event
+      so the worker drains its in-flight job and exits cleanly.
+    - Block on :meth:`JobWorker.run_forever` until the stop event fires.
+
+Why not also start the archive-warning scheduler here?
+    A single daily scan must not run on multiple worker processes at
+    once (each process would emit duplicate notifications). The
+    scheduler stays co-located with the FastHTML web process, which is
+    guaranteed to exist exactly once per deployment. If we ever want
+    to scale web to N replicas, we will need a dedicated cron container
+    — but that is out of scope for #348.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import sys
+import threading
+from types import FrameType
+from typing import NoReturn
+
+logger = logging.getLogger("seadusloome.worker")
+
+
+def _configure_logging() -> None:
+    """Configure stdlib logging matching the format used by ``app.main``.
+
+    Kept deliberately simple: no structlog dependency (the worker
+    container should be importable on a stripped-down image if
+    needed). The format mirrors the one configured by uvicorn in the
+    web container so log aggregation tooling sees consistent fields.
+    """
+    if logging.getLogger().handlers:
+        # Already configured (e.g. when imported under pytest).
+        return
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _install_signal_handlers(stop_event: threading.Event) -> None:
+    """Wire SIGTERM / SIGINT to set *stop_event* for graceful shutdown.
+
+    Docker / Coolify deliver SIGTERM on container stop; an interactive
+    Ctrl-C sends SIGINT. Both must drain the in-flight job (the worker
+    loop checks ``stop_event`` between job claims) rather than
+    abandoning a half-processed row in ``status='running'``.
+
+    The handler is intentionally idempotent — repeated signals just
+    re-set an already-set Event, which is a no-op.
+    """
+
+    def _handle(signum: int, _frame: FrameType | None) -> None:
+        try:
+            sig_name = signal.Signals(signum).name
+        except ValueError:
+            sig_name = str(signum)
+        logger.info("Received %s — initiating graceful shutdown", sig_name)
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
+
+def main() -> NoReturn:
+    """Standalone worker entrypoint. Blocks until SIGTERM / SIGINT.
+
+    Exit codes:
+        0 — clean shutdown via signal.
+        1 — configuration error (e.g. ``WORKER_MODE != "standalone"``).
+    """
+    _configure_logging()
+
+    # Import lazily so that even ``--help`` style invocations or import
+    # checks (e.g. the test that asserts FastHTML is not loaded) avoid
+    # any DB / Postgres pool side effects until main() is actually run.
+    from app.config import get_worker_mode
+
+    try:
+        mode = get_worker_mode()
+    except ValueError as exc:
+        logger.error("Invalid WORKER_MODE: %s", exc)
+        sys.exit(1)
+
+    if mode != "standalone":
+        logger.error(
+            "scripts/run_worker.py refuses to start when WORKER_MODE=%r. "
+            "Set WORKER_MODE=standalone on this container (the web "
+            "container should keep WORKER_MODE=inproc or leave it unset). "
+            "See docs/operations/worker-modes.md for the rationale.",
+            mode,
+        )
+        sys.exit(1)
+
+    from app.jobs.registry import register_all_handlers
+    from app.jobs.worker import _HANDLERS, JobWorker
+
+    register_all_handlers()
+    logger.info(
+        "Standalone worker: registered %d handler(s): %s",
+        len(_HANDLERS),
+        sorted(_HANDLERS.keys()),
+    )
+
+    stop_event = threading.Event()
+    _install_signal_handlers(stop_event)
+
+    worker = JobWorker()
+    logger.info(
+        "Starting standalone JobWorker worker_id=%s poll_interval=%.1fs",
+        worker.worker_id,
+        worker.poll_interval,
+    )
+    try:
+        worker.run_forever(stop_event)
+    except KeyboardInterrupt:
+        # Unlikely (SIGINT handler already sets stop_event), but defensive
+        # in case run_forever is interrupted before the handler installs.
+        logger.info("KeyboardInterrupt — exiting")
+
+    logger.info("Standalone worker exited cleanly")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_worker_standalone.py
+++ b/tests/test_worker_standalone.py
@@ -1,0 +1,290 @@
+"""Tests for the standalone worker mode (#348).
+
+Covers:
+    - ``app.jobs.registry.register_all_handlers`` populates the same
+      handler registry that the inproc worker uses.
+    - Importing ``scripts.run_worker`` does NOT pull in FastHTML /
+      Starlette / ``app.main`` (the whole point of running the worker
+      in a separate, lighter container).
+    - ``app.main.lifespan`` honours ``WORKER_MODE``: skips the worker
+      thread when set to ``standalone``, starts it when set to
+      ``inproc`` (and the legacy ``DISABLE_BACKGROUND_WORKER`` guard
+      keeps tests from spawning anything real).
+    - ``scripts.run_worker.main`` refuses to start unless
+      ``WORKER_MODE=standalone``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# register_all_handlers
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAllHandlers:
+    """The shared handler-wiring entry point must register every handler."""
+
+    def test_register_all_handlers_populates_registry(self):
+        """All known job_types appear in ``_HANDLERS`` after the call."""
+        from app.jobs import registry
+        from app.jobs.worker import _HANDLERS
+
+        registry.register_all_handlers()
+
+        # Phase 2 document pipeline handlers.
+        assert "parse_draft" in _HANDLERS
+        assert "extract_entities" in _HANDLERS
+        assert "analyze_impact" in _HANDLERS
+        assert "export_report" in _HANDLERS
+        assert "draft_cleanup" in _HANDLERS
+
+        # Phase 3 drafter handlers.
+        assert "drafter_clarify" in _HANDLERS
+        assert "drafter_research" in _HANDLERS
+        assert "drafter_structure" in _HANDLERS
+        assert "drafter_draft" in _HANDLERS
+        assert "drafter_regenerate_clause" in _HANDLERS
+
+    def test_register_all_handlers_is_idempotent(self):
+        """Calling twice does not raise and leaves the same callables."""
+        from app.jobs import registry
+        from app.jobs.worker import _HANDLERS
+
+        registry.register_all_handlers()
+        first_snapshot = dict(_HANDLERS)
+
+        registry.register_all_handlers()
+        second_snapshot = dict(_HANDLERS)
+
+        # Same job_types, same handler functions.
+        assert set(first_snapshot.keys()) == set(second_snapshot.keys())
+        for job_type in first_snapshot:
+            assert first_snapshot[job_type] is second_snapshot[job_type]
+
+
+# ---------------------------------------------------------------------------
+# Standalone import does not drag in FastHTML
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneImportIsolation:
+    """``scripts.run_worker`` MUST be importable without ``app.main``.
+
+    The whole point of standalone mode is that the worker container can
+    skip FastHTML / Starlette / uvicorn and stay lean. A regression
+    here (e.g. someone adds ``from app.main import ...`` to the script)
+    would defeat the purpose silently.
+    """
+
+    def test_run_worker_import_does_not_load_app_main(self):
+        """Importing the entrypoint must not transitively import ``app.main``."""
+        # Make sure we're testing a fresh import of run_worker.
+        for mod in ("scripts.run_worker", "app.main"):
+            sys.modules.pop(mod, None)
+
+        # Import scripts.run_worker only — nothing else web-flavoured.
+        importlib.import_module("scripts.run_worker")
+
+        assert "app.main" not in sys.modules, (
+            "scripts.run_worker must NOT transitively import app.main; "
+            "found it in sys.modules after the import."
+        )
+
+    def test_run_worker_import_does_not_load_starlette_apps(self):
+        """No Starlette ``Starlette`` app instance should get built."""
+        for mod_name in ("scripts.run_worker", "app.main"):
+            sys.modules.pop(mod_name, None)
+
+        importlib.import_module("scripts.run_worker")
+
+        # ``starlette.applications`` itself is a library module that
+        # other parts of the project (e.g. ``fasthtml.common``) import.
+        # The guard we actually care about is that the FastHTML *app
+        # module* (which actually constructs the routes and middleware
+        # stack) is not loaded as a side effect of importing the
+        # standalone worker.
+        assert "app.main" not in sys.modules
+
+
+# ---------------------------------------------------------------------------
+# main.py lifespan honours WORKER_MODE
+# ---------------------------------------------------------------------------
+
+
+class TestLifespanRespectsWorkerMode:
+    """The ASGI lifespan must gate worker startup on ``WORKER_MODE``."""
+
+    def test_lifespan_skips_worker_when_standalone(self):
+        """``WORKER_MODE=standalone`` must NOT spawn the worker thread."""
+        import asyncio
+
+        from app import main as app_main
+
+        # Bypass the DISABLE_BACKGROUND_WORKER short-circuit so we
+        # actually reach the WORKER_MODE branch.
+        with (
+            patch.dict(
+                os.environ,
+                {"DISABLE_BACKGROUND_WORKER": "0", "WORKER_MODE": "standalone"},
+                clear=False,
+            ),
+            patch("app.jobs.worker.start_worker_thread") as mock_start_worker,
+            patch(
+                "app.jobs.archive_warning.start_archive_warning_scheduler"
+            ) as mock_start_scheduler,
+        ):
+
+            async def _drive() -> None:
+                gen = app_main.lifespan(MagicMock())
+                # Run the startup half of the generator only.
+                await gen.__anext__()
+                # Close cleanly so the finally-block fires without raising.
+                await gen.aclose()
+
+            asyncio.run(_drive())
+
+            mock_start_worker.assert_not_called()
+            mock_start_scheduler.assert_not_called()
+
+    def test_lifespan_starts_worker_when_inproc(self):
+        """``WORKER_MODE=inproc`` (default) must spawn the worker thread."""
+        import asyncio
+
+        from app import main as app_main
+
+        # Patch the start_* helpers so the test never spawns real
+        # threads against a mocked DB. We also nullify the
+        # DISABLE_BACKGROUND_WORKER flag set by conftest so the
+        # lifespan reaches the WORKER_MODE branch.
+        with (
+            patch.dict(
+                os.environ,
+                {"DISABLE_BACKGROUND_WORKER": "0", "WORKER_MODE": "inproc"},
+                clear=False,
+            ),
+            patch("app.jobs.worker.start_worker_thread") as mock_start_worker,
+            patch(
+                "app.jobs.archive_warning.start_archive_warning_scheduler"
+            ) as mock_start_scheduler,
+            patch("app.jobs.registry.register_all_handlers") as mock_register,
+        ):
+            # ``start_worker_thread`` normally returns a Thread; the
+            # finally block joins it. A MagicMock with .join is enough.
+            mock_thread = MagicMock()
+            mock_start_worker.return_value = mock_thread
+            mock_start_scheduler.return_value = mock_thread
+
+            async def _drive() -> None:
+                gen = app_main.lifespan(MagicMock())
+                await gen.__anext__()
+                await gen.aclose()
+
+            asyncio.run(_drive())
+
+            mock_register.assert_called_once()
+            mock_start_worker.assert_called_once()
+            mock_start_scheduler.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# scripts.run_worker.main guard
+# ---------------------------------------------------------------------------
+
+
+class TestRunWorkerMainGuard:
+    """``main()`` must refuse to run when ``WORKER_MODE != "standalone"``."""
+
+    def test_main_exits_when_worker_mode_is_inproc(self):
+        """Default inproc value should trigger a clear exit(1)."""
+        # Drop any cached import so the lazy ``from app.config import ...``
+        # inside main() picks up the patched env var.
+        sys.modules.pop("scripts.run_worker", None)
+        from scripts import run_worker
+
+        with patch.dict(os.environ, {"WORKER_MODE": "inproc"}, clear=False):
+            with pytest.raises(SystemExit) as excinfo:
+                run_worker.main()
+
+        # SystemExit code 1 — operator forgot to set WORKER_MODE=standalone.
+        assert excinfo.value.code == 1
+
+    def test_main_exits_on_invalid_worker_mode(self):
+        """Unknown values surface via ``get_worker_mode``'s ValueError."""
+        sys.modules.pop("scripts.run_worker", None)
+        from scripts import run_worker
+
+        with patch.dict(os.environ, {"WORKER_MODE": "bogus"}, clear=False):
+            with pytest.raises(SystemExit) as excinfo:
+                run_worker.main()
+
+        assert excinfo.value.code == 1
+
+    def test_main_proceeds_when_standalone(self):
+        """``WORKER_MODE=standalone`` must pass the guard and reach the worker loop.
+
+        We don't actually want to spin a real worker against a real DB
+        in a unit test, so patch ``JobWorker.run_forever`` to a no-op
+        and assert it was invoked. The signal-handler installation is
+        a side effect we accept (the test process is short-lived).
+        """
+        sys.modules.pop("scripts.run_worker", None)
+        from scripts import run_worker
+
+        with (
+            patch.dict(os.environ, {"WORKER_MODE": "standalone"}, clear=False),
+            patch("app.jobs.worker.JobWorker.run_forever") as mock_run_forever,
+            patch("app.jobs.registry.register_all_handlers") as mock_register,
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                run_worker.main()
+
+            assert excinfo.value.code == 0
+            mock_register.assert_called_once()
+            mock_run_forever.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_worker_mode config helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkerMode:
+    """``app.config.get_worker_mode`` is the single source of truth."""
+
+    def test_defaults_to_inproc(self):
+        """Unset env var means inproc (historical behaviour)."""
+        from app.config import get_worker_mode
+
+        # Use a context manager to ensure we restore the original env.
+        original = os.environ.pop("WORKER_MODE", None)
+        try:
+            assert get_worker_mode() == "inproc"
+        finally:
+            if original is not None:
+                os.environ["WORKER_MODE"] = original
+
+    def test_accepts_standalone(self):
+        from app.config import get_worker_mode
+
+        with patch.dict(os.environ, {"WORKER_MODE": "standalone"}, clear=False):
+            assert get_worker_mode() == "standalone"
+
+    def test_normalises_case_and_whitespace(self):
+        from app.config import get_worker_mode
+
+        with patch.dict(os.environ, {"WORKER_MODE": "  Standalone  "}, clear=False):
+            assert get_worker_mode() == "standalone"
+
+    def test_raises_on_unknown_value(self):
+        from app.config import get_worker_mode
+
+        with patch.dict(os.environ, {"WORKER_MODE": "bogus"}, clear=False):
+            with pytest.raises(ValueError, match="WORKER_MODE"):
+                get_worker_mode()

--- a/tests/test_worker_standalone.py
+++ b/tests/test_worker_standalone.py
@@ -112,6 +112,61 @@ class TestStandaloneImportIsolation:
         # standalone worker.
         assert "app.main" not in sys.modules
 
+    def test_register_all_handlers_does_not_load_route_modules(self):
+        """Standalone worker startup must NOT import any ``app.docs`` route module.
+
+        The standalone worker calls
+        :func:`app.jobs.registry.register_all_handlers` to populate the
+        ``@register_handler`` dispatch table. That call imports
+        ``app.docs`` (the package) so the handler modules' module-level
+        decorator side effects fire — but it must NOT pull in the
+        route-registration modules (``app.docs.routes`` /
+        ``app.docs.report_routes`` / submodules of ``app.docs.routes``).
+        Route modules drag in the entire FastHTML route surface; the
+        whole point of standalone mode is to keep the worker container
+        framework-free at startup.
+
+        Regression guard for the #348 PR review finding: previously
+        ``app/docs/__init__.py`` re-exported ``register_draft_routes`` /
+        ``register_report_routes`` from their submodules, so any worker
+        startup that imported ``app.docs`` transitively pulled in
+        ``app.docs.routes`` (and everything below it) as a side effect.
+        """
+        # Force a clean import so the assertion reflects what a fresh
+        # standalone-worker process would do. The route submodules may
+        # have been imported by a sibling test that exercises web
+        # routes, so we drop every plausible entry first.
+        prefixes_to_drop = (
+            "app.docs",
+            "app.main",
+            "app.jobs.registry",
+            "scripts.run_worker",
+        )
+        for key in list(sys.modules.keys()):
+            if any(key == p or key.startswith(p + ".") for p in prefixes_to_drop):
+                del sys.modules[key]
+
+        from app.jobs.registry import register_all_handlers
+
+        register_all_handlers()
+
+        # Route-registration modules must NOT be loaded.
+        leaked_route_modules = sorted(
+            mod
+            for mod in sys.modules
+            if mod == "app.docs.routes"
+            or mod.startswith("app.docs.routes.")
+            or mod == "app.docs.report_routes"
+            or mod == "app.docs.websocket"
+            or mod == "app.docs.ws_export_progress"
+        )
+        assert not leaked_route_modules, (
+            "register_all_handlers() must not transitively import any "
+            f"app.docs route module, but these leaked into sys.modules: "
+            f"{leaked_route_modules}. The standalone worker container "
+            "should stay framework-free at startup."
+        )
+
 
 # ---------------------------------------------------------------------------
 # main.py lifespan honours WORKER_MODE
@@ -122,7 +177,17 @@ class TestLifespanRespectsWorkerMode:
     """The ASGI lifespan must gate worker startup on ``WORKER_MODE``."""
 
     def test_lifespan_skips_worker_when_standalone(self):
-        """``WORKER_MODE=standalone`` must NOT spawn the worker thread."""
+        """``WORKER_MODE=standalone`` must NOT spawn the worker thread.
+
+        The archive-warning scheduler MUST still start in the web
+        lifespan even when the worker runs standalone, because the web
+        process is the canonical singleton host for the daily scan
+        (``scripts/run_worker.py`` deliberately does not start it — see
+        the "Why not also start the archive-warning scheduler here?"
+        docstring there). Skipping the scheduler in standalone mode
+        would silently drop the 90-day draft auto-archive compliance
+        feature on split-process deployments.
+        """
         import asyncio
 
         from app import main as app_main
@@ -140,6 +205,7 @@ class TestLifespanRespectsWorkerMode:
                 "app.jobs.archive_warning.start_archive_warning_scheduler"
             ) as mock_start_scheduler,
         ):
+            mock_start_scheduler.return_value = MagicMock()
 
             async def _drive() -> None:
                 gen = app_main.lifespan(MagicMock())
@@ -150,8 +216,10 @@ class TestLifespanRespectsWorkerMode:
 
             asyncio.run(_drive())
 
+            # Worker thread must NOT start (standalone container owns it).
             mock_start_worker.assert_not_called()
-            mock_start_scheduler.assert_not_called()
+            # Scheduler MUST start (web process is its canonical host).
+            mock_start_scheduler.assert_called_once()
 
     def test_lifespan_starts_worker_when_inproc(self):
         """``WORKER_MODE=inproc`` (default) must spawn the worker thread."""


### PR DESCRIPTION
## Summary
- `WORKER_MODE` env var (`inproc` | `standalone`, default `inproc`) in `app/config.py::get_worker_mode()` with validation
- Lifespan in `app/main.py` branches on mode — standalone logs a clear message and skips worker + archive-warning scheduler
- New `app/jobs/registry.py::register_all_handlers()` is the shared framework-free wiring, called from both inproc lifespan and standalone entrypoint
- `scripts/run_worker.py` — no FastHTML/Starlette imports, stdlib logging, SIGTERM/SIGINT graceful shutdown, refuses to start unless `WORKER_MODE=standalone`. Exposed via `[project.scripts] seadusloome-worker`
- `docker/docker-compose.yml` ships a commented `worker:` block
- Docs: `docs/operations/worker-modes.md` + README pointer
- Closes #348

## Test plan
- [x] `tests/test_worker_standalone.py` — 13 tests (registry idempotency, `app.main` not in sys.modules after importing run_worker, lifespan branching, exit codes, env validation)
- [x] Full job suite (42 tests) green
- [x] ruff + pyright clean

## Notes
- `register_all_handlers` runs **twice** in inproc mode (once via route imports' module-top side-effects, once via the explicit call). Safe because `@register_handler` overwrites the same function object — and it future-proofs against any route-import refactor.
- Archive-warning scheduler stays web-only; documented. If web scales to N replicas, a dedicated cron container will be needed.
- Handler code untouched — only registration plumbing.