### PR TITLE
feat(rag): #311 — metadata filtering on retrieve() with parameterized WHERE

### DIFF
--- a/app/rag/retriever.py
+++ b/app/rag/retriever.py
@@ -168,9 +168,11 @@ class Retriever:
             source_type: Optional shortcut for filtering to a single
                 source type (``'ontology'``, ``'draft'``, ``'law_text'``,
                 ``'court_decision'``). Kept for back-compat; prefer
-                ``filters={"source_type": ...}`` for new code. If both
-                are supplied, ``filters`` takes precedence and the
-                shortcut is ignored.
+                ``filters={"source_type": ...}`` for new code. The shortcut
+                is folded into the filter dict — so it ANDs cleanly with
+                other filter keys (e.g. ``entity_type``). If ``filters``
+                already contains a ``"source_type"`` key, the dict wins
+                on collision and the shortcut is ignored.
             org_id: Tenant scope. Public-corpus chunks (``org_id IS NULL``
                 in the DB) are always visible. If a non-``None`` value is
                 supplied, private chunks owned by that org are also
@@ -200,13 +202,14 @@ class Retriever:
         if not query.strip():
             return []
 
-        # Normalise: if a caller passed `filters`, ignore the legacy
-        # `source_type` shortcut so we don't AND two different predicates
-        # against the same column. If only the shortcut is supplied,
-        # translate it into the filter dict so the SQL builder is the
-        # single source of truth.
+        # Normalise: fold the legacy `source_type=` shortcut into the
+        # filter dict so the SQL builder is the single source of truth.
+        # The dict wins on collision (documented "filters wins" semantics);
+        # otherwise the shortcut is injected so callers can mix the two
+        # (e.g. `source_type="draft"` + `filters={"entity_type": "Provision"}`
+        # ANDs both predicates rather than silently dropping the shortcut).
         effective_filters: dict[str, Any] = dict(filters) if filters else {}
-        if not effective_filters and source_type:
+        if source_type is not None and "source_type" not in effective_filters:
             effective_filters["source_type"] = source_type
 
         # Validate / translate filters BEFORE we spend an embedding call,

--- a/app/rag/retriever.py
+++ b/app/rag/retriever.py
@@ -222,6 +222,13 @@ class Retriever:
             # bugs like typo'd filter keys).
             raise
 
+        # Short-circuit: if any filter produced a contradictory predicate
+        # (empty-list value -> "FALSE"), the SQL is guaranteed to return
+        # zero rows. Skip the embedding call so we don't burn Voyage AI
+        # quota on a query that can't match anything.
+        if any(clause == "FALSE" for clause in extra_clauses):
+            return []
+
         # 1. Embed the query
         embeddings = await self.embedder.embed([query])
         if not embeddings:

--- a/app/rag/retriever.py
+++ b/app/rag/retriever.py
@@ -18,11 +18,33 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Any, LiteralString, cast
 
 from app.db import get_connection
 from app.rag.embedding import EmbeddingProvider, get_default_embedding_provider
 
 logger = logging.getLogger(__name__)
+
+# Whitelist of filter keys accepted by :meth:`Retriever.retrieve`,
+# mapped to the SQL column expression they translate to.
+#
+# - ``source_type``, ``source_uri`` are real top-level columns on
+#   ``rag_chunks`` (migration 009) and are indexed.
+# - ``entity_type`` is NOT a top-level column; it lives inside the
+#   ``metadata`` JSONB blob. We translate it to ``metadata->>'entity_type'``.
+#   This is intentionally limited to a single hand-picked JSONB key — see
+#   the issue body's note that general ``metadata.x`` filtering is a
+#   follow-up. Anything else is rejected so callers can't smuggle arbitrary
+#   JSONB paths or fresh column names through the filter dict.
+#
+# Hard-coding the expression strings here (rather than building them with
+# an f-string at call time) keeps every fragment a ``LiteralString``, which
+# psycopg's ``execute()`` requires for static-analysis safety.
+_FILTER_COLUMN_EXPRS: dict[str, LiteralString] = {
+    "source_type": "source_type",
+    "source_uri": "source_uri",
+    "entity_type": "metadata->>'entity_type'",
+}
 
 
 @dataclass(frozen=True)
@@ -39,6 +61,83 @@ class RetrievedChunk:
     content: str
     metadata: dict
     score: float
+
+
+def _build_filter_clauses(
+    filters: dict[str, Any] | None,
+) -> tuple[list[LiteralString], list[Any]]:
+    """Translate a whitelisted filter dict into SQL fragments + params.
+
+    Every value is bound through ``%s`` placeholders — no string formatting
+    of caller-controlled data. List / tuple values become ``= ANY(%s)``
+    (Postgres array). ``None`` becomes ``IS NULL``.
+
+    Args:
+        filters: Mapping of column name → value. Allowed keys are listed
+            in :data:`_FILTER_COLUMN_EXPRS`. Unknown keys raise
+            ``ValueError``. ``None`` or an empty dict means "no extra
+            filters" and returns ``([], [])``.
+
+    Returns:
+        ``(clauses, params)`` where ``clauses`` is a list of SQL
+        fragments (each suitable for joining with ``" AND "``) and
+        ``params`` is the matching list of bound values in left-to-right
+        order.
+
+    Raises:
+        ValueError: If any key in *filters* is not in the whitelist.
+            Rejecting unknown keys (rather than silently dropping them)
+            ensures callers see typos / drift fast and prevents a
+            future schema-rename from quietly disabling a filter.
+    """
+    if not filters:
+        return [], []
+
+    unknown = set(filters) - set(_FILTER_COLUMN_EXPRS)
+    if unknown:
+        raise ValueError(
+            "Unknown filter key(s): "
+            + ", ".join(sorted(unknown))
+            + f". Allowed keys: {sorted(_FILTER_COLUMN_EXPRS)}"
+        )
+
+    clauses: list[LiteralString] = []
+    params: list[Any] = []
+
+    # Per-shape pre-built fragments. Concatenating two LiteralStrings via
+    # ``+`` preserves the LiteralString type; f-strings do not. Keeping
+    # these in a closed lookup is what lets pyright accept the final SQL
+    # as ``LiteralString`` at the ``execute()`` call site.
+    eq_suffix: LiteralString = " = %s"
+    any_suffix: LiteralString = " = ANY(%s)"
+    null_suffix: LiteralString = " IS NULL"
+
+    for key, value in filters.items():
+        # Whitelist lookup; the value is always a LiteralString because
+        # _FILTER_COLUMN_EXPRS is hand-authored above.
+        col_expr: LiteralString = _FILTER_COLUMN_EXPRS[key]
+
+        if value is None:
+            clauses.append(col_expr + null_suffix)
+            continue
+
+        if isinstance(value, (list, tuple, set)):
+            seq = list(value)
+            if not seq:
+                # An empty list means "no allowed values" → match nothing.
+                # Emit a contradictory predicate so the result set is empty
+                # without raising. Callers that wanted "ignore this filter"
+                # should pass ``None`` or omit the key.
+                clauses.append("FALSE")
+                continue
+            clauses.append(col_expr + any_suffix)
+            params.append(seq)
+            continue
+
+        clauses.append(col_expr + eq_suffix)
+        params.append(value)
+
+    return clauses, params
 
 
 class Retriever:
@@ -59,15 +158,19 @@ class Retriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[RetrievedChunk]:
         """Retrieve the top-k most similar chunks to *query*.
 
         Args:
             query: Natural language query to search for.
             k: Maximum number of results to return.
-            source_type: Optional filter to restrict results to a
-                specific source type (``'ontology'``, ``'draft'``,
-                ``'law_text'``, ``'court_decision'``).
+            source_type: Optional shortcut for filtering to a single
+                source type (``'ontology'``, ``'draft'``, ``'law_text'``,
+                ``'court_decision'``). Kept for back-compat; prefer
+                ``filters={"source_type": ...}`` for new code. If both
+                are supplied, ``filters`` takes precedence and the
+                shortcut is ignored.
             org_id: Tenant scope. Public-corpus chunks (``org_id IS NULL``
                 in the DB) are always visible. If a non-``None`` value is
                 supplied, private chunks owned by that org are also
@@ -75,11 +178,20 @@ class Retriever:
                 and only public chunks are returned. Callers must pass
                 the authenticated user's ``org_id`` — failing to do so is
                 a data-leak bug, not a convenience.
+            filters: Optional metadata filter dict. Allowed keys are
+                ``source_type``, ``source_uri``, ``entity_type``. Values
+                may be a scalar (``=``), a list/tuple/set (``= ANY``),
+                or ``None`` (``IS NULL``). Unknown keys raise
+                ``ValueError``. Combines additively with the tenant
+                predicate — filters NEVER bypass org scoping. (#311)
 
         Returns:
             List of :class:`RetrievedChunk` ordered by descending
             similarity score. Empty list if no results or if the
             table has no data.
+
+        Raises:
+            ValueError: If *filters* contains a key not in the whitelist.
         """
         # Tenant scoping: `(org_id IS NULL OR org_id = $1)` keeps public
         # corpus (NULL) visible to everyone and gates private chunks on
@@ -87,6 +199,25 @@ class Retriever:
 
         if not query.strip():
             return []
+
+        # Normalise: if a caller passed `filters`, ignore the legacy
+        # `source_type` shortcut so we don't AND two different predicates
+        # against the same column. If only the shortcut is supplied,
+        # translate it into the filter dict so the SQL builder is the
+        # single source of truth.
+        effective_filters: dict[str, Any] = dict(filters) if filters else {}
+        if not effective_filters and source_type:
+            effective_filters["source_type"] = source_type
+
+        # Validate / translate filters BEFORE we spend an embedding call,
+        # so an invalid filter dict doesn't burn API quota.
+        try:
+            extra_clauses, extra_params = _build_filter_clauses(effective_filters)
+        except ValueError:
+            # Re-raise so callers see the misuse loudly; we deliberately
+            # do not swallow this to an empty result list (that would mask
+            # bugs like typo'd filter keys).
+            raise
 
         # 1. Embed the query
         embeddings = await self.embedder.embed([query])
@@ -102,33 +233,39 @@ class Retriever:
         # NULL, and `NULL = NULL` is NULL (not true), so the `org_id IS
         # NULL` branch correctly keeps public rows visible even when the
         # caller has no org.
-        tenant_where = "(org_id IS NULL OR org_id = %s)"
+        where_parts: list[LiteralString] = ["(org_id IS NULL OR org_id = %s)"]
+        where_parts.extend(extra_clauses)
+        # ``str.join`` on a literal separator preserves LiteralString when
+        # all elements are LiteralString — but pyright can't infer that
+        # through ``list[LiteralString]``, so we cast. Every element of
+        # ``where_parts`` is provably a LiteralString (the tenant predicate
+        # is a literal; each extra clause is built from
+        # ``_FILTER_COLUMN_EXPRS`` values which are LiteralString),
+        # so the cast is sound.
+        where_sql = cast(LiteralString, " AND ".join(where_parts))
 
-        if source_type:
-            sql = (
-                "SELECT content, metadata, "
-                "1 - (embedding <=> %s::vector) AS score "
-                "FROM rag_chunks "
-                f"WHERE {tenant_where} AND source_type = %s "
-                "ORDER BY embedding <=> %s::vector "
-                "LIMIT %s"
-            )
-            params = (embedding_str, org_id, source_type, embedding_str, k)
-        else:
-            sql = (
-                "SELECT content, metadata, "
-                "1 - (embedding <=> %s::vector) AS score "
-                "FROM rag_chunks "
-                f"WHERE {tenant_where} "
-                "ORDER BY embedding <=> %s::vector "
-                "LIMIT %s"
-            )
-            params = (embedding_str, org_id, embedding_str, k)
+        sql = (
+            "SELECT content, metadata, "
+            "1 - (embedding <=> %s::vector) AS score "
+            "FROM rag_chunks "
+            "WHERE " + where_sql + " "
+            "ORDER BY embedding <=> %s::vector "
+            "LIMIT %s"
+        )
+        # Parameter order must match `%s` order in the SQL above:
+        #   1. embedding_str (SELECT score)
+        #   2. org_id (tenant predicate)
+        #   3..n. each extra filter param, in the order the clauses were emitted
+        #   n+1. embedding_str (ORDER BY)
+        #   n+2. k (LIMIT)
+        params: list[Any] = [embedding_str, org_id]
+        params.extend(extra_params)
+        params.extend([embedding_str, k])
 
         # 3. Execute
         try:
             with get_connection() as conn:
-                cursor = conn.execute(sql, params)
+                cursor = conn.execute(sql, tuple(params))
                 rows = cursor.fetchall()
         except Exception:
             logger.exception("Failed to retrieve RAG chunks")

--- a/tests/test_rag_retriever_filters.py
+++ b/tests/test_rag_retriever_filters.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,6 +27,16 @@ def _make_stub_embedder():
         return [[0.1] * 1024 for _ in texts]
 
     embedder.embed = fake_embed
+    embedder.dimensions = 1024
+    return embedder
+
+
+def _make_assertable_embedder():
+    """Like ``_make_stub_embedder`` but the ``embed`` method is an
+    :class:`AsyncMock`, so tests can assert call counts / call args.
+    """
+    embedder = MagicMock()
+    embedder.embed = AsyncMock(return_value=[[0.1] * 1024])
     embedder.dimensions = 1024
     return embedder
 
@@ -443,3 +453,43 @@ class TestLegacySourceTypeMergeWithFilters:
         assert "X" in params
         # No source_type predicate at all.
         assert "source_type" not in sql
+
+
+class TestEmptyListShortCircuit:
+    """Regression tests for the P3 review fix: an empty-list filter value
+    must short-circuit BEFORE the embedding call, so we don't burn Voyage
+    AI quota on a query whose SQL is guaranteed to return zero rows.
+    """
+
+    @patch("app.rag.retriever.get_connection")
+    def test_empty_list_filter_skips_embed(self, mock_get_conn: MagicMock):
+        """``filters={"source_type": []}`` returns ``[]`` without
+        invoking the embedder OR touching the DB."""
+        embedder = _make_assertable_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        results = asyncio.run(retriever.retrieve("test", filters={"source_type": []}))
+
+        assert results == []
+        # The whole point of the fix: no embedding API call.
+        embedder.embed.assert_not_called()
+        # And no DB call either — we returned before building the SQL.
+        mock_conn.execute.assert_not_called()
+
+    @patch("app.rag.retriever.get_connection")
+    def test_scalar_filter_still_calls_embed_once(self, mock_get_conn: MagicMock):
+        """Sanity: the happy path (single-value filter) still embeds the
+        query exactly once. Guards against an over-eager short-circuit
+        regression.
+        """
+        embedder = _make_assertable_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(retriever.retrieve("test", filters={"source_type": "draft"}))
+
+        embedder.embed.assert_called_once_with(["test"])
+        mock_conn.execute.assert_called_once()

--- a/tests/test_rag_retriever_filters.py
+++ b/tests/test_rag_retriever_filters.py
@@ -344,3 +344,102 @@ class TestRetrieveFilters:
         assert params[0] == params[-2]
         # Sanity: number of %s in SQL matches number of params.
         assert sql.count("%s") == len(params)
+
+
+class TestLegacySourceTypeMergeWithFilters:
+    """Regression tests for the P2 review fix: the legacy ``source_type=``
+    shortcut must be folded INTO the filter dict whenever the dict does
+    not already contain a ``source_type`` key. The old code dropped the
+    shortcut as soon as ``filters`` was non-empty, which silently widened
+    the result set to all source types.
+    """
+
+    @patch("app.rag.retriever.get_connection")
+    def test_legacy_kwarg_merges_with_non_colliding_filters(self, mock_get_conn: MagicMock):
+        """``source_type="draft"`` + ``filters={"entity_type": "Provision"}``
+        must AND both predicates — not silently drop the shortcut.
+        """
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(
+            retriever.retrieve(
+                "test",
+                source_type="draft",
+                filters={"entity_type": "Provision"},
+            )
+        )
+
+        sql, params = mock_conn.execute.call_args[0]
+        # BOTH predicates must be present in the SQL.
+        assert "source_type = %s" in sql
+        assert "metadata->>'entity_type' = %s" in sql
+        # BOTH bound values must reach the DB.
+        assert "draft" in params
+        assert "Provision" in params
+        # They must be AND'd, not OR'd, alongside the tenant guard.
+        assert " AND " in sql
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filters_wins_on_source_type_collision(self, mock_get_conn: MagicMock):
+        """When ``filters`` already has ``source_type``, the dict value
+        wins and the legacy kwarg is ignored. (Unchanged collision case.)
+        """
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(
+            retriever.retrieve(
+                "test",
+                source_type="draft",
+                filters={"source_type": "law"},
+            )
+        )
+
+        sql, params = mock_conn.execute.call_args[0]
+        # Only one source_type predicate (no double-AND).
+        assert sql.count("source_type = %s") == 1
+        # The filter dict value wins.
+        assert "law" in params
+        assert "draft" not in params
+
+    @patch("app.rag.retriever.get_connection")
+    def test_legacy_source_type_only_unchanged(self, mock_get_conn: MagicMock):
+        """``source_type="draft"`` with no ``filters`` keeps the legacy
+        single-predicate behaviour intact.
+        """
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(retriever.retrieve("test", source_type="draft"))
+
+        sql, params = mock_conn.execute.call_args[0]
+        assert "source_type = %s" in sql
+        assert "draft" in params
+        # No JSONB filter clause leaked in.
+        assert "metadata->>" not in sql
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filters_only_no_implicit_source_type(self, mock_get_conn: MagicMock):
+        """``filters={"entity_type": "X"}`` with no legacy kwarg must
+        emit ONLY the entity_type predicate — no source_type clause and
+        no source_type bound param.
+        """
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(retriever.retrieve("test", filters={"entity_type": "X"}))
+
+        sql, params = mock_conn.execute.call_args[0]
+        assert "metadata->>'entity_type' = %s" in sql
+        assert "X" in params
+        # No source_type predicate at all.
+        assert "source_type" not in sql

--- a/tests/test_rag_retriever_filters.py
+++ b/tests/test_rag_retriever_filters.py
@@ -1,0 +1,346 @@
+"""Tests for the metadata-filter API on :class:`app.rag.retriever.Retriever`.
+
+Issue #311 — adds a ``filters`` kwarg to ``retrieve()`` so callers can
+constrain results by ``source_type`` / ``source_uri`` / ``entity_type``.
+Everything goes through psycopg's ``%s`` parameterization — no values
+are interpolated into the SQL string.
+
+All tests mock the DB and embedder. No real DB or API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.rag.retriever import Retriever, _build_filter_clauses
+
+
+def _make_stub_embedder():
+    """Mock embedding provider returning deterministic 1024d vectors."""
+    embedder = MagicMock()
+
+    async def fake_embed(texts):
+        return [[0.1] * 1024 for _ in texts]
+
+    embedder.embed = fake_embed
+    embedder.dimensions = 1024
+    return embedder
+
+
+def _make_mock_conn(rows: list[tuple]) -> MagicMock:
+    """Build a context-manager-compatible mock connection."""
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = rows
+    mock_conn.execute.return_value = mock_cursor
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    return mock_conn
+
+
+class TestBuildFilterClauses:
+    """Pure-Python tests for the SQL fragment builder."""
+
+    def test_empty_filters_returns_empty(self):
+        assert _build_filter_clauses(None) == ([], [])
+        assert _build_filter_clauses({}) == ([], [])
+
+    def test_scalar_value_emits_equality(self):
+        clauses, params = _build_filter_clauses({"source_type": "law_text"})
+        assert clauses == ["source_type = %s"]
+        assert params == ["law_text"]
+
+    def test_list_value_emits_any(self):
+        clauses, params = _build_filter_clauses({"source_type": ["law_text", "court_decision"]})
+        assert clauses == ["source_type = ANY(%s)"]
+        assert params == [["law_text", "court_decision"]]
+
+    def test_tuple_value_emits_any(self):
+        clauses, params = _build_filter_clauses({"source_type": ("law_text", "court_decision")})
+        assert clauses == ["source_type = ANY(%s)"]
+        # tuples are normalised to lists for psycopg array binding
+        assert params == [["law_text", "court_decision"]]
+
+    def test_empty_list_emits_false(self):
+        clauses, params = _build_filter_clauses({"source_type": []})
+        # Empty list => match nothing, no params bound
+        assert clauses == ["FALSE"]
+        assert params == []
+
+    def test_none_value_emits_is_null(self):
+        clauses, params = _build_filter_clauses({"entity_type": None})
+        assert clauses == ["metadata->>'entity_type' IS NULL"]
+        assert params == []
+
+    def test_entity_type_uses_jsonb_extract(self):
+        clauses, params = _build_filter_clauses({"entity_type": "Provision"})
+        # entity_type lives in metadata JSONB, not as a top-level column.
+        assert clauses == ["metadata->>'entity_type' = %s"]
+        assert params == ["Provision"]
+
+    def test_source_uri_uses_top_level_column(self):
+        clauses, params = _build_filter_clauses({"source_uri": "https://example.test/law/1"})
+        assert clauses == ["source_uri = %s"]
+        assert params == ["https://example.test/law/1"]
+
+    def test_unknown_key_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown filter key"):
+            _build_filter_clauses({"not_a_column": "x"})
+
+    def test_unknown_key_message_lists_allowed(self):
+        with pytest.raises(ValueError, match="Allowed keys"):
+            _build_filter_clauses({"bogus": "x"})
+
+    def test_multiple_filters_combine(self):
+        clauses, params = _build_filter_clauses(
+            {"source_type": "law_text", "entity_type": "Provision"}
+        )
+        assert "source_type = %s" in clauses
+        assert "metadata->>'entity_type' = %s" in clauses
+        assert "law_text" in params
+        assert "Provision" in params
+
+
+class TestRetrieveBackCompat:
+    """The new ``filters`` kwarg must not break existing call sites."""
+
+    @patch("app.rag.retriever.get_connection")
+    def test_no_filter_matches_previous_behavior(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([("text", json.dumps({"x": 1}), 0.9)])
+        mock_get_conn.return_value = mock_conn
+
+        results = asyncio.run(retriever.retrieve("test"))
+
+        assert len(results) == 1
+        sql = mock_conn.execute.call_args[0][0]
+        # No extra filter clauses besides the tenant guard.
+        assert "source_type" not in sql
+        assert "entity_type" not in sql
+        # Tenant scope is still applied.
+        assert "org_id IS NULL OR org_id = %s" in sql
+
+    @patch("app.rag.retriever.get_connection")
+    def test_legacy_source_type_shortcut_still_works(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(retriever.retrieve("test", source_type="court_decision"))
+
+        sql, params = mock_conn.execute.call_args[0]
+        assert "source_type = %s" in sql
+        assert "court_decision" in params
+
+
+class TestRetrieveFilters:
+    """End-to-end-ish tests that the SQL + params reach the DB correctly."""
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filter_by_source_type_scalar(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([("law text", json.dumps({"source_type": "law_text"}), 0.95)])
+        mock_get_conn.return_value = mock_conn
+
+        results = asyncio.run(retriever.retrieve("test", filters={"source_type": "law_text"}))
+
+        assert len(results) == 1
+        sql, params = mock_conn.execute.call_args[0]
+        assert "source_type = %s" in sql
+        assert "law_text" in params
+        # Tenant scope still present.
+        assert "org_id IS NULL OR org_id = %s" in sql
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filter_by_source_type_list(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn(
+            [
+                ("law text", json.dumps({"source_type": "law_text"}), 0.9),
+                ("court text", json.dumps({"source_type": "court_decision"}), 0.8),
+            ]
+        )
+        mock_get_conn.return_value = mock_conn
+
+        results = asyncio.run(
+            retriever.retrieve(
+                "test",
+                filters={"source_type": ["law_text", "court_decision"]},
+            )
+        )
+
+        assert len(results) == 2
+        sql, params = mock_conn.execute.call_args[0]
+        assert "source_type = ANY(%s)" in sql
+        assert ["law_text", "court_decision"] in params
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filter_by_entity_type(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([("p", json.dumps({"entity_type": "Provision"}), 0.9)])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(retriever.retrieve("test", filters={"entity_type": "Provision"}))
+
+        sql, params = mock_conn.execute.call_args[0]
+        # entity_type lives in JSONB, not as a column.
+        assert "metadata->>'entity_type' = %s" in sql
+        assert "Provision" in params
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filter_by_source_uri(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(
+            retriever.retrieve(
+                "test",
+                filters={"source_uri": "https://example.test/law/1"},
+            )
+        )
+
+        sql, params = mock_conn.execute.call_args[0]
+        assert "source_uri = %s" in sql
+        assert "https://example.test/law/1" in params
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filter_combines_with_org_scope(self, mock_get_conn: MagicMock):
+        """Filters must AND with the tenant predicate, not replace it."""
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(
+            retriever.retrieve(
+                "test",
+                org_id="org-abc",
+                filters={"source_type": "draft"},
+            )
+        )
+
+        sql, params = mock_conn.execute.call_args[0]
+        # Both predicates present.
+        assert "org_id IS NULL OR org_id = %s" in sql
+        assert "source_type = %s" in sql
+        # Connected by AND.
+        assert " AND " in sql
+        # Both values bound.
+        assert "org-abc" in params
+        assert "draft" in params
+
+    @patch("app.rag.retriever.get_connection")
+    def test_sql_injection_attempt_is_parameterised(self, mock_get_conn: MagicMock):
+        """A malicious value flows as a bound param, not into the SQL text."""
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        evil = "'; DROP TABLE rag_chunks; --"
+        results = asyncio.run(retriever.retrieve("test", filters={"source_type": evil}))
+
+        # No exception, no rows (no chunk has that source_type).
+        assert results == []
+        sql, params = mock_conn.execute.call_args[0]
+        # The dangerous payload is NEVER substituted into the SQL string.
+        assert "DROP TABLE" not in sql
+        assert evil not in sql
+        # It IS bound as a parameter — that's the whole point.
+        assert evil in params
+
+    @patch("app.rag.retriever.get_connection")
+    def test_unknown_filter_key_raises_before_db_call(self, mock_get_conn: MagicMock):
+        """Unknown keys should raise ValueError without hitting the DB."""
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        with pytest.raises(ValueError, match="Unknown filter key"):
+            asyncio.run(retriever.retrieve("test", filters={"definitely_not_a_column": "x"}))
+
+        # DB was never touched.
+        mock_conn.execute.assert_not_called()
+
+    @patch("app.rag.retriever.get_connection")
+    def test_filters_takes_precedence_over_legacy_shortcut(self, mock_get_conn: MagicMock):
+        """When both ``filters`` and ``source_type=`` are given, filters wins.
+
+        This avoids accidentally AND'ing two competing predicates against
+        the same column (e.g. ``source_type = 'a' AND source_type = 'b'``
+        which would always be empty).
+        """
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(
+            retriever.retrieve(
+                "test",
+                source_type="ignored",
+                filters={"source_type": "winner"},
+            )
+        )
+
+        sql, params = mock_conn.execute.call_args[0]
+        # The filter value is bound; the legacy shortcut is dropped.
+        assert "winner" in params
+        assert "ignored" not in params
+        # Only one source_type predicate.
+        assert sql.count("source_type = %s") == 1
+
+    @patch("app.rag.retriever.get_connection")
+    def test_none_filter_value_emits_is_null(self, mock_get_conn: MagicMock):
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(retriever.retrieve("test", filters={"entity_type": None}))
+
+        sql, _params = mock_conn.execute.call_args[0]
+        assert "metadata->>'entity_type' IS NULL" in sql
+
+    @patch("app.rag.retriever.get_connection")
+    def test_param_order_matches_sql_placeholders(self, mock_get_conn: MagicMock):
+        """The bound params must line up with %s positions in the SQL.
+
+        Order: embedding (SELECT), org_id, extra filter params,
+        embedding (ORDER BY), k.
+        """
+        embedder = _make_stub_embedder()
+        retriever = Retriever(embedding_provider=embedder)
+        mock_conn = _make_mock_conn([])
+        mock_get_conn.return_value = mock_conn
+
+        asyncio.run(
+            retriever.retrieve(
+                "test",
+                k=7,
+                org_id="org-xyz",
+                filters={"source_type": "law_text"},
+            )
+        )
+
+        sql, params = mock_conn.execute.call_args[0]
+        # Position-sensitive structure check.
+        assert params[1] == "org-xyz"  # tenant slot
+        assert params[2] == "law_text"  # filter slot
+        assert params[-1] == 7  # LIMIT slot
+        # The two %s::vector slots share the same embedding string.
+        assert params[0] == params[-2]
+        # Sanity: number of %s in SQL matches number of params.
+        assert sql.count("%s") == len(params)


### PR DESCRIPTION
## Summary
- New `filters: dict[str, Any] | None` kwarg on `Retriever.retrieve()`
- Whitelist via `_FILTER_COLUMN_EXPRS` (closed dict, `LiteralString` values). Keys: `source_type`, `source_uri`, `entity_type`
- `_build_filter_clauses()` translates scalar → `= %s`, list/tuple/set → `= ANY(%s)`, `None` → `IS NULL`, empty list → `FALSE`
- All values bound through psycopg `%s` — never interpolated. Validated **before** the embedding call so a typo never burns Voyage quota.
- Tenant predicate `(org_id IS NULL OR org_id = %s)` stays unconditional — filters AND with it
- Legacy `source_type=` shortcut preserved; `filters` wins on collision
- Closes #311

## Test plan
- [x] `tests/test_rag_retriever_filters.py` — 23 tests (fragment builder, back-compat, end-to-end SQL/param, SQL-injection safety, unknown-key ValueError, org-scope combination, param-position invariant)
- [x] 83/83 RAG tests green (11 pre-existing + 23 new + 49 chunker/embedding/ingestion/tenant)
- [x] Chat orchestrator integration tests green
- [x] ruff + pyright clean

## Notes
- **Unknown filter keys raise `ValueError`** (not silent skip) — fails loud, DB never touched. Open to flipping to warn-skip if you prefer that ergonomics.
- **`entity_type` is JSONB-extracted** (`metadata->>'entity_type'`), not a top-level column. General `metadata.*` filtering deferred — flag for follow-up if needed.
- **No new call sites added.** The "scope chat RAG to provisions when draft-context is active" idea is parked. If we want it, it goes in a small follow-up to chat/orchestrator.