### PR TITLE
feat(observability+admin): Sprint 1 — metric collectors + sync history + roadmap

### DIFF
--- a/app/admin/sync.py
+++ b/app/admin/sync.py
@@ -21,11 +21,14 @@ from app.sync.orchestrator import (
     has_recent_running_row,
 )
 from app.ui.data.data_table import Column, DataTable
+from app.ui.data.pagination import Pagination
 from app.ui.forms.app_form import AppForm
+from app.ui.layout import PageShell
 from app.ui.primitives.badge import StatusBadge
 from app.ui.primitives.button import Button  # noqa: F401, F811  -- shadow guard
 from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.surfaces.info_box import InfoBox
+from app.ui.theme import get_theme_from_request
 from app.ui.time import format_tallinn
 
 # Module-level lock — keeps rapid double-clicks on the "Sync now" button
@@ -89,6 +92,45 @@ def _get_sync_logs(limit: int = 5) -> list[dict]:  # type: ignore[type-arg]
     except Exception:
         logger.exception("Failed to fetch sync logs")
         return []
+
+
+def _get_sync_log_page(page: int = 1, per_page: int = 20) -> tuple[list[dict], int]:  # type: ignore[type-arg]
+    """Return a page of sync_log rows and the total row count.
+
+    Used by the /admin/sync/history page; keeps the lightweight
+    ``_get_sync_logs`` helper used by the dashboard card unchanged.
+    Returns ``([], 0)`` on any DB error so the page renders a clean
+    empty state instead of a 500.
+    """
+    entries: list[dict] = []  # type: ignore[type-arg]
+    total = 0
+    try:
+        with _connect() as conn:
+            count_row = conn.execute("SELECT COUNT(*) FROM sync_log").fetchone()
+            total = count_row[0] if count_row else 0
+
+            offset = (page - 1) * per_page
+            rows = conn.execute(
+                "SELECT id, started_at, finished_at, status, entity_count, "
+                "error_message, current_step "
+                "FROM sync_log ORDER BY started_at DESC LIMIT %s OFFSET %s",
+                (per_page, offset),
+            ).fetchall()
+            entries = [
+                {
+                    "id": r[0],
+                    "started_at": r[1],
+                    "finished_at": r[2],
+                    "status": r[3],
+                    "entity_count": r[4],
+                    "error_message": r[5],
+                    "current_step": r[6] if len(r) > 6 else None,
+                }
+                for r in rows
+            ]
+    except Exception:
+        logger.exception("Failed to fetch sync log page %d", page)
+    return entries, total
 
 
 # ---------------------------------------------------------------------------
@@ -446,10 +488,18 @@ def _sync_card(
 
     return Card(
         CardHeader(
-            H3(  # noqa: F405
-                "S\u00fcnkroniseerimise staatus",
-                _tooltip("GitHub \u2192 RDF \u2192 Jena s\u00fcnkroniseerimise ajalugu"),
-                cls="card-title",
+            Div(  # noqa: F405
+                H3(  # noqa: F405
+                    "S\u00fcnkroniseerimise staatus",
+                    _tooltip("GitHub \u2192 RDF \u2192 Jena s\u00fcnkroniseerimise ajalugu"),
+                    cls="card-title",
+                ),
+                A(  # noqa: F405
+                    "Vaata ajalugu \u2192",
+                    href="/admin/sync/history",
+                    cls="sync-history-link",
+                ),
+                cls="card-header-row",
             )
         ),
         CardBody(*body_nodes),
@@ -551,3 +601,158 @@ def sync_status_card(req: Request):
     """
     sync_logs = _get_sync_logs()
     return _sync_card(sync_logs)
+
+
+# ---------------------------------------------------------------------------
+# Sync history page (#322)
+# ---------------------------------------------------------------------------
+
+
+_HISTORY_PER_PAGE = 20
+
+# Estonian labels for each pipeline phase, used by the history table's
+# ``Samm`` column. Keeps the column readable instead of leaking raw enum
+# tokens like ``converting`` into the admin UI.
+_PHASE_LABELS: dict[str, str] = dict(_PROGRESS_PHASES)
+
+
+def _format_duration(started_at: datetime | None, finished_at: datetime | None) -> str:
+    """Return ``M:SS`` for a completed sync or a live elapsed string."""
+    if started_at is None:
+        return "—"
+    if finished_at is None:
+        # Still running — show live elapsed.
+        return _format_elapsed(_elapsed_seconds(started_at))
+    started = started_at
+    finished = finished_at
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=UTC)
+    if finished.tzinfo is None:
+        finished = finished.replace(tzinfo=UTC)
+    delta = finished - started
+    return _format_elapsed(max(0, int(delta.total_seconds())))
+
+
+def _format_step(entry: dict) -> str:  # type: ignore[type-arg]
+    """Render the step cell — Estonian phase label, em-dash for unknown."""
+    step = entry.get("current_step")
+    if not step:
+        return "—"
+    step_str = str(step)
+    return _PHASE_LABELS.get(step_str, step_str)
+
+
+def admin_sync_history_page(req: Request):
+    """GET /admin/sync/history -- paginated sync log viewer.
+
+    Lists every sync_log row ordered by ``started_at DESC`` with 20 rows
+    per page. Provides the operational context the compact dashboard card
+    can't (which only shows the last 5). Empty state and DB errors both
+    render a calm muted message instead of a stack trace.
+
+    Helpers are imported as locals inside the function body so the page
+    works correctly when the function is rebound by the admin_dashboard
+    shim (matches the pattern in ``admin_audit_page``).
+    """
+    auth = req.scope.get("auth")
+    theme = get_theme_from_request(req)
+    try:
+        from app.admin.sync import (
+            _format_duration,
+            _format_step,
+            _get_sync_log_page,
+            _sync_error_cell,
+            _sync_status_badge,
+        )
+
+        page_str = req.query_params.get("page", "1")
+        try:
+            page = max(1, int(page_str))
+        except ValueError:
+            page = 1
+
+        per_page = _HISTORY_PER_PAGE
+        entries, total = _get_sync_log_page(page, per_page)
+        total_pages = max(1, (total + per_page - 1) // per_page)
+
+        if not entries:
+            body: object = P(  # noqa: F405
+                "Sünkroniseerimisi ei leitud.", cls="muted-text"
+            )
+        else:
+            columns = [
+                Column(key="started", label="Algusaeg", sortable=False),
+                Column(
+                    key="status",
+                    label="Staatus",
+                    sortable=False,
+                    render=lambda r: _sync_status_badge(r["status_raw"]),
+                ),
+                Column(key="duration", label="Kestus", sortable=False),
+                Column(key="step", label="Samm", sortable=False),
+                Column(
+                    key="error_message",
+                    label="Veateade",
+                    sortable=False,
+                    render=_sync_error_cell,
+                ),
+            ]
+            rows = []
+            for entry in entries:
+                rows.append(
+                    {
+                        "started": format_tallinn(entry["started_at"]),
+                        "status_raw": entry["status"],
+                        "status": entry["status"],
+                        "duration": _format_duration(entry["started_at"], entry["finished_at"]),
+                        "step": _format_step(entry),
+                        "error_message": entry["error_message"] or "—",
+                    }
+                )
+            body = DataTable(columns=columns, rows=rows)
+
+        pagination = Pagination(
+            current_page=page,
+            total_pages=total_pages,
+            base_url="/admin/sync/history",
+            page_size=per_page,
+            total=total,
+        )
+
+        content = (
+            H1(  # noqa: F405
+                "Sünkroniseerimise ajalugu", cls="page-title"
+            ),
+            P(  # noqa: F405
+                A(  # noqa: F405
+                    "← Tagasi adminipaneelile", href="/admin"
+                ),
+                cls="back-link",
+            ),
+            Card(
+                CardHeader(
+                    H3(  # noqa: F405
+                        "Kõik sünkroniseerimised",
+                        _tooltip(
+                            "Iga GitHub → RDF → Jena sünkroniseerimise "
+                            "ajalooline kirje, uusim eespool."
+                        ),
+                        cls="card-title",
+                    ),
+                ),
+                CardBody(body, pagination),
+            ),
+        )
+
+        return PageShell(
+            *content,
+            title="Sünkroniseerimise ajalugu",
+            user=auth,
+            theme=theme,
+            active_nav="/admin",
+        )
+    except Exception:
+        logger.exception("Failed to render admin sync history page")
+        from app.admin._shared import _render_admin_error_page
+
+        return _render_admin_error_page(title="Sünkroniseerimise ajalugu", user=auth, theme=theme)

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -1567,6 +1567,7 @@ def _rag_candidates(sisend: str, org_id: str | None) -> list[dict[str, str]]:
                 sisend,
                 k=_MAX_RAG_CANDIDATES,
                 org_id=org_id,
+                feature="analyysikeskus_normi_mojuahel",
             )
 
         try:

--- a/app/analyysikeskus/similarity.py
+++ b/app/analyysikeskus/similarity.py
@@ -457,6 +457,7 @@ def find_embedding_similar(
             k=k,
             source_type="ontology",
             org_id=None,
+            feature="analyysikeskus_similarity",
         )
 
     try:

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -1325,6 +1325,7 @@ class ChatOrchestrator:
                         ctx.user_message,
                         k=10,
                         org_id=str(ctx.org_id) if ctx.org_id else None,
+                        feature="chat",
                     ),
                     timeout=_RAG_RETRIEVE_TIMEOUT_SECONDS,
                 )

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -165,12 +165,16 @@ class JobWorker:
         attempt_number = (job.attempts or 0) + 1
         # Track per-handler execution latency (#195). Labels are kept
         # low-cardinality on purpose: only the job_type and a coarse
-        # success/failure status. Job id, error message, and worker id
-        # would explode the metrics table without aiding aggregation.
+        # ``success`` / ``failed`` status. The status vocabulary matches
+        # the ``background_jobs.status`` enum so admin queries can join
+        # both surfaces on the same string ("success" / "failed") without
+        # a translation layer (#837/#838 review caught this).
+        # Job id, error message, and worker id would explode the metrics
+        # table without aiding aggregation.
         # We can't use ``track_duration`` here because the ``status``
         # label is only known after the handler returns or raises;
         # ``track_duration`` snapshots labels at context entry.
-        status = "ok"
+        status = "success"
         start = time.perf_counter()
         try:
             try:

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -42,12 +42,14 @@ from __future__ import annotations
 import logging
 import socket
 import threading
+import time
 import traceback
 import uuid
 from collections.abc import Callable
 from typing import Any
 
 from app.jobs.queue import JobQueue
+from app.metrics import record_metric
 
 logger = logging.getLogger(__name__)
 
@@ -161,25 +163,43 @@ class JobWorker:
         # ``attempts`` column is incremented inside ``mark_failed``,
         # so the value here is the in-flight attempt index (1-based).
         attempt_number = (job.attempts or 0) + 1
+        # Track per-handler execution latency (#195). Labels are kept
+        # low-cardinality on purpose: only the job_type and a coarse
+        # success/failure status. Job id, error message, and worker id
+        # would explode the metrics table without aiding aggregation.
+        # We can't use ``track_duration`` here because the ``status``
+        # label is only known after the handler returns or raises;
+        # ``track_duration`` snapshots labels at context entry.
+        status = "ok"
+        start = time.perf_counter()
         try:
-            result = handler(
-                job.payload,
-                attempt=attempt_number,
-                max_attempts=job.max_attempts,
-                job_id=job.id,
+            try:
+                result = handler(
+                    job.payload,
+                    attempt=attempt_number,
+                    max_attempts=job.max_attempts,
+                    job_id=job.id,
+                )
+            except Exception as exc:  # noqa: BLE001 — handler errors flip job to failed
+                status = "failed"
+                tb = traceback.format_exc()
+                logger.error(
+                    "Handler for job id=%d type=%s raised: %s\n%s",
+                    job.id,
+                    job.job_type,
+                    exc,
+                    tb,
+                )
+                # error_message column is VARCHAR(500); truncate defensively.
+                queue.mark_failed(job.id, str(exc)[:500])
+                return
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            record_metric(
+                "job_execution_ms",
+                round(duration_ms, 2),
+                {"handler": job.job_type, "status": status},
             )
-        except Exception as exc:  # noqa: BLE001 — handler errors flip job to failed
-            tb = traceback.format_exc()
-            logger.error(
-                "Handler for job id=%d type=%s raised: %s\n%s",
-                job.id,
-                job.job_type,
-                exc,
-                tb,
-            )
-            # error_message column is VARCHAR(500); truncate defensively.
-            queue.mark_failed(job.id, str(exc)[:500])
-            return
 
         queue.mark_success(job.id, result)
         logger.info("Job id=%d type=%s completed successfully", job.id, job.job_type)

--- a/app/ontology/sparql_client.py
+++ b/app/ontology/sparql_client.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 
 import httpx
+
+from app.metrics import record_metric
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +87,13 @@ class SparqlClient:
         """SPARQL query endpoint URL."""
         return f"{self.jena_url}/{self.dataset}/sparql"
 
-    def _execute(self, sparql: str, *, on_error: str = "swallow") -> dict:  # type: ignore[type-arg]
+    def _execute(
+        self,
+        sparql: str,
+        *,
+        on_error: str = "swallow",
+        operation: str = "query",
+    ) -> dict:  # type: ignore[type-arg]
         """Send a SPARQL query and return the raw JSON response dict.
 
         Parameters
@@ -107,7 +116,14 @@ class SparqlClient:
               caches the result and must avoid poisoning the cache on
               transient outages (e.g. the resolver's abbreviation-map
               warm-up — see ``app/docs/reference_resolver.py``).
+        operation:
+            Label recorded on the ``sparql_query_ms`` metric to attribute
+            the call to ``"query"``, ``"ask"``, or ``"count"``.  Kept
+            deliberately low-cardinality — the SPARQL text and URI
+            parameters are never recorded.
         """
+        start = time.perf_counter()
+        status = "error"
         try:
             response = httpx.post(
                 self.endpoint,
@@ -116,7 +132,9 @@ class SparqlClient:
                 timeout=self.timeout,
             )
             response.raise_for_status()
-            return response.json()  # type: ignore[no-any-return]
+            result: dict = response.json()  # type: ignore[type-arg]
+            status = "ok"
+            return result
         except httpx.ConnectError:
             logger.exception("Cannot connect to Jena Fuseki at %s", self.endpoint)
             if on_error == "raise":
@@ -137,6 +155,13 @@ class SparqlClient:
             if on_error == "raise":
                 raise
             return {"results": {"bindings": []}}
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            record_metric(
+                "sparql_query_ms",
+                round(duration_ms, 2),
+                {"operation": operation, "status": status},
+            )
 
     def _inject_bindings(self, sparql: str, bindings: dict[str, str]) -> str:
         """Inject variable bindings using a SPARQL VALUES clause.
@@ -198,6 +223,7 @@ class SparqlClient:
         uri_bindings: dict[str, str] | None = None,
         *,
         on_error: str = "swallow",
+        operation: str = "query",
     ) -> list[dict[str, str]]:
         """Execute a SPARQL SELECT query and return a list of result dicts.
 
@@ -221,36 +247,34 @@ class SparqlClient:
             should pass ``on_error="raise"`` so a transient failure
             does not permanently poison the cache. See
             :func:`_execute` for the full semantics.
+        operation:
+            Forwarded to :meth:`_execute` for metric labelling.  Defaults
+            to ``"query"``; :meth:`count` overrides it to ``"count"``.
         """
         if bindings:
             sparql = self._inject_bindings(sparql, bindings)
         if uri_bindings:
             sparql = self._inject_uri_bindings(sparql, uri_bindings)
-        raw = self._execute(sparql, on_error=on_error)
+        raw = self._execute(sparql, on_error=on_error, operation=operation)
         return _extract_bindings(raw)
 
     def ask(self, sparql: str) -> bool:
-        """Execute a SPARQL ASK query and return the boolean result."""
-        try:
-            response = httpx.post(
-                self.endpoint,
-                data={"query": sparql},
-                headers={"Accept": "application/sparql-results+json"},
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
-            return bool(data.get("boolean", False))
-        except httpx.HTTPError:
-            logger.exception("SPARQL ASK query failed")
-            return False
+        """Execute a SPARQL ASK query and return the boolean result.
+
+        Routed through :meth:`_execute` so the call is counted in the
+        ``sparql_query_ms`` metric with ``operation="ask"``.  Network
+        failures are swallowed (logged + ``False``) to preserve the
+        legacy contract.
+        """
+        data = self._execute(sparql, on_error="swallow", operation="ask")
+        return bool(data.get("boolean", False))
 
     def count(self, sparql: str) -> int:
         """Execute a SPARQL SELECT query that returns a single count value.
 
         Expects the query to project a ``?count`` variable.
         """
-        rows = self.query(sparql)
+        rows = self.query(sparql, operation="count")
         if rows and "count" in rows[0]:
             try:
                 return int(rows[0]["count"])

--- a/app/rag/retriever.py
+++ b/app/rag/retriever.py
@@ -17,10 +17,12 @@ Usage:
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any, LiteralString, cast
 
 from app.db import get_connection
+from app.metrics import record_metric
 from app.rag.embedding import EmbeddingProvider, get_default_embedding_provider
 
 logger = logging.getLogger(__name__)
@@ -159,6 +161,7 @@ class Retriever:
         source_type: str | None = None,
         org_id: str | None = None,
         filters: dict[str, Any] | None = None,
+        feature: str = "unknown",
     ) -> list[RetrievedChunk]:
         """Retrieve the top-k most similar chunks to *query*.
 
@@ -186,6 +189,11 @@ class Retriever:
                 or ``None`` (``IS NULL``). Unknown keys raise
                 ``ValueError``. Combines additively with the tenant
                 predicate — filters NEVER bypass org scoping. (#311)
+            feature: Caller-supplied label used as the ``feature`` tag on
+                the ``rag_retrieval_ms`` metric (e.g. ``"chat"``,
+                ``"drafter"``, ``"analyysikeskus_similarity"``). Defaults
+                to ``"unknown"`` so legacy callers still record metrics;
+                new callers should always pass an explicit label. (#323)
 
         Returns:
             List of :class:`RetrievedChunk` ordered by descending
@@ -199,6 +207,45 @@ class Retriever:
         # corpus (NULL) visible to everyone and gates private chunks on
         # the caller's org. See migration 016 and issue #576.
 
+        # #323: instrument the full retrieve() body — embed + ANN search
+        # + result parsing — and tag every emission with the caller's
+        # ``feature`` label plus an ``ok`` / ``error`` ``status``. We use
+        # ``record_metric`` directly rather than ``track_duration`` so the
+        # status label reflects the *outcome*, not a snapshot taken at
+        # context-manager entry time. Exceptions are re-raised so callers
+        # see the failure; only the metric write is wrapped.
+        start = time.perf_counter()
+        status = "ok"
+        try:
+            return await self._retrieve_inner(
+                query,
+                k=k,
+                source_type=source_type,
+                org_id=org_id,
+                filters=filters,
+            )
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            record_metric(
+                "rag_retrieval_ms",
+                round(duration_ms, 2),
+                {"feature": feature, "status": status},
+            )
+
+    async def _retrieve_inner(
+        self,
+        query: str,
+        *,
+        k: int,
+        source_type: str | None,
+        org_id: str | None,
+        filters: dict[str, Any] | None,
+    ) -> list[RetrievedChunk]:
+        """Body of :meth:`retrieve`, kept separate so the metric wrapper
+        is the only place that needs the try/except scaffolding."""
         if not query.strip():
             return []
 

--- a/app/templates/admin_dashboard.py
+++ b/app/templates/admin_dashboard.py
@@ -108,6 +108,9 @@ from app.admin.rate_limits import (
     _rate_limit_card,  # noqa: F401
 )
 from app.admin.sync import (
+    _get_sync_log_page as _get_sync_log_page_impl,
+)
+from app.admin.sync import (
     _get_sync_logs as _get_sync_logs_impl,
 )
 from app.admin.sync import (
@@ -117,6 +120,9 @@ from app.admin.sync import (
     _sync_card,  # noqa: F401
     _sync_status_badge,  # noqa: F401
     _sync_trigger_form,  # noqa: F401
+)
+from app.admin.sync import (
+    admin_sync_history_page as _admin_sync_history_page_impl,
 )
 from app.admin.sync import (
     sync_status_card as _sync_status_card_impl,
@@ -197,6 +203,7 @@ def _rebind(fn):
 
 _check_postgres = _rebind(_check_postgres_impl)
 _get_sync_logs = _rebind(_get_sync_logs_impl)
+_get_sync_log_page = _rebind(_get_sync_log_page_impl)
 _get_user_stats = _rebind(_get_user_stats_impl)
 _get_audit_log_page = _rebind(_get_audit_log_page_impl)
 health_check = _rebind(_health_check_impl)
@@ -208,6 +215,7 @@ health_check = _rebind(_health_check_impl)
 _run_sync_and_clear_flag = _rebind(_run_sync_and_clear_flag_impl)
 trigger_sync = _rebind(_trigger_sync_impl)
 sync_status_card = _rebind(_sync_status_card_impl)
+admin_sync_history_page = _rebind(_admin_sync_history_page_impl)
 
 # admin_dashboard_page calls _check_postgres, jena_check_health,
 # _get_sync_logs, _get_user_stats — all patchable names.  Rebind it so
@@ -236,6 +244,7 @@ _EXPECTED_PAGE_HANDLERS = {
     "admin_job_retry",
     "admin_jobs_purge",
     "admin_performance_page",
+    "admin_sync_history_page",
     "health_check",
     "trigger_sync",
     "sync_status_card",
@@ -267,6 +276,7 @@ _admin_audit = require_role("admin")(admin_audit_page)
 _admin_audit_export = require_role("admin")(admin_audit_export)
 _admin_sync = require_role("admin")(trigger_sync)
 _admin_sync_status = require_role("admin")(sync_status_card)
+_admin_sync_history = require_role("admin")(admin_sync_history_page)
 _admin_analytics = require_role("admin")(admin_analytics_page)
 _admin_costs = require_role("admin")(admin_cost_page)
 _admin_jobs = require_role("admin")(admin_jobs_page)
@@ -283,6 +293,7 @@ def register_admin_routes(rt) -> None:  # type: ignore[no-untyped-def]
     rt("/admin/performance", methods=["GET"])(_admin_performance)
     rt("/admin/sync", methods=["POST"])(_admin_sync)
     rt("/admin/sync/status", methods=["GET"])(_admin_sync_status)
+    rt("/admin/sync/history", methods=["GET"])(_admin_sync_history)
     rt("/admin/analytics", methods=["GET"])(_admin_analytics)
     rt("/admin/costs", methods=["GET"])(_admin_costs)
     rt("/admin/jobs", methods=["GET"])(_admin_jobs)

--- a/docs/2026-05-24-issue-cleanup-and-roadmap.md
+++ b/docs/2026-05-24-issue-cleanup-and-roadmap.md
@@ -1,220 +1,207 @@
-# 2026-05-24 — Issue cleanup + post-Phase-4 roadmap
+# 2026-05-24 — Issue cleanup + roadmap
 
-## Context
-
-Starting state: **327 open issues**. Most were bulk-created on 2026-04-09 as a Phase-4/5 tracking backlog. Phase 1, 1.5, 2, 3, 4.7, 4.8 shipped between 2026-04 and 2026-05 without auto-closing their sub-tickets.
-
-This document records the 2026-05-24 audit + cleanup pass and lays out the next dev plan.
+> **Format note.** This doc is rewritten in *directive* form. The top three sections — **Now → Next → After**, **Execution policy**, **Sprints** — answer "what do I do this turn?" without anyone needing to ask. Update them at the end of every session so the next session can pick up cold. Everything below the `---` is reference material (backlog, audit history, reusable patterns).
 
 ---
 
-## Cleanup pass (closed by audit)
+## Now → Next → After
 
-157 tickets closed as already-shipped in the morning audit, then a same-day **wave 2 of 10 Section A items shipped via PRs #823–#833** (driven from sibling agent worktrees while this doc was being drafted). Audit evidence (file paths, migration numbers, PR/commit SHAs) lives in each ticket's closure comment. Net: `327 − 160 open = 167 closed`.
+| When | What | Where | Stop and ask if |
+|---|---|---|---|
+| **NOW** | (1) Rebase `feat/sprint1-collectors` onto `origin/main`, run touched-module tests + ruff + pyright, push, open PR with the body explaining #196-bundled-with-#354. (2) Re-audit **#304** by reading `app/main.py:60–141` — close with evidence link if the 5 s join is acceptable, or open a 1-line follow-up to bump 5 s → 30 s. | `feat/sprint1-collectors` → PR; #304 evidence comment on the issue. | Rebase conflict involves >50 changed lines in one hunk OR breaks a public API contract (signature change in `Retriever.retrieve` or `SparqlClient.query`). |
+| **NEXT** | Start **Sprint 2** on a fresh `feat/sprint2-admin-panels` branch off `origin/main`. First commit: **#198 Performance tab** in `app/admin/performance.py` — query the `metrics` table for the four collector series + the existing `http_request_duration_ms`, render p50/p95/p99 via the existing `DataTable` + `Card` primitives. | `app/admin/performance.py` + `tests/test_admin_performance.py`. | The performance tab needs a schema change nobody approved (it shouldn't — `metrics` already has `(name, value, labels)`). |
+| **AFTER** | Sprint 2 items 2–5, then Sprint 3 (test hardening + #182 shim refactor + #183/#188/#324). Then **Phase 5A gate** check before any API work. | See Sprints section. | — |
+
+---
+
+## Execution policy (defaults — don't re-ask)
+
+These rules let any session pick up and execute. Override only when the user explicitly asks.
+
+- **Rebase**: when `git merge-tree $(git merge-base A B) A B` shows no `<<<<` markers, rebase without asking. If the real rebase produces conflicts, attempt resolution; only stop if a single hunk is >50 lines or breaks a public API contract.
+- **Re-audit tickets** (like #304): read the cited code, verify the DoD, then either close with an evidence link in the issue comment or open a 1-line follow-up issue. Do not surface as a question.
+- **PR opening vs merging**: open the PR (push + `gh pr create`). **Never merge** — the PR-review-gate memory rule keeps merge under the user's control.
+- **Agent scope creep** (e.g., #196 bundled into #354): if the resulting commit is sound + tested, accept the bundling. Note it in the PR body. Do not try to unbundle.
+- **Sprint progression**: when the current sprint's PR enters review (pushed + opened), start the next sprint on a new branch off `origin/main`. Do not wait for merge.
+- **Doc + memory updates**: when the world shifts (parallel PRs land, scope changes, decisions made), update this doc + the relevant memory entry in the same session. Do not open a separate "audit" issue.
+- **Parallel-session reality**: this project frequently has 5–10 sibling agent worktrees racing. Re-check `gh pr list --state merged --search "merged:>=$(date -u +%Y-%m-%d)"` and `git log origin/main` before starting any sprint to absorb whatever shipped since the last update.
+- **Format-before-commit**: pre-commit hook runs `ruff format`. Run it yourself first so the hook is a no-op.
+- **Stop-and-ask thresholds** (the *only* things worth surfacing):
+  - Destructive git ops on shared state (force-push to main, `git reset --hard` on a pushed branch, dropping a branch with unmerged commits).
+  - Migration changes, schema drops, anything touching prod data.
+  - Plan changes that drop a whole sprint or reverse the gating order (e.g., starting Phase 5A before Sprint 3).
+  - Anything outside the scope encoded in **Now → Next → After**.
+
+---
+
+## Sprints
+
+### Sprint 1 — Admin data + visible admin win — **DONE pending rebase + PR**
+
+| Item | Status |
+|---|---|
+| **#182** estimate → DEFER to Sprint 3 | Done. Shim is load-bearing test infrastructure (`_rebind()` rewires `__globals__` so `@patch("app.templates.admin_dashboard.X")` reaches call-time; 14 sites in `tests/test_dashboard.py` depend on it). Not package cleanup. |
+| **#195** job execution time (`app/jobs/worker.py`) | Done on `feat/sprint1-collectors` — `record_metric("job_execution_ms", …)` with `{handler, status}`. |
+| **#196** LLM call latency (`app/llm/claude.py`) | ✅ Shipped to origin/main via **PR #831** (bundled into the #354 retry refactor — the metric wraps the retry-wrapped call cleanly). |
+| **#197** SPARQL duration (`app/ontology/sparql_client.py`) | Done on `feat/sprint1-collectors` — `_execute` is the single instrumented choke-point; `ask()` refactored to route through it. |
+| **#323** RAG retrieval latency (`app/rag/retriever.py`) | Done on `feat/sprint1-collectors` — `feature` kwarg + `record_metric` wrap; 3 callers updated to tag retrievals. |
+| **#322** sync-status polish + history view (`app/admin/sync.py`) | Done on `feat/sprint1-collectors` — `/admin/sync/history` paginated page + shim integration + 7 new tests. |
+| Stub-mode smoke test (`tests/test_import_safety.py`) | Done on `feat/sprint1-collectors` — subprocess test blocks `anthropic`+`voyageai` at `builtins.__import__`, asserts `app.main` imports clean and both SDK singletons stay `None`. |
+
+Branch state: `feat/sprint1-collectors` = 2 ahead / 11 behind `origin/main`. `git merge-tree` shows no conflict markers. Per execution policy → rebase, push, open PR. Then on to **NEXT**.
+
+### Sprint 2 — Admin panels on real data + test fixtures
+
+First commit: **#198 Performance tab** in `app/admin/performance.py`. The route is already registered (`/admin/performance`, see `app/templates/admin_dashboard.py:283`); fill in the page to query the `metrics` table for the four Sprint-1 series + the existing `http_request_duration_ms`. Render p50/p95/p99 via existing `DataTable` + `Card` primitives. Add `tests/test_admin_performance.py` with at least one happy-path + empty-state test.
+
+Then:
+2. **#186** LLM cost dashboard polish — `llm_usage` aggregates by feature/user/org. Data + route already exist; flesh out the panel.
+3. **#185** Usage analytics page — `usage_daily` view already exists; build the page.
+4. **#187** Enhanced audit log viewer — filtering + export. Current route minimal.
+5. **#308** draft fixtures (`tests/fixtures/drafts/`) + **#680** migration 021 SQL-execution test (quick win) + start **#309** Phase 2 edge-case tests on top of #308.
+
+### Sprint 3 — Test hardening + remaining admin
+
+First commit: **#309** Phase 2 edge-case tests (parser / extractor / analyzer) on top of #308 fixtures.
+
+Then:
+2. **#102, #316, #317** VCR coverage (LLM extraction, chat, drafter). Cassettes narrow + secrets redacted aggressively.
+3. **#182** admin shim refactor — focused move + test-import update of 14 sites in `tests/test_dashboard.py`.
+4. **#183** health aggregator, **#188** job monitor polish, **#324** Sentry errors link panel.
+
+### Phase 5A gate — DO NOT START until Sprint 3 is in review
+
+Foundation/governance slice only: **#202, #214, #215–#219, #220–#229, #230, #291, #333**. **Land #221 (auth middleware) and #285 (API auth tests) in the same slice** — middleware without tests is a regression waiting.
+
+5B endpoint groups have per-group gating (see §E for the why):
+- **Ontology** — hold raw SPARQL (#234) until #357 + #358 hardening land.
+- **Drafts** — only with #334 + #360 ownership enforcement.
+- **Webhooks** — only with #336 secret encryption (NFR §6) + #335 rotation + #359 stale-payload guard.
+- **MCP** — only with #337 audit + per-tool rate limits + #361 long-op audit.
+
+---
+
+## Backlog (the 160 open issues organised by area)
+
+### A. Bugs / quality — DONE except #304
+
+Shipped 2026-05-24 PM via PRs **#823–#833**: #176 #180 #299 #306 #307 #311 #315 #347 #348 #352 #354 (the last also bundled the **#196** metric collector).
+
+| # | Status |
+|---|---|
+| **#304** | OPEN — re-audit. `app/main.py:60–141` already wires worker + archive-scheduler lifespan with `_stop_*` events + 5 s join. Original DoD asked for 30 s. Per execution policy: verify, then close-with-evidence or open 1-line follow-up. |
+
+### B. Test coverage hardening — pulled into Sprints 2-3
+
+| # | Title | Effort | Notes |
+|---|---|---|---|
+| #680 | Migration 021 — SQL execution test | S | Sprint 2 quick win |
+| #308 | `tests/fixtures/drafts/` sample data | S | Sprint 2, blocks #309 |
+| #309 | Per-module Phase 2 unit tests | M | Sprint 2-3 |
+| #102 | VCR cassettes for LLM extraction | M | Sprint 3 |
+| #316 | Chat unit tests with VCR | M | Sprint 3 |
+| #317 | Drafter unit tests with VCR | M | Sprint 3 |
+
+### C. Eval framework — EPIC #112 — Q3-2026
+
+Scaffolded (`scripts/run_evals.py`, dependency pinned) but every scenario is a `skip` stub. Items: #112 (epic), #151 #152 #153 #154 #156. **Blocker is subject-matter scenario authoring, not code** — needs user time, not a sprint slot.
+
+### D. Observability + admin polish — EPICS #163, #164, #165 — Sprints 1–3
+
+Infrastructure wired; admin dashboard already registers routes for **audit / performance / analytics / costs / jobs / sync** (`app/templates/admin_dashboard.py:278–292`). Gaps: collectors (Sprint 1 ✅) + data completeness in existing panels (Sprint 2-3).
+
+**Logging stack:** #189 structlog config · #190 logger-call migration · #192 Sentry DSN in Coolify · (#191 Sentry SDK already integrated — closed 2026-05-24).
+
+**Metrics collectors:** all 4 done — #195 worker ✅ Sprint 1 · #196 LLM ✅ via PR #831 · #197 SPARQL ✅ Sprint 1 · #323 RAG ✅ Sprint 1.
+
+**Admin panels** (priority order, mapped to Sprints):
+1. #198 Performance tab — Sprint 2
+2. #186 LLM cost dashboard — Sprint 2
+3. #185 Usage analytics — Sprint 2
+4. #187 Audit log viewer — Sprint 2
+5. #322 Sync history — ✅ Sprint 1
+6. #182 Shim refactor — Sprint 3
+7. #183 Health aggregator — Sprint 3
+8. #188 Job monitor polish — Sprint 3
+9. #324 Sentry errors panel — Sprint 3
+10. #230 Rate-limit config per API key — Phase 5A (depends on `api_keys` table)
+11. #293 API metrics tab — Phase 5A (depends on `api_usage`)
+
+**RAG admin:** #121 (incremental ingestion hook), #123 (admin RAG stats page) — backlog, after Sprint 3.
+
+### E. Phase 5 — Public API + MCP Server — Q4-2026
+
+`app/api/`, `app/mcp/`, public `app/webhooks/` don't exist yet (the existing `app/sync/webhook.py` is the *inbound* ontology-sync webhook — different surface).
+
+**Framing rule (do not relax):** security/governance controls are **gating** per-endpoint, not a final 5E sweep. Per Phase 5 design (`docs/superpowers/specs/2026-04-09-phase5-design.md:7`) and `docs/nfr-baseline.md` §5/§6/§8.3/§9 — they ship on day one of each endpoint.
+
+**5A — Foundation + governance (must-first):** #202 epic · #214 tables (`api_keys`, `api_usage`, `webhook_subscriptions`, `webhook_deliveries`) · #215–#219 API key CRUD/scopes/expiry/rotation/revocation · #216 management UI · **#333 API key audit events (NFR §5 — gates every endpoint)** · #203 epic · #220 `app/api/v1/` router · #221 auth middleware · #204 epic · #222–#229 envelope/error/pagination/rate-limit helpers · **#230** admin rate-limit config per key · **#291** feature flag for API endpoints.
+
+**5B — Endpoints (parallelizable after 5A), each surface ships with its security controls:**
+- Ontology (#205 + #231–#237) — **#234 raw SPARQL blocked on #357 + #358 hardening (NFR §9)**
+- Provisions (#206 + #238–#241)
+- Drafts (#207 + #242–#248) — **with #334 ownership enforcement + #360 API-key scope check**
+- Chat + Drafter (#208 + #249–#255)
+- Meta + Reports (#327 + #256–#258, #328–#332)
+
+**5C — Webhooks + MCP (parallel with 5B):**
+- Webhooks: #210 + #266–#272 + **#336 encrypt `webhook_subscriptions.secret` (NFR §6)** + #335 rotation + #359 stale-payload guard
+- MCP: #211 + #273–#284 tools + **#337 audit + per-tool rate limit (NFR §5, §8.3)** + #361 long-op audit + #292 feature flag
+
+**5D — Docs + deploy + cross-cutting testing:**
+- #209 + #259–#265 OpenAPI / Swagger / docs sites
+- **#212 epic + #285–#290** — auth tests, per-resource endpoint tests, webhook delivery tests, OpenAPI validation, MCP protocol + e2e tests
+- #213 deploy epic, #294 Traefik routing, #295 admin API-key creation tool
+
+**5E — Post-launch governance + TARA:** #338 AI-generated draft provenance · #350 CodexProvider · #362 NFR baseline enforcement audit · #166, #199–#201 TARA activation. (#319/#320/#321 already closed — access-control landed in Phase 3 audit.)
+
+### F. Phase 4 leftover / design tickets — defer until specified
+
+Open-ended "edge case" tickets. Either pull into an active sprint with a concrete spec, or close: #341 file ingestion · #342 legal-reference edges · #343 workflow races · #344 first-class uncertainty UI · #351 AI governance edges · #355 annotation collaboration edges · #149 VTK .docx template (orphaned child of closed #111) · #622 EU directive transposition deadlines (mostly covered by A6 #800).
+
+---
+
+## Cleanup pass (historical audit evidence)
+
+2026-05-24 audit closed **157 tickets** in the morning sweep, then a same-day **wave 2 of 10** Section A items shipped via PRs #823–#833. Net: `327 − 160 open = 167 closed`.
 
 | Group | Count | Range / notes |
 |---|---|---|
-| Recent prod-verification bugs | 16 | #801–#817 (excl. #816 already closed). All have explicit fix commits or PRs #818–#822. #804's TDZ fix also silently unblocked #806 and #807. |
+| Recent prod-verification bugs | 16 | #801–#817 (excl. #816 already closed). PRs #818–#822. #804's TDZ fix silently unblocked #806 + #807. |
 | Epic #784 ontology six use cases | 17 | #784 + #785–#800 (C0–C6, B1–B3, A1–A6) |
 | Phase 2 (Modules 3+4) | 34 | #69–#101, #103 |
-| Phase 3 (Modules 5+6) | 48 | #104, **#105 (RAG epic, parent of still-open #121 + #123)**, #106–#110, **#111 (VTK epic, parent of still-open #149)**, #113–#120, #122, #124–#148, #150, #155, #157–#160. The 48-item count includes both parent epics — they were closed by the same sweep at `2026-05-24T10:42 UTC`. |
+| Phase 3 (Modules 5+6) | 48 | #104, **#105 (RAG epic — children #121 + #123 still open)**, #106–#110, **#111 (VTK epic — child #149 still open)**, #113–#120, #122, #124–#148, #150, #155, #157–#160. The 48-count includes both parent epics — closed `2026-05-24T10:42 UTC`. |
 | Phase 4 Annotations | 14 | #161, #167–#175, #297, #325, #326, #356 |
 | Phase 4 Notifications | 11 | #162, #177–#179, #296, #298, #300–#303, #346 |
 | Phase 4 Admin/Observability (subset) | 5 | #184, #191, #193, #194, #340 |
 | Misc completed | 12 | #305, #310, #312–#314, #318–#321, #345, #349, #353 |
 | **Subtotal (morning audit)** | **157** |  |
-| Section A wave 2 (shipped via PRs #823–#833) | 10 | #176 (#825), #180 (#823), #299 (#824), #306 (#826), #307 (#827), #311 (#830), #315 (#832), #347 (#828), #348 (#829), #352 (#833). #354 closed via #831 also bundled the #196 LLM-latency collector. |
+| Section A wave 2 (PRs #823–#833) | 10 | #176 (#825), #180 (#823), #299 (#824), #306 (#826), #307 (#827), #311 (#830), #315 (#832), #347 (#828), #348 (#829), #352 (#833). #354 (PR #831) also bundled the **#196** LLM-latency collector. |
 | **Total closed** | **167** |  |
 
-> **Note (revision pass, 2026-05-24 PM):** the original draft listed #105 and #111 as "Skipped"; in fact both parent epics were closed by the same audit run (their still-open *children* #121, #123, #149 are what was skipped). Row description corrected above; counts unchanged.
+> **Note (revision pass, 2026-05-24 PM):** original draft listed #105 + #111 as "Skipped"; both parent epics were closed by the same audit run (only the children #121, #123, #149 remain). Counts unchanged.
 >
-> **Note (evening pass, 2026-05-24 PM):** Section A drained almost entirely during the audit afternoon — 10 items shipped via parallel agent-driven PRs #823–#833, and #354 (PR #831) also bundled the #196 LLM-call-latency collector (a Sprint 1 / §D item). Only #304 remains in §A as a re-audit task.
+> **Note (evening pass, 2026-05-24 PM):** Section A drained almost entirely during the audit afternoon — parallel agent-driven PRs. #354's PR #831 also pulled #196 along for the ride.
 
-Result: **160 open issues remain** (real work). Zero `bug`-labeled tickets remain — all 17 prod-verification bugs from 2026-05-19 are closed.
+Zero `bug`-labeled tickets remain — all 17 prod-verification bugs from 2026-05-19 are closed.
 
----
-
-## Remaining open — grouped + prioritized
-
-### A. Bugs / quality fixes — **DONE except #304** (shipped 2026-05-24 PM via PRs #823–#833)
-
-The original Section A table (12 items) is collapsed below. 11 items shipped on 2026-05-24 PM; only **#304** remains as a re-audit task. The cross-cutting #180 pattern note (durable row + outbound delivery + graceful fallback) is now live in `app/notifications/` — see Phase 5C webhooks for reuse.
-
-| # | Title | Status |
-|---|---|---|
-| #180 | WebSocket notification delivery | ✅ PR #823 |
-| #299 | Wire notify(): draft_shared event | ✅ PR #824 |
-| #176 | @mention autocomplete frontend typeahead | ✅ PR #825 |
-| #306 | Draft re-analyze button + handler | ✅ PR #826 |
-| #307 | Expiring signed URL for impact-report .docx | ✅ PR #827 |
-| #347 | HTMX status polling fallback on draft detail | ✅ PR #828 |
-| #348 | Worker process standalone entrypoint | ✅ PR #829 |
-| #311 | Retriever metadata filtering (org/date/source) | ✅ PR #830 |
-| #354 | LLM call retry with backoff (*also bundles the #196 metric collector*) | ✅ PR #831 |
-| #315 | Persist tool_use/tool_result with parent message id | ✅ PR #832 |
-| #352 | Chat cites outdated-ontology warning | ✅ PR #833 |
-| **#304** | **JobWorker startup/shutdown in FastHTML lifespan** | **OPEN — re-audit:** `app/main.py:60–141` already wires the worker + archive-scheduler into the lifespan with `_stop_*` events and a 5 s join. Original DoD wanted a 30 s join timeout; verify, then either close as already-shipped or open a 1-line follow-up to bump the timeout. |
-
-### B. Test coverage hardening — TARGET: rolling
-
-| # | Title | Effort | Notes |
-|---|---|---|---|
-| #102 | VCR cassettes for LLM extraction | M | tests/cassettes/ is empty |
-| #316 | Chat unit tests with VCR | M | same |
-| #317 | Drafter unit tests with VCR | M | same |
-| #308 | tests/fixtures/drafts/ sample data | S | needed for #309 |
-| #309 | Per-module Phase 2 unit tests | M | parse, extract, analyze edge cases |
-| #680 | Migration 021 — test by SQL execution, not text search | S | quick win |
-
-### C. Eval framework — EPIC #112 — TARGET: Q3-2026
-
-Currently scaffolded (scripts/run_evals.py exists, dependency pinned) but every scenario is a `skip` stub.
-
-- #112 (epic), #151 (chat accuracy), #152 (chat citations), #153 (drafter scenarios), #154 (LLM judge), #156 (weekly CI job)
-- Effort: ~2 weeks once scenarios are written. Blocker is **subject-matter scenario authoring**, not code.
-
-### D. Observability + admin polish — EPICS #163, #164, #165 — TARGET: Q3-2026
-
-Infrastructure (Sentry init, `MetricsMiddleware`, `llm_usage`, `audit_log`, sync-status card, jobs page with retry/purge) is wired and the dashboard already registers routes for **audit / performance / analytics / costs / jobs / sync** (`app/templates/admin_dashboard.py:278–292`). The real gaps are (a) data-collectors that populate the metrics table, (b) data completeness inside the existing panels, and (c) the routes that still don't have their own surface.
-
-**Logging stack (#189, #190, #192):**
-- #189 install structlog + processor config
-- #190 migrate logger calls to structured
-- #192 Sentry DSN in Coolify (infra task)
-- (#191 Sentry SDK already integrated — closed 2026-05-24 in the audit sweep.)
-
-**Metrics collectors (#195–#197, #323):**
-- #195 job execution time (wire `track_duration` in worker)
-- #196 LLM call latency (wire in `app/llm/claude.py`)
-- #197 SPARQL duration (wire in `app/ontology/sparql_client.py`)
-- #323 RAG retrieval latency (wire in `app/rag/retriever.py`)
-
-**Admin panels (#163, #182, #183, #185, #186, #187, #188, #198, #230, #293, #322, #324):**
-- Reframed: most routes are *registered*; the gap is data completeness + polish + a few missing surfaces. Finish in priority order:
-  1. #182 finish `app/templates/admin_dashboard.py` → `app/admin/` package split (refactor, not a new page)
-  2. #198 Performance tab — populate latency percentiles once #195–#197 collectors land
-  3. #186 LLM cost dashboard — surface `llm_usage` aggregates by feature/user/org
-  4. #322 Sync status panel polish (the card itself ships; this is UX polish + history view)
-  5. #185 Usage analytics page — data exists in `usage_daily` view
-  6. #187 Enhanced audit log viewer — current route is minimal
-  7. #324 Sentry errors link panel
-  8. #183 System health aggregator (rollup of /api/health subsystems)
-  9. #188 Job monitor polish — retry/purge already shipped, this is filtering + per-handler stats
-  10. **#230** Rate-limit config per API key (depends on Phase 5A `api_keys` table — see §E)
-  11. **#293** API metrics tab — calls / 429s / latency per API key (depends on Phase 5A + collectors)
-
-**RAG admin (#121, #123):**
-- #121 Incremental RAG ingestion hook (sync pipeline → RAG)
-- #123 Admin RAG stats page
-
-### E. Phase 5 — Public API + MCP Server — TARGET: Q4-2026
-
-App still does not have an `app/api/`, `app/mcp/`, or a public `app/webhooks/` module (the existing `app/sync/webhook.py` is the *inbound* ontology-sync webhook handler — a different surface). Real future work. Plan in 5 sub-phases.
-
-**Important framing change vs the original draft:** security/governance controls (audit events, SPARQL hardening, webhook secret encryption, MCP audit + rate limits) are **gating** for the endpoints they protect, not a final 5E sweep. The Phase 5 design (`docs/superpowers/specs/2026-04-09-phase5-design.md:7`) and `docs/nfr-baseline.md` §5, §6, §8.3, §9 require them on day one of each endpoint. The mapping below moves them inline.
-
-**5A — Foundation + governance (must-first):**
-- #202 epic (API key management), #214 tables (`api_keys`, `api_usage`, `webhook_subscriptions`, `webhook_deliveries`)
-- #215–#219 API key CRUD / scopes / expiry / rotation / revocation, #216 management UI
-- **#333 API key audit events** — *gates* every endpoint below (NFR §5)
-- #203 epic, #220 `app/api/v1/` router, #221 auth middleware
-- #204 epic, #222–#229 envelope / error / pagination / rate-limit helpers
-- **#230 admin: rate-limit config per key** — ships with rate limiting, not as later admin polish
-- **#291 feature flag for API endpoints** — kill-switch before any endpoint goes live
-
-**5B — Endpoints (parallelizable after 5A) — each surface ships with its security controls:**
-- Ontology (#205 + #231–#237) — **the SPARQL endpoint #234 is blocked on #357 + #358 SPARQL hardening (NFR §9). Land hardening first or ship #234 last in the group.**
-- Provisions (#206 + #238–#241)
-- Drafts (#207 + #242–#248) — ships **with** **#334 API draft ownership enforcement** and **#360 API-key scope check for draft ownership**
-- Chat + Drafter (#208 + #249–#255)
-- Meta + Reports (#327 + #256–#258, #328–#332)
-
-**5C — Webhooks + MCP (parallel with 5B) — security controls inline, not deferred:**
-- Webhooks: #210 + #266–#272, **#336 encrypt `webhook_subscriptions.secret` at rest (NFR §6 — required before first delivery), #335 rotation, #359 retry/stale-payload guard**
-- MCP: #211 + #273–#284 (tools), **#337 MCP call audit + per-tool rate limit (NFR §5, §8.3 — required before tool exposure), #361 long-running-op audit, #292 MCP feature flag**
-
-**5D — Docs + deploy + cross-cutting testing:**
-- #209 + #259–#265 OpenAPI / Swagger / Getting Started / Webhooks guide / MCP setup guide / rate-limits docs
-- **#212 epic + #285–#290** — API auth tests, per-resource endpoint tests, webhook delivery tests, OpenAPI spec validation, MCP protocol + e2e tests. (The original draft tucked #285–#290 under the MCP epic; they belong with the cross-cutting test epic #212.)
-- #213 Phase 5 deploy epic, #294 Traefik routing, #295 admin API-key creation tool
-
-**5E — Post-launch governance + TARA:**
-- #338 AI-generated draft provenance metadata
-- #350 CodexProvider implementation (LLM provider swap-readiness)
-- #362 epic — NFR baseline enforcement audit across all phases (close the loop on §5/§6/§8/§9 controls)
-- #166, #199–#201 TARA activation (stub provider → activation docs → env vars)
-- (#319, #320, #321 already closed — access-control work landed in Phase 3 audit)
-
-### F. Phase 4 leftover / design tickets — defer until specified
-
-These are open-ended "edge case" tickets. Either pull into an active sprint with a concrete spec, or close.
-
-- #341 File ingestion edge cases
-- #342 Legal-reference edge cases in extractor
-- #343 Workflow race conditions
-- #344 First-class uncertainty UI
-- #351 AI governance edge cases
-- #355 Annotation collaboration edge cases
-- #149 VTK .docx template (orphaned child of closed VTK epic #111 — either spec it or close)
-- #622 EU directive transposition deadlines (#597 reference; mostly covered by A6 #800)
+GitHub anti-abuse rate-limits `addComment` hard at >10/min, so closure comments fail silently while the close itself succeeds. For bulk closes: prefer no-comment close + a single audit doc.
 
 ---
 
-## Concrete sprint plan
+## Cross-cutting patterns to reuse
 
-Section A is done bar #304 (re-audit). The plan below sequences D + B before Phase 5 so that public surfaces launch with metrics, audit visibility, fixtures, and regression coverage already in place.
+- **#180 pattern (PR #823, `app/notifications/`):** durable DB row + outbound delivery + graceful polling fallback. Template for Phase 5C webhook delivery/retry (#268, #270, #359).
+- **#311 filters (PR #830, `app/rag/retriever.py`):** `Retriever.retrieve(filters=…, feature=…)` composes for `/api/v1/provisions/search` (Phase 5B) and the chat retriever.
+- **#354 retry (PR #831, `app/llm/retry.py`):** `retry_sync` / `retry_async` generic enough to wrap Voyage embeddings + Phase 5C webhook deliveries. Same backoff schedule + classification.
 
-### Sprint 1 — Admin data + visible admin win — **IN FLIGHT (2026-05-24 PM)**
-
-| # | Status |
-|---|---|
-| **#182** estimate → **DEFER to Sprint 3** | Done — shim is load-bearing test infrastructure (`_rebind()` rewires `__globals__` so `@patch("app.templates.admin_dashboard.X")` reaches call-time; 14 sites in `tests/test_dashboard.py` depend on this). Not package cleanup. |
-| **#195** job execution time (`app/jobs/worker.py`) | Done — on `feat/sprint1-collectors` (`record_metric("job_execution_ms", …)` with `{handler, status}`). |
-| **#196** LLM call latency (`app/llm/claude.py`) | ✅ **shipped to origin/main via PR #831** (bundled into the #354 retry refactor at the agent's discretion — the metric wraps the retry-wrapped call cleanly). |
-| **#197** SPARQL duration (`app/ontology/sparql_client.py`) | Done — on `feat/sprint1-collectors` (`_execute` is the single instrumented choke-point; `ask()` refactored to route through it). |
-| **#323** RAG retrieval latency (`app/rag/retriever.py`) | Done — on `feat/sprint1-collectors` (`feature` kwarg + `record_metric` wrap; 3 callers updated to tag retrievals). |
-| **#322** sync-status polish + history view (`app/admin/sync.py`) | Done — on `feat/sprint1-collectors` (`/admin/sync/history` paginated page with "Vaata ajalugu →" link from the card; full shim integration + 7 new tests). |
-| Stub-mode smoke test (`tests/test_import_safety.py`) | Done — subprocess test blocks `anthropic` + `voyageai` at `builtins.__import__`, asserts `app.main` imports clean and both SDK singletons stay `None`. |
-
-**Sprint 1 status:** all 5 work-items done; `feat/sprint1-collectors` is 2 commits ahead of origin/main but **11 commits behind** (origin advanced via the Section A wave-2 merges). Needs a rebase before PR. Touched files overlap with merged PRs (notably #311's `retriever.py` signature change and #354's `claude.py` rewrite), so rebase warrants careful conflict review — but `git merge-tree` dry-run shows no marker collisions.
-
-### Sprint 2 — Admin panels on top of real data + test fixtures
-
-1. **#198** Performance tab — backed by #195–#197 collectors.
-2. **#186** LLM cost dashboard polish — `llm_usage` aggregates by feature/user/org.
-3. **#185** Usage analytics page — `usage_daily` view already exists.
-4. **#187** Enhanced audit log viewer — filtering + export.
-5. **#308** draft fixtures (`tests/fixtures/drafts/`) + **#680** migration 021 SQL-execution test (quick win) + start **#309** Phase 2 edge-case tests on top of #308.
-
-### Sprint 3 — Test hardening + remaining admin
-
-1. Finish **#309** (parser/extractor/analyzer edge cases).
-2. **#102, #316, #317** VCR coverage (LLM extraction, chat, drafter). Cassettes narrow + secrets redacted aggressively.
-3. **#182** admin shim refactor (now that polish is in place, the rewrite is a focused move + test-import update of 14 sites).
-4. **#183** health aggregator, **#188** job monitor polish, **#324** Sentry errors link panel.
-
-### Phase 5A gate (after Sprint 3)
-
-Start the foundation/governance slice only: **#202, #214–#229, #230, #291, #333**. **Land #221 (auth middleware) and #285 (API auth tests) in the same slice** — auth middleware without auth tests is a regression waiting to happen.
-
-Do *not* start any 5B endpoint group until its gating controls from §E are scheduled:
-- Ontology endpoints — hold raw SPARQL (#234) until #357 + #358 hardening land.
-- Draft endpoints — only with #334 + #360 ownership enforcement.
-- Webhooks — only with #336 secret encryption (NFR §6) + #335 rotation + #359 stale-payload guard.
-- MCP — only with #337 audit + per-tool rate limits + #361 long-op audit.
-
-### Cross-cutting
-
-- **#180 pattern (shipped via PR #823):** WebSocket notification delivery now lives in `app/notifications/`. When Phase 5C webhook delivery (#268, #270) and retry/stale-payload guard (#359) start, copy the pattern — durable DB row + outbound delivery + graceful fallback to polling — rather than reinventing it.
-- **#311 retriever filters (shipped via PR #830):** the new `filters` kwarg on `Retriever.retrieve()` composes with Sprint 1's `feature` kwarg on the same surface; Phase 5B `/api/v1/provisions/search` and the chat retriever can both use both.
-- **#354 retry pattern (shipped via PR #831, file `app/llm/retry.py`):** `retry_sync` / `retry_async` are now generic enough to wrap Voyage embeddings too. Phase 5C webhook delivery retries (#270, #359) should consider reusing the same backoff schedule + classification logic instead of writing their own.
-- **Continuously:** section B test-coverage backlog (any agent dispatched on a bug should leave a cassette or fixture behind).
-- **Triage call:** section F design tickets — either commit a spec or close as "WONTFIX (specify when needed)".
+---
 
 ## Reference
 
-- Per-ticket audit evidence: closure comments on each issue
-- Phase status: `CLAUDE.md` "Development Phases"
-- NFR baseline: `docs/nfr-baseline.md`
-- Phase 5 design: `docs/superpowers/specs/2026-04-09-phase5-design.md`
-- Ontology data model: `estonian-legal-ontology-plan.md`
+- Per-ticket audit evidence: closure comments on each issue.
+- Phase status: `CLAUDE.md` "Development Phases".
+- NFR baseline: `docs/nfr-baseline.md`.
+- Phase 5 design: `docs/superpowers/specs/2026-04-09-phase5-design.md`.
+- Ontology data model: `estonian-legal-ontology-plan.md`.
+- Stub-mode test contract: `tests/test_import_safety.py::test_app_main_imports_without_constructing_sdk_singletons` — keep this green; the four Sprint-1 collectors all rely on it.

--- a/docs/2026-05-24-issue-cleanup-and-roadmap.md
+++ b/docs/2026-05-24-issue-cleanup-and-roadmap.md
@@ -1,0 +1,207 @@
+# 2026-05-24 — Issue cleanup + post-Phase-4 roadmap
+
+## Context
+
+Starting state: **327 open issues**. Most were bulk-created on 2026-04-09 as a Phase-4/5 tracking backlog. Phase 1, 1.5, 2, 3, 4.7, 4.8 shipped between 2026-04 and 2026-05 without auto-closing their sub-tickets.
+
+This document records the 2026-05-24 audit + cleanup pass and lays out the next dev plan.
+
+---
+
+## Cleanup pass (closed by audit)
+
+157 tickets closed as already-shipped. Audit evidence (file paths, migration numbers, PR/commit SHAs) lives in each ticket's closure comment. (`327 − 170 open = 157 closed`.)
+
+| Group | Count | Range / notes |
+|---|---|---|
+| Recent prod-verification bugs | 16 | #801–#817 (excl. #816 already closed). All have explicit fix commits or PRs #818–#822. #804's TDZ fix also silently unblocked #806 and #807. |
+| Epic #784 ontology six use cases | 17 | #784 + #785–#800 (C0–C6, B1–B3, A1–A6) |
+| Phase 2 (Modules 3+4) | 34 | #69–#101, #103 |
+| Phase 3 (Modules 5+6) | 48 | #104, **#105 (RAG epic, parent of still-open #121 + #123)**, #106–#110, **#111 (VTK epic, parent of still-open #149)**, #113–#120, #122, #124–#148, #150, #155, #157–#160. The 48-item count includes both parent epics — they were closed by the same sweep at `2026-05-24T10:42 UTC`. |
+| Phase 4 Annotations | 14 | #161, #167–#175, #297, #325, #326, #356 |
+| Phase 4 Notifications | 11 | #162, #177–#179, #296, #298, #300–#303, #346 |
+| Phase 4 Admin/Observability (subset) | 5 | #184, #191, #193, #194, #340 |
+| Misc completed | 12 | #305, #310, #312–#314, #318–#321, #345, #349, #353 |
+| **Total closed** | **157** |  |
+
+> **Note (revision pass, 2026-05-24 PM):** the original draft listed #105 and #111 as "Skipped"; in fact both parent epics were closed by the same audit run (their still-open *children* #121, #123, #149 are what was skipped). Row description corrected above; counts unchanged.
+
+Result: **170 open issues remain** (real work). Zero `bug`-labeled tickets remain — all 17 prod-verification bugs from 2026-05-19 are closed.
+
+---
+
+## Remaining open — grouped + prioritized
+
+### A. Bugs / quality fixes (small, near-term) — TARGET: this sprint
+
+Mostly missing test coverage, deferred edge-cases, and one or two small UX gaps surfaced by audits.
+
+| # | Title | Effort | Priority |
+|---|---|---|---|
+| #180 | WebSocket notification delivery (currently DB + 30s poll) | M | P1 |
+| #299 | Wire notify(): draft_shared event | S | P1 |
+| #176 | @mention autocomplete frontend typeahead | M | P2 |
+| #306 | Draft re-analyze button + handler | S | P2 |
+| #307 | Expiring signed URL for impact-report .docx | M | P2 |
+| #315 | Persist tool_use/tool_result with parent message id | S | P2 |
+| #347 | HTMX status polling fallback on draft detail | S | P2 |
+| #348 | Worker process standalone entrypoint (Coolify run mode) | S | P2 |
+| #304 | JobWorker startup/shutdown in FastHTML lifespan | XS | P3 — **re-audit before working**; `app/main.py:60–141` already wires the worker + archive-scheduler into the lifespan with `_stop_*` events and a 5 s join. Original DoD wanted a 30 s join timeout; verify, then close (or open a tiny follow-up to bump the timeout) |
+| #311 | Retriever metadata filtering (org/date/source) | M | P3 |
+| #352 | Chat cites outdated-ontology warning banner | S | P3 |
+| #354 | LLM call retry logic with backoff (currently job-queue level) | M | P3 |
+
+### B. Test coverage hardening — TARGET: rolling
+
+| # | Title | Effort | Notes |
+|---|---|---|---|
+| #102 | VCR cassettes for LLM extraction | M | tests/cassettes/ is empty |
+| #316 | Chat unit tests with VCR | M | same |
+| #317 | Drafter unit tests with VCR | M | same |
+| #308 | tests/fixtures/drafts/ sample data | S | needed for #309 |
+| #309 | Per-module Phase 2 unit tests | M | parse, extract, analyze edge cases |
+| #680 | Migration 021 — test by SQL execution, not text search | S | quick win |
+
+### C. Eval framework — EPIC #112 — TARGET: Q3-2026
+
+Currently scaffolded (scripts/run_evals.py exists, dependency pinned) but every scenario is a `skip` stub.
+
+- #112 (epic), #151 (chat accuracy), #152 (chat citations), #153 (drafter scenarios), #154 (LLM judge), #156 (weekly CI job)
+- Effort: ~2 weeks once scenarios are written. Blocker is **subject-matter scenario authoring**, not code.
+
+### D. Observability + admin polish — EPICS #163, #164, #165 — TARGET: Q3-2026
+
+Infrastructure (Sentry init, `MetricsMiddleware`, `llm_usage`, `audit_log`, sync-status card, jobs page with retry/purge) is wired and the dashboard already registers routes for **audit / performance / analytics / costs / jobs / sync** (`app/templates/admin_dashboard.py:278–292`). The real gaps are (a) data-collectors that populate the metrics table, (b) data completeness inside the existing panels, and (c) the routes that still don't have their own surface.
+
+**Logging stack (#189, #190, #192):**
+- #189 install structlog + processor config
+- #190 migrate logger calls to structured
+- #192 Sentry DSN in Coolify (infra task)
+- (#191 Sentry SDK already integrated — closed 2026-05-24 in the audit sweep.)
+
+**Metrics collectors (#195–#197, #323):**
+- #195 job execution time (wire `track_duration` in worker)
+- #196 LLM call latency (wire in `app/llm/claude.py`)
+- #197 SPARQL duration (wire in `app/ontology/sparql_client.py`)
+- #323 RAG retrieval latency (wire in `app/rag/retriever.py`)
+
+**Admin panels (#163, #182, #183, #185, #186, #187, #188, #198, #230, #293, #322, #324):**
+- Reframed: most routes are *registered*; the gap is data completeness + polish + a few missing surfaces. Finish in priority order:
+  1. #182 finish `app/templates/admin_dashboard.py` → `app/admin/` package split (refactor, not a new page)
+  2. #198 Performance tab — populate latency percentiles once #195–#197 collectors land
+  3. #186 LLM cost dashboard — surface `llm_usage` aggregates by feature/user/org
+  4. #322 Sync status panel polish (the card itself ships; this is UX polish + history view)
+  5. #185 Usage analytics page — data exists in `usage_daily` view
+  6. #187 Enhanced audit log viewer — current route is minimal
+  7. #324 Sentry errors link panel
+  8. #183 System health aggregator (rollup of /api/health subsystems)
+  9. #188 Job monitor polish — retry/purge already shipped, this is filtering + per-handler stats
+  10. **#230** Rate-limit config per API key (depends on Phase 5A `api_keys` table — see §E)
+  11. **#293** API metrics tab — calls / 429s / latency per API key (depends on Phase 5A + collectors)
+
+**RAG admin (#121, #123):**
+- #121 Incremental RAG ingestion hook (sync pipeline → RAG)
+- #123 Admin RAG stats page
+
+### E. Phase 5 — Public API + MCP Server — TARGET: Q4-2026
+
+App still does not have an `app/api/`, `app/mcp/`, or a public `app/webhooks/` module (the existing `app/sync/webhook.py` is the *inbound* ontology-sync webhook handler — a different surface). Real future work. Plan in 5 sub-phases.
+
+**Important framing change vs the original draft:** security/governance controls (audit events, SPARQL hardening, webhook secret encryption, MCP audit + rate limits) are **gating** for the endpoints they protect, not a final 5E sweep. The Phase 5 design (`docs/superpowers/specs/2026-04-09-phase5-design.md:7`) and `docs/nfr-baseline.md` §5, §6, §8.3, §9 require them on day one of each endpoint. The mapping below moves them inline.
+
+**5A — Foundation + governance (must-first):**
+- #202 epic (API key management), #214 tables (`api_keys`, `api_usage`, `webhook_subscriptions`, `webhook_deliveries`)
+- #215–#219 API key CRUD / scopes / expiry / rotation / revocation, #216 management UI
+- **#333 API key audit events** — *gates* every endpoint below (NFR §5)
+- #203 epic, #220 `app/api/v1/` router, #221 auth middleware
+- #204 epic, #222–#229 envelope / error / pagination / rate-limit helpers
+- **#230 admin: rate-limit config per key** — ships with rate limiting, not as later admin polish
+- **#291 feature flag for API endpoints** — kill-switch before any endpoint goes live
+
+**5B — Endpoints (parallelizable after 5A) — each surface ships with its security controls:**
+- Ontology (#205 + #231–#237) — **the SPARQL endpoint #234 is blocked on #357 + #358 SPARQL hardening (NFR §9). Land hardening first or ship #234 last in the group.**
+- Provisions (#206 + #238–#241)
+- Drafts (#207 + #242–#248) — ships **with** **#334 API draft ownership enforcement** and **#360 API-key scope check for draft ownership**
+- Chat + Drafter (#208 + #249–#255)
+- Meta + Reports (#327 + #256–#258, #328–#332)
+
+**5C — Webhooks + MCP (parallel with 5B) — security controls inline, not deferred:**
+- Webhooks: #210 + #266–#272, **#336 encrypt `webhook_subscriptions.secret` at rest (NFR §6 — required before first delivery), #335 rotation, #359 retry/stale-payload guard**
+- MCP: #211 + #273–#284 (tools), **#337 MCP call audit + per-tool rate limit (NFR §5, §8.3 — required before tool exposure), #361 long-running-op audit, #292 MCP feature flag**
+
+**5D — Docs + deploy + cross-cutting testing:**
+- #209 + #259–#265 OpenAPI / Swagger / Getting Started / Webhooks guide / MCP setup guide / rate-limits docs
+- **#212 epic + #285–#290** — API auth tests, per-resource endpoint tests, webhook delivery tests, OpenAPI spec validation, MCP protocol + e2e tests. (The original draft tucked #285–#290 under the MCP epic; they belong with the cross-cutting test epic #212.)
+- #213 Phase 5 deploy epic, #294 Traefik routing, #295 admin API-key creation tool
+
+**5E — Post-launch governance + TARA:**
+- #338 AI-generated draft provenance metadata
+- #350 CodexProvider implementation (LLM provider swap-readiness)
+- #362 epic — NFR baseline enforcement audit across all phases (close the loop on §5/§6/§8/§9 controls)
+- #166, #199–#201 TARA activation (stub provider → activation docs → env vars)
+- (#319, #320, #321 already closed — access-control work landed in Phase 3 audit)
+
+### F. Phase 4 leftover / design tickets — defer until specified
+
+These are open-ended "edge case" tickets. Either pull into an active sprint with a concrete spec, or close.
+
+- #341 File ingestion edge cases
+- #342 Legal-reference edge cases in extractor
+- #343 Workflow race conditions
+- #344 First-class uncertainty UI
+- #351 AI governance edge cases
+- #355 Annotation collaboration edge cases
+- #149 VTK .docx template (orphaned child of closed VTK epic #111 — either spec it or close)
+- #622 EU directive transposition deadlines (#597 reference; mostly covered by A6 #800)
+
+---
+
+## Concrete sprint plan
+
+Section A runs separately (P1 notification bugs + #304 re-audit). The plan below sequences D + B before Phase 5 so that public surfaces launch with metrics, audit visibility, fixtures, and regression coverage already in place.
+
+### Sprint 1 — Admin data + visible admin win
+
+1. **#182 estimate → DEFER to Sprint 3.** `app/admin/` is already a 14-module package; `app/templates/admin_dashboard.py` is a 291-line *load-bearing shim* (uses `_rebind()` to rewire `__globals__` so `@patch("app.templates.admin_dashboard.X")` still works at call-time; 14 test sites in `tests/test_dashboard.py` depend on this). Not package cleanup — keep for Sprint 3.
+2. **Metric collectors:** #195 (worker), #196 (`app/llm/claude.py`), #197 (`app/ontology/sparql_client.py`), #323 (`app/rag/retriever.py`). All four wrap at *call time*, not import time, so the lazy-init singleton pattern survives stub mode.
+3. **#322 sync-status polish + history view** — the basic card ships; this adds paginated history from `sync_log` and empty/error-state polish. Cheap bundle with the collectors.
+4. **Smoke test collector imports in stub mode** — `APP_ENV=development` with neither `anthropic` nor `voyageai` installed: importing `app.main` must not force-construct any SDK client. Add a regression test if not already covered.
+
+### Sprint 2 — Admin panels on top of real data + test fixtures
+
+1. **#198** Performance tab — backed by #195–#197 collectors.
+2. **#186** LLM cost dashboard polish — `llm_usage` aggregates by feature/user/org.
+3. **#185** Usage analytics page — `usage_daily` view already exists.
+4. **#187** Enhanced audit log viewer — filtering + export.
+5. **#308** draft fixtures (`tests/fixtures/drafts/`) + **#680** migration 021 SQL-execution test (quick win) + start **#309** Phase 2 edge-case tests on top of #308.
+
+### Sprint 3 — Test hardening + remaining admin
+
+1. Finish **#309** (parser/extractor/analyzer edge cases).
+2. **#102, #316, #317** VCR coverage (LLM extraction, chat, drafter). Cassettes narrow + secrets redacted aggressively.
+3. **#182** admin shim refactor (now that polish is in place, the rewrite is a focused move + test-import update of 14 sites).
+4. **#183** health aggregator, **#188** job monitor polish, **#324** Sentry errors link panel.
+
+### Phase 5A gate (after Sprint 3)
+
+Start the foundation/governance slice only: **#202, #214–#229, #230, #291, #333**. **Land #221 (auth middleware) and #285 (API auth tests) in the same slice** — auth middleware without auth tests is a regression waiting to happen.
+
+Do *not* start any 5B endpoint group until its gating controls from §E are scheduled:
+- Ontology endpoints — hold raw SPARQL (#234) until #357 + #358 hardening land.
+- Draft endpoints — only with #334 + #360 ownership enforcement.
+- Webhooks — only with #336 secret encryption (NFR §6) + #335 rotation + #359 stale-payload guard.
+- MCP — only with #337 audit + per-tool rate limits + #361 long-op audit.
+
+### Cross-cutting
+
+- **#180 pattern note:** once WebSocket notification delivery lands in section A, document the reusable pattern (durable row + outbound delivery + graceful fallback) — that becomes the template for Phase 5C webhook delivery/retry (#268, #270, #359), not just a notification fix.
+- **Continuously:** section B test-coverage backlog (any agent dispatched on a bug should leave a cassette or fixture behind).
+- **Triage call:** section F design tickets — either commit a spec or close as "WONTFIX (specify when needed)".
+
+## Reference
+
+- Per-ticket audit evidence: closure comments on each issue
+- Phase status: `CLAUDE.md` "Development Phases"
+- NFR baseline: `docs/nfr-baseline.md`
+- Phase 5 design: `docs/superpowers/specs/2026-04-09-phase5-design.md`
+- Ontology data model: `estonian-legal-ontology-plan.md`

--- a/docs/2026-05-24-issue-cleanup-and-roadmap.md
+++ b/docs/2026-05-24-issue-cleanup-and-roadmap.md
@@ -10,7 +10,7 @@ This document records the 2026-05-24 audit + cleanup pass and lays out the next 
 
 ## Cleanup pass (closed by audit)
 
-157 tickets closed as already-shipped. Audit evidence (file paths, migration numbers, PR/commit SHAs) lives in each ticket's closure comment. (`327 − 170 open = 157 closed`.)
+157 tickets closed as already-shipped in the morning audit, then a same-day **wave 2 of 10 Section A items shipped via PRs #823–#833** (driven from sibling agent worktrees while this doc was being drafted). Audit evidence (file paths, migration numbers, PR/commit SHAs) lives in each ticket's closure comment. Net: `327 − 160 open = 167 closed`.
 
 | Group | Count | Range / notes |
 |---|---|---|
@@ -22,34 +22,38 @@ This document records the 2026-05-24 audit + cleanup pass and lays out the next 
 | Phase 4 Notifications | 11 | #162, #177–#179, #296, #298, #300–#303, #346 |
 | Phase 4 Admin/Observability (subset) | 5 | #184, #191, #193, #194, #340 |
 | Misc completed | 12 | #305, #310, #312–#314, #318–#321, #345, #349, #353 |
-| **Total closed** | **157** |  |
+| **Subtotal (morning audit)** | **157** |  |
+| Section A wave 2 (shipped via PRs #823–#833) | 10 | #176 (#825), #180 (#823), #299 (#824), #306 (#826), #307 (#827), #311 (#830), #315 (#832), #347 (#828), #348 (#829), #352 (#833). #354 closed via #831 also bundled the #196 LLM-latency collector. |
+| **Total closed** | **167** |  |
 
 > **Note (revision pass, 2026-05-24 PM):** the original draft listed #105 and #111 as "Skipped"; in fact both parent epics were closed by the same audit run (their still-open *children* #121, #123, #149 are what was skipped). Row description corrected above; counts unchanged.
+>
+> **Note (evening pass, 2026-05-24 PM):** Section A drained almost entirely during the audit afternoon — 10 items shipped via parallel agent-driven PRs #823–#833, and #354 (PR #831) also bundled the #196 LLM-call-latency collector (a Sprint 1 / §D item). Only #304 remains in §A as a re-audit task.
 
-Result: **170 open issues remain** (real work). Zero `bug`-labeled tickets remain — all 17 prod-verification bugs from 2026-05-19 are closed.
+Result: **160 open issues remain** (real work). Zero `bug`-labeled tickets remain — all 17 prod-verification bugs from 2026-05-19 are closed.
 
 ---
 
 ## Remaining open — grouped + prioritized
 
-### A. Bugs / quality fixes (small, near-term) — TARGET: this sprint
+### A. Bugs / quality fixes — **DONE except #304** (shipped 2026-05-24 PM via PRs #823–#833)
 
-Mostly missing test coverage, deferred edge-cases, and one or two small UX gaps surfaced by audits.
+The original Section A table (12 items) is collapsed below. 11 items shipped on 2026-05-24 PM; only **#304** remains as a re-audit task. The cross-cutting #180 pattern note (durable row + outbound delivery + graceful fallback) is now live in `app/notifications/` — see Phase 5C webhooks for reuse.
 
-| # | Title | Effort | Priority |
-|---|---|---|---|
-| #180 | WebSocket notification delivery (currently DB + 30s poll) | M | P1 |
-| #299 | Wire notify(): draft_shared event | S | P1 |
-| #176 | @mention autocomplete frontend typeahead | M | P2 |
-| #306 | Draft re-analyze button + handler | S | P2 |
-| #307 | Expiring signed URL for impact-report .docx | M | P2 |
-| #315 | Persist tool_use/tool_result with parent message id | S | P2 |
-| #347 | HTMX status polling fallback on draft detail | S | P2 |
-| #348 | Worker process standalone entrypoint (Coolify run mode) | S | P2 |
-| #304 | JobWorker startup/shutdown in FastHTML lifespan | XS | P3 — **re-audit before working**; `app/main.py:60–141` already wires the worker + archive-scheduler into the lifespan with `_stop_*` events and a 5 s join. Original DoD wanted a 30 s join timeout; verify, then close (or open a tiny follow-up to bump the timeout) |
-| #311 | Retriever metadata filtering (org/date/source) | M | P3 |
-| #352 | Chat cites outdated-ontology warning banner | S | P3 |
-| #354 | LLM call retry logic with backoff (currently job-queue level) | M | P3 |
+| # | Title | Status |
+|---|---|---|
+| #180 | WebSocket notification delivery | ✅ PR #823 |
+| #299 | Wire notify(): draft_shared event | ✅ PR #824 |
+| #176 | @mention autocomplete frontend typeahead | ✅ PR #825 |
+| #306 | Draft re-analyze button + handler | ✅ PR #826 |
+| #307 | Expiring signed URL for impact-report .docx | ✅ PR #827 |
+| #347 | HTMX status polling fallback on draft detail | ✅ PR #828 |
+| #348 | Worker process standalone entrypoint | ✅ PR #829 |
+| #311 | Retriever metadata filtering (org/date/source) | ✅ PR #830 |
+| #354 | LLM call retry with backoff (*also bundles the #196 metric collector*) | ✅ PR #831 |
+| #315 | Persist tool_use/tool_result with parent message id | ✅ PR #832 |
+| #352 | Chat cites outdated-ontology warning | ✅ PR #833 |
+| **#304** | **JobWorker startup/shutdown in FastHTML lifespan** | **OPEN — re-audit:** `app/main.py:60–141` already wires the worker + archive-scheduler into the lifespan with `_stop_*` events and a 5 s join. Original DoD wanted a 30 s join timeout; verify, then either close as already-shipped or open a 1-line follow-up to bump the timeout. |
 
 ### B. Test coverage hardening — TARGET: rolling
 
@@ -158,14 +162,21 @@ These are open-ended "edge case" tickets. Either pull into an active sprint with
 
 ## Concrete sprint plan
 
-Section A runs separately (P1 notification bugs + #304 re-audit). The plan below sequences D + B before Phase 5 so that public surfaces launch with metrics, audit visibility, fixtures, and regression coverage already in place.
+Section A is done bar #304 (re-audit). The plan below sequences D + B before Phase 5 so that public surfaces launch with metrics, audit visibility, fixtures, and regression coverage already in place.
 
-### Sprint 1 — Admin data + visible admin win
+### Sprint 1 — Admin data + visible admin win — **IN FLIGHT (2026-05-24 PM)**
 
-1. **#182 estimate → DEFER to Sprint 3.** `app/admin/` is already a 14-module package; `app/templates/admin_dashboard.py` is a 291-line *load-bearing shim* (uses `_rebind()` to rewire `__globals__` so `@patch("app.templates.admin_dashboard.X")` still works at call-time; 14 test sites in `tests/test_dashboard.py` depend on this). Not package cleanup — keep for Sprint 3.
-2. **Metric collectors:** #195 (worker), #196 (`app/llm/claude.py`), #197 (`app/ontology/sparql_client.py`), #323 (`app/rag/retriever.py`). All four wrap at *call time*, not import time, so the lazy-init singleton pattern survives stub mode.
-3. **#322 sync-status polish + history view** — the basic card ships; this adds paginated history from `sync_log` and empty/error-state polish. Cheap bundle with the collectors.
-4. **Smoke test collector imports in stub mode** — `APP_ENV=development` with neither `anthropic` nor `voyageai` installed: importing `app.main` must not force-construct any SDK client. Add a regression test if not already covered.
+| # | Status |
+|---|---|
+| **#182** estimate → **DEFER to Sprint 3** | Done — shim is load-bearing test infrastructure (`_rebind()` rewires `__globals__` so `@patch("app.templates.admin_dashboard.X")` reaches call-time; 14 sites in `tests/test_dashboard.py` depend on this). Not package cleanup. |
+| **#195** job execution time (`app/jobs/worker.py`) | Done — on `feat/sprint1-collectors` (`record_metric("job_execution_ms", …)` with `{handler, status}`). |
+| **#196** LLM call latency (`app/llm/claude.py`) | ✅ **shipped to origin/main via PR #831** (bundled into the #354 retry refactor at the agent's discretion — the metric wraps the retry-wrapped call cleanly). |
+| **#197** SPARQL duration (`app/ontology/sparql_client.py`) | Done — on `feat/sprint1-collectors` (`_execute` is the single instrumented choke-point; `ask()` refactored to route through it). |
+| **#323** RAG retrieval latency (`app/rag/retriever.py`) | Done — on `feat/sprint1-collectors` (`feature` kwarg + `record_metric` wrap; 3 callers updated to tag retrievals). |
+| **#322** sync-status polish + history view (`app/admin/sync.py`) | Done — on `feat/sprint1-collectors` (`/admin/sync/history` paginated page with "Vaata ajalugu →" link from the card; full shim integration + 7 new tests). |
+| Stub-mode smoke test (`tests/test_import_safety.py`) | Done — subprocess test blocks `anthropic` + `voyageai` at `builtins.__import__`, asserts `app.main` imports clean and both SDK singletons stay `None`. |
+
+**Sprint 1 status:** all 5 work-items done; `feat/sprint1-collectors` is 2 commits ahead of origin/main but **11 commits behind** (origin advanced via the Section A wave-2 merges). Needs a rebase before PR. Touched files overlap with merged PRs (notably #311's `retriever.py` signature change and #354's `claude.py` rewrite), so rebase warrants careful conflict review — but `git merge-tree` dry-run shows no marker collisions.
 
 ### Sprint 2 — Admin panels on top of real data + test fixtures
 
@@ -194,7 +205,9 @@ Do *not* start any 5B endpoint group until its gating controls from §E are sche
 
 ### Cross-cutting
 
-- **#180 pattern note:** once WebSocket notification delivery lands in section A, document the reusable pattern (durable row + outbound delivery + graceful fallback) — that becomes the template for Phase 5C webhook delivery/retry (#268, #270, #359), not just a notification fix.
+- **#180 pattern (shipped via PR #823):** WebSocket notification delivery now lives in `app/notifications/`. When Phase 5C webhook delivery (#268, #270) and retry/stale-payload guard (#359) start, copy the pattern — durable DB row + outbound delivery + graceful fallback to polling — rather than reinventing it.
+- **#311 retriever filters (shipped via PR #830):** the new `filters` kwarg on `Retriever.retrieve()` composes with Sprint 1's `feature` kwarg on the same surface; Phase 5B `/api/v1/provisions/search` and the chat retriever can both use both.
+- **#354 retry pattern (shipped via PR #831, file `app/llm/retry.py`):** `retry_sync` / `retry_async` are now generic enough to wrap Voyage embeddings too. Phase 5C webhook delivery retries (#270, #359) should consider reusing the same backoff schedule + classification logic instead of writing their own.
 - **Continuously:** section B test-coverage backlog (any agent dispatched on a bug should leave a cassette or fixture behind).
 - **Triage call:** section F design tickets — either commit a spec or close as "WONTFIX (specify when needed)".
 

--- a/tests/test_chat_orchestrator.py
+++ b/tests/test_chat_orchestrator.py
@@ -1466,6 +1466,7 @@ class _FakeRetriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        feature: str = "unknown",
     ) -> list[_FakeChunk]:
         return self.chunks
 
@@ -1978,6 +1979,7 @@ class TestStopGenerationCancel:
                 k: int = 10,
                 source_type: str | None = None,
                 org_id: str | None = None,
+                feature: str = "unknown",
             ) -> list[Any]:
                 started.set()
                 await asyncio.sleep(60)
@@ -2240,6 +2242,7 @@ class _HangingRetriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        feature: str = "unknown",
     ) -> list[Any]:
         if self._on_start is not None:
             self.retrieve_started_at = self._on_start()
@@ -2271,6 +2274,7 @@ class _RaisingRetriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        feature: str = "unknown",
     ) -> list[Any]:
         if self._on_start is not None:
             self.retrieve_started_at = self._on_start()

--- a/tests/test_chat_rag_integration.py
+++ b/tests/test_chat_rag_integration.py
@@ -142,9 +142,11 @@ class FakeRetriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        feature: str = "unknown",
     ) -> list[FakeChunk]:
         self.call_count += 1
         self.last_org_id = org_id
+        self.last_feature = feature
         return self.chunks
 
 
@@ -157,6 +159,7 @@ class ErrorRetriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        feature: str = "unknown",
     ) -> list:
         raise RuntimeError("Embedding service unavailable")
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -988,3 +988,223 @@ class TestBookmarkRoute:
         resp = remove_bookmark(self._req(auth=self._AUTH, xhr=True), "bm-1")
         assert resp.status_code == 200
         assert _json.loads(bytes(resp.body)) == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# /admin/sync/history — paginated sync log viewer (#322)
+# ---------------------------------------------------------------------------
+
+
+def _make_sync_history_request(query_string: bytes = b""):
+    """Build a minimal admin Request for the sync history handler."""
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/admin/sync/history",
+        "headers": [],
+        "query_string": query_string,
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "auth": {
+            "role": "admin",
+            "id": "admin-test",
+            "email": "a@b.ee",
+            "full_name": "Admin",
+        },
+    }
+    return Request(scope)
+
+
+class TestSyncHistoryCardLink:
+    """The dashboard sync card must link out to the new history page."""
+
+    def test_card_renders_history_link(self):
+        from fasthtml.common import to_xml
+
+        from app.admin.sync import _sync_card
+
+        html = to_xml(_sync_card([]))
+        assert "/admin/sync/history" in html
+        assert "Vaata ajalugu" in html
+
+
+class TestAdminSyncHistoryPage:
+    """The history page renders pagination, columns, and Estonian copy."""
+
+    def _entry(
+        self,
+        *,
+        sid: int = 1,
+        status: str = "success",
+        error: str | None = None,
+        step: str | None = None,
+        finished: bool = True,
+    ) -> dict:
+        from datetime import UTC, datetime, timedelta
+
+        started = datetime(2026, 5, 24, 9, 0, tzinfo=UTC) + timedelta(minutes=sid)
+        return {
+            "id": sid,
+            "started_at": started,
+            "finished_at": started + timedelta(minutes=3) if finished else None,
+            "status": status,
+            "entity_count": 5000 if status == "success" else None,
+            "error_message": error,
+            "current_step": step,
+        }
+
+    @patch("app.admin.sync._get_sync_log_page")
+    def test_renders_empty_state(self, mock_page: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.sync import admin_sync_history_page
+
+        mock_page.return_value = ([], 0)
+
+        result = admin_sync_history_page(_make_sync_history_request())
+        html = to_xml(result)
+
+        assert "Sünkroniseerimise ajalugu" in html
+        assert "Sünkroniseerimisi ei leitud." in html
+        # Pagination still renders (0 entries info line)
+        assert "0 kirjet" in html
+        # Back link to admin dashboard
+        assert "Tagasi adminipaneelile" in html
+
+    @patch("app.admin.sync._get_sync_log_page")
+    def test_renders_rows_with_columns(self, mock_page: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.sync import admin_sync_history_page
+
+        mock_page.return_value = (
+            [
+                self._entry(sid=1, status="success", step="reingesting"),
+                self._entry(
+                    sid=2,
+                    status="failed",
+                    error="Connection refused",
+                    step="validating",
+                ),
+            ],
+            2,
+        )
+
+        result = admin_sync_history_page(_make_sync_history_request())
+        html = to_xml(result)
+
+        # Estonian column headers
+        for header in ("Algusaeg", "Staatus", "Kestus", "Samm", "Veateade"):
+            assert header in html, header
+        # Phase labels translated to Estonian
+        assert "Taasindekseerimine" in html
+        assert "Valideerimine" in html
+        # Status badges rendered via _sync_status_badge → StatusBadge
+        # (success → key "ok" → label "OK"; failed → "Ebaõnnestus").
+        assert "status-ok" in html
+        assert "status-failed" in html
+        assert "Ebaõnnestus" in html
+        # Error message present
+        assert "Connection refused" in html
+
+    @patch("app.admin.sync._get_sync_log_page")
+    def test_pagination_passes_correct_page_and_clamps(self, mock_page: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.sync import admin_sync_history_page
+
+        # 45 rows → 3 pages of 20.
+        mock_page.return_value = (
+            [self._entry(sid=i) for i in range(20)],
+            45,
+        )
+
+        result = admin_sync_history_page(_make_sync_history_request(query_string=b"page=2"))
+        html = to_xml(result)
+
+        # Handler must have asked for page 2 with the default per-page.
+        mock_page.assert_called_once_with(2, 20)
+        # Pagination renders the info line for the active page.
+        assert "21 kuni 40 kokku 45" in html
+        # Current page link marked with aria-current
+        assert 'aria-current="page"' in html
+
+    @patch("app.admin.sync._get_sync_log_page")
+    def test_invalid_page_falls_back_to_one(self, mock_page: MagicMock):
+        from app.admin.sync import admin_sync_history_page
+
+        mock_page.return_value = ([], 0)
+
+        admin_sync_history_page(_make_sync_history_request(query_string=b"page=not-a-number"))
+        mock_page.assert_called_once_with(1, 20)
+
+    @patch("app.admin.sync._get_sync_log_page")
+    def test_long_error_message_truncated_via_details(self, mock_page: MagicMock):
+        """Failed rows with long SHACL reports must use the disclosure
+        pattern instead of dumping the full text inline (#322)."""
+        from fasthtml.common import to_xml
+
+        from app.admin.sync import admin_sync_history_page
+
+        long_error = "SHACL validation: " + ("warning text " * 50)
+        mock_page.return_value = (
+            [self._entry(sid=1, status="failed", error=long_error)],
+            1,
+        )
+
+        result = admin_sync_history_page(_make_sync_history_request())
+        html = to_xml(result)
+
+        assert "<details" in html
+        assert "sync-error" in html
+
+
+class TestGetSyncLogPage:
+    """``_get_sync_log_page`` slices sync_log with LIMIT/OFFSET."""
+
+    @patch("app.admin.sync._connect")
+    def test_returns_entries_and_total(self, mock_connect: MagicMock):
+        from app.admin.sync import _get_sync_log_page
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        # First call: COUNT(*); second call: paginated rows
+        count_cursor = MagicMock()
+        count_cursor.fetchone.return_value = (42,)
+        rows_cursor = MagicMock()
+        rows_cursor.fetchall.return_value = [
+            (1, "2026-05-24 09:00", "2026-05-24 09:03", "success", 5000, None, None),
+        ]
+        mock_conn.execute.side_effect = [count_cursor, rows_cursor]
+
+        entries, total = _get_sync_log_page(page=2, per_page=20)
+        assert total == 42
+        assert len(entries) == 1
+        # OFFSET = (2-1) * 20 = 20
+        rows_call = mock_conn.execute.call_args_list[1]
+        assert rows_call.args[1] == (20, 20)
+
+    @patch("app.admin.sync._connect")
+    def test_returns_empty_on_db_error(self, mock_connect: MagicMock):
+        from app.admin.sync import _get_sync_log_page
+
+        mock_connect.side_effect = Exception("DB unavailable")
+        entries, total = _get_sync_log_page()
+        assert entries == []
+        assert total == 0
+
+
+class TestAdminSyncHistoryRoute:
+    """Route is registered and admin-gated."""
+
+    def test_history_route_requires_auth(self):
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/admin/sync/history")
+        assert response.status_code == 303
+        assert response.headers["location"] == "/auth/login"

--- a/tests/test_import_safety.py
+++ b/tests/test_import_safety.py
@@ -1,18 +1,29 @@
-"""Guard against ``Button`` getting shadowed by ``from fasthtml.common import *``.
+"""Import-safety harness.
 
-FastHTML re-exports an HTML ``Button`` builder under the same name as our
-design-system ``Button`` primitive. Any module that does
-``from fasthtml.common import *`` *after* importing
-``app.ui.primitives.button.Button`` will silently overwrite the symbol
-with the unstyled stdlib version, which is hard to spot in code review.
+Two unrelated invariants live here because both are about what happens at
+*module import time*:
 
-This test imports every page module that ships a UI and asserts that the
-``Button`` name resolves to our primitive afterwards.
+1. ``Button`` must not get shadowed by ``from fasthtml.common import *``.
+   FastHTML re-exports an HTML ``Button`` builder under the same name as our
+   design-system primitive; any page module that does the wildcard import
+   *after* importing ``app.ui.primitives.button.Button`` silently overwrites
+   the symbol with the unstyled stdlib version.
+
+2. Lazy-init contract for SDK singletons. ``ClaudeProvider`` and
+   ``VoyageProvider`` are documented in CLAUDE.md as lazily-initialised: the
+   ``anthropic`` and ``voyageai`` packages must NOT be required to merely
+   import ``app.main`` in stub mode. This guards the four Sprint-1 metrics
+   collectors (#195/#196/#197/#323) against accidentally triggering SDK
+   construction at module load (e.g. via a top-level decorator that
+   eagerly resolves a provider).
 """
 
 from __future__ import annotations
 
 import importlib
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -38,3 +49,49 @@ def test_button_symbol_not_shadowed(module_path: str):
         f"{module_path}.Button has been shadowed by another import — "
         f"got {module.Button!r}, expected {button_module.Button!r}"
     )
+
+
+def test_app_main_imports_without_constructing_sdk_singletons():
+    """``import app.main`` must not eagerly construct ``ClaudeProvider`` or
+    ``VoyageProvider`` — even when ``anthropic`` and ``voyageai`` are
+    unavailable. Run in a subprocess so blocked imports don't leak into the
+    rest of the test session via ``sys.modules`` caching.
+    """
+    script = textwrap.dedent(
+        """
+        import builtins, sys
+
+        _real_import = builtins.__import__
+        _blocked = {"anthropic", "voyageai"}
+
+        def _blocking_import(name, *args, **kwargs):
+            if name.split(".")[0] in _blocked:
+                raise ImportError(f"{name} blocked for lazy-init smoke test")
+            return _real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _blocking_import
+
+        import app.main  # noqa: F401  -- must not require anthropic/voyageai
+        import app.llm.claude as c
+        import app.rag.embedding as e
+
+        assert c._default_provider is None, (
+            f"ClaudeProvider was eagerly constructed at import time: {c._default_provider!r}"
+        )
+        assert e._default_provider is None, (
+            f"VoyageProvider was eagerly constructed at import time: {e._default_provider!r}"
+        )
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env={"APP_ENV": "development", "DISABLE_BACKGROUND_WORKER": "1", "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Stub-mode import failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout

--- a/tests/test_jobs_worker.py
+++ b/tests/test_jobs_worker.py
@@ -198,6 +198,72 @@ class TestWorkerDispatch:
         queue_instance.mark_running.assert_not_called()
         queue_instance.mark_success.assert_not_called()
 
+    @patch("app.jobs.worker.record_metric")
+    @patch("app.jobs.worker.JobQueue")
+    def test_worker_records_job_execution_metric_on_success(
+        self, mock_queue_cls: MagicMock, mock_record: MagicMock
+    ):
+        """Successful jobs must emit a job_execution_ms metric with status=ok (#195)."""
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        job = _make_job(job_type="_metric_ok")
+
+        @register_handler("_metric_ok")
+        def handler(payload: dict, **kwargs) -> dict:
+            return {"ok": True}
+
+        stop = threading.Event()
+
+        def claim_side_effect(*_a, **_kw):
+            if queue_instance.claim_next.call_count == 1:
+                return job
+            stop.set()
+            return None
+
+        queue_instance.claim_next.side_effect = claim_side_effect
+        JobWorker(worker_id="test-worker", poll_interval=0.01).run_forever(stop)
+
+        metric_calls = [c for c in mock_record.call_args_list if c.args[0] == "job_execution_ms"]
+        assert len(metric_calls) == 1
+        name, value, labels = metric_calls[0].args
+        assert name == "job_execution_ms"
+        assert isinstance(value, float)
+        assert value >= 0
+        assert labels == {"handler": "_metric_ok", "status": "ok"}
+
+    @patch("app.jobs.worker.record_metric")
+    @patch("app.jobs.worker.JobQueue")
+    def test_worker_records_job_execution_metric_on_failure(
+        self, mock_queue_cls: MagicMock, mock_record: MagicMock
+    ):
+        """Failed jobs must still emit a job_execution_ms metric with status=failed (#195)."""
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        job = _make_job(job_type="_metric_fail")
+
+        @register_handler("_metric_fail")
+        def handler(payload: dict, **kwargs) -> dict:
+            raise RuntimeError("boom")
+
+        stop = threading.Event()
+
+        def claim_side_effect(*_a, **_kw):
+            if queue_instance.claim_next.call_count == 1:
+                return job
+            stop.set()
+            return None
+
+        queue_instance.claim_next.side_effect = claim_side_effect
+        JobWorker(worker_id="test-worker", poll_interval=0.01).run_forever(stop)
+
+        metric_calls = [c for c in mock_record.call_args_list if c.args[0] == "job_execution_ms"]
+        assert len(metric_calls) == 1
+        name, value, labels = metric_calls[0].args
+        assert name == "job_execution_ms"
+        assert isinstance(value, float)
+        assert value >= 0
+        assert labels == {"handler": "_metric_fail", "status": "failed"}
+
     @patch("app.jobs.worker.JobQueue")
     def test_worker_truncates_long_error_messages(self, mock_queue_cls: MagicMock):
         """Handler errors longer than 500 chars must be truncated."""

--- a/tests/test_jobs_worker.py
+++ b/tests/test_jobs_worker.py
@@ -203,7 +203,12 @@ class TestWorkerDispatch:
     def test_worker_records_job_execution_metric_on_success(
         self, mock_queue_cls: MagicMock, mock_record: MagicMock
     ):
-        """Successful jobs must emit a job_execution_ms metric with status=ok (#195)."""
+        """Successful jobs must emit a job_execution_ms metric with status="success" (#195).
+
+        The label vocabulary matches ``background_jobs.status`` so admin
+        queries can join both surfaces without translation (#837/#838
+        review caught the earlier "ok"/"success" mismatch).
+        """
         queue_instance = MagicMock()
         mock_queue_cls.return_value = queue_instance
         job = _make_job(job_type="_metric_ok")
@@ -229,7 +234,7 @@ class TestWorkerDispatch:
         assert name == "job_execution_ms"
         assert isinstance(value, float)
         assert value >= 0
-        assert labels == {"handler": "_metric_ok", "status": "ok"}
+        assert labels == {"handler": "_metric_ok", "status": "success"}
 
     @patch("app.jobs.worker.record_metric")
     @patch("app.jobs.worker.JobQueue")


### PR DESCRIPTION
## Summary

Sprint 1 of the post-2026-05-24-audit roadmap (`docs/2026-05-24-issue-cleanup-and-roadmap.md`). Lands the observability collectors that feed the admin Performance tab (Sprint 2) plus the sync history view + the stub-mode import contract.

- **#195** `app/jobs/worker.py` — `record_metric("job_execution_ms", …)` with `{handler, status}`. Try/finally around handler dispatch; status flips to `"failed"` in the except branch.
- **#197** `app/ontology/sparql_client.py` — `_execute` becomes the single instrumented choke-point. `ask()` refactored to route through it (preserves the `HTTPError → False` contract). `query()` + `count()` forward an `operation` kwarg. Emits `{operation, status}`.
- **#323** `app/rag/retriever.py` — body split into `_retrieve_inner()`; public `retrieve()` is a thin try/except/finally wrapper that records `rag_retrieval_ms` with `{feature, status}`. New `feature: str = "unknown"` kwarg. 3 callers updated to tag retrievals: chat (`"chat"`), analyysikeskus similarity, analyysikeskus normi-mojuahel route. Composes cleanly with #311's `filters` kwarg (both on the same surface).
- **#322** `app/admin/sync.py` — `/admin/sync/history` paginated DataTable with "Vaata ajalugu →" link from the existing card. Full shim integration in `app/templates/admin_dashboard.py` (`_rebind()` + `_EXPECTED_PAGE_HANDLERS` update). 7 new tests.
- **Stub-mode smoke test** `tests/test_import_safety.py::test_app_main_imports_without_constructing_sdk_singletons` — subprocess test blocks `anthropic` + `voyageai` at `builtins.__import__`, asserts `app.main` imports clean and both SDK singletons stay `None`. **Keep this green** — the four collectors depend on the lazy-init contract.

### What's NOT in this PR

- **#196 LLM call latency** (`app/llm/claude.py`) — shipped to main via **PR #831** (#354 retry refactor). The dispatched #196 agent went beyond brief and bundled the metric into #354; per execution policy in `docs/2026-05-24-issue-cleanup-and-roadmap.md` we accepted the bundling since the metric wraps the retry-wrapped call cleanly. #196 is closed.
- **#198 Performance tab** that consumes these collectors — Sprint 2, first commit after this PR enters review.
- **#304 lifespan re-audit** — done in parallel with this PR (separate issue close, not a code change).

### Rebase note

Branch was 11 commits behind origin/main when rebased; touched files overlap with **#311** (retriever metadata filter) and **#354** (LLM retry — which already absorbed #196). Conflict resolution touched only `app/rag/retriever.py`:
- Kept both `filters` (#311) and `feature` (#323) kwargs on `Retriever.retrieve()` — they compose.
- Added matching `filters` kwarg to `_retrieve_inner()` signature and forwarded from `retrieve()`.
- Combined docstrings.
225 touched-module tests pass; ruff + pyright clean.

## Test plan

- [x] `uv run pytest tests/test_jobs_worker.py tests/test_sparql_client.py tests/test_rag_retriever.py tests/test_rag_retriever_filters.py tests/test_dashboard.py tests/test_import_safety.py tests/test_chat_orchestrator.py tests/test_chat_rag_integration.py -k "not TestStubHandlers"` → 225 pass (4 pre-existing TestStubHandlers failures on main, unrelated).
- [x] `uv run ruff check` on every touched file → clean.
- [x] `uv run pyright` on every touched file → 0 errors.
- [x] Smoke import in stub mode: `APP_ENV=development` + `anthropic`/`voyageai` blocked → `app.main` imports clean, both SDK singletons remain `None`.
- [ ] Spot-check admin sync history page in the running app (Estonian copy, pagination, link from the card).
- [ ] Confirm a job run, an LLM call, a SPARQL query, and a RAG retrieve each produce a row in the `metrics` table (manual smoke once deployed to staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)