### PR TITLE
feat(chat): #352 — warn on outdated ontology citations in conversation view

### DIFF
--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -83,6 +83,14 @@ class Message:
     # non-tool messages and for tool messages persisted before #315.
     tool_use_id: str | None = None
     parent_message_id: uuid.UUID | None = None
+    # Migration 037 (#352) — ontology snapshot tag captured when the
+    # assistant message was generated. Format is
+    # ``"<iso-timestamp>@<entity_count>"`` (see
+    # :mod:`app.chat.ontology_version`). Always NULL on user / tool /
+    # system rows; the tool turns inherit their parent assistant's
+    # snapshot via ``parent_message_id``. NULL on assistant rows
+    # persisted before #352 (so drift detection silently no-ops there).
+    ontology_version: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +146,7 @@ _MESSAGE_COLUMNS = (
     "tokens_input, tokens_output, model, created_at, "
     "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
     "rag_context_encrypted, is_pinned, is_truncated, "
-    "tool_use_id, parent_message_id"
+    "tool_use_id, parent_message_id, ontology_version"
 )
 
 # Legacy SELECT list used when migration 017 has not yet applied (the
@@ -164,6 +172,18 @@ _MESSAGE_COLUMNS_PRE036 = (
     "rag_context_encrypted, is_pinned, is_truncated"
 )
 
+# Migration-037 fallback SELECT list — used when the schema is at v036
+# but pre-037 (the ``ontology_version`` column is absent). Same idea as
+# the v017 / v036 fallbacks: keep the conversation view functional in
+# the narrow window between image deploy and migration apply.
+_MESSAGE_COLUMNS_PRE037 = (
+    "id, conversation_id, role, tool_name, "
+    "tokens_input, tokens_output, model, created_at, "
+    "content_encrypted, tool_input_encrypted, tool_output_encrypted, "
+    "rag_context_encrypted, is_pinned, is_truncated, "
+    "tool_use_id, parent_message_id"
+)
+
 
 def _is_missing_v036_column_error(exc: BaseException) -> bool:
     """Return True when the exception names a migration-036 column.
@@ -176,6 +196,17 @@ def _is_missing_v036_column_error(exc: BaseException) -> bool:
     return "does not exist" in msg and any(
         col in msg for col in ("tool_use_id", "parent_message_id")
     )
+
+
+def _is_missing_v037_column_error(exc: BaseException) -> bool:
+    """Return True when the exception names the migration-037 column.
+
+    Used by the read / write paths to detect "schema is v036 but pre-037"
+    and fall back to the prior SQL. ``ontology_version`` is the new
+    column introduced by #352.
+    """
+    msg = str(exc).lower()
+    return "does not exist" in msg and "ontology_version" in msg
 
 
 def _decode_encrypted_text(ciphertext: bytes | memoryview | None) -> str | None:
@@ -286,6 +317,11 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
     parent_message_id: uuid.UUID | None = (
         coerce_uuid(parent_message_id_raw) if parent_message_id_raw else None
     )
+    # Migration 037 (#352) — ontology_version snapshot tag. Defensive
+    # indexing so pre-037 fixtures (16-tuple rows) and pre-037 SELECT
+    # fallbacks still load cleanly.
+    ontology_version_raw = row[16] if len(row) > 16 else None
+    ontology_version: str | None = str(ontology_version_raw) if ontology_version_raw else None
 
     if content_encrypted is None:
         raise ValueError(
@@ -323,6 +359,7 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
         is_truncated=is_truncated,
         tool_use_id=tool_use_id,
         parent_message_id=parent_message_id,
+        ontology_version=ontology_version,
     )
 
 
@@ -598,6 +635,7 @@ def create_message(
     model: str | None = None,
     tool_use_id: str | None = None,
     parent_message_id: uuid.UUID | str | None = None,
+    ontology_version: str | None = None,
 ) -> Message:
     """Insert a new ``messages`` row and return the created message.
 
@@ -609,6 +647,12 @@ def create_message(
     that requested the tool. Both are NULL for non-tool turns. The CHECK
     constraint defined in migration 036 rejects a non-NULL
     ``tool_use_id`` on any role other than 'tool'.
+
+    Migration 037 (#352) — ``ontology_version`` records the ontology
+    snapshot tag the orchestrator captured at the time this assistant
+    message was generated (see :mod:`app.chat.ontology_version`). Only
+    meaningful on role='assistant' rows; tool rows inherit it via
+    ``parent_message_id``.
     """
     if role not in VALID_ROLES:
         raise ValueError(f"Invalid message role: {role!r}")
@@ -646,8 +690,9 @@ def create_message(
             INSERT INTO messages
                 (conversation_id, role, tool_name, tokens_input, tokens_output, model,
                  content_encrypted, tool_input_encrypted, tool_output_encrypted,
-                 rag_context_encrypted, tool_use_id, parent_message_id)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                 rag_context_encrypted, tool_use_id, parent_message_id,
+                 ontology_version)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING {_MESSAGE_COLUMNS}
             """,
             (
@@ -663,9 +708,50 @@ def create_message(
                 rag_context_ciphertext,
                 tool_use_id,
                 parent_message_id_str,
+                ontology_version,
             ),
         ).fetchone()
     except Exception as exc:
+        # Migration-037 fallback: the ``ontology_version`` column may be
+        # absent in a narrow deploy window where the new image hits a
+        # stale schema cache. When that happens AND the caller didn't
+        # set ``ontology_version``, fall back to the pre-037 INSERT
+        # shape; otherwise the loss of the tag would be silent and
+        # confusing (so we re-raise to surface the schema mismatch).
+        if _is_missing_v037_column_error(exc) and ontology_version is None:
+            logger.warning(
+                "create_message: migration 037 column missing — "
+                "falling back to pre-037 INSERT for conversation=%s",
+                conversation_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            row = conn.execute(
+                f"""
+                INSERT INTO messages
+                    (conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                     content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                     rag_context_encrypted, tool_use_id, parent_message_id)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING {_MESSAGE_COLUMNS_PRE037}
+                """,
+                (
+                    str(conversation_id),
+                    role,
+                    tool_name,
+                    tokens_input,
+                    tokens_output,
+                    model,
+                    content_ciphertext,
+                    tool_input_ciphertext,
+                    tool_output_ciphertext,
+                    rag_context_ciphertext,
+                    tool_use_id,
+                    parent_message_id_str,
+                ),
+            ).fetchone()
         # Migration-036 fallback: the new ``tool_use_id`` /
         # ``parent_message_id`` columns might be absent in a deploy
         # window where the new image hits a stale schema cache (same
@@ -673,10 +759,11 @@ def create_message(
         # When that happens AND the caller didn't ask for either field,
         # transparently fall back to the prior INSERT shape; otherwise
         # the loss of tracking would be silent and confusing.
-        if (
+        elif (
             _is_missing_v036_column_error(exc)
             and tool_use_id is None
             and parent_message_id_str is None
+            and ontology_version is None
         ):
             logger.warning(
                 "create_message: migration 036 columns missing — "
@@ -742,9 +829,36 @@ def list_messages(
         ).fetchall()
     except Exception as exc:
         msg = str(exc).lower()
+        is_v037_missing = _is_missing_v037_column_error(exc)
         is_v036_missing = _is_missing_v036_column_error(exc)
         is_v017_missing = "is_pinned" in msg or "is_truncated" in msg
-        if is_v036_missing:
+        if is_v037_missing:
+            logger.warning(
+                "list_messages: migration 037 column missing — falling back"
+                " to pre-037 SELECT for conversation=%s",
+                conversation_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                rows = conn.execute(
+                    f"""
+                    SELECT {_MESSAGE_COLUMNS_PRE037}
+                    FROM messages
+                    WHERE conversation_id = %s
+                    ORDER BY created_at ASC
+                    """,
+                    (str(conversation_id),),
+                ).fetchall()
+            except Exception:
+                logger.exception(
+                    "Pre-037 fallback list_messages failed for conversation=%s",
+                    conversation_id,
+                )
+                return []
+        elif is_v036_missing:
             logger.warning(
                 "list_messages: migration 036 columns missing — falling back"
                 " to pre-036 SELECT for conversation=%s",
@@ -841,6 +955,41 @@ def update_message_truncated(
         "UPDATE messages SET is_truncated = %s WHERE id = %s",
         (bool(truncated), str(message_id)),
     )
+
+
+def update_message_ontology_version(
+    conn: Any,
+    message_id: uuid.UUID | str,
+    ontology_version: str | None,
+) -> None:
+    """Stamp the ontology snapshot tag on a (typically assistant) message.
+
+    Issue #352: in the multi-round tool-use path the assistant
+    placeholder row is INSERTed before the snapshot tag is known to the
+    caller (the orchestrator captures it once at turn start). Once
+    streaming completes, the terminal-events phase calls this helper to
+    record the snapshot. Pre-037 schemas swallow the UPDATE quietly so
+    the deploy window between image rollout and migration apply does
+    not break chat.
+    """
+    try:
+        conn.execute(
+            "UPDATE messages SET ontology_version = %s WHERE id = %s",
+            (ontology_version, str(message_id)),
+        )
+    except Exception as exc:
+        if _is_missing_v037_column_error(exc):
+            logger.warning(
+                "update_message_ontology_version: migration 037 column missing — "
+                "skipping for message=%s",
+                message_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            return
+        raise
 
 
 def list_pinned_messages(

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -714,16 +714,31 @@ def create_message(
     except Exception as exc:
         # Migration-037 fallback: the ``ontology_version`` column may be
         # absent in a narrow deploy window where the new image hits a
-        # stale schema cache. When that happens AND the caller didn't
-        # set ``ontology_version``, fall back to the pre-037 INSERT
-        # shape; otherwise the loss of the tag would be silent and
-        # confusing (so we re-raise to surface the schema mismatch).
-        if _is_missing_v037_column_error(exc) and ontology_version is None:
-            logger.warning(
-                "create_message: migration 037 column missing — "
-                "falling back to pre-037 INSERT for conversation=%s",
-                conversation_id,
-            )
+        # stale schema cache (psycopg raises ``UndefinedColumn`` from
+        # the server). Fall back to the pre-037 INSERT shape and silently
+        # drop the snapshot tag — losing the tag is strictly better than
+        # losing the assistant message altogether. This mirrors the
+        # pre-036 / pre-017 fallback patterns elsewhere in this module.
+        #
+        # Originally we gated this on ``ontology_version is None`` to
+        # avoid silently losing tags. But the orchestrator passes a
+        # non-None tag on every assistant turn, so the gate effectively
+        # broke INSERTs during the rollout window — see #833 review.
+        if _is_missing_v037_column_error(exc):
+            if ontology_version is not None:
+                logger.warning(
+                    "create_message: migration 037 column missing — "
+                    "dropping ontology_version=%r and falling back to "
+                    "pre-037 INSERT for conversation=%s",
+                    ontology_version,
+                    conversation_id,
+                )
+            else:
+                logger.warning(
+                    "create_message: migration 037 column missing — "
+                    "falling back to pre-037 INSERT for conversation=%s",
+                    conversation_id,
+                )
             try:
                 conn.rollback()
             except Exception:
@@ -1163,7 +1178,11 @@ def fork_conversation(
     # the fork reads in the same order as the source up to the boundary.
     # ``tool_use_id`` is preserved; ``parent_message_id`` is dropped
     # (NULL) because the parent assistant row lives in the source
-    # conversation — see docstring.
+    # conversation — see docstring. ``ontology_version`` (migration 037
+    # / #352) is preserved so the fork keeps drift detection on
+    # previously-cited stale ontology answers (otherwise reviewing a
+    # branched conversation would silently lose the "Ontoloogia on
+    # uuenenud" banner — see #833 review).
     try:
         conn.execute(
             """
@@ -1171,13 +1190,13 @@ def fork_conversation(
                 conversation_id, role, tool_name, tokens_input, tokens_output, model,
                 content_encrypted, tool_input_encrypted, tool_output_encrypted,
                 rag_context_encrypted, is_pinned, is_truncated, created_at,
-                tool_use_id
+                tool_use_id, ontology_version
             )
             SELECT
                 %s, role, tool_name, tokens_input, tokens_output, model,
                 content_encrypted, tool_input_encrypted, tool_output_encrypted,
                 rag_context_encrypted, is_pinned, is_truncated, created_at,
-                tool_use_id
+                tool_use_id, ontology_version
             FROM messages
             WHERE conversation_id = %s AND created_at <= %s
             ORDER BY created_at ASC
@@ -1185,35 +1204,98 @@ def fork_conversation(
             (str(new_conv.id), str(source_conv_id), boundary_created_at),
         )
     except Exception as exc:
-        # Migration-036 fallback for fork — if the new columns aren't
-        # present yet, fall back to the pre-036 INSERT shape so the
-        # rollout window doesn't break fork operations.
-        if not _is_missing_v036_column_error(exc):
-            raise
-        logger.warning(
-            "fork_conversation: migration 036 columns missing — falling back"
-            " to pre-036 copy for source=%s",
-            source_conv_id,
-        )
-        try:
-            conn.rollback()
-        except Exception:
-            pass
-        conn.execute(
-            """
-            INSERT INTO messages (
-                conversation_id, role, tool_name, tokens_input, tokens_output, model,
-                content_encrypted, tool_input_encrypted, tool_output_encrypted,
-                rag_context_encrypted, is_pinned, is_truncated, created_at
+        # Migration-037 fallback for fork — if the ``ontology_version``
+        # column isn't present yet, fall back to the pre-037 shape
+        # (still preserving ``tool_use_id``) so the rollout window
+        # doesn't break fork operations.
+        if _is_missing_v037_column_error(exc):
+            logger.warning(
+                "fork_conversation: migration 037 column missing — falling"
+                " back to pre-037 copy for source=%s",
+                source_conv_id,
             )
-            SELECT
-                %s, role, tool_name, tokens_input, tokens_output, model,
-                content_encrypted, tool_input_encrypted, tool_output_encrypted,
-                rag_context_encrypted, is_pinned, is_truncated, created_at
-            FROM messages
-            WHERE conversation_id = %s AND created_at <= %s
-            ORDER BY created_at ASC
-            """,
-            (str(new_conv.id), str(source_conv_id), boundary_created_at),
-        )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO messages (
+                        conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                        content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                        rag_context_encrypted, is_pinned, is_truncated, created_at,
+                        tool_use_id
+                    )
+                    SELECT
+                        %s, role, tool_name, tokens_input, tokens_output, model,
+                        content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                        rag_context_encrypted, is_pinned, is_truncated, created_at,
+                        tool_use_id
+                    FROM messages
+                    WHERE conversation_id = %s AND created_at <= %s
+                    ORDER BY created_at ASC
+                    """,
+                    (str(new_conv.id), str(source_conv_id), boundary_created_at),
+                )
+            except Exception as exc2:
+                # Cascading fallback — if v036 columns are also missing,
+                # drop ``tool_use_id`` too.
+                if not _is_missing_v036_column_error(exc2):
+                    raise
+                logger.warning(
+                    "fork_conversation: migration 036 columns missing — falling"
+                    " back to pre-036 copy for source=%s",
+                    source_conv_id,
+                )
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                conn.execute(
+                    """
+                    INSERT INTO messages (
+                        conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                        content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                        rag_context_encrypted, is_pinned, is_truncated, created_at
+                    )
+                    SELECT
+                        %s, role, tool_name, tokens_input, tokens_output, model,
+                        content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                        rag_context_encrypted, is_pinned, is_truncated, created_at
+                    FROM messages
+                    WHERE conversation_id = %s AND created_at <= %s
+                    ORDER BY created_at ASC
+                    """,
+                    (str(new_conv.id), str(source_conv_id), boundary_created_at),
+                )
+        elif _is_missing_v036_column_error(exc):
+            logger.warning(
+                "fork_conversation: migration 036 columns missing — falling back"
+                " to pre-036 copy for source=%s",
+                source_conv_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            conn.execute(
+                """
+                INSERT INTO messages (
+                    conversation_id, role, tool_name, tokens_input, tokens_output, model,
+                    content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                    rag_context_encrypted, is_pinned, is_truncated, created_at
+                )
+                SELECT
+                    %s, role, tool_name, tokens_input, tokens_output, model,
+                    content_encrypted, tool_input_encrypted, tool_output_encrypted,
+                    rag_context_encrypted, is_pinned, is_truncated, created_at
+                FROM messages
+                WHERE conversation_id = %s AND created_at <= %s
+                ORDER BY created_at ASC
+                """,
+                (str(new_conv.id), str(source_conv_id), boundary_created_at),
+            )
+        else:
+            raise
     return new_conv

--- a/app/chat/ontology_version.py
+++ b/app/chat/ontology_version.py
@@ -1,0 +1,69 @@
+"""Ontology snapshot tag for chat messages (issue #352).
+
+This is the chat-module's local helper for resolving the live ontology
+snapshot tag. The format intentionally mirrors what
+``app.docs.analyze_handler._get_current_ontology_version`` and
+``app.docs.report_routes._current_ontology_version`` write into
+``impact_reports.ontology_version`` (#345 / migration 032) so a future
+audit query can compare a chat message's snapshot to an impact report's
+snapshot with a direct string equality check.
+
+We keep a separate copy rather than importing from ``app.docs`` so the
+chat module does not pull the impact-analysis dependency tree (and so a
+test patching one path does not silently affect the other module's
+behaviour).
+
+Format: ``"<iso-timestamp>@<entity_count>"`` taken from the most recent
+successful ``sync_log`` row, or ``"unknown"`` when the table is empty or
+the query fails — the same fallback the analyze handler uses so the
+"unknown != unknown" drift case never triggers a false-positive banner
+(both sides of the comparison resolve to ``"unknown"``).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from app.db import get_connection
+
+logger = logging.getLogger(__name__)
+
+
+def get_current_ontology_version() -> str:
+    """Return the live Jena sync snapshot tag.
+
+    Best-effort: any DB error (sync_log missing, pool starved, ...)
+    degrades to ``"unknown"`` so the drift detection never blocks chat.
+    Matches the format used by
+    :func:`app.docs.analyze_handler._get_current_ontology_version` so
+    direct string equality detects drift.
+    """
+    try:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT started_at, entity_count
+                FROM sync_log
+                WHERE status = 'success'
+                ORDER BY started_at DESC
+                LIMIT 1
+                """
+            ).fetchone()
+    except Exception:  # noqa: BLE001 — reproducibility tag is best-effort
+        logger.warning(
+            "chat.ontology_version: could not read sync_log; treating as 'unknown'",
+            exc_info=True,
+        )
+        return "unknown"
+
+    if row is None:
+        return "unknown"
+    started_at, entity_count = row
+    if started_at is None:
+        return "unknown"
+    if isinstance(started_at, datetime):
+        ts = started_at.astimezone(UTC).isoformat()
+    else:
+        ts = str(started_at)
+    return f"{ts}@{entity_count or 0}"

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -64,6 +64,7 @@ from app.chat.models import (
     list_messages,
     update_conversation_title,
 )
+from app.chat.ontology_version import get_current_ontology_version
 from app.chat.rate_limiter import (
     CostBudgetExceededError,
     RateLimitExceededError,
@@ -423,6 +424,7 @@ def _persist_partial_assistant(
     tokens_input: int | None = None,
     tokens_output: int | None = None,
     placeholder_message_id: uuid.UUID | None = None,
+    ontology_version: str | None = None,
 ) -> uuid.UUID | None:
     """Persist a partial / truncated assistant message.
 
@@ -446,7 +448,14 @@ def _persist_partial_assistant(
     after the tool rows. Without this, the timeout / cancel / error
     paths inserted a SECOND assistant row alongside the placeholder,
     leaving two assistant messages for one logical turn (one empty
-    parent + one partial sibling).
+    parent + one partial sibling). The placeholder row already carries
+    the turn's ``ontology_version`` from its initial INSERT, so the
+    UPDATE branch does not re-stamp it.
+
+    ``ontology_version`` (#352) is the snapshot tag the orchestrator
+    captured at turn start; on the INSERT branch (non-tool turns), it
+    is stamped on the new partial row so drift detection works when
+    the user re-opens a cancelled / timed-out conversation.
     """
     if not full_content and not error_suffix:
         # Tool turn whose placeholder was inserted up-front but the model
@@ -521,6 +530,7 @@ def _persist_partial_assistant(
                 rag_context=rag_context_json,
                 tokens_input=tokens_input if tokens_input else None,
                 tokens_output=tokens_output if tokens_output else None,
+                ontology_version=ontology_version,
             )
             if is_truncated:
                 try:
@@ -772,6 +782,15 @@ class _TurnContext:
     completed: bool = False
     cancelled: bool = False
     assistant_msg_id: uuid.UUID | None = None
+
+    # Issue #352 — ontology snapshot tag captured once per turn and
+    # stamped on the persisted assistant row. Resolved lazily in
+    # :meth:`ChatOrchestrator._phase_build_system_prompt` so the
+    # ``sync_log`` lookup runs after auth + history loads (so a stalled
+    # ontology DB doesn't block the cheap pre-stream checks). NULL when
+    # the sync_log is empty or the lookup fails — the conversation view
+    # treats NULL as "snapshot unknown, no drift banner".
+    ontology_version: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1247,6 +1266,32 @@ class ChatOrchestrator:
             impact_summary=impact_summary,
         )
 
+        # Issue #352: capture the live ontology snapshot tag exactly once
+        # per turn. We do this even when no RAG / tool grounding ends up
+        # being used — the snapshot describes "what the assistant could
+        # see when it spoke", not "what it actually consulted". Stamped
+        # onto the assistant row in the persist step below. Fail-open:
+        # any error inside the helper resolves to ``"unknown"``.
+        try:
+            ctx.ontology_version = await asyncio.wait_for(
+                asyncio.to_thread(get_current_ontology_version),
+                timeout=_step_deadline(ctx.pre_stream_start),
+            )
+        except TimeoutError:
+            logger.warning(
+                "Ontology snapshot lookup timed out after %.1fs of "
+                "pre-stream budget for conv=%s; stamping NULL",
+                time.monotonic() - ctx.pre_stream_start,
+                ctx.conversation_id,
+            )
+            ctx.ontology_version = None
+        except Exception:
+            logger.exception(
+                "Ontology snapshot lookup failed for conv=%s; stamping NULL",
+                ctx.conversation_id,
+            )
+            ctx.ontology_version = None
+
     # ------------------------------------------------------------------
     # RAG + streaming + terminal phase methods
     # ------------------------------------------------------------------
@@ -1507,6 +1552,11 @@ class ChatOrchestrator:
                                 "assistant",
                                 ctx.full_content,
                                 model=getattr(self.llm, "_model", None),
+                                # #352: stamp the snapshot tag on the
+                                # placeholder so the assistant row carries
+                                # it even if a later UPDATE never runs
+                                # (turn timeout, cancel, etc.).
+                                ontology_version=ctx.ontology_version,
                             )
                             conn.commit()
                             ctx.assistant_msg_id = assistant_msg.id
@@ -1641,6 +1691,7 @@ class ChatOrchestrator:
                     tokens_input=ctx.tokens_in,
                     tokens_output=ctx.tokens_out,
                     placeholder_message_id=ctx.assistant_msg_id,
+                    ontology_version=ctx.ontology_version,
                 )
             try:
                 await _safe_send(
@@ -1676,6 +1727,7 @@ class ChatOrchestrator:
                     tokens_input=ctx.tokens_in,
                     tokens_output=ctx.tokens_out,
                     placeholder_message_id=ctx.assistant_msg_id,
+                    ontology_version=ctx.ontology_version,
                 )
             )
             # #661: shield the stopped-event send from a second cancel
@@ -1719,6 +1771,7 @@ class ChatOrchestrator:
                 tokens_input=ctx.tokens_in,
                 tokens_output=ctx.tokens_out,
                 placeholder_message_id=ctx.assistant_msg_id,
+                ontology_version=ctx.ontology_version,
             )
             return False
         except Exception:
@@ -1746,6 +1799,7 @@ class ChatOrchestrator:
                     tokens_input=ctx.tokens_in,
                     tokens_output=ctx.tokens_out,
                     placeholder_message_id=ctx.assistant_msg_id,
+                    ontology_version=ctx.ontology_version,
                 )
             try:
                 await _safe_send(
@@ -1806,6 +1860,11 @@ class ChatOrchestrator:
                             tokens_output=ctx.tokens_out if ctx.tokens_out else None,
                             model=getattr(self.llm, "_model", None),
                             rag_context=ctx.rag_context_json,
+                            # #352: stamp the ontology snapshot tag so
+                            # the conversation view can later detect
+                            # drift relative to the live sync_log
+                            # snapshot. NULL when the lookup failed.
+                            ontology_version=ctx.ontology_version,
                         )
                         # Also bump conversation updated_at.
                         conn.execute(

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -1375,6 +1375,13 @@ class ChatOrchestrator:
                 {
                     "content": chunk.content,
                     "source_uri": chunk.metadata.get("source_uri"),
+                    # #833 review: persist source_type so the drift
+                    # detector in app.chat.routes can distinguish
+                    # ontology-grounded chunks (``ontology`` / ``law_text``
+                    # / ``court_decision`` / ``eu_act``) from private
+                    # draft-grounded chunks (``draft``) — only the former
+                    # should trigger the "Ontoloogia on uuenenud" banner.
+                    "source_type": chunk.metadata.get("source_type"),
                     "score": chunk.score,
                 }
                 for chunk in ctx.rag_chunks

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -47,6 +47,7 @@ from app.chat.models import (
     list_conversations_for_user,
     list_messages,
 )
+from app.chat.ontology_version import get_current_ontology_version
 from app.chat.pending_seed import (
     consume_pending_seed,
     create_pending_seed,
@@ -984,6 +985,133 @@ def _rag_sources_block(rag_context: list[dict] | None):
     )
 
 
+# ---------------------------------------------------------------------------
+# #352 — outdated-ontology drift banner
+# ---------------------------------------------------------------------------
+
+
+# Chat tool names that reference ontology nodes. When a stored
+# assistant turn has children of these tool kinds, OR carries
+# ``rag_context`` (RAG chunks are sourced from the ontology), we consider
+# it "ontology-grounded" and worth checking for drift. Other tool names
+# (e.g. future non-ontology tools) would not. Mirrors the executor map
+# in :mod:`app.chat.tools` so it stays in sync when tools are added.
+_ONTOLOGY_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "query_ontology",
+        "search_provisions",
+        "get_draft_impact",
+        "get_provision_details",
+        "get_court_decisions_for_provision",
+        "get_eu_transposition_for_provision",
+        "get_provision_amendments",
+        "get_related_concepts",
+    }
+)
+
+
+def _conversation_has_outdated_ontology_citations(
+    messages: list[Any],
+    current_version: str,
+) -> bool:
+    """Return True when at least one assistant message in *messages*
+    was generated against an older ontology snapshot than *current_version*
+    AND that message actually grounded its answer on ontology nodes
+    (either via RAG chunks or a tool-use turn referencing ontology).
+
+    "Older" is a literal string-inequality check on the snapshot tags
+    (``<iso-timestamp>@<entity_count>`` — see
+    :mod:`app.chat.ontology_version`). NULL / "unknown" on either side
+    is treated as "cannot detect drift" and skipped silently, so the
+    banner never fires on pre-#352 rows (those still carry NULL).
+
+    We pair each assistant row with its tool children (linked via
+    ``parent_message_id`` from migration 036 / #315) so we can tell
+    whether the answer was grounded on the ontology at all — a turn
+    that asked the model a generic question with no RAG chunks and no
+    SPARQL tool use does not deserve a drift banner.
+    """
+    if not current_version or current_version == "unknown":
+        return False
+
+    # Group tool messages by parent so we can ask "did this assistant
+    # turn use an ontology tool?" in O(1).
+    tools_by_parent: dict[Any, list[Any]] = {}
+    for msg in messages:
+        if getattr(msg, "role", None) != "tool":
+            continue
+        parent = getattr(msg, "parent_message_id", None)
+        if parent is None:
+            continue
+        tools_by_parent.setdefault(parent, []).append(msg)
+
+    for msg in messages:
+        if getattr(msg, "role", None) != "assistant":
+            continue
+        msg_version = getattr(msg, "ontology_version", None)
+        if not msg_version or msg_version == "unknown":
+            # Pre-#352 row or lookup-failed row — cannot detect drift.
+            continue
+        if msg_version == current_version:
+            continue
+
+        # Drift candidate — confirm the turn was ontology-grounded.
+        rag_context = getattr(msg, "rag_context", None)
+        if rag_context:
+            return True
+        children = tools_by_parent.get(getattr(msg, "id", None), [])
+        if any((c.tool_name or "") in _ONTOLOGY_TOOL_NAMES for c in children):
+            return True
+
+    return False
+
+
+def _render_outdated_ontology_banner(conv_id: uuid.UUID):
+    """Render the warning banner shown when at least one assistant turn
+    in this conversation was generated against an older ontology
+    snapshot than the live one.
+
+    The "Küsi uuesti" action navigates to ``/chat/{conv_id}`` with the
+    ``?reask=1`` flag — the GET handler resolves the most recent
+    persisted user message and pre-fills the textarea with it
+    (mirroring the #724 seed mechanism, but without burning a token).
+    The user then chooses whether to send. This is intentionally
+    simpler than wiring a one-click "regenerate the last turn"
+    affordance: the user retains full control over what gets re-asked.
+    """
+    return Alert(
+        Div(  # noqa: F405
+            P(  # noqa: F405
+                "Mõned viidatud allikad võivad olla aegunud. "
+                "Ontoloogia on uuenenud pärast nende vastuste "
+                "genereerimist.",
+                cls="chat-outdated-ontology-text",
+            ),
+            A(  # noqa: F405
+                "Küsi uuesti",
+                href=f"/chat/{conv_id}?reask=1",
+                cls="chat-outdated-ontology-reask",
+                title="Eeltäida sisestusväli sinu viimase küsimusega.",
+            ),
+            cls="chat-outdated-ontology-banner",
+        ),
+        variant="warning",
+        title="Ontoloogia on uuenenud",
+        cls="chat-outdated-ontology-alert",
+        data_outdated_ontology="1",
+    )
+
+
+def _resolve_last_user_message_text(messages: list[Any]) -> str:
+    """Return the content of the most recent ``role='user'`` message,
+    or the empty string when no user turn exists. Used by the
+    ``?reask=1`` re-ask flow to pre-fill the textarea."""
+    for msg in reversed(messages):
+        if getattr(msg, "role", None) == "user":
+            return (getattr(msg, "content", None) or "")[:4000]
+    return ""
+
+
 def _render_message(msg: Any):
     """Render a single message as a chat bubble."""
     role = msg.role
@@ -1245,6 +1373,17 @@ def conversation_view_page(req: Request, conv_id: str):
     visible_messages = [m for m in messages if m.role != "system"]
     message_bubbles = [_render_message(m) for m in visible_messages]
 
+    # #352: detect ontology drift across the conversation. We render a
+    # single conversation-level banner (rather than per-message badges)
+    # to keep the chat surface uncluttered — the user is mostly going to
+    # re-ask their question anyway, and the banner makes that the
+    # obvious action.
+    current_ontology_version = get_current_ontology_version()
+    show_outdated_banner = _conversation_has_outdated_ontology_citations(
+        messages, current_ontology_version
+    )
+    outdated_banner = _render_outdated_ontology_banner(parsed) if show_outdated_banner else ""
+
     # #724: a ?seed=<token> means we arrived here from a "Küsi nõustajalt
     # selle leiu kohta" affordance — consume the single-use token and
     # pre-fill the input textarea with the stashed finding/question. The
@@ -1263,6 +1402,15 @@ def conversation_view_page(req: Request, conv_id: str):
             consumed = None
         if consumed is not None:
             prefill_text = consumed[0] or ""
+
+    # #352: ``?reask=1`` is the "Küsi uuesti" affordance on the
+    # outdated-ontology banner. When present (and no seed token took
+    # precedence above), pre-fill the textarea with the most recent
+    # persisted user message so the user can re-send it against the
+    # fresh ontology. A reload without ``?reask=1`` shows an empty
+    # textarea, matching the seed-token UX.
+    if not prefill_text and req.query_params.get("reask") == "1":
+        prefill_text = _resolve_last_user_message_text(messages)
 
     # Empty-state — only shown on the initial render with no user/assistant turns.
     prompts = _DRAFT_EXAMPLE_PROMPTS if conversation.context_draft_id else _DEFAULT_EXAMPLE_PROMPTS
@@ -1405,6 +1553,13 @@ def conversation_view_page(req: Request, conv_id: str):
     content_parts: list = []
     if draft_header:
         content_parts.append(draft_header)
+    # #352: drift banner sits between the draft header and the chat
+    # container so it is the first thing the user sees inside the
+    # conversation surface but does not displace the existing
+    # draft-context header. Rendered as empty string when no drift is
+    # detected, so the layout is unchanged in the happy path.
+    if outdated_banner:
+        content_parts.append(outdated_banner)
     content_parts.append(chat_container)
 
     # Vendor libs for markdown rendering on the client side. The URLs pin

--- a/app/chat/routes.py
+++ b/app/chat/routes.py
@@ -1010,6 +1010,55 @@ _ONTOLOGY_TOOL_NAMES: frozenset[str] = frozenset(
 )
 
 
+# RAG ``source_type`` values that are sourced from the public ontology
+# (the JSON-LD source graph synced into Jena Fuseki) — see
+# ``migrations/009_rag_chunks.sql`` for the CHECK constraint. A chunk
+# tagged with one of these source types reflects ontology state at
+# retrieval time, so a stale snapshot tag on the same turn means the
+# answer may now be outdated. ``draft`` chunks (private uploads) are
+# explicitly excluded — they are tenant-private and unaffected by
+# ontology-side drift.
+_ONTOLOGY_RAG_SOURCE_TYPES: frozenset[str] = frozenset(
+    {
+        "ontology",
+        "law_text",
+        "court_decision",
+        "eu_act",
+    }
+)
+
+
+def _rag_context_grounds_on_ontology(rag_context: Any) -> bool:
+    """Return True when at least one chunk in *rag_context* is sourced
+    from the public ontology (not a private draft).
+
+    ``rag_context`` is the persisted list-of-dicts produced by
+    :mod:`app.chat.orchestrator` (see ``rag_context_json`` build site).
+    Post-#833 each chunk carries a ``source_type`` field — when present,
+    we accept the chunk only if its ``source_type`` is in
+    :data:`_ONTOLOGY_RAG_SOURCE_TYPES`. Pre-#833 chunks (and any chunk
+    where ``source_type`` is missing/None) are accepted to preserve the
+    older behaviour and keep the banner working for legacy rows.
+    """
+    if not rag_context or not isinstance(rag_context, list):
+        return False
+    for chunk in rag_context:
+        if not isinstance(chunk, dict):
+            # Unexpected shape — be defensive and treat as
+            # ontology-grounded to preserve the older behaviour.
+            return True
+        source_type = chunk.get("source_type")
+        if source_type is None:
+            # Legacy chunk persisted before #833 — no source_type was
+            # captured, so we cannot rule it out. Treat as
+            # ontology-grounded so historical drift detection still
+            # fires for those rows.
+            return True
+        if source_type in _ONTOLOGY_RAG_SOURCE_TYPES:
+            return True
+    return False
+
+
 def _conversation_has_outdated_ontology_citations(
     messages: list[Any],
     current_version: str,
@@ -1030,6 +1079,12 @@ def _conversation_has_outdated_ontology_citations(
     whether the answer was grounded on the ontology at all — a turn
     that asked the model a generic question with no RAG chunks and no
     SPARQL tool use does not deserve a drift banner.
+
+    #833 review: RAG ``source_type`` is now consulted before accepting
+    the chunk as ontology-grounded. A chunk tagged ``source_type='draft'``
+    is private to the tenant and unaffected by ontology drift, so
+    seeing only draft chunks in ``rag_context`` does NOT fire the
+    banner.
     """
     if not current_version or current_version == "unknown":
         return False
@@ -1057,7 +1112,7 @@ def _conversation_has_outdated_ontology_citations(
 
         # Drift candidate — confirm the turn was ontology-grounded.
         rag_context = getattr(msg, "rag_context", None)
-        if rag_context:
+        if _rag_context_grounds_on_ontology(rag_context):
             return True
         children = tools_by_parent.get(getattr(msg, "id", None), [])
         if any((c.tool_name or "") in _ONTOLOGY_TOOL_NAMES for c in children):

--- a/migrations/037_message_ontology_version.sql
+++ b/migrations/037_message_ontology_version.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- Migration 037: messages.ontology_version (#352)
+-- =============================================================================
+--
+-- Issue #352 ("Chat cites outdated ontology warning"):
+--   When a chat assistant message cites ontology nodes (provisions, EU
+--   acts, court decisions, etc.) via the RAG retrieval or the SPARQL
+--   tools, we want to remember which snapshot of the ontology the
+--   message was grounded against. Then, on conversation view, we can
+--   detect "ontology has been updated since this answer was generated"
+--   and surface a banner inviting the user to re-ask.
+--
+--   This mirrors the pattern established by #345 + migration 032 for
+--   ``impact_reports.ontology_version`` — the value is the same
+--   ``<iso-timestamp>@<entity_count>`` snapshot tag produced by
+--   ``app/docs/analyze_handler.py::_get_current_ontology_version`` (and
+--   the chat module's local copy in ``app/chat/ontology_version.py``).
+--
+-- Column semantics:
+--   - ``ontology_version`` is TEXT NULL. NULL means "we don't know what
+--     snapshot this message used" — true for every assistant message
+--     persisted before this migration applied, and true for any message
+--     whose ontology lookup failed gracefully. NULL is treated as
+--     "cannot detect drift" by the conversation view (no banner shown).
+--   - Stamped only on role='assistant' rows by the orchestrator. Tool
+--     rows inherit the snapshot via their parent_message_id (added by
+--     migration 036 / #315) — there is no point storing the same
+--     snapshot tag on every tool row.
+--   - NOT FK'd anywhere — the value is a reproducibility tag derived
+--     from the live ``sync_log`` table at message-write time, not a
+--     persistent identifier.
+--
+-- Idempotency:
+--   - ADD COLUMN IF NOT EXISTS for the column.
+--   - No backfill: existing assistant rows stay NULL on purpose
+--     (their pre-#352 snapshot is unknowable).
+--
+-- ROLLBACK procedure (manual; requires app on pre-#352 code):
+--   ALTER TABLE messages DROP COLUMN IF EXISTS ontology_version;
+--   DELETE FROM schema_migrations WHERE version = '037_message_ontology_version';
+-- =============================================================================
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS ontology_version TEXT NULL;

--- a/tests/test_chat_models_encryption.py
+++ b/tests/test_chat_models_encryption.py
@@ -44,8 +44,9 @@ def _echo_row(conn_mock: MagicMock) -> list[Any]:
     """Capture the INSERT params and build a matching row for ``fetchone``.
 
     Migration 026 dropped the plaintext payload columns. Migration 036
-    (#315) added ``tool_use_id`` + ``parent_message_id``; the INSERT
-    now binds 12 positional params and ``_MESSAGE_COLUMNS`` is 16 wide.
+    (#315) added ``tool_use_id`` + ``parent_message_id``. Migration 037
+    (#352) added ``ontology_version``. The INSERT now binds 13
+    positional params and ``_MESSAGE_COLUMNS`` is 17 wide.
     """
     params = conn_mock.execute.call_args.args[1]
     (
@@ -61,6 +62,7 @@ def _echo_row(conn_mock: MagicMock) -> list[Any]:
         rag_context_ct,
         tool_use_id,
         parent_message_id,
+        ontology_version,
     ) = params
     now = datetime.now(UTC)
     return [
@@ -80,6 +82,7 @@ def _echo_row(conn_mock: MagicMock) -> list[Any]:
         False,  # is_truncated (v017)
         tool_use_id,
         parent_message_id,
+        ontology_version,
     ]
 
 

--- a/tests/test_chat_outdated_ontology.py
+++ b/tests/test_chat_outdated_ontology.py
@@ -1,0 +1,651 @@
+# pyright: reportArgumentType=false
+"""Tests for the outdated-ontology drift banner (#352).
+
+Covers:
+  - Migration 037 adds ``messages.ontology_version`` (integration test;
+    skipped when ``DATABASE_URL`` is not set).
+  - The orchestrator stamps the live ontology snapshot tag on the
+    persisted assistant row.
+  - The conversation view renders the warning banner when at least one
+    assistant message has a stale snapshot AND that message is
+    ontology-grounded (RAG context or ontology tool children).
+  - The banner is absent when versions match, when versions are
+    ``"unknown"``, or when the assistant turn cited no ontology.
+  - The banner carries the "Küsi uuesti" affordance pointing at
+    ``/chat/{conv_id}?reask=1``.
+  - The ``?reask=1`` flow pre-fills the textarea with the most recent
+    user turn so the user can re-ask the same question against the
+    fresh ontology.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.chat.models import Conversation, Message
+
+# ---------------------------------------------------------------------------
+# Fixtures and shared helpers (mirrors tests/test_chat_routes.py + _orchestrator.py)
+# ---------------------------------------------------------------------------
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_CONV_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _make_conversation(
+    *,
+    conv_id: uuid.UUID = _CONV_ID,
+    org_id: str = _ORG_ID,
+    user_id: str = _USER_ID,
+    title: str = "Test vestlus",
+) -> Conversation:
+    now = datetime.now(UTC)
+    return Conversation(
+        id=conv_id,
+        user_id=uuid.UUID(user_id),
+        org_id=uuid.UUID(org_id),
+        title=title,
+        context_draft_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_message(
+    role: str = "user",
+    content: str = "Tere",
+    *,
+    msg_id: uuid.UUID | None = None,
+    ontology_version: str | None = None,
+    rag_context: list[dict] | None = None,
+    tool_name: str | None = None,
+    parent_message_id: uuid.UUID | None = None,
+) -> Message:
+    now = datetime.now(UTC)
+    return Message(
+        id=msg_id or uuid.uuid4(),
+        conversation_id=_CONV_ID,
+        role=role,
+        content=content,
+        tool_name=tool_name,
+        tool_input=None,
+        tool_output=None,
+        rag_context=rag_context,
+        tokens_input=None,
+        tokens_output=None,
+        model=None,
+        created_at=now,
+        ontology_version=ontology_version,
+        parent_message_id=parent_message_id,
+    )
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Migration 037 — column existence (integration test)
+# ---------------------------------------------------------------------------
+
+
+class TestMigration037Column:
+    """Verifies that migration 037 adds ``messages.ontology_version`` as a
+    nullable TEXT column. Skipped when ``DATABASE_URL`` is unset (same
+    pattern as ``tests/test_migration_025.py``)."""
+
+    def test_messages_ontology_version_column_exists(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("integration test — DATABASE_URL not set")
+        from app.db import get_connection
+
+        with get_connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT data_type, is_nullable
+                FROM information_schema.columns
+                WHERE table_name = 'messages'
+                  AND column_name = 'ontology_version'
+                """
+            )
+            row = cur.fetchone()
+        assert row is not None, (
+            "messages.ontology_version column missing — migration 037 not applied"
+        )
+        data_type, is_nullable = row
+        assert data_type == "text", f"expected TEXT, got {data_type!r}"
+        assert is_nullable == "YES", f"expected nullable, got {is_nullable!r}"
+
+
+# ---------------------------------------------------------------------------
+# Drift detector (pure function — no DB / TestClient required)
+# ---------------------------------------------------------------------------
+
+
+class TestDriftDetector:
+    def test_no_drift_when_versions_match(self):
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version="2026-05-20T10:00:00+00:00@90000",
+                rag_context=[{"source_uri": "estleg:ks_113", "score": 0.9}],
+            ),
+        ]
+        assert (
+            _conversation_has_outdated_ontology_citations(msgs, "2026-05-20T10:00:00+00:00@90000")
+            is False
+        )
+
+    def test_no_drift_when_assistant_version_is_unknown(self):
+        """Pre-#352 rows carry NULL (or "unknown"); the banner must NOT fire."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version=None,
+                rag_context=[{"source_uri": "estleg:ks_113"}],
+            ),
+            _make_message(
+                "assistant",
+                "Vastus2...",
+                ontology_version="unknown",
+                rag_context=[{"source_uri": "estleg:ks_114"}],
+            ),
+        ]
+        assert (
+            _conversation_has_outdated_ontology_citations(msgs, "2026-05-21T10:00:00+00:00@90100")
+            is False
+        )
+
+    def test_no_drift_when_current_version_is_unknown(self):
+        """Live sync_log unavailable → "unknown"; do NOT show banner."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version="2026-05-20T10:00:00+00:00@90000",
+                rag_context=[{"source_uri": "estleg:ks_113"}],
+            ),
+        ]
+        assert _conversation_has_outdated_ontology_citations(msgs, "unknown") is False
+
+    def test_no_drift_when_assistant_did_not_cite_ontology(self):
+        """An older snapshot tag without RAG context AND without ontology
+        tool children does not warrant a banner — the answer was not
+        grounded on the ontology in the first place."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Räägi mulle nalja"),
+            _make_message(
+                "assistant",
+                "Naljakas vastus...",
+                ontology_version="2026-05-20T10:00:00+00:00@90000",
+                rag_context=None,
+            ),
+        ]
+        assert (
+            _conversation_has_outdated_ontology_citations(msgs, "2026-05-21T10:00:00+00:00@90100")
+            is False
+        )
+
+    def test_drift_detected_when_rag_grounded_assistant_is_stale(self):
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus tugineb sätetele...",
+                ontology_version="2026-05-20T10:00:00+00:00@90000",
+                rag_context=[
+                    {"source_uri": "estleg:ks_113", "score": 0.9},
+                    {"source_uri": "estleg:ks_114", "score": 0.8},
+                ],
+            ),
+        ]
+        assert (
+            _conversation_has_outdated_ontology_citations(msgs, "2026-05-21T11:00:00+00:00@90100")
+            is True
+        )
+
+    def test_drift_detected_when_tool_grounded_assistant_is_stale(self):
+        """An assistant turn that invoked ``search_provisions`` (or any
+        other ontology tool) qualifies even without RAG context — the
+        tool answer itself came from the ontology."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        assistant_id = uuid.uuid4()
+        msgs = [
+            _make_message("user", "Otsi sätet TsiviilS § 113"),
+            _make_message(
+                "assistant",
+                "Otsisin ja leidsin...",
+                msg_id=assistant_id,
+                ontology_version="2026-05-20T10:00:00+00:00@90000",
+                rag_context=None,
+            ),
+            _make_message(
+                "tool",
+                '{"results": []}',
+                tool_name="search_provisions",
+                parent_message_id=assistant_id,
+            ),
+        ]
+        assert (
+            _conversation_has_outdated_ontology_citations(msgs, "2026-05-21T11:00:00+00:00@90100")
+            is True
+        )
+
+    def test_drift_ignores_non_ontology_tools(self):
+        """Hypothetical future non-ontology tool children should NOT
+        trigger the banner. The current _ONTOLOGY_TOOL_NAMES set is the
+        gatekeeper."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        assistant_id = uuid.uuid4()
+        msgs = [
+            _make_message("user", "Mis kell on?"),
+            _make_message(
+                "assistant",
+                "Kell on...",
+                msg_id=assistant_id,
+                ontology_version="2026-05-20T10:00:00+00:00@90000",
+                rag_context=None,
+            ),
+            _make_message(
+                "tool",
+                '{"now": "2026-05-21"}',
+                tool_name="get_current_time",
+                parent_message_id=assistant_id,
+            ),
+        ]
+        assert (
+            _conversation_has_outdated_ontology_citations(msgs, "2026-05-21T11:00:00+00:00@90100")
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Conversation view — end-to-end banner rendering
+# ---------------------------------------------------------------------------
+
+
+_OLD_VERSION = "2026-05-20T10:00:00+00:00@90000"
+_NEW_VERSION = "2026-05-21T11:00:00+00:00@90100"
+
+
+class TestConversationViewBanner:
+    @patch("app.chat.routes.get_current_ontology_version", return_value=_NEW_VERSION)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_banner_when_no_messages(self, mock_provider, mock_connect, _mock_ver):
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=[]),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "Mõned viidatud allikad võivad olla aegunud" not in resp.text
+
+    @patch("app.chat.routes.get_current_ontology_version", return_value=_NEW_VERSION)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_banner_when_all_versions_match(self, mock_provider, mock_connect, _mock_ver):
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version=_NEW_VERSION,
+                rag_context=[{"source_uri": "estleg:ks_113"}],
+            ),
+        ]
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=msgs),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "Mõned viidatud allikad võivad olla aegunud" not in resp.text
+
+    @patch("app.chat.routes.get_current_ontology_version", return_value=_NEW_VERSION)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_banner_shown_when_assistant_is_stale(self, mock_provider, mock_connect, _mock_ver):
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        msgs = [
+            _make_message("user", "Mis on TsiviilS § 113?"),
+            _make_message(
+                "assistant",
+                "Vastus tugineb sätetele...",
+                ontology_version=_OLD_VERSION,
+                rag_context=[{"source_uri": "estleg:ks_113", "score": 0.9}],
+            ),
+        ]
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=msgs),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "Mõned viidatud allikad võivad olla aegunud" in resp.text
+            assert "Ontoloogia on uuenenud" in resp.text
+
+    @patch("app.chat.routes.get_current_ontology_version", return_value=_NEW_VERSION)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_banner_contains_reask_link(self, mock_provider, mock_connect, _mock_ver):
+        """DoD: the banner must link to a 'Küsi uuesti' affordance that
+        the user can click to re-ask the question against fresh data."""
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version=_OLD_VERSION,
+                rag_context=[{"source_uri": "estleg:ks_113"}],
+            ),
+        ]
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=msgs),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "Küsi uuesti" in resp.text
+            assert f"/chat/{_CONV_ID}?reask=1" in resp.text
+
+    @patch("app.chat.routes.get_current_ontology_version", return_value=_NEW_VERSION)
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_reask_prefills_textarea_with_last_user_message(
+        self, mock_provider, mock_connect, _mock_ver
+    ):
+        """When the user clicks the banner's 'Küsi uuesti' link, the
+        view prefills the textarea with the most recent persisted user
+        message (so the user can choose whether to re-send it)."""
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vana vastus...",
+                ontology_version=_OLD_VERSION,
+                rag_context=[{"source_uri": "estleg:ks_113"}],
+            ),
+            _make_message("user", "Aga § 114?"),
+            _make_message(
+                "assistant",
+                "Veel üks vastus...",
+                ontology_version=_OLD_VERSION,
+                rag_context=[{"source_uri": "estleg:ks_114"}],
+            ),
+        ]
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=msgs),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}?reask=1")
+            assert resp.status_code == 200
+            # The most recent user turn ends up inside the textarea body.
+            # FastHTML renders the textarea's positional string child as
+            # its body content.
+            assert "Aga § 114?" in resp.text
+
+    @patch("app.chat.routes.get_current_ontology_version", return_value="unknown")
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_no_banner_when_sync_log_unavailable(self, mock_provider, mock_connect, _mock_ver):
+        """When the live ontology version resolves to 'unknown' (sync_log
+        empty, DB error), we must NOT show a banner — that would be a
+        false positive."""
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _make_conversation()
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version=_OLD_VERSION,
+                rag_context=[{"source_uri": "estleg:ks_113"}],
+            ),
+        ]
+        with (
+            patch("app.chat.routes.get_conversation", return_value=conv),
+            patch("app.chat.routes.list_messages", return_value=msgs),
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 200
+            assert "Mõned viidatud allikad võivad olla aegunud" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — stamps ontology_version on assistant message
+# ---------------------------------------------------------------------------
+
+
+_ORCH_USER_ID = "11111111-1111-1111-1111-111111111111"
+_ORCH_ORG_ID = "22222222-2222-2222-2222-222222222222"
+_ORCH_CONV_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_ORCH_MSG_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+
+
+def _orch_auth() -> dict[str, Any]:
+    return {"id": _ORCH_USER_ID, "org_id": _ORCH_ORG_ID}
+
+
+def _orch_conv() -> Conversation:
+    now = datetime.now(UTC)
+    return Conversation(
+        id=_ORCH_CONV_ID,
+        user_id=uuid.UUID(_ORCH_USER_ID),
+        org_id=uuid.UUID(_ORCH_ORG_ID),
+        title="Test",
+        context_draft_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _orch_base_conv_row(conv: Conversation) -> tuple[Any, ...]:
+    return (
+        conv.id,
+        conv.user_id,
+        conv.org_id,
+        conv.title,
+        None,
+        conv.created_at,
+        conv.updated_at,
+    )
+
+
+def _orch_user_row() -> tuple[Any, ...]:
+    """A minimal post-026 messages row tuple for create_message RETURNING."""
+    return (
+        uuid.uuid4(),
+        _ORCH_CONV_ID,
+        "user",
+        "x",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        datetime.now(UTC),
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+class TestOrchestratorStampsOntologyVersion:
+    """The orchestrator must capture the live ontology version once per
+    turn and pass it to ``create_message`` for the persisted assistant
+    row. Mirrors the patterns in ``tests/test_chat_orchestrator.py``."""
+
+    @patch(
+        "app.chat.orchestrator.get_current_ontology_version",
+        return_value=_NEW_VERSION,
+    )
+    @patch("app.chat.orchestrator.create_message")
+    @patch("app.chat.orchestrator.get_connection")
+    def test_assistant_message_carries_ontology_version(
+        self, mock_get_conn, mock_create_msg, _mock_ver
+    ):
+        # Reuse the existing fake LLM / SPARQL classes from the
+        # orchestrator test suite — they already implement every
+        # abstract method on ``LLMProvider`` (complete / extract_json /
+        # count_tokens / acomplete / astream).
+        from app.chat.orchestrator import ChatOrchestrator
+        from app.llm.provider import StreamEvent
+        from tests.test_chat_orchestrator import FakeLLM, FakeSparql, _Collector
+
+        conn = MagicMock()
+        mock_get_conn.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_get_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        conv = _orch_conv()
+        call_counter = {"n": 0}
+
+        def side_effect_fetchone():
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                return _orch_base_conv_row(conv)
+            return _orch_user_row()
+
+        conn.execute.return_value.fetchone = side_effect_fetchone
+        conn.execute.return_value.fetchall.return_value = []
+        mock_create_msg.return_value = MagicMock(id=_ORCH_MSG_ID)
+
+        events = [
+            [
+                StreamEvent(type="content", delta="Tere!"),
+                StreamEvent(type="stop", tokens_input=10, tokens_output=5),
+            ]
+        ]
+        orchestrator = ChatOrchestrator(FakeLLM(events), FakeSparql())  # type: ignore[arg-type]
+        collector = _Collector()
+        asyncio.run(orchestrator.handle_message(_ORCH_CONV_ID, "Tere", _orch_auth(), collector))
+
+        assistant_calls = [
+            c for c in mock_create_msg.call_args_list if c.args[2:3] == ("assistant",)
+        ]
+        assert assistant_calls, "expected at least one assistant create_message call"
+        assistant_call = assistant_calls[-1]
+        assert assistant_call.kwargs.get("ontology_version") == _NEW_VERSION, (
+            "assistant message must be stamped with the live ontology "
+            f"snapshot tag — got {assistant_call.kwargs.get('ontology_version')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-org isolation (regression guard — banner must not leak)
+# ---------------------------------------------------------------------------
+
+
+_OTHER_ORG_ID = "22222222-2222-2222-2222-222222222222"
+
+
+class TestCrossOrgIsolation:
+    """Adding the banner must not relax the owner-only access check on
+    the conversation view. A user from a different org gets the same
+    not-found response they got before #352."""
+
+    @patch("app.chat.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_cross_org_still_returns_not_found(self, mock_provider, mock_connect):
+        mock_provider.return_value = _stub_provider()
+        conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        other_user = "99999999-9999-9999-9999-999999999999"
+        conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=other_user)
+        with patch("app.chat.routes.get_conversation", return_value=conv):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}")
+            assert resp.status_code == 404
+            # And the banner text must NOT appear on the not-found page.
+            assert "Mõned viidatud allikad võivad olla aegunud" not in resp.text

--- a/tests/test_chat_outdated_ontology.py
+++ b/tests/test_chat_outdated_ontology.py
@@ -649,3 +649,411 @@ class TestCrossOrgIsolation:
             assert resp.status_code == 404
             # And the banner text must NOT appear on the not-found page.
             assert "Mõned viidatud allikad võivad olla aegunud" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# #833 review fixes — pre-037 fallback, fork preservation, RAG drift filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _fernet_key_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a deterministic Fernet key for the create_message tests
+    in this section (mirrors ``tests/test_chat_models.py``)."""
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("STORAGE_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    import app.storage.encrypted as encrypted_module
+
+    monkeypatch.setattr(encrypted_module, "_fernet", None)
+
+
+class TestCreateMessagePre037Fallback:
+    """#833 review (P1): when the assistant message INSERT hits an
+    ``UndefinedColumn`` for ``ontology_version`` (deploy window before
+    migration 037 applies), the helper MUST retry without the column.
+
+    The previous code gated the fallback on ``ontology_version is None``
+    — but the orchestrator always passes the live snapshot tag, so the
+    gate effectively turned every assistant INSERT into a hard failure
+    until migration 037 landed.
+    """
+
+    def test_assistant_insert_falls_back_when_column_missing(self, _fernet_key_local):
+        from app.chat.models import create_message
+        from app.storage import encrypt_text
+
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+        msg_id = uuid.uuid4()
+        now = datetime.now(UTC)
+
+        # A pre-037 row tuple is 16 wide (no ``ontology_version`` at the
+        # tail). ``_row_to_message`` indexes defensively, so a 16-tuple
+        # loads cleanly with ``ontology_version=None``.
+        pre_037_row = (
+            msg_id,
+            conv_id,
+            "assistant",
+            None,  # tool_name
+            10,  # tokens_input
+            5,  # tokens_output
+            "claude",
+            now,
+            encrypt_text("Vastus tugineb sätetele..."),
+            None,
+            None,
+            None,
+            False,  # is_pinned
+            False,  # is_truncated
+            None,  # tool_use_id
+            None,  # parent_message_id
+        )
+
+        # First execute call raises UndefinedColumn-shaped error; second
+        # (the pre-037 fallback) returns the legacy row.
+        call_state = {"n": 0}
+
+        def execute_side_effect(*_args, **_kwargs):
+            call_state["n"] += 1
+            cursor = MagicMock()
+            if call_state["n"] == 1:
+                # Simulate psycopg's UndefinedColumn surface text.
+                raise Exception('column "ontology_version" of relation "messages" does not exist')
+            cursor.fetchone.return_value = pre_037_row
+            return cursor
+
+        conn.execute.side_effect = execute_side_effect
+
+        # Orchestrator-style call: passes a non-None ontology_version tag.
+        result = create_message(
+            conn,
+            conv_id,
+            "assistant",
+            "Vastus tugineb sätetele...",
+            tokens_input=10,
+            tokens_output=5,
+            model="claude",
+            ontology_version=_NEW_VERSION,
+        )
+
+        # The message persisted (this is the load-bearing assertion —
+        # before the fix, the orchestrator silently dropped the assistant
+        # turn during the rollout window).
+        assert result is not None
+        assert result.id == msg_id
+        assert result.role == "assistant"
+        # The tag is dropped because the column doesn't exist yet.
+        assert result.ontology_version is None
+        # We attempted the v037 INSERT then fell back to the pre-037
+        # shape — at least 2 calls (a rollback() between them is fine
+        # but not load-bearing for this assertion).
+        assert call_state["n"] == 2
+        # The fallback INSERT must NOT mention ``ontology_version``.
+        fallback_sql = conn.execute.call_args_list[-1].args[0]
+        assert "ontology_version" not in fallback_sql
+
+    def test_fallback_only_triggers_for_v037_undefined_column(self, _fernet_key_local):
+        """A generic SQL error (not a missing column) must NOT trigger
+        the v037 fallback — that would mask real failures."""
+        from app.chat.models import create_message
+
+        conn = MagicMock()
+        conv_id = uuid.uuid4()
+
+        def execute_side_effect(*_args, **_kwargs):
+            raise RuntimeError("unrelated DB error")
+
+        conn.execute.side_effect = execute_side_effect
+
+        with pytest.raises(RuntimeError, match="unrelated DB error"):
+            create_message(
+                conn,
+                conv_id,
+                "assistant",
+                "Vastus",
+                ontology_version=_NEW_VERSION,
+            )
+
+
+class TestForkPreservesOntologyVersion:
+    """#833 review (P2): ``fork_conversation`` previously dropped
+    ``ontology_version`` from copied messages, so a forked thread lost
+    drift detection on already-cited stale ontology answers. The SELECT
+    and INSERT shapes must now carry the column through."""
+
+    def test_fork_select_and_insert_include_ontology_version(self):
+        from app.chat.models import fork_conversation
+
+        conn = MagicMock()
+        source_conv_id = uuid.uuid4()
+        boundary_msg_id = uuid.uuid4()
+        boundary_created_at = datetime(2026, 5, 20, 10, 0, tzinfo=UTC)
+
+        # boundary lookup, get_conversation(source), create_conversation(new)
+        source_conv_row = (
+            source_conv_id,
+            uuid.UUID(_USER_ID),
+            uuid.UUID(_ORG_ID),
+            "Algvestlus",
+            None,
+            datetime.now(UTC),
+            datetime.now(UTC),
+        )
+        new_conv_id = uuid.uuid4()
+        new_conv_row = (
+            new_conv_id,
+            uuid.UUID(_USER_ID),
+            uuid.UUID(_ORG_ID),
+            "Jätk: Algvestlus",
+            None,
+            datetime.now(UTC),
+            datetime.now(UTC),
+        )
+
+        conn.execute.return_value.fetchone.side_effect = [
+            (boundary_created_at, source_conv_id),
+            source_conv_row,
+            new_conv_row,
+        ]
+
+        fork_conversation(
+            conn,
+            source_conv_id,
+            boundary_msg_id,
+            user_id=uuid.UUID(_USER_ID),
+            org_id=uuid.UUID(_ORG_ID),
+        )
+
+        # The INSERT ... SELECT must mention ``ontology_version`` in
+        # both column lists (read source + write copy).
+        final_sql = conn.execute.call_args_list[-1].args[0]
+        assert "INSERT INTO messages" in final_sql
+        # Both occurrences (INSERT column list and SELECT column list).
+        assert final_sql.count("ontology_version") == 2
+
+    def test_fork_falls_back_to_pre_037_when_column_missing(self):
+        """If the ``ontology_version`` column is absent (pre-037 deploy),
+        fork must still succeed with a pre-037 INSERT shape that
+        preserves ``tool_use_id``."""
+        from app.chat.models import fork_conversation
+
+        conn = MagicMock()
+        source_conv_id = uuid.uuid4()
+        boundary_msg_id = uuid.uuid4()
+        boundary_created_at = datetime(2026, 5, 20, 10, 0, tzinfo=UTC)
+
+        source_conv_row = (
+            source_conv_id,
+            uuid.UUID(_USER_ID),
+            uuid.UUID(_ORG_ID),
+            "Algvestlus",
+            None,
+            datetime.now(UTC),
+            datetime.now(UTC),
+        )
+        new_conv_id = uuid.uuid4()
+        new_conv_row = (
+            new_conv_id,
+            uuid.UUID(_USER_ID),
+            uuid.UUID(_ORG_ID),
+            "Jätk: Algvestlus",
+            None,
+            datetime.now(UTC),
+            datetime.now(UTC),
+        )
+
+        # 1: boundary, 2: source conv, 3: new conv, 4: INSERT (raises),
+        # 5: pre-037 INSERT (succeeds).
+        fetchone_results = iter(
+            [
+                (boundary_created_at, source_conv_id),
+                source_conv_row,
+                new_conv_row,
+            ]
+        )
+
+        call_state = {"n": 0}
+
+        def execute_side_effect(*args, **_kwargs):
+            sql = args[0] if args else ""
+            cursor = MagicMock()
+            if "INSERT INTO messages" in sql:
+                call_state["n"] += 1
+                if call_state["n"] == 1 and "ontology_version" in sql:
+                    raise Exception(
+                        'column "ontology_version" of relation "messages" does not exist'
+                    )
+                return cursor
+            try:
+                cursor.fetchone.return_value = next(fetchone_results)
+            except StopIteration:
+                cursor.fetchone.return_value = None
+            return cursor
+
+        conn.execute.side_effect = execute_side_effect
+
+        fork_conversation(
+            conn,
+            source_conv_id,
+            boundary_msg_id,
+            user_id=uuid.UUID(_USER_ID),
+            org_id=uuid.UUID(_ORG_ID),
+        )
+
+        # We attempted the v037 INSERT then the v037-less fallback.
+        assert call_state["n"] == 2
+        # Final INSERT must omit ``ontology_version`` but still carry
+        # ``tool_use_id`` (preserving the v036 information).
+        final_insert_sql = [
+            c.args[0] for c in conn.execute.call_args_list if "INSERT INTO messages" in c.args[0]
+        ][-1]
+        assert "ontology_version" not in final_insert_sql
+        assert "tool_use_id" in final_insert_sql
+
+
+class TestRagDriftFiltersBySourceType:
+    """#833 review (P3): the drift detector previously treated any
+    non-empty ``rag_context`` as ontology-grounded. RAG can contain
+    private draft chunks, which are unaffected by ontology drift — they
+    must NOT fire the banner. Post-fix the detector consults
+    ``chunk['source_type']`` and accepts only ontology source types."""
+
+    def test_draft_only_rag_does_not_fire_banner(self):
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Mis on minu eelnõu mõju?"),
+            _make_message(
+                "assistant",
+                "Sinu eelnõu paragrahvid mõjutavad...",
+                ontology_version=_OLD_VERSION,
+                # Only draft-source chunks → not ontology-grounded.
+                rag_context=[
+                    {
+                        "source_uri": "draft:abc/§3",
+                        "source_type": "draft",
+                        "score": 0.9,
+                    },
+                    {
+                        "source_uri": "draft:abc/§4",
+                        "source_type": "draft",
+                        "score": 0.7,
+                    },
+                ],
+            ),
+        ]
+        assert _conversation_has_outdated_ontology_citations(msgs, _NEW_VERSION) is False
+
+    def test_adding_ontology_source_chunk_fires_banner(self):
+        """As soon as a single ontology-source chunk appears in the
+        rag_context, the stale tag flips the banner on."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Aga TsiviilS § 113?"),
+            _make_message(
+                "assistant",
+                "Vastus tugineb...",
+                ontology_version=_OLD_VERSION,
+                rag_context=[
+                    {
+                        "source_uri": "draft:abc/§3",
+                        "source_type": "draft",
+                        "score": 0.9,
+                    },
+                    {
+                        "source_uri": "estleg:ks_113",
+                        "source_type": "ontology",
+                        "score": 0.8,
+                    },
+                ],
+            ),
+        ]
+        assert _conversation_has_outdated_ontology_citations(msgs, _NEW_VERSION) is True
+
+    def test_law_text_and_court_decision_are_ontology_grounded(self):
+        """``law_text`` and ``court_decision`` are public-ontology
+        source types and MUST trigger the banner on stale versions."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        for source_type in ("law_text", "court_decision", "eu_act"):
+            msgs = [
+                _make_message("user", "Otsi"),
+                _make_message(
+                    "assistant",
+                    "Vastus...",
+                    ontology_version=_OLD_VERSION,
+                    rag_context=[
+                        {
+                            "source_uri": f"x:{source_type}",
+                            "source_type": source_type,
+                            "score": 0.9,
+                        },
+                    ],
+                ),
+            ]
+            assert _conversation_has_outdated_ontology_citations(msgs, _NEW_VERSION) is True, (
+                f"source_type={source_type} should be ontology-grounded"
+            )
+
+    def test_legacy_chunk_without_source_type_still_fires(self):
+        """Pre-#833 rag_context rows do not carry ``source_type``. To
+        avoid silently disabling drift detection on historical rows,
+        chunks without a ``source_type`` field are accepted as
+        ontology-grounded (the older behaviour)."""
+        from app.chat.routes import _conversation_has_outdated_ontology_citations
+
+        msgs = [
+            _make_message("user", "Mis on TsiviilS?"),
+            _make_message(
+                "assistant",
+                "Vastus...",
+                ontology_version=_OLD_VERSION,
+                # No ``source_type`` key — legacy shape.
+                rag_context=[{"source_uri": "estleg:ks_113", "score": 0.9}],
+            ),
+        ]
+        assert _conversation_has_outdated_ontology_citations(msgs, _NEW_VERSION) is True
+
+    def test_orchestrator_persists_source_type_in_rag_context_json(self):
+        """The orchestrator's ``rag_context_json`` builder must carry
+        ``source_type`` from chunk metadata into the persisted JSON so
+        the drift detector can rely on it post-#833."""
+        from app.rag.retriever import RetrievedChunk
+
+        # Re-run the small builder block from app/chat/orchestrator.py
+        # by emulating the same comprehension. We do not invoke the
+        # full streaming path; this test pins the field set in the
+        # serialised shape.
+        chunks = [
+            RetrievedChunk(
+                content="Säte X",
+                metadata={"source_uri": "estleg:ks_113", "source_type": "ontology"},
+                score=0.9,
+            ),
+            RetrievedChunk(
+                content="Draft Y",
+                metadata={"source_uri": "draft:abc/§3", "source_type": "draft"},
+                score=0.7,
+            ),
+        ]
+        rag_context_json = [
+            {
+                "content": chunk.content,
+                "source_uri": chunk.metadata.get("source_uri"),
+                "source_type": chunk.metadata.get("source_type"),
+                "score": chunk.score,
+            }
+            for chunk in chunks
+        ]
+        assert rag_context_json[0]["source_type"] == "ontology"
+        assert rag_context_json[1]["source_type"] == "draft"
+
+        # And the drift detector correctly filters this serialised shape.
+        from app.chat.routes import _rag_context_grounds_on_ontology
+
+        assert _rag_context_grounds_on_ontology(rag_context_json) is True
+        # Stripping the ontology chunk leaves draft-only → not grounded.
+        assert _rag_context_grounds_on_ontology(rag_context_json[1:]) is False

--- a/tests/test_chat_tool_use_history.py
+++ b/tests/test_chat_tool_use_history.py
@@ -111,9 +111,10 @@ def _make_message_row(
 def _echo_row_for_create(conn_mock: MagicMock):
     """Replay a ``RETURNING`` row from the params bound to the INSERT.
 
-    The INSERT in :func:`create_message` binds 12 positional params
-    (post-#315). We zip them back into the 16-column row order so the
-    round-trip returns a faithful Message.
+    The INSERT in :func:`create_message` binds 13 positional params
+    (post-#352: #315's 12 + ``ontology_version``). We zip them back
+    into the 17-column row order so the round-trip returns a faithful
+    Message.
     """
 
     def _build_row():
@@ -131,6 +132,7 @@ def _echo_row_for_create(conn_mock: MagicMock):
             rag_context_ct,
             tool_use_id,
             parent_message_id,
+            ontology_version,
         ) = params
         return [
             uuid.uuid4(),
@@ -149,6 +151,7 @@ def _echo_row_for_create(conn_mock: MagicMock):
             False,
             tool_use_id,
             parent_message_id,
+            ontology_version,
         ]
 
     return _build_row
@@ -269,11 +272,15 @@ class TestCreateMessageToolUseFields:
         assert msg.parent_message_id == parent_id
 
         # Confirm the bound SQL params include the new fields.
+        # Bind order (post-#352): conv_id, role, tool_name, tokens_in,
+        # tokens_out, model, content_ct, tool_input_ct, tool_output_ct,
+        # rag_context_ct, tool_use_id (idx 10), parent_message_id (idx 11),
+        # ontology_version (idx 12).
         params = conn.execute.call_args.args[1]
-        # tool_use_id is the second-to-last positional bind.
-        assert params[-2] == "toolu_42"
-        # parent_message_id is the last positional bind, stringified.
-        assert params[-1] == str(parent_id)
+        assert params[10] == "toolu_42"
+        assert params[11] == str(parent_id)
+        # ontology_version is NULL for tool rows.
+        assert params[12] is None
 
     def test_persists_without_tool_fields_for_assistant_turn(self):
         """A non-tool message must not set the new fields."""
@@ -284,8 +291,10 @@ class TestCreateMessageToolUseFields:
         assert msg.tool_use_id is None
         assert msg.parent_message_id is None
         params = conn.execute.call_args.args[1]
-        assert params[-2] is None
-        assert params[-1] is None
+        # Bind indices: 10=tool_use_id, 11=parent_message_id, 12=ontology_version.
+        assert params[10] is None
+        assert params[11] is None
+        assert params[12] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Stacked on #832 (#315).** Merge that first; this PR's base is `feat/315-tool-use-history`.
- Migration **037** adds nullable `messages.ontology_version TEXT`
- New `app/chat/ontology_version.py::get_current_ontology_version()` mirrors the format used by analyze_handler (`"<iso>@<entity_count>"` or `"unknown"`); kept local so chat doesn't import from docs
- Orchestrator captures the snapshot once per turn in `_TurnContext.ontology_version` (resolved in `_phase_build_system_prompt`, async-wrapped under existing pre-stream budget) and stamps it on every assistant persist path — the multi-round tool-use placeholder INSERT, the non-tool terminal INSERT, and all four `_persist_partial_assistant` paths (timeout / cancel / ws-dead / error)
- `conversation_view_page` calls `_conversation_has_outdated_ontology_citations`; conversation-level banner rendered between draft header and chat container
- `?reask=1` pre-fills the textarea with the most recent user turn — user retains control over what gets sent
- Closes #352

## Test plan
- [x] `tests/test_chat_outdated_ontology.py` — 15 tests + 1 skipped integration (migration column existence, drift detector across versions/NULL/"unknown"/non-ontology/RAG-grounded/tool-grounded, conversation banner render, link, reask prefill, sync_log unavailable → no false positive, orchestrator persistence, cross-org isolation)
- [x] Full chat suite (314 tests) green
- [x] Full global suite (3286 tests) green
- [x] ruff + pyright clean

## Design decisions
- **Conversation-level banner**, not per-message badges — simpler, matches "user is going to re-ask anyway". Per-message badges would require touching `_render_message` and adding CSS for a new badge primitive. Easy to add later if desired.
- **"Küsi uuesti"** = navigate to `/chat/{conv_id}?reask=1` which pre-fills the textarea with the last user message (no token mint, no WS auto-send). Closer to seed-token UX than a one-click regenerate.

## Notes
- `ontology_version` is **plaintext TEXT** — it's a reproducibility tag, not PII. No interaction with Fernet ciphertext columns.
- Deploy-window fallback pattern (pre-037 INSERT/SELECT shapes) added so the schema mismatch window doesn't break chat.