### PR TITLE
feat(llm): #354 — retry on transient API errors with exp backoff

### DIFF
--- a/app/llm/claude.py
+++ b/app/llm/claude.py
@@ -22,7 +22,9 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from app.llm.provider import LLMProvider, StreamEvent
+from app.llm.retry import retry_async, retry_sync
 from app.llm.scrubber import scrub_messages, scrub_prompt
+from app.metrics import record_metric
 
 logger = logging.getLogger(__name__)
 
@@ -128,8 +130,6 @@ class ClaudeProvider(LLMProvider):
         if self._stubbed:
             return f"[STUB Claude] {prompt[:40]}..."
 
-        import anthropic as _anthropic
-
         client = self._get_client()
 
         scrubbed_prompt = scrub_prompt(prompt, allow_raw=allow_raw)
@@ -147,41 +147,32 @@ class ClaudeProvider(LLMProvider):
         if scrubbed_system:
             create_kwargs["system"] = scrubbed_system
 
+        # #196: instrument per-call latency. We can't use ``track_duration``
+        # here because labels captured at context entry can't reflect the
+        # ``status`` outcome — fall back to manual timing + record_metric.
+        # #354: retry transient errors (429/5xx/network) with bounded backoff.
+        status = "ok"
+        _start = time.perf_counter()
         try:
-            response = client.messages.create(**create_kwargs)
-        except _anthropic.RateLimitError:
-            logger.warning(
-                "Anthropic rate limit hit (prompt length=%d). Retrying in 10s...",
-                len(prompt),
+            response = retry_sync(
+                lambda: client.messages.create(**create_kwargs),
+                context="complete",
             )
-            time.sleep(10)
-            try:
-                response = client.messages.create(**create_kwargs)
-            except Exception:
-                logger.exception(
-                    "Anthropic retry failed after rate limit (prompt length=%d)",
-                    len(prompt),
-                )
-                raise
-        except _anthropic.APITimeoutError:
-            logger.warning(
-                "Anthropic timeout (prompt length=%d). Retrying...",
-                len(prompt),
-            )
-            try:
-                response = client.messages.create(**create_kwargs)
-            except Exception:
-                logger.exception(
-                    "Anthropic retry failed after timeout (prompt length=%d)",
-                    len(prompt),
-                )
-                raise
-        except _anthropic.APIError:
-            logger.exception(
-                "Anthropic API error (prompt length=%d)",
-                len(prompt),
-            )
+        except Exception:
+            status = "error"
             raise
+        finally:
+            _duration_ms = (time.perf_counter() - _start) * 1000
+            record_metric(
+                "llm_call_ms",
+                round(_duration_ms, 2),
+                {
+                    "feature": feature,
+                    "model": self._model,
+                    "operation": "complete",
+                    "status": status,
+                },
+            )
 
         content = response.content[0].text if response.content else ""
 
@@ -260,7 +251,26 @@ class ClaudeProvider(LLMProvider):
         client = self._get_client()
         count_fn = getattr(client, "count_tokens", None)
         if callable(count_fn):  # pragma: no cover
-            result: Any = count_fn(text)
+            # #196: instrument per-call latency.
+            status = "ok"
+            _start = time.perf_counter()
+            try:
+                result: Any = count_fn(text)
+            except Exception:
+                status = "error"
+                raise
+            finally:
+                _duration_ms = (time.perf_counter() - _start) * 1000
+                record_metric(
+                    "llm_call_ms",
+                    round(_duration_ms, 2),
+                    {
+                        "feature": "count_tokens",
+                        "model": self._model,
+                        "operation": "count_tokens",
+                        "status": status,
+                    },
+                )
             return int(result)
         return len(text) // 4
 
@@ -307,8 +317,6 @@ class ClaudeProvider(LLMProvider):
         if self._stubbed:
             return f"[STUB Claude async] {prompt[:40]}..."
 
-        import anthropic as _anthropic
-
         client = self._get_async_client()
 
         scrubbed_prompt = scrub_prompt(prompt, allow_raw=allow_raw)
@@ -326,40 +334,31 @@ class ClaudeProvider(LLMProvider):
         if scrubbed_system:
             create_kwargs["system"] = scrubbed_system
 
+        # #196: instrument per-call latency (see ``complete`` for rationale).
+        # #354: retry transient errors (429/5xx/network) with bounded backoff.
+        status = "ok"
+        _start = time.perf_counter()
+
+        async def _call() -> Any:
+            return await client.messages.create(**create_kwargs)
+
         try:
-            response = await client.messages.create(**create_kwargs)
-        except _anthropic.RateLimitError:
-            logger.warning(
-                "Anthropic async rate limit hit (prompt length=%d). Retrying...",
-                len(prompt),
-            )
-            try:
-                response = await client.messages.create(**create_kwargs)
-            except Exception:
-                logger.exception(
-                    "Anthropic async retry failed after rate limit (prompt length=%d)",
-                    len(prompt),
-                )
-                raise
-        except _anthropic.APITimeoutError:
-            logger.warning(
-                "Anthropic async timeout (prompt length=%d). Retrying...",
-                len(prompt),
-            )
-            try:
-                response = await client.messages.create(**create_kwargs)
-            except Exception:
-                logger.exception(
-                    "Anthropic async retry failed after timeout (prompt length=%d)",
-                    len(prompt),
-                )
-                raise
-        except _anthropic.APIError:
-            logger.exception(
-                "Anthropic async API error (prompt length=%d)",
-                len(prompt),
-            )
+            response = await retry_async(_call, context="acomplete")
+        except Exception:
+            status = "error"
             raise
+        finally:
+            _duration_ms = (time.perf_counter() - _start) * 1000
+            record_metric(
+                "llm_call_ms",
+                round(_duration_ms, 2),
+                {
+                    "feature": feature,
+                    "model": self._model,
+                    "operation": "acomplete",
+                    "status": status,
+                },
+            )
 
         content = response.content[0].text if response.content else ""
 
@@ -440,73 +439,113 @@ class ClaudeProvider(LLMProvider):
         # key by the event ``index`` so interleaved blocks don't collide.
         tool_blocks: dict[int, dict[str, Any]] = {}
 
-        async with client.messages.stream(**create_kwargs) as stream:
-            async for event in stream:
-                event_type = getattr(event, "type", None)
-                if event_type is None:
-                    continue
+        # #196: instrument per-call latency. We measure wall-time spent in
+        # the streaming context (open → final event consumed). The metric is
+        # recorded once per call, regardless of consumer cancel timing.
+        # #354: retry only the *open* call. Mid-stream failures aren't
+        # retried because we'd duplicate already-emitted deltas.
+        stream_status = "ok"
+        _stream_start = time.perf_counter()
 
-                if event_type == "content_block_start":
-                    content_block = getattr(event, "content_block", None)
-                    if content_block is None:
+        async def _open_stream() -> Any:
+            # ``messages.stream(...)`` returns a context manager; we enter
+            # it manually so the retry helper can re-run the open while we
+            # keep the resulting stream object for iteration below.
+            ctx = client.messages.stream(**create_kwargs)
+            stream_obj = await ctx.__aenter__()
+            # Stash the ctx on the stream so we can call __aexit__ later.
+            stream_obj.__stream_ctx__ = ctx  # type: ignore[attr-defined]
+            return stream_obj
+
+        try:
+            stream = await retry_async(_open_stream, context="astream-open")
+            ctx = stream.__stream_ctx__  # type: ignore[attr-defined]
+            try:
+                async for event in stream:
+                    event_type = getattr(event, "type", None)
+                    if event_type is None:
                         continue
-                    if getattr(content_block, "type", None) == "tool_use":
-                        idx = getattr(event, "index", len(tool_blocks))
-                        tool_blocks[idx] = {
-                            "id": getattr(content_block, "id", ""),
-                            "name": getattr(content_block, "name", ""),
-                            "json_buf": "",
-                        }
-                elif event_type == "content_block_delta":
-                    delta_obj = getattr(event, "delta", None)
-                    if delta_obj is None:
-                        continue
-                    delta_type = getattr(delta_obj, "type", None)
-                    if delta_type == "input_json_delta":
+
+                    if event_type == "content_block_start":
+                        content_block = getattr(event, "content_block", None)
+                        if content_block is None:
+                            continue
+                        if getattr(content_block, "type", None) == "tool_use":
+                            idx = getattr(event, "index", len(tool_blocks))
+                            tool_blocks[idx] = {
+                                "id": getattr(content_block, "id", ""),
+                                "name": getattr(content_block, "name", ""),
+                                "json_buf": "",
+                            }
+                    elif event_type == "content_block_delta":
+                        delta_obj = getattr(event, "delta", None)
+                        if delta_obj is None:
+                            continue
+                        delta_type = getattr(delta_obj, "type", None)
+                        if delta_type == "input_json_delta":
+                            idx = getattr(event, "index", None)
+                            block = tool_blocks.get(idx) if idx is not None else None
+                            if block is not None:
+                                block["json_buf"] += getattr(delta_obj, "partial_json", "") or ""
+                        elif hasattr(delta_obj, "text"):
+                            # Plain text delta (text_delta for SSE, or legacy
+                            # shape where .text is set directly).
+                            text = delta_obj.text
+                            if text:
+                                yield StreamEvent(type="content", delta=text)
+                    elif event_type == "content_block_stop":
                         idx = getattr(event, "index", None)
-                        block = tool_blocks.get(idx) if idx is not None else None
-                        if block is not None:
-                            block["json_buf"] += getattr(delta_obj, "partial_json", "") or ""
-                    elif hasattr(delta_obj, "text"):
-                        # Plain text delta (text_delta for SSE, or legacy
-                        # shape where .text is set directly).
-                        text = delta_obj.text
-                        if text:
-                            yield StreamEvent(type="content", delta=text)
-                elif event_type == "content_block_stop":
-                    idx = getattr(event, "index", None)
-                    block = tool_blocks.pop(idx, None) if idx is not None else None
-                    if block is None:
-                        continue
-                    buf = block["json_buf"]
-                    try:
-                        parsed_input: dict = json.loads(buf) if buf else {}
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            "ClaudeProvider.astream: failed to parse tool_use "
-                            "input JSON for tool=%s (buf length=%d); emitting empty dict",
-                            block["name"],
-                            len(buf),
+                        block = tool_blocks.pop(idx, None) if idx is not None else None
+                        if block is None:
+                            continue
+                        buf = block["json_buf"]
+                        try:
+                            parsed_input: dict = json.loads(buf) if buf else {}
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "ClaudeProvider.astream: failed to parse tool_use "
+                                "input JSON for tool=%s (buf length=%d); emitting empty dict",
+                                block["name"],
+                                len(buf),
+                            )
+                            parsed_input = {}
+                        if not isinstance(parsed_input, dict):
+                            parsed_input = {}
+                        yield StreamEvent(
+                            type="tool_use",
+                            tool_name=block["name"],
+                            tool_input=parsed_input,
+                            tool_use_id=block["id"] or None,
                         )
-                        parsed_input = {}
-                    if not isinstance(parsed_input, dict):
-                        parsed_input = {}
-                    yield StreamEvent(
-                        type="tool_use",
-                        tool_name=block["name"],
-                        tool_input=parsed_input,
-                        tool_use_id=block["id"] or None,
-                    )
-                elif event_type == "message_delta":
-                    usage = getattr(event, "usage", None)
-                    if usage:
-                        tokens_output = getattr(usage, "output_tokens", 0)
-                elif event_type == "message_start":
-                    msg = getattr(event, "message", None)
-                    if msg:
-                        usage = getattr(msg, "usage", None)
+                    elif event_type == "message_delta":
+                        usage = getattr(event, "usage", None)
                         if usage:
-                            tokens_input = getattr(usage, "input_tokens", 0)
+                            tokens_output = getattr(usage, "output_tokens", 0)
+                    elif event_type == "message_start":
+                        msg = getattr(event, "message", None)
+                        if msg:
+                            usage = getattr(msg, "usage", None)
+                            if usage:
+                                tokens_input = getattr(usage, "input_tokens", 0)
+            finally:
+                # Close the context we manually entered above so the
+                # underlying httpx stream is released even on errors.
+                await ctx.__aexit__(None, None, None)
+        except Exception:
+            stream_status = "error"
+            raise
+        finally:
+            _stream_duration_ms = (time.perf_counter() - _stream_start) * 1000
+            record_metric(
+                "llm_call_ms",
+                round(_stream_duration_ms, 2),
+                {
+                    "feature": feature,
+                    "model": self._model,
+                    "operation": "astream",
+                    "status": stream_status,
+                },
+            )
 
         # #662 / post-review fix: yield the stop event FIRST so the
         # orchestrator can read the per-turn tokens off it and persist

--- a/app/llm/retry.py
+++ b/app/llm/retry.py
@@ -1,0 +1,234 @@
+"""Retry helpers for transient LLM API failures (#354).
+
+Wraps Anthropic SDK calls with bounded exponential backoff so transient
+errors (rate limits, 5xx, network blips) don't bubble up to handlers as
+hard failures. Permanent errors (400 / 401 / 403) fail fast because they
+won't fix themselves on retry.
+
+Counting convention
+-------------------
+The DoD wording "up to 3 attempts (1s, 5s, 30s)" is read as:
+
+* ``_BACKOFF = [1.0, 5.0, 30.0]`` — three sleep durations.
+* ``MAX_RETRIES = 3`` — retry up to three times, so the worst case is
+  one initial attempt + three retries = four calls in total.
+* On a permanent error the call raises immediately with zero retries.
+
+Streaming caveat
+----------------
+We only retry the *stream-open* call, never the iteration. If a stream
+has already begun emitting deltas and dies mid-flight, restarting it
+would produce duplicate output that the chat orchestrator can't safely
+reconcile. The handler sees the original error and decides what to do.
+
+Cost-tracking caveat
+--------------------
+Retries here wrap the SDK call only. ``log_usage`` is invoked *after*
+the wrapped call returns successfully (in the existing call sites in
+``app.llm.claude``), so a retried-then-succeeded request still logs
+exactly one usage row, and a fully failed request logs none.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+# Status codes that warrant retry — transient server / rate-limit conditions.
+_RETRYABLE_HTTP: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+# Status codes that must fail fast — broken request / auth / permissions.
+_NON_RETRYABLE_HTTP: frozenset[int] = frozenset({400, 401, 403})
+
+# Sleep durations (seconds) before retries 1, 2, 3.
+_BACKOFF: tuple[float, ...] = (1.0, 5.0, 30.0)
+
+# Total retries after the initial attempt. Worst case = 1 + MAX_RETRIES calls.
+MAX_RETRIES: int = 3
+
+
+def _http_status(exc: BaseException) -> int | None:
+    """Best-effort extraction of an HTTP status code from an exception.
+
+    Anthropic SDK ``APIStatusError`` subclasses expose ``.status_code``
+    directly; we also check ``.response.status_code`` for httpx-shaped
+    errors. Returns ``None`` when the exception isn't tied to an HTTP
+    response (e.g. ``ConnectionError``, ``TimeoutError``).
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        return status
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        if isinstance(status, int):
+            return status
+    return None
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Decide whether *exc* represents a transient failure worth retrying.
+
+    Policy:
+    * HTTP status in ``_RETRYABLE_HTTP`` → retry.
+    * HTTP status in ``_NON_RETRYABLE_HTTP`` → never retry.
+    * No HTTP status (network/timeout) → retry.
+    * Other HTTP statuses (e.g. 404, 409, 422) → don't retry; the caller's
+      payload is wrong, not the server.
+    """
+    # Network / timeout errors carry no status code.
+    if isinstance(exc, TimeoutError | ConnectionError):
+        return True
+
+    try:
+        import anthropic
+    except ImportError:  # pragma: no cover — anthropic is a hard dep
+        anthropic = None  # type: ignore[assignment]
+
+    if anthropic is not None:
+        # APIConnectionError covers timeouts and connection drops in the
+        # Anthropic SDK; they don't carry a status code.
+        if isinstance(exc, anthropic.APIConnectionError):
+            return True
+
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover — httpx is a hard dep
+        httpx = None  # type: ignore[assignment]
+
+    if httpx is not None:
+        # Generic httpx transport errors (DNS, timeouts) — no status.
+        if isinstance(exc, httpx.TransportError):
+            return True
+
+    status = _http_status(exc)
+    if status is None:
+        # Unknown shape — be conservative and DON'T retry. Random bugs
+        # shouldn't trigger 3 extra calls.
+        return False
+    if status in _NON_RETRYABLE_HTTP:
+        return False
+    return status in _RETRYABLE_HTTP
+
+
+def _wait_for_attempt(attempt: int) -> float:
+    """Return the sleep duration before the *attempt*-th retry (1-indexed).
+
+    ``attempt=1`` → wait before the first retry (after the initial call
+    failed). Falls back to the last backoff slot for attempts that exceed
+    the configured table — defensive, shouldn't trigger under MAX_RETRIES.
+    """
+    if attempt <= 0:
+        return 0.0
+    if attempt - 1 < len(_BACKOFF):
+        return _BACKOFF[attempt - 1]
+    return _BACKOFF[-1]
+
+
+def retry_sync[T](
+    fn: Callable[[], T],
+    *,
+    context: str = "anthropic",
+) -> T:
+    """Call *fn* with bounded retries on transient errors (sync).
+
+    Args:
+        fn: Zero-arg callable that performs the actual SDK call. Use a
+            closure or ``functools.partial`` to bind the real arguments.
+        context: Short label inserted into log messages (e.g. ``"complete"``,
+            ``"acomplete"``, ``"astream-open"``).
+
+    Returns:
+        Whatever *fn* returns on its first successful attempt.
+
+    Raises:
+        The last underlying exception when retries are exhausted, or
+        immediately when the error is non-retryable.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            return fn()
+        except Exception as exc:
+            last_exc = exc
+            if not _is_retryable(exc):
+                logger.warning(
+                    "LLM %s permanent error (no retry): %s: %s",
+                    context,
+                    type(exc).__name__,
+                    exc,
+                )
+                raise
+            if attempt >= MAX_RETRIES:
+                logger.warning(
+                    "LLM %s retries exhausted after %d attempts: %s: %s",
+                    context,
+                    attempt + 1,
+                    type(exc).__name__,
+                    exc,
+                )
+                raise
+            wait = _wait_for_attempt(attempt + 1)
+            logger.warning(
+                "LLM %s retry attempt %d after %.1fs: %s: %s",
+                context,
+                attempt + 1,
+                wait,
+                type(exc).__name__,
+                exc,
+            )
+            time.sleep(wait)
+    # Unreachable — the loop either returns or raises — but mypy wants it.
+    assert last_exc is not None  # pragma: no cover
+    raise last_exc  # pragma: no cover
+
+
+async def retry_async[T](
+    fn: Callable[[], Awaitable[T]],
+    *,
+    context: str = "anthropic-async",
+) -> T:
+    """Async counterpart of :func:`retry_sync`.
+
+    Uses ``asyncio.sleep`` between attempts so the event loop isn't
+    blocked while we back off.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            return await fn()
+        except Exception as exc:
+            last_exc = exc
+            if not _is_retryable(exc):
+                logger.warning(
+                    "LLM %s permanent error (no retry): %s: %s",
+                    context,
+                    type(exc).__name__,
+                    exc,
+                )
+                raise
+            if attempt >= MAX_RETRIES:
+                logger.warning(
+                    "LLM %s retries exhausted after %d attempts: %s: %s",
+                    context,
+                    attempt + 1,
+                    type(exc).__name__,
+                    exc,
+                )
+                raise
+            wait = _wait_for_attempt(attempt + 1)
+            logger.warning(
+                "LLM %s retry attempt %d after %.1fs: %s: %s",
+                context,
+                attempt + 1,
+                wait,
+                type(exc).__name__,
+                exc,
+            )
+            await asyncio.sleep(wait)
+    assert last_exc is not None  # pragma: no cover
+    raise last_exc  # pragma: no cover

--- a/app/rag/embedding.py
+++ b/app/rag/embedding.py
@@ -139,10 +139,16 @@ class VoyageProvider(EmbeddingProvider):
             return results
 
         client = self._get_client()
-        response = await client.embed(
-            texts,
-            model=self._model,
-        )
+
+        # #354: retry transient errors (429/5xx/network) with bounded backoff.
+        # Voyage AI uses httpx underneath and raises status-code-bearing errors,
+        # so the same retry policy applies.
+        from app.llm.retry import retry_async
+
+        async def _call() -> Any:
+            return await client.embed(texts, model=self._model)
+
+        response = await retry_async(_call, context="voyage-embed")
 
         # Log cost (Voyage charges per token)
         total_tokens = getattr(response, "total_tokens", 0)

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -255,7 +255,7 @@ class TestClaudeRealMode:
         assert isinstance(result, dict)
         assert result == {"error": "failed to parse"}
 
-    @patch("app.llm.claude.time.sleep")
+    @patch("app.llm.retry.time.sleep")
     @patch("app.llm.claude.ClaudeProvider._log_cost")
     def test_complete_rate_limit_retries(
         self,
@@ -263,7 +263,7 @@ class TestClaudeRealMode:
         mock_sleep: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """RateLimitError triggers a 10s sleep + retry."""
+        """RateLimitError triggers the retry helper (#354) and succeeds."""
         import anthropic
 
         provider = self._make_provider(monkeypatch)
@@ -283,7 +283,8 @@ class TestClaudeRealMode:
         result = provider.complete("test prompt")
 
         assert result == "Success after retry"
-        mock_sleep.assert_called_once_with(10)
+        # First retry sleeps for 1s (the first slot of _BACKOFF).
+        mock_sleep.assert_called_once_with(1.0)
         assert mock_client.messages.create.call_count == 2
 
     @patch("app.llm.claude.ClaudeProvider._log_cost")

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -1,0 +1,699 @@
+"""Tests for ``app.llm.retry`` (#354).
+
+Covers:
+* Retry on retryable statuses (429, 500, 502, 503, 504).
+* Fail-fast on permanent statuses (400, 401, 403).
+* Retry on network/timeout errors (no status code).
+* Exhaustion of the retry budget surfaces the last exception.
+* Cost-tracker `_log_cost` is called exactly once on eventual success
+  (no double-counting on retried-then-succeeded calls).
+* Mid-stream errors are NOT retried (different code path; documented).
+
+All sleeps are monkeypatched so the suite runs in milliseconds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Direct tests for the retry helper module
+# ---------------------------------------------------------------------------
+
+
+class TestRetryClassification:
+    """``_is_retryable`` should encode the DoD policy precisely."""
+
+    def test_429_is_retryable(self):
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(status_code=429)
+        assert _is_retryable(exc) is True  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("status", [500, 502, 503, 504])
+    def test_5xx_is_retryable(self, status: int):
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(status_code=status)
+        assert _is_retryable(exc) is True  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("status", [400, 401, 403])
+    def test_4xx_permanent_is_not_retryable(self, status: int):
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(status_code=status)
+        assert _is_retryable(exc) is False  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("status", [404, 409, 422])
+    def test_other_4xx_is_not_retryable(self, status: int):
+        """Errors like 404/409/422 mean a bad request payload — not retryable."""
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(status_code=status)
+        assert _is_retryable(exc) is False  # type: ignore[arg-type]
+
+    def test_connection_error_is_retryable(self):
+        from app.llm.retry import _is_retryable
+
+        assert _is_retryable(ConnectionError("dns failure")) is True
+
+    def test_timeout_error_is_retryable(self):
+        from app.llm.retry import _is_retryable
+
+        assert _is_retryable(TimeoutError("slow")) is True
+
+    def test_anthropic_connection_error_is_retryable(self):
+        """Anthropic's APIConnectionError (no status_code) is retryable."""
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.APIConnectionError(request=MagicMock())
+        assert _is_retryable(exc) is True
+
+    def test_anthropic_api_timeout_is_retryable(self):
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.APITimeoutError(request=MagicMock())
+        assert _is_retryable(exc) is True
+
+    def test_anthropic_rate_limit_is_retryable(self):
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        assert _is_retryable(exc) is True
+
+    def test_anthropic_authentication_error_is_not_retryable(self):
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.AuthenticationError(
+            message="bad key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        assert _is_retryable(exc) is False
+
+    def test_anthropic_bad_request_is_not_retryable(self):
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.BadRequestError(
+            message="bad",
+            response=MagicMock(status_code=400),
+            body=None,
+        )
+        assert _is_retryable(exc) is False
+
+    def test_anthropic_permission_denied_is_not_retryable(self):
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.PermissionDeniedError(
+            message="no",
+            response=MagicMock(status_code=403),
+            body=None,
+        )
+        assert _is_retryable(exc) is False
+
+    def test_anthropic_internal_server_error_is_retryable(self):
+        import anthropic
+
+        from app.llm.retry import _is_retryable
+
+        exc = anthropic.InternalServerError(
+            message="oops",
+            response=MagicMock(status_code=500),
+            body=None,
+        )
+        assert _is_retryable(exc) is True
+
+    def test_unknown_exception_is_not_retryable(self):
+        """A plain RuntimeError with no status carries no signal — fail fast."""
+        from app.llm.retry import _is_retryable
+
+        assert _is_retryable(RuntimeError("???")) is False
+
+
+class TestRetryBackoffSchedule:
+    def test_backoff_schedule_matches_dod(self):
+        """DoD says (1s, 5s, 30s)."""
+        from app.llm.retry import _BACKOFF
+
+        assert _BACKOFF == (1.0, 5.0, 30.0)
+
+    def test_max_retries_is_three(self):
+        from app.llm.retry import MAX_RETRIES
+
+        assert MAX_RETRIES == 3
+
+    def test_wait_for_attempt_returns_each_slot(self):
+        from app.llm.retry import _BACKOFF, _wait_for_attempt
+
+        assert _wait_for_attempt(1) == _BACKOFF[0]
+        assert _wait_for_attempt(2) == _BACKOFF[1]
+        assert _wait_for_attempt(3) == _BACKOFF[2]
+
+    def test_wait_for_attempt_beyond_table_uses_last_slot(self):
+        from app.llm.retry import _BACKOFF, _wait_for_attempt
+
+        assert _wait_for_attempt(99) == _BACKOFF[-1]
+
+
+class TestRetrySyncBehaviour:
+    @patch("app.llm.retry.time.sleep")
+    def test_succeeds_first_attempt_no_sleep(self, mock_sleep: MagicMock):
+        from app.llm.retry import retry_sync
+
+        fn = MagicMock(return_value="ok")
+        assert retry_sync(fn) == "ok"
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("app.llm.retry.time.sleep")
+    def test_429_then_success_logs_one_retry(self, mock_sleep: MagicMock):
+        import anthropic
+
+        from app.llm.retry import retry_sync
+
+        rl = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        fn = MagicMock(side_effect=[rl, rl, "ok"])
+        assert retry_sync(fn) == "ok"
+        assert fn.call_count == 3
+        # Two retries → two sleeps: 1.0s and 5.0s.
+        assert mock_sleep.call_args_list == [((1.0,),), ((5.0,),)]
+
+    @patch("app.llm.retry.time.sleep")
+    def test_500_exhausts_retries_and_raises(self, mock_sleep: MagicMock):
+        import anthropic
+
+        from app.llm.retry import MAX_RETRIES, retry_sync
+
+        err = anthropic.InternalServerError(
+            message="boom",
+            response=MagicMock(status_code=500),
+            body=None,
+        )
+        fn = MagicMock(side_effect=err)
+        with pytest.raises(anthropic.InternalServerError):
+            retry_sync(fn)
+
+        # Initial + MAX_RETRIES retries = MAX_RETRIES + 1 calls.
+        assert fn.call_count == MAX_RETRIES + 1
+        # Sleeps for retries 1, 2, 3 → 1.0, 5.0, 30.0.
+        assert mock_sleep.call_args_list == [((1.0,),), ((5.0,),), ((30.0,),)]
+
+    @patch("app.llm.retry.time.sleep")
+    def test_401_fails_fast_with_no_sleep(self, mock_sleep: MagicMock):
+        import anthropic
+
+        from app.llm.retry import retry_sync
+
+        err = anthropic.AuthenticationError(
+            message="bad key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        fn = MagicMock(side_effect=err)
+        with pytest.raises(anthropic.AuthenticationError):
+            retry_sync(fn)
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("app.llm.retry.time.sleep")
+    def test_400_fails_fast_with_no_sleep(self, mock_sleep: MagicMock):
+        import anthropic
+
+        from app.llm.retry import retry_sync
+
+        err = anthropic.BadRequestError(
+            message="malformed",
+            response=MagicMock(status_code=400),
+            body=None,
+        )
+        fn = MagicMock(side_effect=err)
+        with pytest.raises(anthropic.BadRequestError):
+            retry_sync(fn)
+        fn.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("app.llm.retry.time.sleep")
+    def test_502_retries(self, mock_sleep: MagicMock):
+        """502 (typed via APIStatusError subclass)."""
+        from anthropic import APIStatusError
+
+        from app.llm.retry import retry_sync
+
+        err = APIStatusError(
+            message="bad gateway",
+            response=MagicMock(status_code=502),
+            body=None,
+        )
+        fn = MagicMock(side_effect=[err, "ok"])
+        assert retry_sync(fn) == "ok"
+        assert fn.call_count == 2
+
+    @patch("app.llm.retry.time.sleep")
+    def test_connection_error_retries(self, mock_sleep: MagicMock):
+        from app.llm.retry import retry_sync
+
+        fn = MagicMock(side_effect=[ConnectionError("dns"), "ok"])
+        assert retry_sync(fn) == "ok"
+        assert fn.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+
+    @patch("app.llm.retry.time.sleep")
+    def test_logs_each_retry(self, mock_sleep: MagicMock, caplog):
+        import logging
+
+        import anthropic
+
+        from app.llm.retry import retry_sync
+
+        rl = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        fn = MagicMock(side_effect=[rl, rl, "ok"])
+        with caplog.at_level(logging.WARNING, logger="app.llm.retry"):
+            retry_sync(fn, context="test")
+
+        retry_msgs = [r for r in caplog.records if "retry attempt" in r.getMessage()]
+        assert len(retry_msgs) == 2
+        # First retry log mentions attempt 1 + 1.0s wait.
+        first = retry_msgs[0].getMessage()
+        assert "attempt 1" in first
+        assert "1.0s" in first
+
+
+class TestRetryAsyncBehaviour:
+    """Mirror of the sync tests for the async path."""
+
+    def test_async_succeeds_first_attempt(self, monkeypatch: pytest.MonkeyPatch):
+        from app.llm.retry import retry_async
+
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", AsyncMock())
+
+        async def _fn() -> str:
+            return "ok"
+
+        assert asyncio.run(retry_async(_fn)) == "ok"
+
+    def test_async_429_then_success(self, monkeypatch: pytest.MonkeyPatch):
+        import anthropic
+
+        from app.llm.retry import retry_async
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+
+        rl = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        seq = [rl, "ok"]
+
+        async def _fn() -> str:
+            v = seq.pop(0)
+            if isinstance(v, Exception):
+                raise v
+            return v
+
+        assert asyncio.run(retry_async(_fn)) == "ok"
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    def test_async_500_exhausts(self, monkeypatch: pytest.MonkeyPatch):
+        import anthropic
+
+        from app.llm.retry import MAX_RETRIES, retry_async
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+
+        err = anthropic.InternalServerError(
+            message="boom",
+            response=MagicMock(status_code=500),
+            body=None,
+        )
+        calls = {"n": 0}
+
+        async def _fn() -> str:
+            calls["n"] += 1
+            raise err
+
+        with pytest.raises(anthropic.InternalServerError):
+            asyncio.run(retry_async(_fn))
+
+        assert calls["n"] == MAX_RETRIES + 1
+        assert sleep_mock.await_args_list == [((1.0,),), ((5.0,),), ((30.0,),)]
+
+    def test_async_401_fails_fast(self, monkeypatch: pytest.MonkeyPatch):
+        import anthropic
+
+        from app.llm.retry import retry_async
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+
+        err = anthropic.AuthenticationError(
+            message="bad key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+
+        async def _fn() -> str:
+            raise err
+
+        with pytest.raises(anthropic.AuthenticationError):
+            asyncio.run(retry_async(_fn))
+        sleep_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Integration: ClaudeProvider must call cost-tracker exactly once on retry
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeProviderRetryIntegration:
+    def _make_provider(self, monkeypatch: pytest.MonkeyPatch):
+        from app.llm.claude import ClaudeProvider
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("CLAUDE_MODEL", "claude-sonnet-4-6")
+        return ClaudeProvider()
+
+    def _make_response(self, text: str = "ok") -> SimpleNamespace:
+        block = SimpleNamespace(text=text)
+        usage = SimpleNamespace(input_tokens=10, output_tokens=5)
+        return SimpleNamespace(content=[block], usage=usage)
+
+    @patch("app.llm.retry.time.sleep")
+    @patch("app.llm.claude.ClaudeProvider._log_cost")
+    def test_complete_logs_cost_once_on_retried_success(
+        self,
+        mock_log_cost: MagicMock,
+        mock_sleep: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Retried-then-succeeded calls log usage exactly once."""
+        import anthropic
+
+        provider = self._make_provider(monkeypatch)
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        rl = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        mock_client.messages.create.side_effect = [rl, self._make_response("ok")]
+
+        provider.complete("hi")
+
+        # The wrapped SDK call was retried, but cost-tracker fires once.
+        assert mock_client.messages.create.call_count == 2
+        mock_log_cost.assert_called_once()
+
+    @patch("app.llm.retry.time.sleep")
+    @patch("app.llm.claude.ClaudeProvider._log_cost")
+    def test_complete_does_not_log_cost_on_total_failure(
+        self,
+        mock_log_cost: MagicMock,
+        mock_sleep: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """If all retries fail, no llm_usage row is logged."""
+        import anthropic
+
+        from app.llm.retry import MAX_RETRIES
+
+        provider = self._make_provider(monkeypatch)
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        err = anthropic.InternalServerError(
+            message="boom",
+            response=MagicMock(status_code=500),
+            body=None,
+        )
+        mock_client.messages.create.side_effect = err
+
+        with pytest.raises(anthropic.InternalServerError):
+            provider.complete("hi")
+
+        assert mock_client.messages.create.call_count == MAX_RETRIES + 1
+        mock_log_cost.assert_not_called()
+
+    @patch("app.llm.retry.time.sleep")
+    @patch("app.llm.claude.ClaudeProvider._log_cost")
+    def test_complete_401_fails_fast(
+        self,
+        mock_log_cost: MagicMock,
+        mock_sleep: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """401 raises after the first attempt with no retries."""
+        import anthropic
+
+        provider = self._make_provider(monkeypatch)
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        err = anthropic.AuthenticationError(
+            message="bad key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        mock_client.messages.create.side_effect = err
+
+        with pytest.raises(anthropic.AuthenticationError):
+            provider.complete("hi")
+
+        mock_client.messages.create.assert_called_once()
+        mock_sleep.assert_not_called()
+        mock_log_cost.assert_not_called()
+
+    def test_acomplete_logs_cost_once_on_retried_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Async retry path also logs usage exactly once."""
+        import anthropic
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+
+        provider = self._make_provider(monkeypatch)
+        mock_client = MagicMock()
+        provider._async_client = mock_client
+
+        rl = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        mock_client.messages.create = AsyncMock(
+            side_effect=[rl, self._make_response("ok")],
+        )
+
+        with patch("app.llm.claude.ClaudeProvider._log_cost") as mock_log_cost:
+            result = asyncio.run(provider.acomplete("hi"))
+
+        assert result == "ok"
+        assert mock_client.messages.create.call_count == 2
+        mock_log_cost.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Streaming: mid-stream failures are NOT retried
+# ---------------------------------------------------------------------------
+
+
+class TestStreamMidStreamErrorNotRetried:
+    """A failure *after* the stream begins emitting must not be retried.
+
+    Restarting a stream that has already pushed deltas to the client would
+    produce duplicate output the orchestrator can't safely reconcile. We
+    surface the error and let the handler decide.
+    """
+
+    def test_mid_stream_error_propagates(self, monkeypatch: pytest.MonkeyPatch):
+        from app.llm.claude import ClaudeProvider
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        provider = ClaudeProvider()
+        mock_client = MagicMock()
+        provider._async_client = mock_client
+
+        # Open succeeds; iteration raises on the second event.
+        emit_count = {"n": 0}
+
+        class _BrokenStream:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                emit_count["n"] += 1
+                if emit_count["n"] == 1:
+                    return SimpleNamespace(
+                        type="content_block_delta",
+                        delta=SimpleNamespace(text="partial"),
+                    )
+                raise ConnectionError("network died mid-stream")
+
+        class _Ctx:
+            async def __aenter__(self):
+                return _BrokenStream()
+
+            async def __aexit__(self, *args):
+                return False
+
+        mock_client.messages.stream = MagicMock(return_value=_Ctx())
+
+        async def _drain():
+            received = []
+            with pytest.raises(ConnectionError):
+                async for evt in provider.astream("hi"):
+                    received.append(evt)
+            return received
+
+        events = asyncio.run(_drain())
+        # We got the first delta before the error — proves we didn't retry.
+        assert any(e.type == "content" for e in events)
+        # Stream open was only called once — no retry of the open after
+        # the partial deltas, because the failure occurred during iteration.
+        mock_client.messages.stream.assert_called_once()
+
+    def test_stream_open_429_retried(self, monkeypatch: pytest.MonkeyPatch):
+        """If the open itself raises 429, the open is retried."""
+        import anthropic
+
+        from app.llm.claude import ClaudeProvider
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        provider = ClaudeProvider()
+        mock_client = MagicMock()
+        provider._async_client = mock_client
+
+        rl = anthropic.RateLimitError(
+            message="rl",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+
+        class _OkStream:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise StopAsyncIteration
+
+        class _OkCtx:
+            async def __aenter__(self):
+                return _OkStream()
+
+            async def __aexit__(self, *args):
+                return False
+
+        class _BadCtx:
+            async def __aenter__(self):
+                raise rl
+
+            async def __aexit__(self, *args):
+                return False
+
+        # First open raises 429; second open returns a normal empty stream.
+        mock_client.messages.stream = MagicMock(side_effect=[_BadCtx(), _OkCtx()])
+
+        with patch("app.llm.claude.ClaudeProvider._log_cost"):
+
+            async def _drain():
+                async for _ in provider.astream("hi"):
+                    pass
+
+            asyncio.run(_drain())
+
+        assert mock_client.messages.stream.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Voyage embedding provider shares the same retry policy.
+# ---------------------------------------------------------------------------
+
+
+class TestVoyageEmbeddingRetry:
+    """The retry helper is symmetric for Voyage's async embed() call."""
+
+    def test_embed_retries_on_429(self, monkeypatch: pytest.MonkeyPatch):
+        from app.rag.embedding import VoyageProvider
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+
+        provider = VoyageProvider()
+        # Skip the lazy-init by pre-setting the client.
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        # Voyage doesn't expose its own typed errors in our deps, so simulate
+        # a status-bearing exception that ``_is_retryable`` treats as transient.
+        class _FakeRateLimitError(Exception):
+            status_code = 429
+
+        response = MagicMock(embeddings=[[0.1] * 1024], total_tokens=10)
+        mock_client.embed = AsyncMock(side_effect=[_FakeRateLimitError(), response])
+
+        result = asyncio.run(provider.embed(["hello"]))
+
+        assert result == [[0.1] * 1024]
+        assert mock_client.embed.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    def test_embed_fails_fast_on_401(self, monkeypatch: pytest.MonkeyPatch):
+        from app.rag.embedding import VoyageProvider
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+
+        provider = VoyageProvider()
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        class _FakeAuthError(Exception):
+            status_code = 401
+
+        mock_client.embed = AsyncMock(side_effect=_FakeAuthError())
+
+        with pytest.raises(_FakeAuthError):
+            asyncio.run(provider.embed(["hello"]))
+
+        mock_client.embed.assert_called_once()
+        sleep_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- New `app/llm/retry.py` with `retry_sync` / `retry_async` helpers
- **Policy:** retry on 429 + {500, 502, 503, 504} + network/timeout; fail-fast on 400/401/403 (and other 4xx like 404/409/422 which signal bad payloads)
- **Schedule:** 3 retries with sleeps `(1s, 5s, 30s)` → worst-case 4 total attempts
- Each retry logs at WARNING with attempt number, wait, and error class
- Replaces the ad-hoc one-shot retry in `ClaudeProvider.complete`/`.acomplete` and the stream-open in `.astream`
- Cost-tracker fires exactly once on eventual success; zero times on total exhaustion
- Bonus: `VoyageProvider.embed` wrapped symmetrically (trivially identical shape)
- Closes #354

## Test plan
- [x] `tests/test_llm_retry.py` — 45 new tests: classification per status, schedule + count, sync/async loops with mocked sleep, fail-fast, cost-tracker-called-once-on-retry, no-cost-on-total-failure, mid-stream-error-not-retried, stream-open-429-retried, Voyage symmetry
- [x] Updated `test_llm_provider.py::test_complete_rate_limit_retries` to assert new 1.0s first-slot sleep
- [x] Full suite 3318 passed
- [x] ruff + pyright clean

## Stream caveat
Retry only wraps `messages.stream(...).__aenter__()` by manually entering the context manager and stashing it on the stream object for proper `__aexit__` on exit. **Iteration errors propagate** — restarting a stream that already emitted deltas to the orchestrator would duplicate output. This is the correct trade-off, but worth noting on review.