### PR TITLE
feat(chat): #315 — persist tool_use/tool_result with parent linking + tool_use_id

### DIFF
--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -77,6 +77,12 @@ class Message:
     # flags. Defaulted for backward compatibility with pre-017 fixtures.
     is_pinned: bool = False
     is_truncated: bool = False
+    # Migration 036 (#315) — tool-use tracking. ``tool_use_id`` is
+    # Anthropic's ``toolu_...`` identifier; ``parent_message_id`` points
+    # at the assistant turn that requested the tool. Both are NULL for
+    # non-tool messages and for tool messages persisted before #315.
+    tool_use_id: str | None = None
+    parent_message_id: uuid.UUID | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -121,11 +127,18 @@ def _is_missing_v017_column_error(exc: BaseException) -> bool:
 # truth and is NOT NULL at the DB level. The ``_row_to_message`` reader
 # raises if it ever sees a NULL ciphertext so a future regression cannot
 # silently serve "no content".
+#
+# Migration 036 (#315) adds ``tool_use_id`` + ``parent_message_id`` at
+# the tail of the SELECT list so the row converter can pull them via
+# positional lookup with defensive ``len(row) > N`` guards (mirroring
+# the migration-017 pattern). Test fixtures that pre-date #315 still
+# load cleanly with the existing 14-tuple shape.
 _MESSAGE_COLUMNS = (
     "id, conversation_id, role, tool_name, "
     "tokens_input, tokens_output, model, created_at, "
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
-    "rag_context_encrypted, is_pinned, is_truncated"
+    "rag_context_encrypted, is_pinned, is_truncated, "
+    "tool_use_id, parent_message_id"
 )
 
 # Legacy SELECT list used when migration 017 has not yet applied (the
@@ -138,6 +151,31 @@ _MESSAGE_COLUMNS_PRE017 = (
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
     "rag_context_encrypted"
 )
+
+# Migration-036 fallback SELECT list — used when the schema is at v017
+# but pre-036 (the ``tool_use_id`` / ``parent_message_id`` columns are
+# absent). Same idea as the v017 fallback: keep the conversation view
+# functional in the narrow window between image deploy and migration
+# apply.
+_MESSAGE_COLUMNS_PRE036 = (
+    "id, conversation_id, role, tool_name, "
+    "tokens_input, tokens_output, model, created_at, "
+    "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
+    "rag_context_encrypted, is_pinned, is_truncated"
+)
+
+
+def _is_missing_v036_column_error(exc: BaseException) -> bool:
+    """Return True when the exception names a migration-036 column.
+
+    Used by the read / write paths to detect "schema is v017 but pre-036"
+    and fall back to the prior SQL. ``tool_use_id`` and
+    ``parent_message_id`` are the new columns introduced by #315.
+    """
+    msg = str(exc).lower()
+    return "does not exist" in msg and any(
+        col in msg for col in ("tool_use_id", "parent_message_id")
+    )
 
 
 def _decode_encrypted_text(ciphertext: bytes | memoryview | None) -> str | None:
@@ -218,6 +256,11 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
     source of truth and is NOT NULL at the DB layer. We re-assert the
     invariant here so a regression that re-introduces a NULL write
     surfaces as a hard error instead of an empty message body.
+
+    Migration 036 (#315) adds two trailing columns — ``tool_use_id`` and
+    ``parent_message_id``. Indexing is defensive (``len(row) > N`` +
+    ``None`` fallback) so pre-036 fixtures and pre-036 SELECT fallbacks
+    still load cleanly.
     """
     msg_id = row[0]
     conversation_id = row[1]
@@ -235,6 +278,14 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
     # pre-017 SELECT fallback (12-tuple rows) still loads cleanly.
     is_pinned = bool(row[12]) if len(row) > 12 and row[12] is not None else False
     is_truncated = bool(row[13]) if len(row) > 13 and row[13] is not None else False
+    # Migration 036 (#315) — tool_use_id + parent_message_id. Defensive
+    # indexing so pre-036 fixtures (14-tuple rows) still load cleanly.
+    tool_use_id_raw = row[14] if len(row) > 14 else None
+    parent_message_id_raw = row[15] if len(row) > 15 else None
+    tool_use_id: str | None = str(tool_use_id_raw) if tool_use_id_raw else None
+    parent_message_id: uuid.UUID | None = (
+        coerce_uuid(parent_message_id_raw) if parent_message_id_raw else None
+    )
 
     if content_encrypted is None:
         raise ValueError(
@@ -270,6 +321,8 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
         created_at=created_at,
         is_pinned=is_pinned,
         is_truncated=is_truncated,
+        tool_use_id=tool_use_id,
+        parent_message_id=parent_message_id,
     )
 
 
@@ -543,10 +596,19 @@ def create_message(
     tokens_input: int | None = None,
     tokens_output: int | None = None,
     model: str | None = None,
+    tool_use_id: str | None = None,
+    parent_message_id: uuid.UUID | str | None = None,
 ) -> Message:
     """Insert a new ``messages`` row and return the created message.
 
     The caller is responsible for committing the transaction.
+
+    Migration 036 (#315) — ``tool_use_id`` records Claude's
+    ``toolu_...`` identifier from the streaming ``tool_use`` block;
+    ``parent_message_id`` links a role='tool' row to the assistant turn
+    that requested the tool. Both are NULL for non-tool turns. The CHECK
+    constraint defined in migration 036 rejects a non-NULL
+    ``tool_use_id`` on any role other than 'tool'.
     """
     if role not in VALID_ROLES:
         raise ValueError(f"Invalid message role: {role!r}")
@@ -574,28 +636,81 @@ def create_message(
         else None
     )
 
-    row = conn.execute(
-        f"""
-        INSERT INTO messages
-            (conversation_id, role, tool_name, tokens_input, tokens_output, model,
-             content_encrypted, tool_input_encrypted, tool_output_encrypted,
-             rag_context_encrypted)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        RETURNING {_MESSAGE_COLUMNS}
-        """,
-        (
-            str(conversation_id),
-            role,
-            tool_name,
-            tokens_input,
-            tokens_output,
-            model,
-            content_ciphertext,
-            tool_input_ciphertext,
-            tool_output_ciphertext,
-            rag_context_ciphertext,
-        ),
-    ).fetchone()
+    parent_message_id_str: str | None = (
+        str(parent_message_id) if parent_message_id is not None else None
+    )
+
+    try:
+        row = conn.execute(
+            f"""
+            INSERT INTO messages
+                (conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                 content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                 rag_context_encrypted, tool_use_id, parent_message_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING {_MESSAGE_COLUMNS}
+            """,
+            (
+                str(conversation_id),
+                role,
+                tool_name,
+                tokens_input,
+                tokens_output,
+                model,
+                content_ciphertext,
+                tool_input_ciphertext,
+                tool_output_ciphertext,
+                rag_context_ciphertext,
+                tool_use_id,
+                parent_message_id_str,
+            ),
+        ).fetchone()
+    except Exception as exc:
+        # Migration-036 fallback: the new ``tool_use_id`` /
+        # ``parent_message_id`` columns might be absent in a deploy
+        # window where the new image hits a stale schema cache (same
+        # pattern as the migration-017 fallback in ``list_messages``).
+        # When that happens AND the caller didn't ask for either field,
+        # transparently fall back to the prior INSERT shape; otherwise
+        # the loss of tracking would be silent and confusing.
+        if (
+            _is_missing_v036_column_error(exc)
+            and tool_use_id is None
+            and parent_message_id_str is None
+        ):
+            logger.warning(
+                "create_message: migration 036 columns missing — "
+                "falling back to pre-036 INSERT for conversation=%s",
+                conversation_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            row = conn.execute(
+                f"""
+                INSERT INTO messages
+                    (conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                     content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                     rag_context_encrypted)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING {_MESSAGE_COLUMNS_PRE036}
+                """,
+                (
+                    str(conversation_id),
+                    role,
+                    tool_name,
+                    tokens_input,
+                    tokens_output,
+                    model,
+                    content_ciphertext,
+                    tool_input_ciphertext,
+                    tool_output_ciphertext,
+                    rag_context_ciphertext,
+                ),
+            ).fetchone()
+        else:
+            raise
     if row is None:
         raise RuntimeError("INSERT ... RETURNING messages produced no row")
     return _row_to_message(row)
@@ -607,12 +722,13 @@ def list_messages(
 ) -> list[Message]:
     """Return all messages in a conversation, ordered by ``created_at`` ASC.
 
-    Falls back to a SELECT without the migration-017 columns if those
-    columns do not yet exist on the target database. This keeps the
-    conversation view functional during a window where the app image
-    was deployed but migration 017 has not yet been applied — otherwise
-    users open a historical conversation and see the empty-state prompt
-    cards instead of their history (reported after #596 rolled out).
+    Falls back to a SELECT without the migration-036 columns (and then
+    the migration-017 columns) if those columns do not yet exist on the
+    target database. This keeps the conversation view functional during
+    a window where the app image was deployed but the relevant migration
+    has not yet been applied — otherwise users open a historical
+    conversation and see the empty-state prompt cards instead of their
+    history (reported after #596 rolled out).
     """
     try:
         rows = conn.execute(
@@ -625,12 +741,40 @@ def list_messages(
             (str(conversation_id),),
         ).fetchall()
     except Exception as exc:
-        # Psycopg raises ``UndefinedColumn`` (SQLSTATE 42703) when the
-        # new columns are missing. Matching by message text keeps us
-        # compatible with psycopg2 and psycopg3 without importing
-        # driver-specific exception classes.
         msg = str(exc).lower()
-        if "is_pinned" in msg or "is_truncated" in msg or "does not exist" in msg:
+        is_v036_missing = _is_missing_v036_column_error(exc)
+        is_v017_missing = "is_pinned" in msg or "is_truncated" in msg
+        if is_v036_missing:
+            logger.warning(
+                "list_messages: migration 036 columns missing — falling back"
+                " to pre-036 SELECT for conversation=%s",
+                conversation_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT {_MESSAGE_COLUMNS_PRE036}
+                    FROM messages
+                    WHERE conversation_id = %s
+                    ORDER BY created_at ASC
+                    """,
+                    (str(conversation_id),),
+                ).fetchall()
+            except Exception:
+                logger.exception(
+                    "Pre-036 fallback list_messages failed for conversation=%s",
+                    conversation_id,
+                )
+                return []
+        elif is_v017_missing or "does not exist" in msg:
+            # Psycopg raises ``UndefinedColumn`` (SQLSTATE 42703) when
+            # any new column is missing. Matching by message text keeps
+            # us compatible with psycopg2 and psycopg3 without importing
+            # driver-specific exception classes.
             logger.warning(
                 "list_messages: migration 017 columns missing — falling back"
                 " to pre-017 SELECT for conversation=%s",
@@ -817,6 +961,17 @@ def fork_conversation(
     The new conversation's title is ``"Jätk: <original title>"`` with
     ``title_is_custom=False`` so the auto-title job can still refine it.
 
+    Migration 036 (#315): ``tool_use_id`` is copied verbatim; the
+    ``parent_message_id`` is *not* — tool rows in the fork would
+    otherwise reference the parent assistant id in the source
+    conversation, which would fail the FK once that conversation is
+    deleted (and is semantically wrong anyway: the fork is an
+    independent thread). A follow-up improvement could remap the
+    parent ids to the freshly-inserted assistant rows; for now we drop
+    the parent link to avoid corruption, which means a forked
+    conversation's tool rows render flat (no grouping under the
+    assistant turn).
+
     The caller is responsible for committing the transaction.
     """
     # Look up the fork point so we can bound the message copy by
@@ -857,21 +1012,59 @@ def fork_conversation(
     # Copy messages byte-for-byte — only the encrypted BYTEA columns
     # carry payload after migration 026. ``created_at`` is preserved so
     # the fork reads in the same order as the source up to the boundary.
-    conn.execute(
-        """
-        INSERT INTO messages (
-            conversation_id, role, tool_name, tokens_input, tokens_output, model,
-            content_encrypted, tool_input_encrypted, tool_output_encrypted,
-            rag_context_encrypted, is_pinned, is_truncated, created_at
+    # ``tool_use_id`` is preserved; ``parent_message_id`` is dropped
+    # (NULL) because the parent assistant row lives in the source
+    # conversation — see docstring.
+    try:
+        conn.execute(
+            """
+            INSERT INTO messages (
+                conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                rag_context_encrypted, is_pinned, is_truncated, created_at,
+                tool_use_id
+            )
+            SELECT
+                %s, role, tool_name, tokens_input, tokens_output, model,
+                content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                rag_context_encrypted, is_pinned, is_truncated, created_at,
+                tool_use_id
+            FROM messages
+            WHERE conversation_id = %s AND created_at <= %s
+            ORDER BY created_at ASC
+            """,
+            (str(new_conv.id), str(source_conv_id), boundary_created_at),
         )
-        SELECT
-            %s, role, tool_name, tokens_input, tokens_output, model,
-            content_encrypted, tool_input_encrypted, tool_output_encrypted,
-            rag_context_encrypted, is_pinned, is_truncated, created_at
-        FROM messages
-        WHERE conversation_id = %s AND created_at <= %s
-        ORDER BY created_at ASC
-        """,
-        (str(new_conv.id), str(source_conv_id), boundary_created_at),
-    )
+    except Exception as exc:
+        # Migration-036 fallback for fork — if the new columns aren't
+        # present yet, fall back to the pre-036 INSERT shape so the
+        # rollout window doesn't break fork operations.
+        if not _is_missing_v036_column_error(exc):
+            raise
+        logger.warning(
+            "fork_conversation: migration 036 columns missing — falling back"
+            " to pre-036 copy for source=%s",
+            source_conv_id,
+        )
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        conn.execute(
+            """
+            INSERT INTO messages (
+                conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                rag_context_encrypted, is_pinned, is_truncated, created_at
+            )
+            SELECT
+                %s, role, tool_name, tokens_input, tokens_output, model,
+                content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                rag_context_encrypted, is_pinned, is_truncated, created_at
+            FROM messages
+            WHERE conversation_id = %s AND created_at <= %s
+            ORDER BY created_at ASC
+            """,
+            (str(new_conv.id), str(source_conv_id), boundary_created_at),
+        )
     return new_conv

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -449,6 +449,25 @@ def _persist_partial_assistant(
     parent + one partial sibling).
     """
     if not full_content and not error_suffix:
+        # Tool turn whose placeholder was inserted up-front but the model
+        # produced no text (cancelled / socket-dropped / errored before
+        # the first delta). Delete the empty row so the conversation
+        # doesn't keep an empty assistant bubble forever. Non-tool turns
+        # (no placeholder) just return — nothing was inserted to begin
+        # with.
+        if placeholder_message_id is not None:
+            try:
+                with get_connection() as conn:
+                    conn.execute(
+                        "DELETE FROM messages WHERE id = %s",
+                        (str(placeholder_message_id),),
+                    )
+                    conn.commit()
+            except Exception:
+                logger.exception(
+                    "Failed to delete empty placeholder %s after interrupted tool turn",
+                    placeholder_message_id,
+                )
         return None
 
     text = full_content
@@ -1596,7 +1615,7 @@ class ChatOrchestrator:
                 _TURN_DEADLINE_SECONDS,
                 ctx.conversation_id,
             )
-            if ctx.full_content:
+            if ctx.full_content or ctx.assistant_msg_id is not None:
                 # #660: psycopg is sync; offload the partial-persist so
                 # a cancellation handler doesn't block the event loop.
                 # Post-review fix to #688: forward the per-turn token
@@ -1606,6 +1625,11 @@ class ChatOrchestrator:
                 # (tool turn that timed out after the parent INSERT but
                 # before the final UPDATE), UPDATE the placeholder
                 # rather than INSERTing a second assistant row.
+                # #315 review follow-up: keep calling the persist helper
+                # even when no content has been streamed yet, as long as
+                # a placeholder exists — that way the error_suffix lands
+                # on the placeholder row (or the placeholder gets deleted
+                # if the helper has nothing to write).
                 await asyncio.to_thread(
                     _persist_partial_assistant,
                     ctx.conversation_id,
@@ -1700,12 +1724,17 @@ class ChatOrchestrator:
         except Exception:
             logger.exception("LLM streaming failed for conversation %s", ctx.conversation_id)
             # M1: persist partial content with error suffix when streaming fails.
-            if ctx.full_content:
+            if ctx.full_content or ctx.assistant_msg_id is not None:
                 # #660: offload the sync persist so the
                 # cancellation/error path doesn't block the event loop.
                 # #315 review fix: forward the placeholder id so a tool
                 # turn that errored after the parent INSERT UPDATEs that
                 # row rather than inserting a sibling assistant row.
+                # #315 review follow-up: keep calling the persist helper
+                # even when no content has been streamed yet, as long as
+                # a placeholder exists — that way the error_suffix lands
+                # on the placeholder row (or the placeholder gets deleted
+                # if the helper has nothing to write).
                 await asyncio.to_thread(
                     _persist_partial_assistant,
                     ctx.conversation_id,

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -422,6 +422,7 @@ def _persist_partial_assistant(
     error_suffix: str | None = None,
     tokens_input: int | None = None,
     tokens_output: int | None = None,
+    placeholder_message_id: uuid.UUID | None = None,
 ) -> uuid.UUID | None:
     """Persist a partial / truncated assistant message.
 
@@ -436,6 +437,16 @@ def _persist_partial_assistant(
     persisted the partial assistant row with NULL tokens despite the
     LLM having produced billable output that ``_log_cost`` already
     recorded in the ``llm_usage`` table.
+
+    #315 review fix (double-insert): when ``placeholder_message_id`` is
+    set (a tool turn had already inserted the parent assistant row up
+    front so tool rows could link via ``parent_message_id``), UPDATE
+    that row in place with the partial content + tokens + rag_context
+    + ``is_truncated`` flag and bump ``created_at = NOW()`` so it sorts
+    after the tool rows. Without this, the timeout / cancel / error
+    paths inserted a SECOND assistant row alongside the placeholder,
+    leaving two assistant messages for one logical turn (one empty
+    parent + one partial sibling).
     """
     if not full_content and not error_suffix:
         return None
@@ -444,6 +455,42 @@ def _persist_partial_assistant(
     if error_suffix:
         text = f"{text}{error_suffix}"
 
+    # Tool-turn path: a placeholder assistant row already exists. UPDATE
+    # in place instead of inserting a second row.
+    if placeholder_message_id is not None:
+        try:
+            with get_connection() as conn:
+                _update_assistant_payload(
+                    conn,
+                    placeholder_message_id,
+                    content=text,
+                    tokens_input=tokens_input if tokens_input else None,
+                    tokens_output=tokens_output if tokens_output else None,
+                    rag_context=rag_context_json,
+                )
+                if is_truncated:
+                    try:
+                        conn.execute(
+                            "UPDATE messages SET is_truncated = TRUE WHERE id = %s",
+                            (str(placeholder_message_id),),
+                        )
+                    except Exception:
+                        # Column may not exist yet (migration 017 not applied).
+                        logger.debug(
+                            "Could not set is_truncated on placeholder %s — column missing?",
+                            placeholder_message_id,
+                            exc_info=True,
+                        )
+                conn.commit()
+                return placeholder_message_id
+        except Exception:
+            logger.exception(
+                "Failed to update placeholder assistant message %s with partial content",
+                placeholder_message_id,
+            )
+            return None
+
+    # Non-tool turn: no placeholder, INSERT as before.
     try:
         with get_connection() as conn:
             msg = create_message(
@@ -577,6 +624,16 @@ def _update_assistant_payload(
     used by :func:`app.chat.models.create_message` — so the on-disk
     representation matches a fresh INSERT exactly. ``rag_context`` is
     JSON-encoded then encrypted (NULL for None).
+
+    #315 review fix (ordering): also bumps ``created_at = NOW()`` so the
+    placeholder sorts AFTER the tool rows that were inserted between the
+    initial placeholder INSERT and this UPDATE. Without this, history
+    loaded by ``list_messages`` (``ORDER BY created_at ASC``) returns
+    ``[assistant_final, tool_call, tool_result, next_user]`` — the wrong
+    semantic order for replay to Claude, which requires
+    ``tool_call → tool_result → assistant_final``. Using the DB's
+    ``NOW()`` rather than Python's ``datetime.now()`` avoids clock-skew
+    issues between the app process and PostgreSQL.
     """
     from app.storage import encrypt_text
 
@@ -592,7 +649,8 @@ def _update_assistant_payload(
         SET content_encrypted = %s,
             tokens_input = %s,
             tokens_output = %s,
-            rag_context_encrypted = %s
+            rag_context_encrypted = %s,
+            created_at = NOW()
         WHERE id = %s
         """,
         (
@@ -1544,6 +1602,10 @@ class ChatOrchestrator:
                 # Post-review fix to #688: forward the per-turn token
                 # counts captured so far so the assistant message row
                 # records billable tokens even on the deadline path.
+                # #315 review fix: when a placeholder already exists
+                # (tool turn that timed out after the parent INSERT but
+                # before the final UPDATE), UPDATE the placeholder
+                # rather than INSERTing a second assistant row.
                 await asyncio.to_thread(
                     _persist_partial_assistant,
                     ctx.conversation_id,
@@ -1554,6 +1616,7 @@ class ChatOrchestrator:
                     error_suffix=" [Viga: serveri vastus võttis liiga kaua aega]",
                     tokens_input=ctx.tokens_in,
                     tokens_output=ctx.tokens_out,
+                    placeholder_message_id=ctx.assistant_msg_id,
                 )
             try:
                 await _safe_send(
@@ -1575,6 +1638,9 @@ class ChatOrchestrator:
             # already chose to record the partial; let it complete. Also
             # offload to a thread so psycopg I/O doesn't block the event
             # loop during the cancellation path.
+            # #315 review fix: when a placeholder already exists (tool
+            # turn cancelled mid-flight), UPDATE it rather than INSERTing
+            # a second assistant row.
             ctx.assistant_msg_id = await asyncio.shield(
                 asyncio.to_thread(
                     _persist_partial_assistant,
@@ -1585,6 +1651,7 @@ class ChatOrchestrator:
                     is_truncated=True,
                     tokens_input=ctx.tokens_in,
                     tokens_output=ctx.tokens_out,
+                    placeholder_message_id=ctx.assistant_msg_id,
                 )
             )
             # #661: shield the stopped-event send from a second cancel
@@ -1615,6 +1682,9 @@ class ChatOrchestrator:
             # and bail without sending further events.
             # #660: offload the sync persist so the event loop is free
             # to drain other connections while we save the partial.
+            # #315 review fix: forward the placeholder id so a tool turn
+            # interrupted by an unresponsive socket UPDATEs the parent
+            # row rather than inserting a sibling.
             await asyncio.to_thread(
                 _persist_partial_assistant,
                 ctx.conversation_id,
@@ -1624,6 +1694,7 @@ class ChatOrchestrator:
                 is_truncated=True,
                 tokens_input=ctx.tokens_in,
                 tokens_output=ctx.tokens_out,
+                placeholder_message_id=ctx.assistant_msg_id,
             )
             return False
         except Exception:
@@ -1632,6 +1703,9 @@ class ChatOrchestrator:
             if ctx.full_content:
                 # #660: offload the sync persist so the
                 # cancellation/error path doesn't block the event loop.
+                # #315 review fix: forward the placeholder id so a tool
+                # turn that errored after the parent INSERT UPDATEs that
+                # row rather than inserting a sibling assistant row.
                 await asyncio.to_thread(
                     _persist_partial_assistant,
                     ctx.conversation_id,
@@ -1642,6 +1716,7 @@ class ChatOrchestrator:
                     error_suffix=" [Viga: vastus katkestati]",
                     tokens_input=ctx.tokens_in,
                     tokens_output=ctx.tokens_out,
+                    placeholder_message_id=ctx.assistant_msg_id,
                 )
             try:
                 await _safe_send(

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -556,6 +556,55 @@ def _persist_user_message(conversation_id: uuid.UUID, user_message: str) -> None
         conn.commit()
 
 
+def _update_assistant_payload(
+    conn: Any,
+    message_id: uuid.UUID,
+    *,
+    content: str,
+    tokens_input: int | None,
+    tokens_output: int | None,
+    rag_context: list[dict[str, Any]] | None,
+) -> None:
+    """Update an existing assistant ``messages`` row with the final payload.
+
+    #315: when a turn invokes tools, an assistant row is inserted
+    up-front so the tool rows can link via ``parent_message_id``. Once
+    streaming completes, this helper updates the placeholder with the
+    final ciphertext + token counts + RAG context instead of inserting
+    a second row.
+
+    ``content`` is re-encrypted with the storage Fernet — same primitive
+    used by :func:`app.chat.models.create_message` — so the on-disk
+    representation matches a fresh INSERT exactly. ``rag_context`` is
+    JSON-encoded then encrypted (NULL for None).
+    """
+    from app.storage import encrypt_text
+
+    content_ciphertext = encrypt_text(content) if content else encrypt_text("")
+    rag_context_ciphertext: bytes | None = (
+        encrypt_text(json.dumps(rag_context, ensure_ascii=False))
+        if rag_context is not None
+        else None
+    )
+    conn.execute(
+        """
+        UPDATE messages
+        SET content_encrypted = %s,
+            tokens_input = %s,
+            tokens_output = %s,
+            rag_context_encrypted = %s
+        WHERE id = %s
+        """,
+        (
+            content_ciphertext,
+            tokens_input,
+            tokens_output,
+            rag_context_ciphertext,
+            str(message_id),
+        ),
+    )
+
+
 def _check_budget_in_own_tx(org_id: uuid.UUID | str) -> None:
     """Run the per-org cost-budget check in its own short-lived tx.
 
@@ -1362,6 +1411,37 @@ class ChatOrchestrator:
                 # not tool fan-out.
                 tool_rounds += 1
                 tool_call_segments: list[str] = []
+
+                # #315: persist the assistant turn that requested the
+                # tools BEFORE running them, so each tool row can link
+                # back via ``parent_message_id``. We use whatever
+                # content has streamed so far (may be empty when the
+                # turn opens with a tool_use); the terminal-events
+                # phase UPDATEs this row with the final content + token
+                # counts. Skipped when an assistant row already exists
+                # for this turn (multi-round tool use: the same parent
+                # links every tool the turn requested).
+                if ctx.assistant_msg_id is None:
+                    try:
+                        with get_connection() as conn:
+                            assistant_msg = create_message(
+                                conn,
+                                ctx.conversation_id,
+                                "assistant",
+                                ctx.full_content,
+                                model=getattr(self.llm, "_model", None),
+                            )
+                            conn.commit()
+                            ctx.assistant_msg_id = assistant_msg.id
+                    except Exception:
+                        logger.exception(
+                            "Failed to persist parent assistant message for tool turn"
+                        )
+                        # Continue without a parent link rather than
+                        # losing the tool rows entirely; they will be
+                        # stored with parent_message_id=NULL and still
+                        # carry tool_use_id for replay.
+
                 for pending in pending_tools:
                     tool_name = pending["name"]
                     tool_input = pending["input"]
@@ -1384,6 +1464,13 @@ class ChatOrchestrator:
                     )
 
                     # Persist tool message.
+                    # #315: link to the parent assistant row via
+                    # ``parent_message_id`` and store Claude's
+                    # ``tool_use_id`` so the renderer can group the
+                    # tool under its parent and the replay path can
+                    # rebuild the ``tool_use → tool_result`` pairing
+                    # the Anthropic API requires for multi-turn tool
+                    # use.
                     try:
                         with get_connection() as conn:
                             create_message(
@@ -1394,6 +1481,8 @@ class ChatOrchestrator:
                                 tool_name=tool_name,
                                 tool_input=tool_input,
                                 tool_output=tool_result,
+                                tool_use_id=tool_use_id,
+                                parent_message_id=ctx.assistant_msg_id,
                             )
                             conn.commit()
                     except Exception:
@@ -1571,28 +1660,58 @@ class ChatOrchestrator:
         """
         # 7. Persist assistant message (only when streaming completed
         # successfully).
+        #
+        # #315: when the turn invoked tools, an assistant row was
+        # already inserted up-front so the tool rows could link to it
+        # via ``parent_message_id``. In that case we UPDATE the
+        # placeholder with the final content / tokens / rag_context
+        # rather than INSERTing a second row. Pure-text turns still
+        # hit the INSERT path below.
         if ctx.completed:
-            try:
-                with get_connection() as conn:
-                    assistant_msg = create_message(
-                        conn,
-                        ctx.conversation_id,
-                        "assistant",
-                        ctx.full_content,
-                        tokens_input=ctx.tokens_in if ctx.tokens_in else None,
-                        tokens_output=ctx.tokens_out if ctx.tokens_out else None,
-                        model=getattr(self.llm, "_model", None),
-                        rag_context=ctx.rag_context_json,
+            if ctx.assistant_msg_id is not None:
+                try:
+                    with get_connection() as conn:
+                        _update_assistant_payload(
+                            conn,
+                            ctx.assistant_msg_id,
+                            content=ctx.full_content,
+                            tokens_input=ctx.tokens_in if ctx.tokens_in else None,
+                            tokens_output=ctx.tokens_out if ctx.tokens_out else None,
+                            rag_context=ctx.rag_context_json,
+                        )
+                        # Also bump conversation updated_at.
+                        conn.execute(
+                            "UPDATE conversations SET updated_at = now() WHERE id = %s",
+                            (str(ctx.conversation_id),),
+                        )
+                        conn.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to update placeholder assistant message %s",
+                        ctx.assistant_msg_id,
                     )
-                    # Also bump conversation updated_at.
-                    conn.execute(
-                        "UPDATE conversations SET updated_at = now() WHERE id = %s",
-                        (str(ctx.conversation_id),),
-                    )
-                    conn.commit()
-                    ctx.assistant_msg_id = assistant_msg.id
-            except Exception:
-                logger.exception("Failed to persist assistant message")
+            else:
+                try:
+                    with get_connection() as conn:
+                        assistant_msg = create_message(
+                            conn,
+                            ctx.conversation_id,
+                            "assistant",
+                            ctx.full_content,
+                            tokens_input=ctx.tokens_in if ctx.tokens_in else None,
+                            tokens_output=ctx.tokens_out if ctx.tokens_out else None,
+                            model=getattr(self.llm, "_model", None),
+                            rag_context=ctx.rag_context_json,
+                        )
+                        # Also bump conversation updated_at.
+                        conn.execute(
+                            "UPDATE conversations SET updated_at = now() WHERE id = %s",
+                            (str(ctx.conversation_id),),
+                        )
+                        conn.commit()
+                        ctx.assistant_msg_id = assistant_msg.id
+                except Exception:
+                    logger.exception("Failed to persist assistant message")
 
         # 8. Emit done, then sources, then (optionally) follow_ups.
         try:
@@ -1741,6 +1860,16 @@ def _build_llm_messages(
 
     History is capped to the most recent ``_MAX_HISTORY_MESSAGES``
     entries to prevent context window overflow for long conversations.
+
+    #315: ``tool`` rows in history are rendered with their
+    ``tool_use_id`` + ``tool_name`` + ``tool_input`` so the LLM can
+    reconstruct what it asked for and what it got back. The textual
+    shape mirrors the live tool-call segments emitted inside
+    :meth:`ChatOrchestrator._phase_stream_llm` so the model sees a
+    consistent transcript whether the tool ran in this turn or a
+    previous one. Without this, history-replayed conversations dropped
+    every persisted tool turn from the prompt and Claude lost the
+    grounding for the answer it gave originally.
     """
     # M2: cap history to most recent N messages
     if len(history) > _MAX_HISTORY_MESSAGES:
@@ -1751,7 +1880,28 @@ def _build_llm_messages(
     parts: list[str] = []
     for msg in capped_history:
         role_label = msg.role.upper()
-        parts.append(f"[{role_label}]: {msg.content}")
+        if msg.role == "tool":
+            # Render a persisted tool turn so it can replay through the
+            # same prompt shape the live tool loop uses. We include the
+            # ``tool_use_id`` (Anthropic's ``toolu_...``) when present so
+            # any future shift to a structured messages array carries
+            # the pairing intact; today the flat-string prompt only
+            # needs a stable textual representation.
+            tool_use_id = getattr(msg, "tool_use_id", None) or ""
+            tool_name = getattr(msg, "tool_name", None) or "tool"
+            tool_input = getattr(msg, "tool_input", None) or {}
+            try:
+                tool_input_json = json.dumps(tool_input)
+            except (TypeError, ValueError):
+                tool_input_json = "{}"
+            tool_output = msg.content or ""
+            id_marker = f" id={tool_use_id}" if tool_use_id else ""
+            parts.append(
+                f"[TOOL_CALL{id_marker} name={tool_name}]({tool_input_json})\n"
+                f"[TOOL_RESULT{id_marker}]({tool_output})"
+            )
+        else:
+            parts.append(f"[{role_label}]: {msg.content}")
     parts.append(f"[USER]: {user_message}")
     return parts
 

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -22,6 +22,7 @@ Cross-org access returns 404 to avoid leaking conversation existence.
 from __future__ import annotations
 
 import html as _html
+import json
 import logging
 import uuid
 from datetime import datetime
@@ -1062,14 +1063,66 @@ def _render_message(msg: Any):
             data_message_id=msg_id,
         )
     elif role == "tool":
+        # #315: surface the tool call so the persisted tool turns are
+        # visible in the conversation history (the live stream already
+        # shows them via the WS ``tool_use`` / ``tool_result`` events,
+        # but a page reload would otherwise hide every previously-run
+        # tool — only the final assistant text remained). The tool input
+        # / output are JSON-formatted inside a ``<details>`` so the bubble
+        # stays compact and the structured payload is on-demand.
         tool_name = msg.tool_name or "tool"
+        tool_input = getattr(msg, "tool_input", None)
+        tool_output = getattr(msg, "tool_output", None)
+        try:
+            tool_input_text = (
+                json.dumps(tool_input, ensure_ascii=False, indent=2)
+                if tool_input is not None
+                else ""
+            )
+        except (TypeError, ValueError):
+            tool_input_text = ""
+        try:
+            tool_output_text = (
+                json.dumps(tool_output, ensure_ascii=False, indent=2)
+                if tool_output is not None
+                else (msg.content or "")
+            )
+        except (TypeError, ValueError):
+            tool_output_text = msg.content or ""
+
+        details_children: list = []
+        if tool_input_text:
+            details_children.append(
+                Div(  # noqa: F405
+                    Strong("Sisend:"),  # noqa: F405
+                    Pre(tool_input_text, cls="chat-tool-input"),  # noqa: F405
+                    cls="chat-tool-section",
+                )
+            )
+        if tool_output_text:
+            details_children.append(
+                Div(  # noqa: F405
+                    Strong("Tulemus:"),  # noqa: F405
+                    Pre(tool_output_text, cls="chat-tool-result"),  # noqa: F405
+                    cls="chat-tool-section",
+                )
+            )
+        # ``data-parent-message-id`` lets future CSS / JS group tool
+        # bubbles visually under their parent assistant turn.
+        parent_id = getattr(msg, "parent_message_id", None)
         return Div(  # noqa: F405
-            Div(  # noqa: F405
-                P(f"[{tool_name}]", cls="chat-tool-label"),  # noqa: F405
-                cls="chat-bubble chat-bubble-tool",
+            Details(  # noqa: F405
+                Summary(  # noqa: F405
+                    Span(f"[{tool_name}]", cls="chat-tool-label"),  # noqa: F405
+                    " ",
+                    Span("(tööriistakutse)", cls="chat-tool-hint"),  # noqa: F405
+                ),
+                *details_children,
+                cls="chat-tool-activity chat-tool-activity-done",
             ),
             cls="chat-message chat-message-tool",
             data_message_id=msg_id,
+            data_parent_message_id=str(parent_id) if parent_id else "",
         )
     # system messages are hidden
     return ""

--- a/migrations/036_message_tool_use_tracking.sql
+++ b/migrations/036_message_tool_use_tracking.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- Migration 036: messages.tool_use_id + messages.parent_message_id (#315)
+-- =============================================================================
+--
+-- Issue #315 ("Persist tool_use/tool_result in messages table"):
+--   The messages table (migration 008) already carries tool_name / tool_input /
+--   tool_output for role='tool' rows. What's MISSING is:
+--
+--     1. ``tool_use_id`` — Claude's API identifier (e.g. ``toolu_...``) that
+--        ties a streaming ``tool_use`` block to its follow-up
+--        ``tool_result`` block. Without it we cannot reconstruct the
+--        Anthropic tool-use protocol from persisted history when replaying
+--        a multi-turn conversation, and we cannot match orchestrator
+--        emissions to their persisted rows.
+--
+--     2. ``parent_message_id`` — pointer back to the assistant turn that
+--        triggered the tool call. A single assistant turn can request N
+--        tools (see ``app/chat/orchestrator.py::_run_stream_loop``); without
+--        a parent link, the persisted tool rows float free of the message
+--        they belong to. The UI cannot group them under the assistant
+--        bubble, and a follow-up history loader cannot rebuild the
+--        ``tool_use → tool_result`` pairing required by the Anthropic
+--        Messages API for multi-turn tool use.
+--
+-- Both columns are NULLable: a chat message that never invoked a tool
+-- carries NULL in both, so the columns are additive and backwards
+-- compatible. The CHECK constraint ensures a ``tool_use_id`` only ever
+-- appears on a role='tool' row (defensive — the orchestrator never sets
+-- it on user/assistant/system rows, but a future regression would be
+-- caught at the DB layer).
+--
+-- Cascade semantics:
+--   - parent_message_id REFERENCES messages(id) ON DELETE CASCADE.
+--     Deleting the assistant turn that triggered the tool calls
+--     automatically removes the tool rows. This matches the implicit
+--     contract: a tool row only makes sense in the context of the
+--     assistant turn that requested it.
+--
+-- Idempotency:
+--   - ADD COLUMN IF NOT EXISTS for both columns.
+--   - CREATE INDEX IF NOT EXISTS for both indexes.
+--   - The CHECK constraint is added via a DO block that probes
+--     pg_constraint so a re-run does not duplicate it.
+--
+-- ROLLBACK procedure (manual; requires app on pre-#315 code):
+--   ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_tool_use_id_role_chk;
+--   DROP INDEX IF EXISTS idx_messages_tool_use;
+--   DROP INDEX IF EXISTS idx_messages_parent;
+--   ALTER TABLE messages DROP COLUMN IF EXISTS parent_message_id;
+--   ALTER TABLE messages DROP COLUMN IF EXISTS tool_use_id;
+--   DELETE FROM schema_migrations WHERE version = '036_message_tool_use_tracking';
+-- =============================================================================
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS tool_use_id TEXT NULL;
+
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS parent_message_id UUID NULL
+        REFERENCES messages(id) ON DELETE CASCADE;
+
+-- Defensive CHECK: ``tool_use_id`` may only be set on a role='tool' row.
+-- A regression that wrote it onto an assistant / user row would silently
+-- corrupt the replay pairing logic, so we reject it at the DB layer.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'messages_tool_use_id_role_chk'
+    ) THEN
+        ALTER TABLE messages
+            ADD CONSTRAINT messages_tool_use_id_role_chk
+            CHECK (tool_use_id IS NULL OR role = 'tool');
+    END IF;
+END $$;
+
+-- Index for the "load tool children of an assistant turn" query pattern
+-- (renderer groups tool rows under their parent). Partial: messages
+-- without a parent are the overwhelming majority and would just bloat
+-- the index.
+CREATE INDEX IF NOT EXISTS idx_messages_parent
+    ON messages (parent_message_id)
+    WHERE parent_message_id IS NOT NULL;
+
+-- Index for the "look up a tool row by its Anthropic tool_use_id within
+-- a conversation" pattern, used by the history-to-API replay code to
+-- pair tool_use blocks with their tool_result blocks. Partial for the
+-- same reason as above.
+CREATE INDEX IF NOT EXISTS idx_messages_tool_use
+    ON messages (conversation_id, tool_use_id)
+    WHERE tool_use_id IS NOT NULL;

--- a/tests/test_chat_models_encryption.py
+++ b/tests/test_chat_models_encryption.py
@@ -43,9 +43,9 @@ _CONV_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
 def _echo_row(conn_mock: MagicMock) -> list[Any]:
     """Capture the INSERT params and build a matching row for ``fetchone``.
 
-    Migration 026 dropped the plaintext payload columns; the INSERT now
-    binds 10 positional params and ``_MESSAGE_COLUMNS`` is 14 wide
-    (no ``content``/``tool_input``/``tool_output``/``rag_context``).
+    Migration 026 dropped the plaintext payload columns. Migration 036
+    (#315) added ``tool_use_id`` + ``parent_message_id``; the INSERT
+    now binds 12 positional params and ``_MESSAGE_COLUMNS`` is 16 wide.
     """
     params = conn_mock.execute.call_args.args[1]
     (
@@ -59,6 +59,8 @@ def _echo_row(conn_mock: MagicMock) -> list[Any]:
         tool_input_ct,
         tool_output_ct,
         rag_context_ct,
+        tool_use_id,
+        parent_message_id,
     ) = params
     now = datetime.now(UTC)
     return [
@@ -74,6 +76,10 @@ def _echo_row(conn_mock: MagicMock) -> list[Any]:
         tool_input_ct,
         tool_output_ct,
         rag_context_ct,
+        False,  # is_pinned (v017)
+        False,  # is_truncated (v017)
+        tool_use_id,
+        parent_message_id,
     ]
 
 

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -1295,7 +1295,10 @@ class TestPartialPersistTokensCapture:
                 else:
                     raise asyncio.CancelledError()
 
-        with patch("app.chat.orchestrator.execute_tool", return_value={"results": []}):
+        with (
+            patch("app.chat.orchestrator.execute_tool", return_value={"results": []}),
+            patch("app.chat.orchestrator._update_assistant_payload") as mock_update,
+        ):
             llm = CancellingLLM()
             collector = _Collector()
             orchestrator = ChatOrchestrator(llm, FakeSparql())
@@ -1307,14 +1310,21 @@ class TestPartialPersistTokensCapture:
         # The orchestrator should have persisted a partial assistant row
         # via the CancelledError handler with the tokens captured from
         # round 1's stop event.
-        assistant_calls = [
-            c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
-        ]
-        assert assistant_calls, "CancelledError path must persist a partial assistant row"
-        # Last call is the partial-persist (round 1's stop set tokens=300/80).
-        assistant_call = assistant_calls[-1]
-        assert assistant_call.kwargs.get("tokens_input") == 300
-        assert assistant_call.kwargs.get("tokens_output") == 80
+        #
+        # #315 Fix 2: when the tool turn was already underway (placeholder
+        # assistant INSERTed before the tool ran), the cancel path now
+        # UPDATEs that placeholder in place rather than inserting a
+        # second assistant row. So the tokens land on the
+        # ``_update_assistant_payload`` call, not on a new
+        # ``create_message`` call. Pre-fix this test relied on the buggy
+        # double-insert; post-fix it verifies the UPDATE carries the
+        # tokens.
+        assert mock_update.called, (
+            "CancelledError path on a tool turn must UPDATE the assistant placeholder"
+        )
+        update_kwargs = mock_update.call_args.kwargs
+        assert update_kwargs.get("tokens_input") == 300
+        assert update_kwargs.get("tokens_output") == 80
 
 
 class TestOrchestratorPartialPersistence:

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -1084,20 +1084,33 @@ class TestAssistantTokensPersistence:
         orchestrator = ChatOrchestrator(llm, FakeSparql())
         asyncio.run(orchestrator.handle_message(_CONV_ID, "Test", _auth(), collector))
 
-        assistant_calls = [
+        # #315: in the multi-round tool-use path, an assistant
+        # placeholder row is INSERTED via ``create_message`` BEFORE the
+        # tool runs (so the tool row can reference it via
+        # ``parent_message_id``). The final tokens land on that row via
+        # an ``UPDATE messages SET ... tokens_input = %s, tokens_output =
+        # %s ...`` issued by ``_update_assistant_payload`` — so the
+        # last-round-wins assertion now reads off the UPDATE bind
+        # params rather than the create_message kwargs.
+        assistant_creates = [
             c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
         ]
-        assert assistant_calls, "expected an assistant create_message call"
-        assistant_call = assistant_calls[-1]
-        # Last-round-wins: 180 (not 100+180=280) and 120 (not 50+120=170).
-        assert assistant_call.kwargs.get("tokens_input") == 180, (
-            f"expected last round's tokens_input=180, got "
-            f"{assistant_call.kwargs.get('tokens_input')}"
-        )
-        assert assistant_call.kwargs.get("tokens_output") == 120, (
-            f"expected last round's tokens_output=120, got "
-            f"{assistant_call.kwargs.get('tokens_output')}"
-        )
+        assert assistant_creates, "expected an assistant create_message placeholder"
+
+        update_calls = [
+            call
+            for call in conn.execute.call_args_list
+            if isinstance(call.args[0], str)
+            and "UPDATE messages" in call.args[0]
+            and "tokens_input" in call.args[0]
+        ]
+        assert update_calls, "expected an UPDATE messages SET tokens_input/tokens_output call"
+        update_call = update_calls[-1]
+        params = update_call.args[1]
+        # Bind order in _update_assistant_payload: content_ct, tokens_in,
+        # tokens_out, rag_context_ct, message_id.
+        assert params[1] == 180, f"expected last round's tokens_input=180, got {params[1]}"
+        assert params[2] == 120, f"expected last round's tokens_output=120, got {params[2]}"
 
 
 class TestStepDeadlineBudget:

--- a/tests/test_chat_tool_use_history.py
+++ b/tests/test_chat_tool_use_history.py
@@ -715,3 +715,446 @@ def test_check_constraint_rejects_tool_use_id_on_non_tool_role():
         conn.execute("DELETE FROM users WHERE id = %s", (str(user_id),))
         conn.execute("DELETE FROM organizations WHERE id = %s", (str(org_id),))
         conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# #315 review fixes — placeholder UPDATE shifts created_at; partial persist
+# UPDATEs the placeholder instead of inserting a sibling row.
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAssistantPayloadBumpsCreatedAt:
+    """Fix 1 (ordering): ``_update_assistant_payload`` must bump
+    ``created_at`` to ``NOW()`` so the placeholder sorts AFTER the tool
+    rows that were inserted between the initial placeholder INSERT and
+    the final UPDATE. Otherwise ``list_messages`` ``ORDER BY created_at
+    ASC`` returns the placeholder first and the replay path emits
+    ``[assistant_final, tool_call, tool_result]`` instead of
+    ``[tool_call, tool_result, assistant_final]``.
+    """
+
+    def test_update_sql_includes_created_at_now(self):
+        from app.chat.orchestrator import _update_assistant_payload
+
+        conn = MagicMock()
+        _update_assistant_payload(
+            conn,
+            uuid.uuid4(),
+            content="Lõplik vastus",
+            tokens_input=100,
+            tokens_output=50,
+            rag_context=None,
+        )
+        # The UPDATE statement is the only call.
+        sql = conn.execute.call_args.args[0]
+        # The SET clause must include ``created_at = NOW()`` so the
+        # placeholder sorts after the tool rows inserted while streaming.
+        normalized = " ".join(sql.split()).lower()
+        assert "set" in normalized
+        assert "created_at = now()" in normalized
+        # The non-deprecated payload columns are still updated.
+        assert "content_encrypted" in normalized
+        assert "tokens_input" in normalized
+        assert "tokens_output" in normalized
+        assert "rag_context_encrypted" in normalized
+
+
+class TestToolTurnReplayOrdering:
+    """Fix 1 end-to-end: simulate a tool turn through the orchestrator
+    and assert the persisted ordering is suitable for replay.
+
+    We can't observe row ``created_at`` directly without a real DB, so
+    we assert the *UPDATE* on the assistant placeholder fires AFTER the
+    tool row INSERTs — which is the operational guarantee that, combined
+    with ``SET created_at = NOW()``, produces the
+    ``tool_call → tool_result → assistant_final`` order on the next
+    ``list_messages`` call.
+    """
+
+    @patch("app.chat.orchestrator.execute_tool")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_placeholder_update_happens_after_tool_inserts(self, mock_get_conn, mock_exec_tool):
+        # Order log: each create_message INSERT and each
+        # _update_assistant_payload UPDATE appends here.
+        ordering: list[str] = []
+
+        assistant_uuid = uuid.uuid4()
+
+        def _fake_create(conn, conv_id, role, content, **kwargs):
+            ordering.append(f"INSERT:{role}")
+            msg_id = assistant_uuid if role == "assistant" else uuid.uuid4()
+            return MagicMock(id=msg_id)
+
+        def _fake_update(conn, message_id, **kwargs):
+            ordering.append(f"UPDATE:{message_id}")
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+        conn.execute.return_value.fetchone.return_value = base_conv_row
+        conn.execute.return_value.fetchall.return_value = []
+
+        async def fake_exec_tool(name, inp, sparql, auth=None):
+            return {"results": [{"uri": "estleg:X"}]}
+
+        mock_exec_tool.side_effect = fake_exec_tool
+
+        with (
+            patch("app.chat.orchestrator.create_message", side_effect=_fake_create),
+            patch("app.chat.orchestrator._update_assistant_payload", side_effect=_fake_update),
+        ):
+            orchestrator = ChatOrchestrator(_FakeToolLLM(), _FakeSparql())
+            collector = _Collector()
+            asyncio.run(
+                orchestrator.handle_message(
+                    _CONV_ID, "Otsi", {"id": _USER_ID, "org_id": _ORG_ID}, collector
+                )
+            )
+
+        # Filter to the events we care about for ordering.
+        tool_inserts = [i for i, ev in enumerate(ordering) if ev == "INSERT:tool"]
+        assistant_updates = [i for i, ev in enumerate(ordering) if ev.startswith("UPDATE:")]
+        assistant_inserts = [i for i, ev in enumerate(ordering) if ev == "INSERT:assistant"]
+
+        assert tool_inserts, "tool row INSERT must occur"
+        assert assistant_inserts, "assistant placeholder INSERT must occur"
+        assert assistant_updates, (
+            "the assistant placeholder must be UPDATEd with the final answer "
+            "(this is the path that bumps created_at to NOW())"
+        )
+        # The placeholder INSERT comes first, then tool rows, then the
+        # final UPDATE — that UPDATE is where created_at is bumped, so
+        # the row's effective sort key ends up AFTER the tool rows.
+        assert assistant_inserts[0] < tool_inserts[0], (
+            "placeholder must be inserted before tool rows so they can link via parent_message_id"
+        )
+        assert tool_inserts[-1] < assistant_updates[-1], (
+            "tool rows must be inserted before the placeholder UPDATE — "
+            "otherwise NOW() on the UPDATE wouldn't push created_at past the tool rows"
+        )
+
+    def test_list_messages_replay_order_after_update(self):
+        """Direct unit test on the replay shape: when an assistant row's
+        ``created_at`` is greater than the tool rows' ``created_at``
+        (the post-fix state), ``_build_llm_messages`` over a
+        ``created_at`` ASC ordering renders
+        ``[TOOL_CALL → TOOL_RESULT → assistant_final]`` — the correct
+        replay order for the next Claude turn.
+        """
+        from datetime import timedelta
+
+        from app.chat.orchestrator import _build_llm_messages
+
+        t0 = datetime.now(UTC)
+
+        user_msg = Message(
+            id=uuid.uuid4(),
+            conversation_id=_CONV_ID,
+            role="user",
+            content="Otsi sätteid",
+            tool_name=None,
+            tool_input=None,
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=t0,
+        )
+        tool_msg = Message(
+            id=uuid.uuid4(),
+            conversation_id=_CONV_ID,
+            role="tool",
+            content='{"results": []}',
+            tool_name="search_provisions",
+            tool_input={"keywords": "andmekaitse"},
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=t0 + timedelta(seconds=1),
+            tool_use_id="toolu_ordering_001",
+        )
+        # POST-FIX: the placeholder UPDATE bumps created_at past the
+        # tool row, so the ASC-ordered list sees the assistant row LAST.
+        assistant_msg = Message(
+            id=uuid.uuid4(),
+            conversation_id=_CONV_ID,
+            role="assistant",
+            content="Leidsin §1.",
+            tool_name=None,
+            tool_input=None,
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=t0 + timedelta(seconds=2),
+        )
+
+        history = [user_msg, tool_msg, assistant_msg]
+        parts = _build_llm_messages(history, "Mis veel?")
+
+        # Find the indices of the three semantically relevant entries.
+        tool_idx = next(i for i, p in enumerate(parts) if "TOOL_CALL" in p and "TOOL_RESULT" in p)
+        assistant_idx = next(i for i, p in enumerate(parts) if p.startswith("[ASSISTANT]:"))
+        user_idx = next(i for i, p in enumerate(parts) if p == "[USER]: Mis veel?")
+
+        # The tool turn comes BEFORE the assistant's final answer,
+        # which comes BEFORE the new user message. This is the order
+        # Claude requires; the pre-fix state had assistant_idx <
+        # tool_idx and broke replay.
+        assert tool_idx < assistant_idx < user_idx, (
+            f"Expected tool_call -> assistant_final -> user, got order: {parts}"
+        )
+
+
+class TestPartialPersistUpdatesPlaceholder:
+    """Fix 2 (double-insert): when a placeholder assistant row already
+    exists for a tool turn, ``_persist_partial_assistant`` must UPDATE
+    that row in place rather than INSERTing a second assistant row.
+    Otherwise the timeout / cancel / error paths leave two assistant
+    messages for a single logical turn — the empty parent + a partial
+    sibling — and replay sees a corrupted history.
+    """
+
+    @patch("app.chat.orchestrator._update_assistant_payload")
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_with_placeholder_updates_in_place(
+        self, mock_get_conn, mock_create_msg, mock_update_payload
+    ):
+        """When ``placeholder_message_id`` is set, the helper must:
+
+        * NOT call ``create_message`` (would insert a second row).
+        * Call ``_update_assistant_payload`` with the existing id.
+        * Return the placeholder id unchanged.
+        """
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        placeholder_id = uuid.uuid4()
+
+        result = _persist_partial_assistant(
+            _CONV_ID,
+            "osaline sisu",
+            "fake-model",
+            None,
+            is_truncated=True,
+            tokens_input=42,
+            tokens_output=17,
+            placeholder_message_id=placeholder_id,
+        )
+
+        assert result == placeholder_id, (
+            "Returning the placeholder id signals to callers that the same row was reused"
+        )
+        # Critical: no second assistant INSERT happened.
+        mock_create_msg.assert_not_called()
+        # The placeholder was UPDATEd with the partial content + tokens.
+        mock_update_payload.assert_called_once()
+        call_kwargs = mock_update_payload.call_args.kwargs
+        # The id passed positionally as the second arg.
+        positional = mock_update_payload.call_args.args
+        assert positional[1] == placeholder_id
+        assert call_kwargs.get("content") == "osaline sisu"
+        assert call_kwargs.get("tokens_input") == 42
+        assert call_kwargs.get("tokens_output") == 17
+
+    @patch("app.chat.orchestrator._update_assistant_payload")
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_without_placeholder_inserts_as_before(
+        self, mock_get_conn, mock_create_msg, mock_update_payload
+    ):
+        """Backwards compatibility: non-tool turns (no placeholder)
+        still INSERT a fresh assistant row as before."""
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+        new_msg_id = uuid.uuid4()
+        mock_create_msg.return_value = MagicMock(id=new_msg_id)
+
+        result = _persist_partial_assistant(
+            _CONV_ID,
+            "osaline sisu",
+            "fake-model",
+            None,
+            is_truncated=True,
+            tokens_input=42,
+            tokens_output=17,
+            placeholder_message_id=None,
+        )
+
+        assert result == new_msg_id
+        mock_create_msg.assert_called_once()
+        # The UPDATE helper must NOT have been used in the non-tool path.
+        mock_update_payload.assert_not_called()
+
+    @patch("app.chat.orchestrator.execute_tool")
+    @patch("app.chat.orchestrator._persist_partial_assistant")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_timeout_on_tool_turn_passes_placeholder(
+        self, mock_get_conn, mock_persist, mock_exec_tool
+    ):
+        """End-to-end: a tool turn that hits the turn deadline AFTER
+        the placeholder is inserted must pass ``placeholder_message_id``
+        into ``_persist_partial_assistant`` so the helper UPDATEs the
+        existing placeholder rather than inserting a second assistant
+        row."""
+        from app.chat.orchestrator import _TURN_DEADLINE_SECONDS  # noqa: F401
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        base_conv_row = (
+            conv.id,
+            conv.user_id,
+            conv.org_id,
+            conv.title,
+            None,
+            conv.created_at,
+            conv.updated_at,
+        )
+        conn.execute.return_value.fetchone.return_value = base_conv_row
+        conn.execute.return_value.fetchall.return_value = []
+
+        async def fake_exec_tool(name, inp, sparql, auth=None):
+            return {"results": []}
+
+        mock_exec_tool.side_effect = fake_exec_tool
+
+        assistant_uuid = uuid.uuid4()
+
+        # The LLM emits a tool_use on round 1 (which inserts the
+        # placeholder), then hangs on round 2 by sleeping past the
+        # turn deadline. We force a TimeoutError directly to avoid a
+        # real 120s sleep.
+        class HangingToolLLM(LLMProvider):
+            def __init__(self):
+                self._model = "fake-model"
+                self._calls = 0
+
+            def complete(self, prompt, **kw):  # pragma: no cover
+                return "x"
+
+            def extract_json(self, prompt, **kw):  # pragma: no cover
+                return {}
+
+            def count_tokens(self, text):  # pragma: no cover
+                return 0
+
+            async def acomplete(self, prompt, **kw):  # pragma: no cover
+                return "x"
+
+            async def astream(self, prompt, **kw):  # type: ignore[override]
+                if self._calls == 0:
+                    self._calls += 1
+                    yield StreamEvent(type="content", delta="Otsin...")
+                    yield StreamEvent(
+                        type="tool_use",
+                        tool_name="search_provisions",
+                        tool_input={"keywords": "x"},
+                        tool_use_id="toolu_timeout",
+                    )
+                    yield StreamEvent(type="stop")
+                else:
+                    # Simulate a stuck upstream by sleeping forever; the
+                    # orchestrator's asyncio.wait_for will cancel us.
+                    await asyncio.sleep(3600)
+
+        with patch("app.chat.orchestrator.create_message") as mock_create:
+
+            def _fake_create(conn, conv_id, role, content, **kwargs):
+                msg_id = assistant_uuid if role == "assistant" else uuid.uuid4()
+                return MagicMock(id=msg_id)
+
+            mock_create.side_effect = _fake_create
+
+            # Squeeze the turn deadline so the test runs in <1s.
+            with patch("app.chat.orchestrator._TURN_DEADLINE_SECONDS", 0.05):
+                orchestrator = ChatOrchestrator(HangingToolLLM(), _FakeSparql())
+                collector = _Collector()
+                asyncio.run(
+                    orchestrator.handle_message(
+                        _CONV_ID, "Otsi", {"id": _USER_ID, "org_id": _ORG_ID}, collector
+                    )
+                )
+
+        # _persist_partial_assistant must have been called from the
+        # timeout path with the placeholder id forwarded.
+        assert mock_persist.called, "the timeout path must call _persist_partial_assistant"
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs.get("placeholder_message_id") == assistant_uuid, (
+            "Fix 2: the timeout path must forward the placeholder id so the "
+            "partial-persist UPDATEs the existing assistant row instead of "
+            "inserting a sibling. Got "
+            f"placeholder_message_id={call_kwargs.get('placeholder_message_id')!r}, "
+            f"expected={assistant_uuid!r}"
+        )
+
+    @patch("app.chat.orchestrator._update_assistant_payload")
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_only_one_row_for_timed_out_tool_turn(
+        self, mock_get_conn, mock_create_msg, mock_update_payload
+    ):
+        """End-to-end count: when a tool turn times out after the
+        placeholder is inserted, the partial-persist path must NOT call
+        ``create_message`` again. Otherwise the conversation ends up with
+        TWO assistant rows (the original empty placeholder + a new
+        partial sibling) for one logical turn — the exact double-insert
+        bug Fix 2 addresses.
+        """
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Simulate the orchestrator-level flow: the placeholder was
+        # already inserted earlier in the tool-turn pre-insert step
+        # (mocked away here; we just hold its id). Now the timeout path
+        # calls _persist_partial_assistant with the placeholder id.
+        placeholder_id = uuid.uuid4()
+
+        result = _persist_partial_assistant(
+            _CONV_ID,
+            "osaline...",
+            "fake-model",
+            None,
+            is_truncated=True,
+            error_suffix=" [Viga: aegus]",
+            tokens_input=10,
+            tokens_output=5,
+            placeholder_message_id=placeholder_id,
+        )
+
+        assert result == placeholder_id
+        # Crucial assertion: NO new assistant INSERT happened during the
+        # partial-persist path. Pre-fix this method always called
+        # create_message, producing the double-insert.
+        mock_create_msg.assert_not_called()
+        # And the UPDATE on the placeholder did happen.
+        mock_update_payload.assert_called_once()
+        positional = mock_update_payload.call_args.args
+        assert positional[1] == placeholder_id

--- a/tests/test_chat_tool_use_history.py
+++ b/tests/test_chat_tool_use_history.py
@@ -1,0 +1,717 @@
+# pyright: reportArgumentType=false
+"""Tests for tool_use / tool_result history persistence (#315).
+
+Migration 036 added two columns to ``messages``:
+
+    * ``tool_use_id`` (TEXT NULL) — Claude's ``toolu_...`` identifier.
+    * ``parent_message_id`` (UUID NULL, FK → messages.id ON DELETE CASCADE)
+      — points at the assistant turn that triggered the tool call.
+
+Plus two partial indexes (``idx_messages_parent``,
+``idx_messages_tool_use``) and a defensive CHECK constraint
+(``messages_tool_use_id_role_chk``) that pins ``tool_use_id`` to
+``role='tool'`` rows.
+
+These tests cover:
+
+    * The Message dataclass exposes the two new fields.
+    * ``create_message`` writes and reads them.
+    * ``list_messages`` returns them.
+    * ``_build_llm_messages`` renders persisted tool turns into the
+      prompt so a multi-turn history replay does not silently drop the
+      tool_use / tool_result pair.
+    * The orchestrator inserts a parent assistant row up-front when a
+      turn invokes tools and persists the tool row with
+      ``tool_use_id`` + ``parent_message_id``.
+    * A schema-level integration test (skipped unless ``DATABASE_URL``
+      is set) verifies the migration applied with the expected columns,
+      constraints, and indexes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.chat.models import Message, _row_to_message, create_message
+from app.chat.orchestrator import (
+    ChatOrchestrator,
+    _build_llm_messages,
+)
+from app.llm.provider import LLMProvider, StreamEvent
+
+# ---------------------------------------------------------------------------
+# Fernet key fixture — same shape as test_chat_models_encryption.py
+# ---------------------------------------------------------------------------
+
+_CONV_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_USER_ID = "11111111-1111-1111-1111-111111111111"
+_ORG_ID = "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a deterministic Fernet key for every test in this module."""
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("STORAGE_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    import app.storage.encrypted as encrypted_module
+
+    monkeypatch.setattr(encrypted_module, "_fernet", None)
+
+
+# ---------------------------------------------------------------------------
+# Row fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_message_row(
+    *,
+    msg_id: uuid.UUID | None = None,
+    role: str = "tool",
+    content: str = "{}",
+    tool_name: str | None = "query_ontology",
+    tool_input: dict | None = None,
+    tool_output: dict | None = None,
+    tool_use_id: str | None = "toolu_test_001",
+    parent_message_id: uuid.UUID | None = None,
+) -> tuple[Any, ...]:
+    """Build a 16-tuple row matching :data:`app.chat.models._MESSAGE_COLUMNS`."""
+    from app.storage import encrypt_text
+
+    tool_input_ct = encrypt_text(json.dumps(tool_input)) if tool_input is not None else None
+    tool_output_ct = encrypt_text(json.dumps(tool_output)) if tool_output is not None else None
+    return (
+        msg_id or uuid.uuid4(),
+        _CONV_ID,
+        role,
+        tool_name,
+        None,  # tokens_input
+        None,  # tokens_output
+        None,  # model
+        datetime.now(UTC),
+        encrypt_text(content),
+        tool_input_ct,
+        tool_output_ct,
+        None,  # rag_context_encrypted
+        False,  # is_pinned
+        False,  # is_truncated
+        tool_use_id,
+        str(parent_message_id) if parent_message_id else None,
+    )
+
+
+def _echo_row_for_create(conn_mock: MagicMock):
+    """Replay a ``RETURNING`` row from the params bound to the INSERT.
+
+    The INSERT in :func:`create_message` binds 12 positional params
+    (post-#315). We zip them back into the 16-column row order so the
+    round-trip returns a faithful Message.
+    """
+
+    def _build_row():
+        params = conn_mock.execute.call_args.args[1]
+        (
+            _conversation_id,
+            role,
+            tool_name,
+            tokens_input,
+            tokens_output,
+            model,
+            content_ct,
+            tool_input_ct,
+            tool_output_ct,
+            rag_context_ct,
+            tool_use_id,
+            parent_message_id,
+        ) = params
+        return [
+            uuid.uuid4(),
+            _CONV_ID,
+            role,
+            tool_name,
+            tokens_input,
+            tokens_output,
+            model,
+            datetime.now(UTC),
+            content_ct,
+            tool_input_ct,
+            tool_output_ct,
+            rag_context_ct,
+            False,
+            False,
+            tool_use_id,
+            parent_message_id,
+        ]
+
+    return _build_row
+
+
+# ---------------------------------------------------------------------------
+# Dataclass + row mapping
+# ---------------------------------------------------------------------------
+
+
+class TestMessageDataclass:
+    def test_defaults_to_none(self):
+        msg = Message(
+            id=uuid.uuid4(),
+            conversation_id=_CONV_ID,
+            role="user",
+            content="Tere",
+            tool_name=None,
+            tool_input=None,
+            tool_output=None,
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=datetime.now(UTC),
+        )
+        assert msg.tool_use_id is None
+        assert msg.parent_message_id is None
+
+    def test_accepts_tool_use_id_and_parent(self):
+        parent = uuid.uuid4()
+        msg = Message(
+            id=uuid.uuid4(),
+            conversation_id=_CONV_ID,
+            role="tool",
+            content="{}",
+            tool_name="query_ontology",
+            tool_input={"q": "?s"},
+            tool_output={"results": []},
+            rag_context=None,
+            tokens_input=None,
+            tokens_output=None,
+            model=None,
+            created_at=datetime.now(UTC),
+            tool_use_id="toolu_abc",
+            parent_message_id=parent,
+        )
+        assert msg.tool_use_id == "toolu_abc"
+        assert msg.parent_message_id == parent
+
+
+class TestRowToMessage:
+    def test_reads_v036_columns(self):
+        parent = uuid.uuid4()
+        row = _make_message_row(
+            tool_use_id="toolu_xyz",
+            parent_message_id=parent,
+            tool_input={"q": "select"},
+            tool_output={"results": []},
+        )
+        msg = _row_to_message(row)
+        assert msg.tool_use_id == "toolu_xyz"
+        assert msg.parent_message_id == parent
+        assert msg.tool_input == {"q": "select"}
+        assert msg.tool_output == {"results": []}
+
+    def test_pre_036_row_loads_with_none_tool_use_fields(self):
+        """A 14-tuple row (pre-#315 fixtures) must still load cleanly."""
+        from app.storage import encrypt_text
+
+        row = (
+            uuid.uuid4(),
+            _CONV_ID,
+            "tool",
+            "search_provisions",
+            None,
+            None,
+            None,
+            datetime.now(UTC),
+            encrypt_text("{}"),
+            None,
+            None,
+            None,
+            False,
+            False,
+        )
+        msg = _row_to_message(row)
+        assert msg.tool_use_id is None
+        assert msg.parent_message_id is None
+        assert msg.role == "tool"
+
+
+# ---------------------------------------------------------------------------
+# create_message
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMessageToolUseFields:
+    def test_persists_tool_use_id_and_parent(self):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.side_effect = _echo_row_for_create(conn)
+
+        parent_id = uuid.uuid4()
+        msg = create_message(
+            conn,
+            _CONV_ID,
+            "tool",
+            json.dumps({"results": []}),
+            tool_name="query_ontology",
+            tool_input={"query": "SELECT ?s WHERE { ?s ?p ?o }"},
+            tool_output={"results": []},
+            tool_use_id="toolu_42",
+            parent_message_id=parent_id,
+        )
+
+        assert msg.role == "tool"
+        assert msg.tool_use_id == "toolu_42"
+        assert msg.parent_message_id == parent_id
+
+        # Confirm the bound SQL params include the new fields.
+        params = conn.execute.call_args.args[1]
+        # tool_use_id is the second-to-last positional bind.
+        assert params[-2] == "toolu_42"
+        # parent_message_id is the last positional bind, stringified.
+        assert params[-1] == str(parent_id)
+
+    def test_persists_without_tool_fields_for_assistant_turn(self):
+        """A non-tool message must not set the new fields."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.side_effect = _echo_row_for_create(conn)
+
+        msg = create_message(conn, _CONV_ID, "assistant", "Tere!")
+        assert msg.tool_use_id is None
+        assert msg.parent_message_id is None
+        params = conn.execute.call_args.args[1]
+        assert params[-2] is None
+        assert params[-1] is None
+
+
+# ---------------------------------------------------------------------------
+# _build_llm_messages — multi-turn history replay
+# ---------------------------------------------------------------------------
+
+
+def _make_message_obj(
+    *,
+    role: str,
+    content: str,
+    tool_name: str | None = None,
+    tool_input: dict | None = None,
+    tool_use_id: str | None = None,
+) -> Message:
+    return Message(
+        id=uuid.uuid4(),
+        conversation_id=_CONV_ID,
+        role=role,
+        content=content,
+        tool_name=tool_name,
+        tool_input=tool_input,
+        tool_output=None,
+        rag_context=None,
+        tokens_input=None,
+        tokens_output=None,
+        model=None,
+        created_at=datetime.now(UTC),
+        tool_use_id=tool_use_id,
+        parent_message_id=None,
+    )
+
+
+class TestBuildLLMMessagesPreservesToolTurns:
+    def test_mixed_history_includes_tool_call_segment(self):
+        """The replay prompt must surface every persisted tool turn so a
+        history-driven follow-up call sees what the assistant asked for
+        and what it received (mirrors the live tool-call segment shape)."""
+        history = [
+            _make_message_obj(role="user", content="Otsi sätteid"),
+            _make_message_obj(role="assistant", content="Otsin..."),
+            _make_message_obj(
+                role="tool",
+                content='{"results": [{"uri": "estleg:X"}]}',
+                tool_name="search_provisions",
+                tool_input={"keywords": "andmekaitse"},
+                tool_use_id="toolu_history_1",
+            ),
+            _make_message_obj(role="assistant", content="Leidsin §1."),
+        ]
+        parts = _build_llm_messages(history, "Mis veel?")
+
+        joined = "\n\n".join(parts)
+        # The tool turn must render as a TOOL_CALL/TOOL_RESULT segment.
+        assert "[TOOL_CALL" in joined
+        assert "[TOOL_RESULT" in joined
+        assert "search_provisions" in joined
+        assert "toolu_history_1" in joined
+        # The tail must be the new user message.
+        assert parts[-1] == "[USER]: Mis veel?"
+
+    def test_tool_without_use_id_still_renders(self):
+        """Pre-#315 persisted tool rows have NULL tool_use_id but must
+        still appear in the prompt; otherwise older history would be
+        silently truncated."""
+        history = [
+            _make_message_obj(role="user", content="Otsi"),
+            _make_message_obj(
+                role="tool",
+                content='{"results": []}',
+                tool_name="query_ontology",
+                tool_input={"q": "?"},
+                tool_use_id=None,
+            ),
+        ]
+        parts = _build_llm_messages(history, "ok")
+        joined = "\n\n".join(parts)
+        assert "[TOOL_CALL" in joined
+        assert "[TOOL_RESULT" in joined
+        assert "query_ontology" in joined
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration — tool turn persists with parent linkage
+# ---------------------------------------------------------------------------
+
+
+class _Collector:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def __call__(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+class _FakeToolLLM(LLMProvider):
+    """Emits one tool_use, then text on the follow-up round."""
+
+    def __init__(self) -> None:
+        self._model = "fake-model"
+        self._calls = 0
+
+    def complete(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover
+        return "x"
+
+    def extract_json(self, prompt: str, **kwargs: Any) -> dict:  # pragma: no cover
+        return {}
+
+    def count_tokens(self, text: str) -> int:  # pragma: no cover
+        return 0
+
+    async def acomplete(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover
+        return "x"
+
+    async def astream(self, prompt: str, **kwargs: Any):  # type: ignore[override]
+        if self._calls == 0:
+            self._calls += 1
+            yield StreamEvent(
+                type="tool_use",
+                tool_name="search_provisions",
+                tool_input={"keywords": "andmekaitse"},
+                tool_use_id="toolu_orchestrator_001",
+            )
+            yield StreamEvent(type="stop")
+        else:
+            yield StreamEvent(type="content", delta="Leidsin sätte.")
+            yield StreamEvent(type="stop")
+
+
+class _FakeSparql:
+    def query(self, q: str) -> list:  # pragma: no cover
+        return []
+
+
+def _make_conversation():
+    now = datetime.now(UTC)
+    from app.chat.models import Conversation
+
+    return Conversation(
+        id=_CONV_ID,
+        user_id=uuid.UUID(_USER_ID),
+        org_id=uuid.UUID(_ORG_ID),
+        title="Test",
+        context_draft_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestOrchestratorPersistsToolUseLinkage:
+    @patch("app.chat.orchestrator.execute_tool")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_tool_turn_writes_parent_and_use_id(self, mock_get_conn, mock_exec_tool):
+        """A turn that invokes a tool must:
+
+        * Insert a parent assistant row up-front.
+        * Insert the tool row with ``tool_use_id`` + ``parent_message_id``
+          populated.
+        """
+        # Capture every create_message call so we can assert ordering.
+        creates: list[dict[str, Any]] = []
+
+        # We patch ``create_message`` at the orchestrator module so we
+        # can intercept WITHOUT having to fake the full RETURNING row
+        # shape three times.
+        with patch("app.chat.orchestrator.create_message") as mock_create:
+            assistant_uuid = uuid.uuid4()
+
+            def _fake_create(conn, conv_id, role, content, **kwargs):
+                creates.append({"role": role, "content": content, **kwargs})
+                # The orchestrator captures the returned id as the
+                # parent for subsequent tool inserts; give the assistant
+                # a known UUID so we can assert it propagated.
+                msg_id = assistant_uuid if role == "assistant" else uuid.uuid4()
+                return MagicMock(id=msg_id)
+
+            mock_create.side_effect = _fake_create
+
+            conn = MagicMock()
+            mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+            mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+            conv = _make_conversation()
+            # ``side_effect_fetchone`` returns the conversation row on
+            # the first ``execute().fetchone()`` (the load) and then a
+            # dummy assistant row on subsequent reads (history load is
+            # routed to ``fetchall`` instead).
+            base_conv_row = (
+                conv.id,
+                conv.user_id,
+                conv.org_id,
+                conv.title,
+                None,
+                conv.created_at,
+                conv.updated_at,
+            )
+            conn.execute.return_value.fetchone.return_value = base_conv_row
+            conn.execute.return_value.fetchall.return_value = []
+
+            async def fake_exec_tool(name, inp, sparql, auth=None):
+                return {"results": [{"uri": "estleg:X"}]}
+
+            mock_exec_tool.side_effect = fake_exec_tool
+
+            collector = _Collector()
+            orchestrator = ChatOrchestrator(_FakeToolLLM(), _FakeSparql())
+            asyncio.run(
+                orchestrator.handle_message(
+                    _CONV_ID, "Otsi", {"id": _USER_ID, "org_id": _ORG_ID}, collector
+                )
+            )
+
+        # Pick out the create_message calls by role.
+        assistant_creates = [c for c in creates if c["role"] == "assistant"]
+        tool_creates = [c for c in creates if c["role"] == "tool"]
+        user_creates = [c for c in creates if c["role"] == "user"]
+
+        assert user_creates, "user message must be persisted"
+        assert assistant_creates, "an assistant placeholder must be inserted before the tool row"
+        assert tool_creates, "the tool row must be persisted"
+
+        tool_call = tool_creates[0]
+        assert tool_call["tool_use_id"] == "toolu_orchestrator_001"
+        assert tool_call["parent_message_id"] == assistant_uuid
+        assert tool_call["tool_name"] == "search_provisions"
+        assert tool_call["tool_input"] == {"keywords": "andmekaitse"}
+
+
+# ---------------------------------------------------------------------------
+# Migration schema test (integration — skipped without DATABASE_URL)
+# ---------------------------------------------------------------------------
+
+
+def _skip_if_no_db():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("integration test — DATABASE_URL not set")
+
+
+def test_migration_036_adds_columns():
+    _skip_if_no_db()
+    from app.db import get_connection
+
+    with get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'messages'
+              AND column_name IN ('tool_use_id', 'parent_message_id')
+            ORDER BY column_name
+            """
+        )
+        cols = {r[0]: (r[1], r[2]) for r in cur.fetchall()}
+
+    assert "tool_use_id" in cols, "migration 036 must add tool_use_id"
+    assert "parent_message_id" in cols, "migration 036 must add parent_message_id"
+
+    # tool_use_id is TEXT NULL
+    tool_use_type, tool_use_nullable = cols["tool_use_id"]
+    assert tool_use_type == "text"
+    assert tool_use_nullable == "YES"
+
+    # parent_message_id is UUID NULL
+    parent_type, parent_nullable = cols["parent_message_id"]
+    assert parent_type == "uuid"
+    assert parent_nullable == "YES"
+
+
+def test_migration_036_creates_indexes():
+    _skip_if_no_db()
+    from app.db import get_connection
+
+    with get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexname FROM pg_indexes
+            WHERE tablename = 'messages'
+              AND indexname IN ('idx_messages_parent', 'idx_messages_tool_use')
+            ORDER BY indexname
+            """
+        )
+        names = {r[0] for r in cur.fetchall()}
+    assert "idx_messages_parent" in names
+    assert "idx_messages_tool_use" in names
+
+
+def test_migration_036_adds_check_constraint():
+    _skip_if_no_db()
+    from app.db import get_connection
+
+    with get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT conname FROM pg_constraint
+            WHERE conname = 'messages_tool_use_id_role_chk'
+            """
+        )
+        rows = cur.fetchall()
+    assert rows, "migration 036 must add the messages_tool_use_id_role_chk CHECK"
+
+
+def test_parent_message_cascade_delete():
+    """Deleting a parent assistant message cascades to its tool children."""
+    _skip_if_no_db()
+    from app.db import get_connection
+
+    with get_connection() as conn:
+        # Set up a tiny fixture: org + user + conversation + assistant
+        # + tool linked by parent_message_id.
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        conv_id = uuid.uuid4()
+        conn.execute(
+            "INSERT INTO organizations (id, name) VALUES (%s, %s)",
+            (str(org_id), "tool-cascade-test-org"),
+        )
+        conn.execute(
+            (
+                "INSERT INTO users (id, email, password_hash, org_id, role) "
+                "VALUES (%s, %s, %s, %s, %s)"
+            ),
+            (
+                str(user_id),
+                f"toolcascade-{uuid.uuid4().hex}@example.com",
+                "x",
+                str(org_id),
+                "drafter",
+            ),
+        )
+        conn.execute(
+            ("INSERT INTO conversations (id, user_id, org_id, title) VALUES (%s, %s, %s, %s)"),
+            (str(conv_id), str(user_id), str(org_id), "test"),
+        )
+
+        from app.storage import encrypt_text
+
+        assistant_id = uuid.uuid4()
+        tool_id = uuid.uuid4()
+        conn.execute(
+            (
+                "INSERT INTO messages "
+                "(id, conversation_id, role, content_encrypted) "
+                "VALUES (%s, %s, %s, %s)"
+            ),
+            (str(assistant_id), str(conv_id), "assistant", encrypt_text("hi")),
+        )
+        conn.execute(
+            (
+                "INSERT INTO messages "
+                "(id, conversation_id, role, content_encrypted, "
+                " tool_use_id, parent_message_id) "
+                "VALUES (%s, %s, %s, %s, %s, %s)"
+            ),
+            (
+                str(tool_id),
+                str(conv_id),
+                "tool",
+                encrypt_text("{}"),
+                "toolu_cascade_test",
+                str(assistant_id),
+            ),
+        )
+        conn.commit()
+
+        # Delete the parent. The CASCADE must remove the tool child.
+        conn.execute("DELETE FROM messages WHERE id = %s", (str(assistant_id),))
+        conn.commit()
+
+        row = conn.execute("SELECT 1 FROM messages WHERE id = %s", (str(tool_id),)).fetchone()
+        assert row is None, "tool row should have cascaded with its parent"
+
+        # Cleanup the fixture rows we created.
+        conn.execute("DELETE FROM conversations WHERE id = %s", (str(conv_id),))
+        conn.execute("DELETE FROM users WHERE id = %s", (str(user_id),))
+        conn.execute("DELETE FROM organizations WHERE id = %s", (str(org_id),))
+        conn.commit()
+
+
+def test_check_constraint_rejects_tool_use_id_on_non_tool_role():
+    """Defensive: tool_use_id may only be set on role='tool'."""
+    _skip_if_no_db()
+    import psycopg
+
+    from app.db import get_connection
+    from app.storage import encrypt_text
+
+    with get_connection() as conn:
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        conv_id = uuid.uuid4()
+        conn.execute(
+            "INSERT INTO organizations (id, name) VALUES (%s, %s)",
+            (str(org_id), "tool-check-test-org"),
+        )
+        conn.execute(
+            (
+                "INSERT INTO users (id, email, password_hash, org_id, role) "
+                "VALUES (%s, %s, %s, %s, %s)"
+            ),
+            (
+                str(user_id),
+                f"toolcheck-{uuid.uuid4().hex}@example.com",
+                "x",
+                str(org_id),
+                "drafter",
+            ),
+        )
+        conn.execute(
+            ("INSERT INTO conversations (id, user_id, org_id, title) VALUES (%s, %s, %s, %s)"),
+            (str(conv_id), str(user_id), str(org_id), "test"),
+        )
+        conn.commit()
+
+        with pytest.raises(psycopg.errors.CheckViolation):
+            conn.execute(
+                (
+                    "INSERT INTO messages "
+                    "(conversation_id, role, content_encrypted, tool_use_id) "
+                    "VALUES (%s, %s, %s, %s)"
+                ),
+                (str(conv_id), "assistant", encrypt_text("nope"), "toolu_bad"),
+            )
+        conn.rollback()
+
+        # Cleanup.
+        conn.execute("DELETE FROM conversations WHERE id = %s", (str(conv_id),))
+        conn.execute("DELETE FROM users WHERE id = %s", (str(user_id),))
+        conn.execute("DELETE FROM organizations WHERE id = %s", (str(org_id),))
+        conn.commit()

--- a/tests/test_chat_tool_use_history.py
+++ b/tests/test_chat_tool_use_history.py
@@ -1158,3 +1158,95 @@ class TestPartialPersistUpdatesPlaceholder:
         mock_update_payload.assert_called_once()
         positional = mock_update_payload.call_args.args
         assert positional[1] == placeholder_id
+
+    @patch("app.chat.orchestrator._update_assistant_payload")
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_empty_content_with_placeholder_deletes_row(
+        self, mock_get_conn, mock_create_msg, mock_update_payload
+    ):
+        """Post-review regression: when a tool turn is interrupted
+        (CancelledError / WebSocketSendTimeout / Exception) BEFORE any
+        text has been streamed, ``_persist_partial_assistant`` used to
+        early-return at ``if not full_content and not error_suffix``,
+        leaving the up-front placeholder row as an empty assistant
+        bubble forever in conversation history.
+
+        The fix: when called with ``placeholder_message_id`` set but no
+        content and no error_suffix, the helper must DELETE the
+        placeholder row instead of returning silently. Non-tool turns
+        (no placeholder) still just return None — nothing was inserted
+        for them to begin with.
+        """
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        placeholder_id = uuid.uuid4()
+
+        result = _persist_partial_assistant(
+            _CONV_ID,
+            "",  # No content streamed before the interrupt.
+            "fake-model",
+            None,
+            is_truncated=True,
+            error_suffix=None,
+            tokens_input=None,
+            tokens_output=None,
+            placeholder_message_id=placeholder_id,
+        )
+
+        assert result is None, "When there is nothing to persist the helper must still return None"
+        # No new INSERT and no UPDATE — nothing to write.
+        mock_create_msg.assert_not_called()
+        mock_update_payload.assert_not_called()
+        # Critical: the orphan placeholder row must be deleted so the
+        # conversation history doesn't keep an empty assistant bubble.
+        delete_calls = [
+            call
+            for call in conn.execute.call_args_list
+            if call.args and "DELETE FROM messages" in call.args[0]
+        ]
+        assert len(delete_calls) == 1, (
+            "The empty placeholder must be DELETEd exactly once. "
+            f"Got execute calls: {conn.execute.call_args_list}"
+        )
+        # The DELETE must target the placeholder id we passed in.
+        assert delete_calls[0].args[1] == (str(placeholder_id),)
+        conn.commit.assert_called_once()
+
+    @patch("app.chat.orchestrator._update_assistant_payload")
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_empty_content_without_placeholder_is_still_noop(
+        self, mock_get_conn, mock_create_msg, mock_update_payload
+    ):
+        """Backwards-compat partner to the DELETE regression above:
+        non-tool turns (no placeholder) with no content and no
+        error_suffix must remain a pure noop — no DB access at all.
+        """
+        from app.chat.orchestrator import _persist_partial_assistant
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = _persist_partial_assistant(
+            _CONV_ID,
+            "",
+            "fake-model",
+            None,
+            is_truncated=True,
+            error_suffix=None,
+            tokens_input=None,
+            tokens_output=None,
+            placeholder_message_id=None,
+        )
+
+        assert result is None
+        mock_create_msg.assert_not_called()
+        mock_update_payload.assert_not_called()
+        # No connection should have been opened — pure early return.
+        mock_get_conn.assert_not_called()


### PR DESCRIPTION
## Summary
- **Migration 036** adds `tool_use_id TEXT`, `parent_message_id UUID FK ON DELETE CASCADE`, two partial indexes, and a CHECK that pins `tool_use_id` to `role='tool'`
- Orchestrator inserts an assistant placeholder before tools run, links each tool row via `parent_message_id` + `tool_use_id`, and UPDATEs the placeholder at the end (new helper `_update_assistant_payload`)
- `_build_llm_messages` renders persisted tool turns as `[TOOL_CALL][TOOL_RESULT]` segments — history replay no longer drops tool calls
- Conversation view renders tool messages as collapsible `<details>` with formatted input/output
- Defensive fallbacks for both deploy windows (pre-017, pre-036) so a stale schema cache doesn't break the view
- Closes #315

## Test plan
- [x] `tests/test_chat_tool_use_history.py` — 14 tests (9 unit pass; 5 integration gated on `DATABASE_URL` will verify column/index/CHECK/cascade in CI/prod)
- [x] `tests/test_chat_orchestrator.py` updated — multi-round tokens test reads UPDATE bind instead of `create_message` kwargs
- [x] `tests/test_chat_models_encryption.py` — echo helper updated to 12 INSERT params
- [x] 75 chat tests pass locally; 293 across the broader chat suite pass
- [x] ruff + pyright clean

## Encryption
- `tool_input` and `tool_output` already go through `tool_input_encrypted` / `tool_output_encrypted` BYTEA columns (migration 014; plaintext dropped by 026). `_update_assistant_payload` reuses the same `encrypt_text` primitive for the placeholder's content + rag_context — **zero new plaintext-at-rest surface**.
- New `tool_use_id` is Anthropic's opaque `toolu_...` identifier (no PII), stored unencrypted.

## Migration apply
Could not run `scripts/migrate.py up` locally — no Postgres on 127.0.0.1:5432. Migration will run via Coolify on deploy. Integration tests gated on `DATABASE_URL` will verify in CI/prod.