### PR TITLE
refactor+feat(admin): Sprint 3 — shim refactor + health + job monitor + Sentry panel

### DIFF
--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -1,11 +1,5 @@
-"""Admin package — system health, sync, jobs, usage, audit, and dashboard.
+"""Admin package: system health, sync, jobs, usage, audit, and dashboard."""
 
-Re-exports ``register_admin_routes`` from the backward-compatible shim so
-that ``from app.admin import register_admin_routes`` works correctly and
-existing ``@patch("app.templates.admin_dashboard.…")`` decorators in the
-test suite keep taking effect.
-"""
-
-from app.templates.admin_dashboard import register_admin_routes
+from app.admin.routes import register_admin_routes
 
 __all__ = ["register_admin_routes"]

--- a/app/admin/dashboard.py
+++ b/app/admin/dashboard.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
 
-from app.admin.health import _check_postgres, _health_card, jena_check_health
+from app.admin.health import (
+    _check_postgres,
+    _health_aggregator_card,
+    _health_card,
+    jena_check_health,
+)
 from app.admin.jobs import _job_queue_card
 from app.admin.llm_usage import _llm_usage_card
 from app.admin.rate_limits import _rate_limit_card
+from app.admin.sentry_panel import _sentry_panel_card
 from app.admin.sync import _get_sync_logs, _sync_card
 from app.admin.users import _get_user_stats, _quick_links_card, _user_stats_card
 from app.ui.layout import PageShell
@@ -70,10 +76,12 @@ def admin_dashboard_page(req: Request):
             dismissible=True,
         ),
         _health_card(jena_ok, pg_ok),
+        _health_aggregator_card(),
         _sync_card(sync_logs),
         _job_queue_card(),
         _llm_usage_card(),
         _rate_limit_card(),
+        _sentry_panel_card(),
         _user_stats_card(user_stats),
         _quick_links_card(),
         _version_footer(),

--- a/app/admin/health.py
+++ b/app/admin/health.py
@@ -1,19 +1,45 @@
-"""Admin health checks and health card rendering."""
+"""Admin health checks, aggregator card, and aggregator detail page.
+
+The original module owned a tiny ``_health_card`` showing two pills
+(Jena + Postgres) plus the unauthenticated ``/api/health`` JSON probe.
+Issue #183 layered on a richer rollup: ``_get_system_health`` collects a
+broader set of signals (pgvector extension, last sync_log status,
+worker activity, HTTP traffic) and ``_health_aggregator_card`` renders
+those as a single Card on the admin dashboard, with a link to the
+``/admin/health/aggregator`` detail page for timestamps + error
+messages + a manual refresh button.
+
+Why this lives next to the existing health code instead of a new
+``app.admin.health_aggregator`` module:
+
+* The two pieces share the postgres / jena reachability probes — the
+  aggregator is a strict superset, not a parallel implementation.
+* The shim re-exports ``_check_postgres`` and ``health_check`` from
+  this module; keeping the new helpers here means the shim's import
+  list stays minimal and the patch-where-used contract is unchanged.
+* Tests can patch ``app.admin.health.<name>`` for every signal in one
+  place rather than juggling two modules.
+"""
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
+from typing import Any
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from app.admin._shared import _tooltip
+from app.admin._shared import _render_admin_error_page, _tooltip
 from app.db import get_connection as _connect
 from app.sync.jena_loader import check_health as jena_check_health
+from app.ui.layout import PageShell
 from app.ui.primitives.badge import StatusBadge
 from app.ui.primitives.button import Button  # noqa: F401, F811  -- shadow guard
 from app.ui.surfaces.card import Card, CardBody, CardHeader
+from app.ui.theme import get_theme_from_request
+from app.ui.time import format_tallinn
 from app.version import read_version  # noqa: F401  -- rebound onto shim module
 
 logger = logging.getLogger(__name__)
@@ -30,8 +56,148 @@ def _check_postgres() -> bool:
         return False
 
 
+def _check_pgvector() -> bool:
+    """Check if the pgvector extension is installed in the active database.
+
+    Returns ``False`` if the extension is missing **or** the lookup
+    query itself fails (treated as "not available"). The aggregator
+    downgrades to ``degraded`` when this is false because chat and the
+    RAG retriever can't function without it, but core legal workflows
+    (impact analysis, drafter wizard) continue to work.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT extname FROM pg_extension WHERE extname = 'vector'"
+            ).fetchone()
+        return row is not None
+    except Exception:
+        logger.exception("pgvector extension check failed")
+        return False
+
+
+def _get_last_sync() -> dict[str, Any] | None:
+    """Return the most recent ``sync_log`` row's summary, or ``None``.
+
+    Only the fields the aggregator card + detail page need are returned:
+    status, finished_at, duration in seconds, and the error_message
+    (which the detail page surfaces inline). When the table is empty
+    or the query fails, ``None`` is returned so callers can render the
+    "Sünki pole veel tehtud" empty state.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT status, started_at, finished_at, error_message "
+                "FROM sync_log "
+                "ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+        if not row:
+            return None
+        status, started_at, finished_at, error_message = row
+        duration_s: float | None = None
+        if started_at is not None and finished_at is not None:
+            try:
+                duration_s = max(0.0, (finished_at - started_at).total_seconds())
+            except Exception:  # pragma: no cover — defensive
+                duration_s = None
+        return {
+            "status": status,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "duration_s": duration_s,
+            "error_message": error_message,
+        }
+    except Exception:
+        logger.exception("Failed to fetch last sync_log row")
+        return None
+
+
+def _get_worker_recent_activity() -> int:
+    """Return count of ``job_execution_ms`` metric rows in the last 5 minutes.
+
+    This is the signal PR #835's worker-side instrumentation publishes
+    on every completed job. Until that PR lands the value will be 0,
+    which is intentional — the aggregator surfaces "Töötaja aktiivsus:
+    0" rather than crashing or hiding the row.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM metrics "
+                "WHERE name = 'job_execution_ms' "
+                "  AND recorded_at >= now() - interval '5 minutes'"
+            ).fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        logger.exception("Failed to count recent worker activity")
+        return 0
+
+
+def _get_metrics_recent_count() -> int:
+    """Return total metric rows recorded in the last 5 minutes.
+
+    Sourced from ``MetricsMiddleware`` which records one row per HTTP
+    request. A non-zero value is the simplest proof that the app is
+    serving traffic and the metrics flush pipeline is healthy.
+    """
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM metrics WHERE recorded_at >= now() - interval '5 minutes'"
+            ).fetchone()
+        return int(row[0]) if row else 0
+    except Exception:
+        logger.exception("Failed to count recent metrics rows")
+        return 0
+
+
+def _get_system_health() -> dict[str, Any]:
+    """Aggregate broad system signals for the dashboard rollup card.
+
+    ``overall_status`` is derived as:
+
+    * ``"down"`` if Postgres is unreachable (everything else depends on it),
+    * ``"degraded"`` if pgvector or Jena is failing (core workflows still
+      function but a major subsystem is offline),
+    * ``"ok"`` when every hard check passes.
+
+    The function never raises — each underlying probe swallows its own
+    exception and returns a falsy / safe default so a partially
+    broken environment still renders a card the admin can act on.
+    """
+    pg_ok = _check_postgres()
+    jena_ok = jena_check_health()
+    pgvector_ok = _check_pgvector() if pg_ok else False
+    last_sync = _get_last_sync() if pg_ok else None
+    worker_recent = _get_worker_recent_activity() if pg_ok else 0
+    metrics_recent = _get_metrics_recent_count() if pg_ok else 0
+
+    if not pg_ok:
+        overall = "down"
+    elif not (pgvector_ok and jena_ok):
+        overall = "degraded"
+    else:
+        overall = "ok"
+
+    return {
+        "postgres_ok": pg_ok,
+        "jena_ok": jena_ok,
+        "pgvector_ok": pgvector_ok,
+        "last_sync": last_sync,
+        "worker_recent_activity": worker_recent,
+        "metrics_recent_count": metrics_recent,
+        "overall_status": overall,
+    }
+
+
 def _health_card(jena_ok: bool, pg_ok: bool):
-    """Render the system health card."""
+    """Render the legacy small two-pill health card.
+
+    Kept for callers that haven't migrated to the richer aggregator
+    card yet (the JSON ``/api/health`` endpoint still uses the same
+    two reachability probes).
+    """
     body = Dl(  # noqa: F405
         Dt("Apache Jena Fuseki"),  # noqa: F405
         Dd(StatusBadge("ok") if jena_ok else StatusBadge("failed")),  # noqa: F405
@@ -42,13 +208,250 @@ def _health_card(jena_ok: bool, pg_ok: bool):
     return Card(
         CardHeader(
             H3(  # noqa: F405
-                "S\u00fcsteemi tervis",
-                _tooltip("Jena ja Postgres \u00fchenduse staatus"),
+                "Süsteemi tervis",
+                _tooltip("Jena ja Postgres ühenduse staatus"),
                 cls="card-title",
             )
         ),
         CardBody(body),
     )
+
+
+def _last_sync_summary(last_sync: dict[str, Any] | None) -> str:
+    """Format the ``Viimane sünk`` row for the aggregator card."""
+    if last_sync is None:
+        return "Sünki pole veel tehtud"
+    status = last_sync.get("status") or "?"
+    finished_at = last_sync.get("finished_at")
+    if finished_at is None:
+        return f"{status} (lõpetamata)"
+    return f"{status} • {format_tallinn(finished_at)}"
+
+
+def _bool_badge(ok: bool):
+    """Render a green OK / red Ebaõnnestus pill for boolean health rows."""
+    return StatusBadge("ok") if ok else StatusBadge("failed")
+
+
+def _activity_badge(count: int):
+    """Render a count as a neutral/primary status badge.
+
+    Zero counts use the muted ``pending`` variant so the admin reads it
+    as "nothing happening yet" rather than "broken"; non-zero counts
+    use the primary running variant to mirror the live-traffic feel.
+    """
+    if count <= 0:
+        return StatusBadge("pending")
+    # Re-use the StatusBadge formatting but surface the actual number
+    # rather than the canned "Töötab" label.
+    return Span(  # noqa: F405
+        Span("", cls="status-dot", aria_hidden="true"),  # noqa: F405
+        str(count),
+        cls="badge badge-primary status-badge status-running",
+        role="status",
+    )
+
+
+def _overall_badge(status: str):
+    """Map ``overall_status`` to a StatusBadge."""
+    if status == "ok":
+        return StatusBadge("ok")
+    if status == "degraded":
+        return StatusBadge("warning")
+    return StatusBadge("failed")
+
+
+def _health_aggregator_card():
+    """Render the broad system-health rollup card for the admin dashboard.
+
+    One row per subsystem with a status badge; the bottom carries a
+    "Vaata üksikasju →" link to ``/admin/health/aggregator`` where
+    timestamps and last-error messages are surfaced.
+    """
+    health = _get_system_health()
+    last_sync = health["last_sync"]
+    body = Dl(  # noqa: F405
+        Dt("Postgres"),  # noqa: F405
+        Dd(_bool_badge(health["postgres_ok"])),  # noqa: F405
+        Dt("Jena"),  # noqa: F405
+        Dd(_bool_badge(health["jena_ok"])),  # noqa: F405
+        Dt("pgvector"),  # noqa: F405
+        Dd(_bool_badge(health["pgvector_ok"])),  # noqa: F405
+        Dt("Viimane sünk"),  # noqa: F405
+        Dd(_last_sync_summary(last_sync)),  # noqa: F405
+        Dt("Töötaja aktiivsus (5m)"),  # noqa: F405
+        Dd(_activity_badge(int(health["worker_recent_activity"]))),  # noqa: F405
+        Dt("Metrics (5m)"),  # noqa: F405
+        Dd(_activity_badge(int(health["metrics_recent_count"]))),  # noqa: F405
+        cls="info-list",
+    )
+    return Card(
+        CardHeader(
+            Div(  # noqa: F405
+                H3(  # noqa: F405
+                    "Süsteemi tervis (koond)",
+                    _tooltip(
+                        "Postgres, Jena, pgvector, viimane sünk, "
+                        "töötaja aktiivsus ja üldine "
+                        "veebiliiklus"
+                    ),
+                    cls="card-title",
+                ),
+                _overall_badge(str(health["overall_status"])),
+                cls="card-title-row",
+            )
+        ),
+        CardBody(
+            body,
+            P(  # noqa: F405
+                A(  # noqa: F405
+                    "Vaata üksikasju →",
+                    href="/admin/health/aggregator",
+                ),
+                cls="card-link",
+            ),
+        ),
+        id="health-aggregator-card",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detail page
+# ---------------------------------------------------------------------------
+
+
+def _detail_row(label: str, value):  # type: ignore[no-untyped-def]
+    """Render a single Dt/Dd pair for the aggregator detail page."""
+    return (Dt(label), Dd(value))  # noqa: F405
+
+
+def _format_duration(seconds: float | None) -> str:
+    """Format a duration in seconds as ``M:SS`` or ``-`` when unknown."""
+    if seconds is None:
+        return "—"
+    secs = int(seconds)
+    minutes, rem = divmod(secs, 60)
+    return f"{minutes}:{rem:02d}"
+
+
+def _aggregator_detail_body(health: dict[str, Any]):
+    """Render the rich detail view used by ``/admin/health/aggregator``."""
+    last_sync = health["last_sync"]
+    rows: list = []
+
+    # Subsystem reachability
+    rows.extend(_detail_row("Postgres", _bool_badge(health["postgres_ok"])))
+    rows.extend(_detail_row("Jena", _bool_badge(health["jena_ok"])))
+    rows.extend(_detail_row("pgvector", _bool_badge(health["pgvector_ok"])))
+
+    # Sync status with timestamps + error message
+    if last_sync is None:
+        rows.extend(_detail_row("Viimane sünk", "Sünki pole veel tehtud"))
+    else:
+        sync_lines: list = [
+            P(  # noqa: F405
+                Strong("Staatus: "),  # noqa: F405
+                str(last_sync.get("status") or "—"),
+            ),
+            P(  # noqa: F405
+                Strong("Algusaeg: "),  # noqa: F405
+                format_tallinn(last_sync.get("started_at")),
+            ),
+            P(  # noqa: F405
+                Strong("Lõpetamise aeg: "),  # noqa: F405
+                format_tallinn(last_sync.get("finished_at")),
+            ),
+            P(  # noqa: F405
+                Strong("Kestus: "),  # noqa: F405
+                _format_duration(last_sync.get("duration_s")),
+            ),
+        ]
+        error_message = last_sync.get("error_message")
+        if error_message:
+            sync_lines.append(
+                Details(  # noqa: F405
+                    Summary("Veateade"),  # noqa: F405
+                    Pre(str(error_message), cls="sync-error-full"),  # noqa: F405
+                    cls="sync-error",
+                )
+            )
+        rows.extend(_detail_row("Viimane sünk", Div(*sync_lines)))  # noqa: F405
+
+    # Activity counts with the cutoff window made explicit
+    rows.extend(
+        _detail_row(
+            "Töötaja aktiivsus (5m)",
+            _activity_badge(int(health["worker_recent_activity"])),
+        )
+    )
+    rows.extend(
+        _detail_row(
+            "Metrics kirjeid (5m)",
+            _activity_badge(int(health["metrics_recent_count"])),
+        )
+    )
+
+    # When the snapshot was taken — useful when the page is left open.
+    rows.extend(
+        _detail_row(
+            "Snapshot võetud",
+            format_tallinn(datetime.now(UTC)),
+        )
+    )
+
+    return Dl(*rows, cls="info-list")  # noqa: F405
+
+
+def admin_health_page(req: Request):
+    """GET /admin/health/aggregator — system-health detail page.
+
+    Renders the same signals as the dashboard card with timestamps,
+    last sync error message, and a plain GET refresh button so an
+    admin can re-poll without going back to ``/admin``.
+    """
+    auth = req.scope.get("auth")
+    theme = get_theme_from_request(req)
+    try:
+        health = _get_system_health()
+        content = (
+            H1("Süsteemi tervis", cls="page-title"),  # noqa: F405
+            P(A("← Tagasi adminipaneelile", href="/admin"), cls="back-link"),  # noqa: F405
+            Card(
+                CardHeader(
+                    Div(  # noqa: F405
+                        H3(  # noqa: F405
+                            "Koondvaade",
+                            cls="card-title",
+                        ),
+                        _overall_badge(str(health["overall_status"])),
+                        cls="card-title-row",
+                    )
+                ),
+                CardBody(
+                    _aggregator_detail_body(health),
+                    P(  # noqa: F405
+                        A(  # noqa: F405
+                            "Värskenda",
+                            href="/admin/health/aggregator",
+                            cls="btn btn-secondary",
+                            role="button",
+                        ),
+                        cls="card-actions",
+                    ),
+                ),
+                id="health-aggregator-detail",
+            ),
+        )
+        return PageShell(
+            *content,
+            title="Süsteemi tervis",
+            user=auth,
+            theme=theme,
+            active_nav="/admin",
+        )
+    except Exception:
+        logger.exception("Failed to render admin health aggregator page")
+        return _render_admin_error_page(title="Süsteemi tervis", user=auth, theme=theme)
 
 
 def health_check(req: Request):

--- a/app/admin/job_monitor.py
+++ b/app/admin/job_monitor.py
@@ -1,14 +1,23 @@
 """Admin job monitor page — full-page view of background job health.
 
-Provides summary badges, per-type breakdown, recent failures with
-expandable error messages, retry and purge actions. All data comes
-from the ``background_jobs`` table.
+Provides summary badges, per-type breakdown, per-handler 24h aggregate
+stats (count / success rate / p95 duration) sourced from the
+``metrics`` table, a paginated + filterable failed-jobs table with
+expandable error messages, retry and purge actions, and an HTMX-loaded
+detail fragment per job (payload JSON + traceback + attempts history).
+
+Job rows come from ``background_jobs``; per-handler stats come from
+``metrics`` rows whose ``name = 'job_execution_ms'`` (collector ships
+with PR #835). When no metrics rows exist the per-handler card renders
+a graceful empty-state in Estonian.
 """
 
 from __future__ import annotations
 
+import json
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from urllib.parse import urlencode
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
@@ -16,6 +25,8 @@ from starlette.responses import JSONResponse
 
 from app.db import get_connection as _connect
 from app.ui.data.data_table import Column, DataTable
+from app.ui.data.pagination import Pagination
+from app.ui.forms.app_form import AppForm
 from app.ui.layout import PageShell
 from app.ui.primitives.badge import Badge, BadgeVariant
 from app.ui.primitives.button import Button  # noqa: F401, F811  -- shadow guard
@@ -24,6 +35,14 @@ from app.ui.theme import get_theme_from_request
 from app.ui.time import format_tallinn
 
 logger = logging.getLogger(__name__)
+
+# Status values accepted from filter input. The DB uses 'success' rather
+# than 'completed' (see migrations/005), so the filter normalises the
+# UI-friendly 'completed' alias into 'success' before querying.
+_VALID_STATUSES: tuple[str, ...] = ("pending", "running", "failed", "success")
+_STATUS_ALIASES: dict[str, str] = {"completed": "success"}
+
+_DEFAULT_PAGE_SIZE = 20
 
 
 # ---------------------------------------------------------------------------
@@ -84,8 +103,119 @@ def _get_type_breakdown() -> list[dict]:  # type: ignore[type-arg]
     return breakdown
 
 
+def _parse_date(value: str | None) -> date | None:
+    """Parse a date string (YYYY-MM-DD) or return None on any failure."""
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return None
+
+
+def _normalise_status(value: str | None) -> str | None:
+    """Map UI-friendly status values to DB values; reject anything unknown."""
+    if not value:
+        return None
+    v = value.strip().lower()
+    v = _STATUS_ALIASES.get(v, v)
+    return v if v in _VALID_STATUSES else None
+
+
+def _build_jobs_where(
+    *,
+    handlers: list[str] | None = None,
+    status: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> tuple[str, list]:
+    """Build a WHERE clause for ``background_jobs`` filtering.
+
+    ``handlers`` filters ``job_type`` via ``= ANY(%s)`` so we keep
+    parameterisation tight (no IN-list string interpolation). The
+    date range is applied against ``started_at`` per the issue spec
+    so a job that has not started yet is excluded from time-windowed
+    views.
+    """
+    clauses: list[str] = []
+    params: list = []
+
+    if handlers:
+        clauses.append("job_type = ANY(%s)")
+        params.append(list(handlers))
+    if status:
+        clauses.append("status = %s")
+        params.append(status)
+    if date_from:
+        clauses.append("started_at >= %s")
+        params.append(datetime.combine(date_from, datetime.min.time()))
+    if date_to:
+        clauses.append("started_at < %s")
+        params.append(datetime.combine(date_to + timedelta(days=1), datetime.min.time()))
+
+    where = " AND ".join(clauses) if clauses else "TRUE"
+    return where, params
+
+
+def _get_filtered_jobs_page(
+    *,
+    page: int = 1,
+    per_page: int = _DEFAULT_PAGE_SIZE,
+    handlers: list[str] | None = None,
+    status: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> tuple[list[dict], int]:  # type: ignore[type-arg]
+    """Return a page of background_jobs matching the filters + total count."""
+    jobs: list[dict] = []  # type: ignore[type-arg]
+    total = 0
+    try:
+        where, params = _build_jobs_where(
+            handlers=handlers, status=status, date_from=date_from, date_to=date_to
+        )
+        with _connect() as conn:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM background_jobs WHERE {where}",  # type: ignore[arg-type]
+                params,
+            ).fetchone()
+            total = row[0] if row else 0
+
+            offset = (page - 1) * per_page
+            rows = conn.execute(
+                f"SELECT id, job_type, status, error_message, attempts, max_attempts, "  # type: ignore[arg-type]
+                f"finished_at, started_at, created_at "
+                f"FROM background_jobs "
+                f"WHERE {where} "
+                f"ORDER BY COALESCE(finished_at, started_at, created_at) DESC NULLS LAST "
+                f"LIMIT %s OFFSET %s",
+                [*params, per_page, offset],
+            ).fetchall()
+            jobs = [
+                {
+                    "id": r[0],
+                    "job_type": r[1],
+                    "status": r[2],
+                    "error_message": r[3] or "",
+                    "attempts": r[4],
+                    "max_attempts": r[5],
+                    "finished_at": r[6],
+                    "started_at": r[7],
+                    "created_at": r[8],
+                }
+                for r in rows
+            ]
+    except Exception:
+        logger.exception("Failed to fetch filtered jobs page %d", page)
+    return jobs, total
+
+
 def _get_recent_failed(limit: int = 20) -> list[dict]:  # type: ignore[type-arg]
-    """Return recent failed jobs with error messages."""
+    """Return recent failed jobs with error messages.
+
+    Kept for backwards compatibility — the main page now uses
+    ``_get_filtered_jobs_page``, but unit tests + the route module
+    still import this helper.
+    """
     jobs: list[dict] = []  # type: ignore[type-arg]
     try:
         with _connect() as conn:
@@ -113,6 +243,85 @@ def _get_recent_failed(limit: int = 20) -> list[dict]:  # type: ignore[type-arg]
     except Exception:
         logger.exception("Failed to fetch recent failed jobs")
     return jobs
+
+
+def _get_handler_stats_24h() -> list[dict]:  # type: ignore[type-arg]
+    """Return per-handler aggregate stats from the ``metrics`` table.
+
+    Reads rows with ``name = 'job_execution_ms'`` recorded in the last
+    24 hours and aggregates them per ``labels->>'handler'``:
+
+    * ``count`` — total samples
+    * ``success_rate`` — fraction (0–1) where ``labels->>'status' = 'success'``
+    * ``p95_ms`` — 95th-percentile duration via ``percentile_cont``
+
+    Returns ``[]`` on any error or when the collector has not yet
+    written any rows — caller renders the empty-state.
+    """
+    stats: list[dict] = []  # type: ignore[type-arg]
+    try:
+        cutoff = datetime.now(UTC) - timedelta(hours=24)
+        with _connect() as conn:
+            rows = conn.execute(
+                "SELECT labels->>'handler' AS handler, "
+                "       COUNT(*)::int AS samples, "
+                "       AVG(CASE WHEN labels->>'status' = 'success' THEN 1.0 ELSE 0.0 END) "
+                "         AS success_rate, "
+                "       percentile_cont(0.95) WITHIN GROUP (ORDER BY value) AS p95_ms "
+                "FROM metrics "
+                "WHERE name = 'job_execution_ms' "
+                "  AND recorded_at >= %s "
+                "  AND labels->>'handler' IS NOT NULL "
+                "GROUP BY labels->>'handler' "
+                "ORDER BY samples DESC, handler ASC",
+                (cutoff,),
+            ).fetchall()
+            stats = [
+                {
+                    "handler": r[0],
+                    "count": int(r[1]) if r[1] is not None else 0,
+                    "success_rate": float(r[2]) if r[2] is not None else 0.0,
+                    "p95_ms": float(r[3]) if r[3] is not None else 0.0,
+                }
+                for r in rows
+            ]
+    except Exception:
+        logger.exception("Failed to fetch per-handler metrics aggregates")
+    return stats
+
+
+def _get_job_detail(job_id: int) -> dict | None:  # type: ignore[type-arg]
+    """Return a single background_jobs row keyed by id, or None."""
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                "SELECT id, job_type, status, payload, error_message, attempts, "
+                "max_attempts, started_at, finished_at, created_at, scheduled_for, "
+                "claimed_by, claimed_at, result "
+                "FROM background_jobs WHERE id = %s",
+                (job_id,),
+            ).fetchone()
+            if not row:
+                return None
+            return {
+                "id": row[0],
+                "job_type": row[1],
+                "status": row[2],
+                "payload": row[3],
+                "error_message": row[4] or "",
+                "attempts": row[5],
+                "max_attempts": row[6],
+                "started_at": row[7],
+                "finished_at": row[8],
+                "created_at": row[9],
+                "scheduled_for": row[10],
+                "claimed_by": row[11],
+                "claimed_at": row[12],
+                "result": row[13],
+            }
+    except Exception:
+        logger.exception("Failed to fetch job detail id=%d", job_id)
+        return None
 
 
 def _retry_job(job_id: int) -> bool:
@@ -156,6 +365,38 @@ def _purge_completed(days: int = 7) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Filter handling
+# ---------------------------------------------------------------------------
+
+
+def _extract_filters(req: Request) -> dict:  # type: ignore[type-arg]
+    """Extract filter values from query params.
+
+    Multi-select ``handler`` uses ``getlist`` so repeated
+    ``?handler=parse_draft&handler=extract_entities`` survives.
+    """
+    qp = req.query_params
+    return {
+        "handlers": [h for h in qp.getlist("handler") if h],
+        "status": qp.get("status", ""),
+        "from": qp.get("from", ""),
+        "to": qp.get("to", ""),
+    }
+
+
+def _filter_query_string(filters: dict) -> str:  # type: ignore[type-arg]
+    """Re-encode current filters as a query string (without ``page``)."""
+    pairs: list[tuple[str, str]] = []
+    for h in filters.get("handlers", []) or []:
+        pairs.append(("handler", h))
+    for key, target in (("status", "status"), ("from", "from"), ("to", "to")):
+        v = filters.get(key, "")
+        if v:
+            pairs.append((target, v))
+    return urlencode(pairs)
+
+
+# ---------------------------------------------------------------------------
 # Rendering helpers
 # ---------------------------------------------------------------------------
 
@@ -168,9 +409,9 @@ _STATUS_VARIANT: dict[str, BadgeVariant] = {
 
 _STATUS_LABEL = {
     "pending": "Ootel",
-    "running": "T\u00f6\u00f6tab",
-    "failed": "Eba\u00f5nnestunud",
-    "success": "\u00d5nnestunud",
+    "running": "Töötab",
+    "failed": "Ebaõnnestunud",
+    "success": "Õnnestunud",
 }
 
 
@@ -189,14 +430,14 @@ def _summary_badges(counts: dict[str, int]):
 def _type_breakdown_table(breakdown: list[dict]):  # type: ignore[type-arg]
     """Render the per-job-type breakdown table."""
     if not breakdown:
-        return P("T\u00f6\u00f6de ei leitud.", cls="muted-text")  # noqa: F405
+        return P("Tööde ei leitud.", cls="muted-text")  # noqa: F405
 
     columns = [
-        Column(key="job_type", label="T\u00f6\u00f6 t\u00fc\u00fcp", sortable=False),
+        Column(key="job_type", label="Töö tüüp", sortable=False),
         Column(key="pending", label="Ootel", sortable=False),
-        Column(key="running", label="T\u00f6\u00f6tab", sortable=False),
-        Column(key="failed", label="Eba\u00f5nnestunud", sortable=False),
-        Column(key="success", label="\u00d5nnestunud", sortable=False),
+        Column(key="running", label="Töötab", sortable=False),
+        Column(key="failed", label="Ebaõnnestunud", sortable=False),
+        Column(key="success", label="Õnnestunud", sortable=False),
     ]
     rows = [
         {
@@ -211,46 +452,226 @@ def _type_breakdown_table(breakdown: list[dict]):  # type: ignore[type-arg]
     return DataTable(columns=columns, rows=rows)
 
 
-def _failed_jobs_table(failed_jobs: list[dict]):  # type: ignore[type-arg]
-    """Render the recent failed jobs with expandable errors and retry buttons."""
-    if not failed_jobs:
-        return P("Eba\u00f5nnestunud t\u00f6\u00f6sid ei leitud.", cls="muted-text")  # noqa: F405
+def _handler_stats_card(stats: list[dict]):  # type: ignore[type-arg]
+    """Render the 24h per-handler metrics card.
+
+    When the collector hasn't written any rows yet (``stats == []``) we
+    show a neutral empty-state explaining what the card will eventually
+    surface — the issue explicitly calls this out as the expected
+    pre-PR-#835 behaviour.
+    """
+    if not stats:
+        empty = P(  # noqa: F405
+            "Aktiivsuse statistikat pole veel kogutud. "
+            "Tööde kestust hakatakse koguma kohe, kui taustatööde "
+            "telemeetria on aktiveeritud.",
+            cls="muted-text",
+        )
+        return Card(
+            CardHeader(
+                H3(
+                    "Töötlejate statistika (viimased 24h)",  # noqa: F405
+                    cls="card-title",
+                ),
+            ),
+            CardBody(empty),
+        )
+
+    columns = [
+        Column(key="handler", label="Töötleja", sortable=False),
+        Column(key="count", label="Käivitusi", sortable=False),
+        Column(key="success_rate", label="Edukuse määr", sortable=False),
+        Column(key="p95_ms", label="p95 kestus", sortable=False),
+    ]
+    rows = []
+    for s in stats:
+        rate_pct = f"{s['success_rate'] * 100:.1f}%"
+        p95 = f"{s['p95_ms']:.0f} ms"
+        rows.append(
+            {
+                "handler": s["handler"],
+                "count": str(s["count"]),
+                "success_rate": rate_pct,
+                "p95_ms": p95,
+            }
+        )
+    return Card(
+        CardHeader(
+            H3(
+                "Töötlejate statistika (viimased 24h)",  # noqa: F405
+                cls="card-title",
+            ),
+        ),
+        CardBody(DataTable(columns=columns, rows=rows)),
+    )
+
+
+def _filter_form(
+    filters: dict,  # type: ignore[type-arg]
+    handler_options: list[str],
+) -> object:
+    """Render the filter form (handler multi-select + status + dates)."""
+    # Status dropdown
+    status_choices = [
+        ("", "Kõik staatused"),
+        ("pending", "Ootel"),
+        ("running", "Töötab"),
+        ("failed", "Ebaõnnestunud"),
+        ("success", "Õnnestunud"),
+    ]
+    status_options = []
+    for value, label in status_choices:
+        selected = "selected" if filters.get("status", "") == value else None
+        status_options.append(Option(label, value=value, selected=selected))  # noqa: F405
+
+    # Handler multi-select (Estonian "Töötleja tüüp")
+    selected_handlers = set(filters.get("handlers", []) or [])
+    handler_opts = []
+    for h in handler_options:
+        selected = "selected" if h in selected_handlers else None
+        handler_opts.append(Option(h, value=h, selected=selected))  # noqa: F405
+
+    return AppForm(
+        Div(  # noqa: F405
+            Div(  # noqa: F405
+                Label("Töötleja tüüp", fr="filter-handler"),  # noqa: F405
+                Select(  # noqa: F405
+                    *handler_opts,
+                    name="handler",
+                    id="filter-handler",
+                    multiple=True,
+                    size=min(6, max(3, len(handler_options))) if handler_options else 3,
+                ),
+                cls="filter-field",
+            ),
+            Div(  # noqa: F405
+                Label("Staatus", fr="filter-status"),  # noqa: F405
+                Select(*status_options, name="status", id="filter-status"),  # noqa: F405
+                cls="filter-field",
+            ),
+            Div(  # noqa: F405
+                Label("Alguskuupäev", fr="filter-from"),  # noqa: F405
+                Input(  # noqa: F405
+                    type="date",
+                    name="from",
+                    id="filter-from",
+                    value=filters.get("from", ""),
+                ),
+                cls="filter-field",
+            ),
+            Div(  # noqa: F405
+                Label("Lõppkuupäev", fr="filter-to"),  # noqa: F405
+                Input(  # noqa: F405
+                    type="date",
+                    name="to",
+                    id="filter-to",
+                    value=filters.get("to", ""),
+                ),
+                cls="filter-field",
+            ),
+            cls="filter-row",
+        ),
+        Div(  # noqa: F405
+            Button("Filtreeri", type="submit", variant="primary", size="sm"),
+            A(  # noqa: F405
+                "Tühjenda",
+                href="/admin/jobs",
+                cls="btn btn-secondary btn-sm",
+            ),
+            cls="filter-actions",
+        ),
+        method="get",
+        action="/admin/jobs",
+        cls="jobs-filter-form",
+    )
+
+
+def _jobs_table(
+    jobs: list[dict],  # type: ignore[type-arg]
+    status_filter: str | None,
+) -> object:
+    """Render the filtered jobs table with expandable errors + actions.
+
+    Each row exposes a Details disclosure that lazily HTMX-loads the
+    detail fragment from ``/admin/jobs/{id}/detail`` on first open
+    (``hx_trigger="toggle once"``). The retry button stays inline so
+    admins can recover from a failure without expanding the row.
+    """
+    if not jobs:
+        return P(  # noqa: F405
+            "Töid antud filtritega ei leitud.",
+            cls="muted-text",
+        )
 
     rows_ft = []
-    for job in failed_jobs:
-        error = job["error_message"]
+    for job in jobs:
+        error = job.get("error_message", "")
         short_error = error[:120] + "..." if len(error) > 120 else error
-        finished = job["finished_at"]
-        finished_str = format_tallinn(finished)
+        finished = job.get("finished_at")
+        finished_str = format_tallinn(finished) if finished else "—"
+        status_value = job.get("status", "")
+        status_label = _STATUS_LABEL.get(status_value, status_value)
+        status_variant = _STATUS_VARIANT.get(status_value, "default")
+        status_cell = Badge(status_label, variant=status_variant)
 
-        # Expandable error: Details element for long errors
-        if len(error) > 120:
-            error_cell = Details(  # noqa: F405
+        # Error cell
+        if error and len(error) > 120:
+            error_cell: object = Details(  # noqa: F405
                 Summary(short_error),  # noqa: F405
                 Pre(error, cls="error-detail-pre"),  # noqa: F405
                 cls="error-expandable",
             )
-        else:
+        elif error:
             error_cell = Span(short_error)  # noqa: F405
+        else:
+            error_cell = Span("—")  # noqa: F405
 
-        retry_btn = Button(
-            "Proovi uuesti",
-            hx_post=f"/admin/jobs/{job['id']}/retry",
-            hx_target="#job-monitor-content",
-            hx_swap="innerHTML",
-            variant="secondary",
-            size="sm",
-        )
+        retry_btn: object
+        if status_value == "failed":
+            retry_btn = Button(
+                "Proovi uuesti",
+                hx_post=f"/admin/jobs/{job['id']}/retry",
+                hx_target="#job-monitor-content",
+                hx_swap="innerHTML",
+                variant="secondary",
+                size="sm",
+            )
+        else:
+            retry_btn = Span("—", cls="muted-text")  # noqa: F405
 
+        # Job row + expand row pair. The expand row holds a Div target
+        # that the disclosure fragment HTMX-swaps into on first open.
+        detail_target_id = f"job-detail-{job['id']}"
         rows_ft.append(
             Tr(  # noqa: F405
                 Td(str(job["id"]), data_label="ID"),  # noqa: F405
-                Td(job["job_type"], data_label="T\u00fc\u00fcp"),  # noqa: F405
+                Td(job["job_type"], data_label="Tüüp"),  # noqa: F405
+                Td(status_cell, data_label="Staatus"),  # noqa: F405
                 Td(error_cell, data_label="Veateade"),  # noqa: F405
                 Td(  # noqa: F405
-                    f"{job['attempts']}/{job['max_attempts']}", data_label="Katseid"
+                    f"{job.get('attempts', 0)}/{job.get('max_attempts', 0)}",
+                    data_label="Katseid",
                 ),
-                Td(finished_str, data_label="L\u00f5petatud"),  # noqa: F405
+                Td(finished_str, data_label="Lõpetatud"),  # noqa: F405
+                Td(  # noqa: F405
+                    Details(  # noqa: F405
+                        Summary(  # noqa: F405
+                            "Näita detaile",
+                            cls="job-detail-summary",
+                        ),
+                        Div(  # noqa: F405
+                            P(  # noqa: F405
+                                "Laen...", cls="muted-text"
+                            ),
+                            id=detail_target_id,
+                            hx_get=f"/admin/jobs/{job['id']}/detail",
+                            hx_trigger="toggle once from:closest details",
+                            hx_swap="innerHTML",
+                        ),
+                        cls="job-detail-disclosure",
+                    ),
+                    data_label="Detailid",
+                ),
                 Td(retry_btn, data_label="Toiming"),  # noqa: F405
             )
         )
@@ -260,48 +681,159 @@ def _failed_jobs_table(failed_jobs: list[dict]):  # type: ignore[type-arg]
             Thead(  # noqa: F405
                 Tr(  # noqa: F405
                     Th("ID", scope="col"),  # noqa: F405
-                    Th("T\u00fc\u00fcp", scope="col"),  # noqa: F405
+                    Th("Tüüp", scope="col"),  # noqa: F405
+                    Th("Staatus", scope="col"),  # noqa: F405
                     Th("Veateade", scope="col"),  # noqa: F405
                     Th("Katseid", scope="col"),  # noqa: F405
-                    Th("L\u00f5petatud", scope="col"),  # noqa: F405
+                    Th("Lõpetatud", scope="col"),  # noqa: F405
+                    Th("Detailid", scope="col"),  # noqa: F405
                     Th("Toiming", scope="col"),  # noqa: F405
                 )
             ),
             Tbody(*rows_ft),  # noqa: F405
             cls="data-table",
             role="table",
+            data_status_filter=status_filter or "",
         ),
         cls="data-table-wrapper",
     )
 
 
-def _job_monitor_content() -> object:
-    """Render the full job monitor content (swappable via HTMX)."""
+def _render_job_detail_fragment(job: dict) -> object:  # type: ignore[type-arg]
+    """Render the disclosure body for a single job row.
+
+    Sections: payload JSON · attempts history · traceback (when failed).
+    All copy is Estonian; the payload is pretty-printed JSON.
+    """
+    payload = job.get("payload")
+    try:
+        payload_pretty = json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        payload_pretty = str(payload) if payload is not None else "—"
+
+    history_items = [
+        Li(f"Loodud: {format_tallinn(job['created_at'])}")  # noqa: F405
+        if job.get("created_at")
+        else Li("Loomise aega pole salvestatud"),  # noqa: F405
+    ]
+    if job.get("scheduled_for"):
+        history_items.append(
+            Li(f"Planeeritud: {format_tallinn(job['scheduled_for'])}")  # noqa: F405
+        )
+    if job.get("claimed_at"):
+        claimed_by = job.get("claimed_by") or "?"
+        history_items.append(
+            Li(  # noqa: F405
+                f"Võetud töösse: {format_tallinn(job['claimed_at'])} (töötaja: {claimed_by})"
+            )
+        )
+    if job.get("started_at"):
+        history_items.append(
+            Li(f"Alustatud: {format_tallinn(job['started_at'])}")  # noqa: F405
+        )
+    if job.get("finished_at"):
+        history_items.append(
+            Li(f"Lõpetatud: {format_tallinn(job['finished_at'])}")  # noqa: F405
+        )
+    history_items.append(
+        Li(f"Katseid: {job.get('attempts', 0)}/{job.get('max_attempts', 0)}")  # noqa: F405
+    )
+
+    sections: list = [
+        H4("Päringu sisu (payload)", cls="job-detail-heading"),  # noqa: F405
+        Pre(payload_pretty, cls="job-detail-payload"),  # noqa: F405
+        H4("Katsete ajalugu", cls="job-detail-heading"),  # noqa: F405
+        Ul(*history_items, cls="job-detail-history"),  # noqa: F405
+    ]
+
+    error = job.get("error_message", "")
+    if error:
+        sections.extend(
+            [
+                H4("Veateade / stacktrace", cls="job-detail-heading"),  # noqa: F405
+                Pre(error, cls="job-detail-traceback"),  # noqa: F405
+            ]
+        )
+
+    return Div(*sections, cls="job-detail-fragment")  # noqa: F405
+
+
+def _job_monitor_content(req: Request | None = None) -> object:
+    """Render the full job monitor content (swappable via HTMX).
+
+    ``req`` is optional so the legacy zero-arg callers (the retry and
+    purge handlers, plus old unit tests) keep working — when missing
+    we render an unfiltered first page.
+    """
     counts = _get_status_counts()
     breakdown = _get_type_breakdown()
-    failed_jobs = _get_recent_failed()
+    handler_stats = _get_handler_stats_24h()
+
+    # Filter + pagination state
+    filters: dict = {"handlers": [], "status": "", "from": "", "to": ""}
+    page = 1
+    if req is not None:
+        filters = _extract_filters(req)
+        page_str = req.query_params.get("page", "1")
+        try:
+            page = max(1, int(page_str))
+        except ValueError:
+            page = 1
+
+    status_value = _normalise_status(filters.get("status", "") or None)
+    date_from = _parse_date(filters.get("from", "") or None)
+    date_to = _parse_date(filters.get("to", "") or None)
+    handlers = filters.get("handlers", []) or None
+
+    jobs, total = _get_filtered_jobs_page(
+        page=page,
+        per_page=_DEFAULT_PAGE_SIZE,
+        handlers=handlers,
+        status=status_value,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    total_pages = max(1, (total + _DEFAULT_PAGE_SIZE - 1) // _DEFAULT_PAGE_SIZE)
+
+    qs = _filter_query_string(filters)
+    base_url = f"/admin/jobs?{qs}" if qs else "/admin/jobs"
+    pagination = Pagination(
+        current_page=page,
+        total_pages=total_pages,
+        base_url=base_url,
+        page_size=_DEFAULT_PAGE_SIZE,
+        total=total,
+    )
+
+    handler_options = [b["job_type"] for b in breakdown]
+    filter_form = _filter_form(filters, handler_options)
 
     return Div(  # noqa: F405
         Card(
-            CardHeader(H3("Kokkuv\u00f5te", cls="card-title")),  # noqa: F405
+            CardHeader(H3("Kokkuvõte", cls="card-title")),  # noqa: F405
             CardBody(_summary_badges(counts)),
         ),
+        _handler_stats_card(handler_stats),
         Card(
-            CardHeader(H3("T\u00f6\u00f6de t\u00fc\u00fcbi kaupa", cls="card-title")),  # noqa: F405
+            CardHeader(H3("Tööde tüübi kaupa", cls="card-title")),  # noqa: F405
             CardBody(_type_breakdown_table(breakdown)),
+        ),
+        Card(
+            CardHeader(H3("Filtrid", cls="card-title")),  # noqa: F405
+            CardBody(filter_form),
         ),
         Card(
             CardHeader(
                 Div(  # noqa: F405
-                    H3("Viimased eba\u00f5nnestunud t\u00f6\u00f6d", cls="card-title"),  # noqa: F405
+                    H3("Tööde loend", cls="card-title"),  # noqa: F405
                     Button(
-                        "Puhasta vanad t\u00f6\u00f6d",
+                        "Puhasta vanad tööd",
                         hx_post="/admin/jobs/purge",
                         hx_target="#job-monitor-content",
                         hx_swap="innerHTML",
                         hx_confirm=(
-                            "Kas olete kindel? Kustutab \u00f5nnestunud "
-                            "t\u00f6\u00f6d, mis on vanemad kui 7 p\u00e4eva."
+                            "Kas olete kindel? Kustutab õnnestunud "
+                            "tööd, mis on vanemad kui 7 päeva."
                         ),
                         variant="danger",
                         size="sm",
@@ -309,7 +841,7 @@ def _job_monitor_content() -> object:
                     cls="card-header-row",
                 ),
             ),
-            CardBody(_failed_jobs_table(failed_jobs)),
+            CardBody(_jobs_table(jobs, status_value), pagination),
         ),
         id="job-monitor-content",
     )
@@ -333,14 +865,14 @@ def admin_jobs_page(req: Request):
         from app.admin.job_monitor import _job_monitor_content
 
         content = (
-            H1("T\u00f6\u00f6de monitor", cls="page-title"),  # noqa: F405
-            P(A("\u2190 Tagasi adminipaneelile", href="/admin"), cls="back-link"),  # noqa: F405
-            _job_monitor_content(),
+            H1("Tööde monitor", cls="page-title"),  # noqa: F405
+            P(A("← Tagasi adminipaneelile", href="/admin"), cls="back-link"),  # noqa: F405
+            _job_monitor_content(req),
         )
 
         return PageShell(
             *content,
-            title="T\u00f6\u00f6de monitor",
+            title="Tööde monitor",
             user=auth,
             theme=theme,
             active_nav="/admin",
@@ -349,7 +881,7 @@ def admin_jobs_page(req: Request):
         logger.exception("Failed to render admin jobs page")
         from app.admin._shared import _render_admin_error_page
 
-        return _render_admin_error_page(title="T\u00f6\u00f6de monitor", user=auth, theme=theme)
+        return _render_admin_error_page(title="Tööde monitor", user=auth, theme=theme)
 
 
 def admin_job_retry(req: Request, id: int):
@@ -359,14 +891,14 @@ def admin_job_retry(req: Request, id: int):
 
         success = _retry_job(id)
         if not success:
-            msg = "T\u00f6\u00f6d ei leitud v\u00f5i ei ole eba\u00f5nnestunud staatuses."
+            msg = "Tööd ei leitud või ei ole ebaõnnestunud staatuses."
             return JSONResponse({"error": msg}, status_code=404)
         # Return refreshed content
-        return _job_monitor_content()
+        return _job_monitor_content(req)
     except Exception:
         logger.exception("Failed to retry admin job id=%s", id)
         return JSONResponse(
-            {"error": "T\u00f6\u00f6 taask\u00e4ivitamine eba\u00f5nnestus."},
+            {"error": "Töö taaskäivitamine ebaõnnestus."},
             status_code=500,
         )
 
@@ -379,10 +911,42 @@ def admin_jobs_purge(req: Request):
         deleted = _purge_completed(days=7)
         logger.info("Purged %d completed jobs older than 7 days", deleted)
         # Return refreshed content
-        return _job_monitor_content()
+        return _job_monitor_content(req)
     except Exception:
         logger.exception("Failed to purge completed jobs")
         return JSONResponse(
-            {"error": "T\u00f6\u00f6de puhastamine eba\u00f5nnestus."},
+            {"error": "Tööde puhastamine ebaõnnestus."},
             status_code=500,
+        )
+
+
+def admin_job_detail(req: Request, id: int):
+    """GET /admin/jobs/{id}/detail -- HTMX-loaded detail fragment.
+
+    Returns a Div with the payload JSON (pretty-printed), attempts
+    history, and traceback (if failed). When the row is missing or
+    the DB fails, returns a small in-place error fragment so the
+    disclosure doesn't appear empty.
+    """
+    try:
+        from app.admin.job_monitor import _get_job_detail, _render_job_detail_fragment
+
+        job = _get_job_detail(id)
+        if job is None:
+            return Div(  # noqa: F405
+                P(  # noqa: F405
+                    "Tööd ei leitud.",
+                    cls="muted-text",
+                ),
+                cls="job-detail-fragment",
+            )
+        return _render_job_detail_fragment(job)
+    except Exception:
+        logger.exception("Failed to render admin job detail id=%s", id)
+        return Div(  # noqa: F405
+            P(  # noqa: F405
+                "Detailide laadimine ebaõnnestus.",
+                cls="muted-text",
+            ),
+            cls="job-detail-fragment",
         )

--- a/app/admin/job_monitor.py
+++ b/app/admin/job_monitor.py
@@ -252,7 +252,11 @@ def _get_handler_stats_24h() -> list[dict]:  # type: ignore[type-arg]
     24 hours and aggregates them per ``labels->>'handler'``:
 
     * ``count`` — total samples
-    * ``success_rate`` — fraction (0–1) where ``labels->>'status' = 'success'``
+    * ``success_rate`` — fraction (0–1) where ``labels->>'status' IN ('ok',
+      'success')``. The metric collector emits ``'success'`` post-#835
+      (2026-05-25); we still accept the historical ``'ok'`` label so older
+      rows in the ``metrics`` table count toward the same success bucket
+      instead of being silently treated as failures.
     * ``p95_ms`` — 95th-percentile duration via ``percentile_cont``
 
     Returns ``[]`` on any error or when the collector has not yet
@@ -265,7 +269,8 @@ def _get_handler_stats_24h() -> list[dict]:  # type: ignore[type-arg]
             rows = conn.execute(
                 "SELECT labels->>'handler' AS handler, "
                 "       COUNT(*)::int AS samples, "
-                "       AVG(CASE WHEN labels->>'status' = 'success' THEN 1.0 ELSE 0.0 END) "
+                "       AVG(CASE WHEN labels->>'status' IN ('ok', 'success') "
+                "                THEN 1.0 ELSE 0.0 END) "
                 "         AS success_rate, "
                 "       percentile_cont(0.95) WITHIN GROUP (ORDER BY value) AS p95_ms "
                 "FROM metrics "

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -36,9 +36,15 @@ from app.admin.audit import (
 )
 from app.admin.cost_dashboard import admin_cost_export, admin_cost_page
 from app.admin.dashboard import admin_dashboard_page
-from app.admin.health import health_check
-from app.admin.job_monitor import admin_job_retry, admin_jobs_page, admin_jobs_purge
+from app.admin.health import admin_health_page, health_check
+from app.admin.job_monitor import (
+    admin_job_detail,
+    admin_job_retry,
+    admin_jobs_page,
+    admin_jobs_purge,
+)
 from app.admin.performance import admin_performance_page
+from app.admin.sentry_panel import admin_sentry_page
 from app.admin.sync import admin_sync_history_page, sync_status_card, trigger_sync
 from app.auth.roles import require_role
 
@@ -73,3 +79,6 @@ def register_admin_routes(rt) -> None:  # type: ignore[no-untyped-def]
     rt("/admin/jobs/{id}/retry", methods=["POST"])(require_role("admin")(admin_job_retry))
     rt("/admin/jobs/purge", methods=["POST"])(require_role("admin")(admin_jobs_purge))
     rt("/api/health", methods=["GET"])(health_check)
+    rt("/admin/health/aggregator", methods=["GET"])(require_role("admin")(admin_health_page))
+    rt("/admin/sentry", methods=["GET"])(require_role("admin")(admin_sentry_page))
+    rt("/admin/jobs/{id}/detail", methods=["GET"])(require_role("admin")(admin_job_detail))

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,5 +1,75 @@
-"""Admin route registration — delegates to the backward-compatible shim."""
+"""Admin route registration.
 
-from app.templates.admin_dashboard import register_admin_routes
+Owns the wiring between FastHTML's ``rt`` decorator and the page handlers
+that live in the ``app.admin.*`` sub-modules. Every route is wrapped in
+``require_role("admin")`` so unauthenticated or non-admin callers get the
+standard auth redirect/403 before the handler runs.
+
+Why this module exists (post-refactor pattern, replaces the historical
+``app.templates.admin_dashboard`` shim):
+
+* Each admin sub-module (``health``, ``sync``, ``audit``, ``analytics``,
+  ``cost_dashboard``, ``job_monitor``, ``performance``) owns its own
+  handlers and DB helpers. Tests patch helpers on the real module path
+  (e.g. ``@patch("app.admin.sync._get_sync_logs")``) — there is no more
+  ``__globals__`` rebinding indirection.
+* Handlers that depend on private helpers in the same module either
+  import them at module scope (when they only touch public names) or
+  re-import them as locals inside the handler body (when they are kept
+  patchable by tests).
+* Adding a new admin route: implement the handler in the relevant
+  sub-module, then add one ``rt(...)`` line below. No shim updates
+  needed; no completeness invariant to maintain.
+"""
+
+from __future__ import annotations
+
+from app.admin.analytics import (
+    admin_analytics_export,
+    admin_analytics_page,
+    admin_analytics_refresh,
+)
+from app.admin.audit import (
+    admin_audit_detail,
+    admin_audit_export,
+    admin_audit_page,
+)
+from app.admin.cost_dashboard import admin_cost_export, admin_cost_page
+from app.admin.dashboard import admin_dashboard_page
+from app.admin.health import health_check
+from app.admin.job_monitor import admin_job_retry, admin_jobs_page, admin_jobs_purge
+from app.admin.performance import admin_performance_page
+from app.admin.sync import admin_sync_history_page, sync_status_card, trigger_sync
+from app.auth.roles import require_role
 
 __all__ = ["register_admin_routes"]
+
+
+def register_admin_routes(rt) -> None:  # type: ignore[no-untyped-def]
+    """Register admin dashboard routes on the FastHTML route decorator *rt*.
+
+    All ``/admin/*`` routes are wrapped with ``require_role("admin")``; the
+    JSON ``/api/health`` endpoint stays unauthenticated so external uptime
+    monitors (Coolify, etc.) can hit it.
+    """
+    rt("/admin", methods=["GET"])(require_role("admin")(admin_dashboard_page))
+    rt("/admin/audit", methods=["GET"])(require_role("admin")(admin_audit_page))
+    rt("/admin/audit/export", methods=["GET"])(require_role("admin")(admin_audit_export))
+    rt("/admin/audit/detail/{id}", methods=["GET"])(require_role("admin")(admin_audit_detail))
+    rt("/admin/performance", methods=["GET"])(require_role("admin")(admin_performance_page))
+    rt("/admin/sync", methods=["POST"])(require_role("admin")(trigger_sync))
+    rt("/admin/sync/status", methods=["GET"])(require_role("admin")(sync_status_card))
+    rt("/admin/sync/history", methods=["GET"])(require_role("admin")(admin_sync_history_page))
+    rt("/admin/analytics", methods=["GET"])(require_role("admin")(admin_analytics_page))
+    rt("/admin/analytics/refresh", methods=["POST"])(
+        require_role("admin")(admin_analytics_refresh)
+    )
+    rt("/admin/analytics/export", methods=["GET"])(
+        require_role("admin")(admin_analytics_export)
+    )
+    rt("/admin/costs", methods=["GET"])(require_role("admin")(admin_cost_page))
+    rt("/admin/costs/export", methods=["GET"])(require_role("admin")(admin_cost_export))
+    rt("/admin/jobs", methods=["GET"])(require_role("admin")(admin_jobs_page))
+    rt("/admin/jobs/{id}/retry", methods=["POST"])(require_role("admin")(admin_job_retry))
+    rt("/admin/jobs/purge", methods=["POST"])(require_role("admin")(admin_jobs_purge))
+    rt("/api/health", methods=["GET"])(health_check)

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -70,9 +70,7 @@ def register_admin_routes(rt) -> None:  # type: ignore[no-untyped-def]
     rt("/admin/analytics/refresh", methods=["POST"])(
         require_role("admin")(admin_analytics_refresh)
     )
-    rt("/admin/analytics/export", methods=["GET"])(
-        require_role("admin")(admin_analytics_export)
-    )
+    rt("/admin/analytics/export", methods=["GET"])(require_role("admin")(admin_analytics_export))
     rt("/admin/costs", methods=["GET"])(require_role("admin")(admin_cost_page))
     rt("/admin/costs/export", methods=["GET"])(require_role("admin")(admin_cost_export))
     rt("/admin/jobs", methods=["GET"])(require_role("admin")(admin_jobs_page))

--- a/app/admin/sentry_panel.py
+++ b/app/admin/sentry_panel.py
@@ -1,0 +1,283 @@
+"""Admin Sentry errors panel card and detail page.
+
+Read-only Sentry API integration (#324) that surfaces the most recent
+issues from the project's Sentry instance on the admin dashboard, plus
+a dedicated ``/admin/sentry`` detail page with a refresh button.
+
+Design notes:
+    * **Optional integration.** The Sentry API call is only attempted when
+      all three of ``SENTRY_API_TOKEN``, ``SENTRY_ORG_SLUG``, and
+      ``SENTRY_PROJECT_SLUG`` are set in the environment. Any missing
+      variable yields ``None`` from :func:`_get_recent_sentry_errors`
+      and the card renders an "ei ole konfigureeritud" empty state.
+    * **Graceful degradation.** Every external HTTP call is wrapped in
+      try/except so a Sentry outage, timeout, or 5xx response degrades
+      to "Sentry API ei vasta" rather than a 500. The 3-second timeout
+      keeps the admin page snappy even when Sentry is slow.
+    * **Secret hygiene.** ``SENTRY_API_TOKEN`` is sent in the
+      ``Authorization`` header and never logged. Only the public org +
+      project slugs are embedded in the "Vaata Sentrys" link.
+    * **No new deps.** ``httpx`` is already a project dependency (used
+      by other modules) and the official Sentry SDK is *not* required
+      for this read-only panel.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+from fasthtml.common import *  # noqa: F403
+from starlette.requests import Request
+
+from app.admin._shared import _tooltip
+from app.ui.data.data_table import Column, DataTable
+from app.ui.layout import PageShell
+from app.ui.primitives.badge import Badge, StatusBadge
+from app.ui.primitives.button import Button  # noqa: F401, F811  -- shadow guard
+from app.ui.surfaces.card import Card, CardBody, CardHeader
+from app.ui.theme import get_theme_from_request
+
+logger = logging.getLogger(__name__)
+
+_SENTRY_API_TIMEOUT_SECONDS = 3.0
+_SENTRY_MAX_ISSUES = 5
+
+
+def _sentry_env() -> tuple[str, str, str] | None:
+    """Return ``(token, org, project)`` if all three env vars are set, else ``None``.
+
+    Centralising this lookup makes it trivial to unit-test the
+    not-configured branch with ``monkeypatch.delenv`` and keeps the
+    token-vs-slug distinction local to this module.
+    """
+    token = os.environ.get("SENTRY_API_TOKEN")
+    org = os.environ.get("SENTRY_ORG_SLUG")
+    project = os.environ.get("SENTRY_PROJECT_SLUG")
+    if not (token and org and project):
+        return None
+    return token, org, project
+
+
+def _sentry_issues_url(org: str, project: str) -> str:
+    """Return the public Sentry issues URL for the configured project.
+
+    Only the slugs are interpolated — no token. Safe to render in HTML.
+    """
+    return f"https://{org}.sentry.io/issues/?project={project}"
+
+
+def _get_recent_sentry_errors() -> list[dict[str, Any]] | None:
+    """Query the Sentry API for recent issues for the configured project.
+
+    Returns:
+        * ``None`` when any of ``SENTRY_API_TOKEN``, ``SENTRY_ORG_SLUG``,
+          ``SENTRY_PROJECT_SLUG`` is missing — signals "not configured".
+        * ``[]`` (empty list) when Sentry returned 0 issues OR when the
+          API call failed (timeout, non-2xx, network error). The caller
+          renders an empty/error state from this — failures degrade
+          rather than raising.
+        * ``list[dict]`` of at most ``_SENTRY_MAX_ISSUES`` entries with
+          keys ``title``, ``last_seen``, ``count``, ``level``, ``link``.
+    """
+    env = _sentry_env()
+    if env is None:
+        return None
+    token, org, project = env
+
+    url = f"https://sentry.io/api/0/projects/{org}/{project}/issues/"
+    params = {"query": "is:unresolved", "limit": str(_SENTRY_MAX_ISSUES)}
+    headers = {"Authorization": f"Bearer {token}"}
+
+    try:
+        response = httpx.get(
+            url,
+            params=params,
+            headers=headers,
+            timeout=_SENTRY_API_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        # NEVER include the headers/token in the log message.
+        logger.exception("Sentry API request failed for project=%s/%s", org, project)
+        return []
+
+    if response.status_code != 200:
+        logger.warning(
+            "Sentry API returned status=%s for project=%s/%s",
+            response.status_code,
+            org,
+            project,
+        )
+        return []
+
+    try:
+        payload = response.json()
+    except Exception:
+        logger.exception("Sentry API returned non-JSON body for project=%s/%s", org, project)
+        return []
+
+    if not isinstance(payload, list):
+        logger.warning("Sentry API returned unexpected payload type for %s/%s", org, project)
+        return []
+
+    issues: list[dict[str, Any]] = []
+    for raw in payload[:_SENTRY_MAX_ISSUES]:
+        if not isinstance(raw, dict):
+            continue
+        issues.append(
+            {
+                "title": str(raw.get("title") or raw.get("culprit") or "(pealkiri puudub)"),
+                "last_seen": str(raw.get("lastSeen") or ""),
+                "count": str(raw.get("count") or "0"),
+                "level": str(raw.get("level") or "error"),
+                "link": str(raw.get("permalink") or _sentry_issues_url(org, project)),
+            }
+        )
+    return issues
+
+
+def _level_badge(level: str):
+    """Map a Sentry level string to a coloured Badge."""
+    variant: str = "default"
+    if level in ("fatal", "error"):
+        variant = "danger"
+    elif level == "warning":
+        variant = "warning"
+    elif level == "info":
+        variant = "primary"
+    return Badge(level, variant=variant)  # type: ignore[arg-type]
+
+
+def _sentry_table(issues: list[dict[str, Any]]):
+    """Render the issues list as a DataTable.
+
+    ``level`` and ``link`` columns use a ``render`` callback so the
+    Badge/anchor FT nodes are emitted directly instead of being
+    stringified by DataTable's default ``str(row[key])`` path.
+    """
+    rows = [
+        {
+            "title": issue["title"],
+            "level": _level_badge(issue["level"]),
+            "count": issue["count"],
+            "last_seen": issue["last_seen"],
+            "link": A(  # noqa: F405
+                "Ava Sentrys →",
+                href=issue["link"],
+                target="_blank",
+                rel="noopener noreferrer",
+            ),
+        }
+        for issue in issues
+    ]
+    columns = [
+        Column(key="title", label="Pealkiri", sortable=False),
+        Column(key="level", label="Tase", sortable=False, render=lambda r: r["level"]),
+        Column(key="count", label="Esinemisi", sortable=False),
+        Column(key="last_seen", label="Viimati nähti", sortable=False),
+        Column(key="link", label="Vaata", sortable=False, render=lambda r: r["link"]),
+    ]
+    return DataTable(columns=columns, rows=rows)
+
+
+def _sentry_panel_card():
+    """Render the Sentry errors card for the admin dashboard.
+
+    States rendered:
+        1. **Not configured** (``_get_recent_sentry_errors()`` is ``None``):
+           an info note pointing to the setup doc.
+        2. **No recent errors** (empty list): a green StatusBadge plus
+           "Hiljutisi vigu pole.".
+        3. **Issues present**: a 5-row DataTable plus a "Vaata Sentrys"
+           link to the project's issues page.
+    """
+    issues = _get_recent_sentry_errors()
+
+    if issues is None:
+        body: object = Div(  # noqa: F405
+            P(  # noqa: F405
+                "Sentry pole konfigureeritud. Seadista keskkonnamuutujad "
+                "SENTRY_API_TOKEN, SENTRY_ORG_SLUG ja SENTRY_PROJECT_SLUG "
+                "(vt docs/superpowers/specs/2026-04-09-phase4-design.md "
+                "Sentry seadistuse jaoks).",
+                cls="muted-text",
+            ),
+        )
+    elif not issues:
+        body = Div(  # noqa: F405
+            P(  # noqa: F405
+                StatusBadge("ok"),
+                " Hiljutisi vigu pole.",
+            ),
+        )
+    else:
+        env = _sentry_env()
+        # env cannot be None here because issues was not None.
+        assert env is not None
+        _token, org, project = env
+        body = Div(  # noqa: F405
+            _sentry_table(issues),
+            P(  # noqa: F405
+                A(  # noqa: F405
+                    "Vaata Sentrys →",
+                    href=_sentry_issues_url(org, project),
+                    target="_blank",
+                    rel="noopener noreferrer",
+                    cls="back-link",
+                ),
+            ),
+        )
+
+    return Card(
+        CardHeader(
+            H3(  # noqa: F405
+                "Sentry vead",
+                _tooltip("Viimased lahendamata vead Sentry projektis"),
+                cls="card-title",
+            )
+        ),
+        CardBody(body),
+        id="sentry-panel-card",
+    )
+
+
+def admin_sentry_page(req: Request):
+    """GET /admin/sentry -- detail view of recent Sentry errors with a refresh button.
+
+    Helpers are imported as locals to stay consistent with the rest of
+    the admin sub-modules; the outer try/except renders a styled error
+    banner instead of letting an unexpected failure bubble up as a raw
+    500.
+    """
+    auth = req.scope.get("auth")
+    theme = get_theme_from_request(req)
+    try:
+        from app.admin.sentry_panel import _sentry_panel_card
+
+        content = (
+            H1("Sentry vead", cls="page-title"),  # noqa: F405
+            P(A("← Tagasi adminipaneelile", href="/admin"), cls="back-link"),  # noqa: F405
+            P(  # noqa: F405
+                A(  # noqa: F405
+                    "Värskenda",
+                    href="/admin/sentry",
+                    cls="btn btn-secondary btn-sm",
+                ),
+            ),
+            _sentry_panel_card(),
+        )
+
+        return PageShell(
+            *content,
+            title="Sentry vead",
+            user=auth,
+            theme=theme,
+            active_nav="/admin",
+        )
+    except Exception:
+        logger.exception("Failed to render admin sentry page")
+        from app.admin._shared import _render_admin_error_page
+
+        return _render_admin_error_page(title="Sentry vead", user=auth, theme=theme)

--- a/app/templates/admin_dashboard.py
+++ b/app/templates/admin_dashboard.py
@@ -1,334 +1,37 @@
-"""Admin dashboard — backward-compatible shim.
+"""Backward-compatible re-export module for the admin dashboard.
 
-The real implementation lives in ``app.admin.*`` sub-modules.  This module
-re-exports every public and "underscore-public" name so that existing code
-doing ``from app.templates.admin_dashboard import X`` or
-``@patch("app.templates.admin_dashboard.X")`` continues to work.
+The real implementation lives in ``app.admin.*`` sub-modules — see
+``app/admin/routes.py`` for route wiring and the per-module handlers
+(``app.admin.health``, ``app.admin.sync``, ``app.admin.audit``, ...).
 
-A handful of functions are *rebound* (their ``__globals__`` dict is swapped
-to point at **this** module) so that ``@patch`` decorators that replace
-``_connect``, ``jena_check_health``, ``_check_postgres``, or
-``_get_sync_logs`` on this module actually affect the function at call-time.
-Without rebinding, the function objects would resolve those names from the
-sub-module where they were originally defined, and the patches would have
-no effect.
+This module exists purely so that code paths that historically imported
+from ``app.templates.admin_dashboard`` keep working:
+
+* ``from app.templates.admin_dashboard import register_admin_routes``
+* ``from app.templates.admin_dashboard import _get_sync_logs``
+* the import-safety test (``tests/test_import_safety.py``), which
+  imports this module to verify the design-system ``Button`` symbol
+  isn't shadowed by ``from fasthtml.common import *``.
+
+**Do not add new symbols here.** Put new admin code in the relevant
+``app.admin.*`` sub-module and patch it on its real path in tests
+(e.g. ``@patch("app.admin.sync._get_sync_logs")``). The historical
+``_rebind`` / ``_EXPECTED_PAGE_HANDLERS`` machinery is gone — tests now
+patch helpers on the modules that own them.
 """
 
 from __future__ import annotations
 
-import csv  # noqa: F401  -- used by rebound audit_export
-import io  # noqa: F401  -- used by rebound audit_export
-import logging
-import os  # noqa: F401  -- used by rebound sync
-import threading
-import types as _types
-from datetime import UTC, date, datetime, timedelta  # noqa: F401  -- used by rebound funcs
+# Re-exports for ``from app.templates.admin_dashboard import X`` callers.
+# The Button re-export also keeps the ``test_import_safety`` guard happy.
+from app.admin.health import _check_postgres, health_check  # noqa: F401
 
-from fasthtml.common import *  # noqa: F403, F401
-from starlette.requests import Request  # noqa: F401  -- used by rebound page handlers
-from starlette.responses import JSONResponse, Response  # noqa: F401
-
-from app.admin._shared import _tooltip  # noqa: F401
-from app.admin.analytics import (
-    _get_last_refresh,  # noqa: F401
-    _get_usage_by_org,  # noqa: F401
-    _get_usage_data,  # noqa: F401
-    _refresh_usage_daily,  # noqa: F401
-    _usage_summary,  # noqa: F401
-)
-from app.admin.analytics import (
-    admin_analytics_export as _admin_analytics_export_impl,
-)
-from app.admin.analytics import (
-    admin_analytics_page as _admin_analytics_page_impl,
-)
-from app.admin.analytics import (
-    admin_analytics_refresh as _admin_analytics_refresh_impl,
-)
-from app.admin.audit import (
-    _get_audit_log_page as _get_audit_log_page_impl,
-)
-from app.admin.audit import (
-    admin_audit_detail as _admin_audit_detail_impl,
-)
-from app.admin.audit import (
-    admin_audit_export as _admin_audit_export_impl,
-)
-from app.admin.audit import (
-    admin_audit_page as _admin_audit_page_impl,
-)
-from app.admin.cost_dashboard import (
-    _get_cost_by_feature,  # noqa: F401
-    _get_cost_by_model,  # noqa: F401
-    _get_cost_by_org,  # noqa: F401
-    _get_daily_trend,  # noqa: F401
-    _get_monthly_trend,  # noqa: F401
-    _get_top_users,  # noqa: F401
-)
-from app.admin.cost_dashboard import (
-    admin_cost_export as _admin_cost_export_impl,
-)
-from app.admin.cost_dashboard import (
-    admin_cost_page as _admin_cost_page_impl,
-)
-from app.admin.dashboard import (
-    _version_footer,  # noqa: F401  -- resolved at call-time in rebound admin_dashboard_page
-)
-from app.admin.dashboard import (
-    admin_dashboard_page as _admin_dashboard_page_impl,
-)
-from app.admin.health import (
-    _check_postgres as _check_postgres_impl,
-)
-from app.admin.health import (
-    _health_card,  # noqa: F401
-)
-from app.admin.health import (
-    health_check as _health_check_impl,
-)
-from app.admin.job_monitor import (
-    _get_recent_failed,  # noqa: F401
-    _get_status_counts,  # noqa: F401
-    _get_type_breakdown,  # noqa: F401
-    _purge_completed,  # noqa: F401
-    _retry_job,  # noqa: F401
-)
-from app.admin.job_monitor import (
-    admin_job_retry as _admin_job_retry_impl,
-)
-from app.admin.job_monitor import (
-    admin_jobs_page as _admin_jobs_page_impl,
-)
-from app.admin.job_monitor import (
-    admin_jobs_purge as _admin_jobs_purge_impl,
-)
-from app.admin.jobs import (
-    _get_job_queue_snapshot,  # noqa: F401
-    _job_queue_card,  # noqa: F401
-)
-from app.admin.llm_usage import (
-    _get_llm_usage_stats,  # noqa: F401
-    _llm_usage_card,  # noqa: F401
-)
-from app.admin.performance import (
-    _get_job_durations,  # noqa: F401
-    _get_latency_percentiles,  # noqa: F401
-    _get_llm_latencies,  # noqa: F401
-    _get_slowest_routes,  # noqa: F401
-)
-from app.admin.performance import (
-    admin_performance_page as _admin_performance_page_impl,
-)
-from app.admin.rate_limits import (
-    _get_rate_limit_stats,  # noqa: F401
-    _rate_limit_card,  # noqa: F401
-)
-from app.admin.sync import (
-    _get_sync_log_page as _get_sync_log_page_impl,
-)
-from app.admin.sync import (
-    _get_sync_logs as _get_sync_logs_impl,
-)
-from app.admin.sync import (
-    _run_sync_and_clear_flag as _run_sync_and_clear_flag_impl,
-)
-from app.admin.sync import (
-    _sync_card,  # noqa: F401
-    _sync_status_badge,  # noqa: F401
-    _sync_trigger_form,  # noqa: F401
-)
-from app.admin.sync import (
-    admin_sync_history_page as _admin_sync_history_page_impl,
-)
-from app.admin.sync import (
-    sync_status_card as _sync_status_card_impl,
-)
-from app.admin.sync import (
-    trigger_sync as _trigger_sync_impl,
-)
-from app.admin.users import (
-    _get_user_stats as _get_user_stats_impl,
-)
-from app.admin.users import (
-    _quick_links_card,  # noqa: F401
-    _user_stats_card,  # noqa: F401
-)
-from app.auth.roles import require_role
-from app.db import get_connection as _connect  # noqa: F401
+# Public — route registration. Imported by ``app.main`` indirectly via
+# ``app.admin.__init__``; kept here so old direct imports still resolve.
+from app.admin.routes import register_admin_routes
+from app.admin.sync import _get_sync_logs, sync_status_card, trigger_sync  # noqa: F401
+from app.admin.users import _get_user_stats  # noqa: F401
 from app.sync.jena_loader import check_health as jena_check_health  # noqa: F401
-from app.sync.orchestrator import (
-    PHASE_CLONING,  # noqa: F401  -- referenced by rebound trigger_sync
-    _insert_running_row,  # noqa: F401  -- referenced by rebound trigger_sync
-    has_recent_running_row,  # noqa: F401  -- referenced by rebound trigger_sync
-)
-from app.ui.data.data_table import Column, DataTable  # noqa: F401  -- used by rebound pages
-from app.ui.data.pagination import Pagination  # noqa: F401
-from app.ui.forms.app_form import AppForm  # noqa: F401
-from app.ui.layout import PageShell  # noqa: F401  -- used by rebound page handlers
-from app.ui.primitives.badge import Badge, BadgeVariant, StatusBadge  # noqa: F401
-from app.ui.primitives.button import Button  # noqa: F401, F811  -- shadow guard #419
-from app.ui.surfaces.card import Card, CardBody, CardHeader  # noqa: F401
-from app.ui.surfaces.info_box import InfoBox  # noqa: F401
-from app.ui.theme import get_theme_from_request  # noqa: F401  -- used by rebound page handlers
-from app.version import read_version  # noqa: F401  -- referenced by rebound health_check
+from app.ui.primitives.button import Button  # noqa: F401  -- shadow guard #419
 
-# Module-level state expected by tests (e.g. ``admin_dashboard._sync_in_progress``).
-_sync_lock = threading.Lock()
-_sync_in_progress = False
-
-logger = logging.getLogger(__name__)
-
-_SYNC_STATUS_MAP = {
-    "running": ("running", "K\u00e4imas"),
-    "success": ("ok", "\u00d5nnestus"),
-    "failed": ("failed", "Eba\u00f5nnestus"),
-}
-
-# ---------------------------------------------------------------------------
-# Rebinding helper
-# ---------------------------------------------------------------------------
-
-
-def _rebind(fn):
-    """Return a copy of *fn* whose ``__globals__`` point to THIS module.
-
-    This lets ``@patch("app.templates.admin_dashboard.X")`` affect the
-    function when it looks up ``X`` at call-time, because it now resolves
-    names from this module's dict rather than the sub-module's.
-    """
-    rebound = _types.FunctionType(
-        fn.__code__,
-        globals(),  # THIS module's global dict
-        fn.__name__,
-        fn.__defaults__,
-        fn.__closure__,
-    )
-    rebound.__module__ = __name__
-    rebound.__qualname__ = fn.__qualname__
-    rebound.__doc__ = fn.__doc__
-    if fn.__kwdefaults__:
-        rebound.__kwdefaults__ = fn.__kwdefaults__
-    rebound.__annotations__ = fn.__annotations__
-    return rebound
-
-
-# ---------------------------------------------------------------------------
-# Rebound functions — tests patch names on THIS module and expect these
-# functions to see the patched values.
-# ---------------------------------------------------------------------------
-
-_check_postgres = _rebind(_check_postgres_impl)
-_get_sync_logs = _rebind(_get_sync_logs_impl)
-_get_sync_log_page = _rebind(_get_sync_log_page_impl)
-_get_user_stats = _rebind(_get_user_stats_impl)
-_get_audit_log_page = _rebind(_get_audit_log_page_impl)
-health_check = _rebind(_health_check_impl)
-
-# trigger_sync and _run_sync_and_clear_flag use ``global _sync_in_progress``
-# which writes to __globals__["_sync_in_progress"] — after rebinding that
-# points to THIS module's _sync_in_progress, which is exactly what the
-# tests assert against.
-_run_sync_and_clear_flag = _rebind(_run_sync_and_clear_flag_impl)
-trigger_sync = _rebind(_trigger_sync_impl)
-sync_status_card = _rebind(_sync_status_card_impl)
-admin_sync_history_page = _rebind(_admin_sync_history_page_impl)
-
-# admin_dashboard_page calls _check_postgres, jena_check_health,
-# _get_sync_logs, _get_user_stats — all patchable names.  Rebind it so
-# patches on this module take effect when the page is rendered.
-admin_dashboard_page = _rebind(_admin_dashboard_page_impl)
-admin_audit_page = _rebind(_admin_audit_page_impl)
-admin_audit_export = _rebind(_admin_audit_export_impl)
-admin_audit_detail = _rebind(_admin_audit_detail_impl)
-admin_analytics_page = _rebind(_admin_analytics_page_impl)
-admin_analytics_refresh = _rebind(_admin_analytics_refresh_impl)
-admin_analytics_export = _rebind(_admin_analytics_export_impl)
-admin_cost_page = _rebind(_admin_cost_page_impl)
-admin_cost_export = _rebind(_admin_cost_export_impl)
-admin_jobs_page = _rebind(_admin_jobs_page_impl)
-admin_job_retry = _rebind(_admin_job_retry_impl)
-admin_jobs_purge = _rebind(_admin_jobs_purge_impl)
-admin_performance_page = _rebind(_admin_performance_page_impl)
-
-# ---------------------------------------------------------------------------
-# Completeness check — warn if a new admin page handler is added without
-# a corresponding _rebind() call.  Run once at import time.
-# ---------------------------------------------------------------------------
-_EXPECTED_PAGE_HANDLERS = {
-    "admin_dashboard_page",
-    "admin_audit_page",
-    "admin_audit_export",
-    "admin_audit_detail",
-    "admin_analytics_page",
-    "admin_analytics_refresh",
-    "admin_analytics_export",
-    "admin_cost_page",
-    "admin_cost_export",
-    "admin_jobs_page",
-    "admin_job_retry",
-    "admin_jobs_purge",
-    "admin_performance_page",
-    "admin_sync_history_page",
-    "health_check",
-    "trigger_sync",
-    "sync_status_card",
-}
-_rebound_names = {
-    name
-    for name in _EXPECTED_PAGE_HANDLERS
-    if name in globals()
-    and callable(globals()[name])
-    and getattr(globals()[name], "__module__", None) == __name__
-}
-_missing = _EXPECTED_PAGE_HANDLERS - _rebound_names
-if _missing:
-    import warnings as _warnings
-
-    _warnings.warn(
-        f"admin_dashboard shim: missing rebinds for {_missing}. "
-        "Add _rebind() calls for new admin page handlers.",
-        stacklevel=1,
-    )
-
-
-# ---------------------------------------------------------------------------
-# Apply admin role decorator & route registration
-# ---------------------------------------------------------------------------
-
-_admin_dashboard = require_role("admin")(admin_dashboard_page)
-_admin_audit = require_role("admin")(admin_audit_page)
-_admin_audit_export = require_role("admin")(admin_audit_export)
-_admin_audit_detail = require_role("admin")(admin_audit_detail)
-_admin_sync = require_role("admin")(trigger_sync)
-_admin_sync_status = require_role("admin")(sync_status_card)
-_admin_sync_history = require_role("admin")(admin_sync_history_page)
-_admin_analytics = require_role("admin")(admin_analytics_page)
-_admin_analytics_refresh = require_role("admin")(admin_analytics_refresh)
-_admin_analytics_export = require_role("admin")(admin_analytics_export)
-_admin_costs = require_role("admin")(admin_cost_page)
-_admin_costs_export = require_role("admin")(admin_cost_export)
-_admin_jobs = require_role("admin")(admin_jobs_page)
-_admin_job_retry = require_role("admin")(admin_job_retry)
-_admin_jobs_purge = require_role("admin")(admin_jobs_purge)
-_admin_performance = require_role("admin")(admin_performance_page)
-
-
-def register_admin_routes(rt) -> None:  # type: ignore[no-untyped-def]
-    """Register admin dashboard routes on the FastHTML route decorator *rt*."""
-    rt("/admin", methods=["GET"])(_admin_dashboard)
-    rt("/admin/audit", methods=["GET"])(_admin_audit)
-    rt("/admin/audit/export", methods=["GET"])(_admin_audit_export)
-    rt("/admin/audit/detail/{id}", methods=["GET"])(_admin_audit_detail)
-    rt("/admin/performance", methods=["GET"])(_admin_performance)
-    rt("/admin/sync", methods=["POST"])(_admin_sync)
-    rt("/admin/sync/status", methods=["GET"])(_admin_sync_status)
-    rt("/admin/sync/history", methods=["GET"])(_admin_sync_history)
-    rt("/admin/analytics", methods=["GET"])(_admin_analytics)
-    rt("/admin/analytics/refresh", methods=["POST"])(_admin_analytics_refresh)
-    rt("/admin/analytics/export", methods=["GET"])(_admin_analytics_export)
-    rt("/admin/costs", methods=["GET"])(_admin_costs)
-    rt("/admin/costs/export", methods=["GET"])(_admin_costs_export)
-    rt("/admin/jobs", methods=["GET"])(_admin_jobs)
-    rt("/admin/jobs/{id}/retry", methods=["POST"])(_admin_job_retry)
-    rt("/admin/jobs/purge", methods=["POST"])(_admin_jobs_purge)
-    rt("/api/health", methods=["GET"])(health_check)
+__all__ = ["register_admin_routes"]

--- a/tests/test_admin_health.py
+++ b/tests/test_admin_health.py
@@ -1,0 +1,348 @@
+"""Tests for the system-health aggregator (#183).
+
+Covers:
+- ``_get_system_health`` returns the expected dict for the green path.
+- Missing pgvector downgrades ``overall_status`` to ``"degraded"``.
+- Postgres unreachable forces ``overall_status`` to ``"down"`` and short-
+  circuits the remaining DB-backed probes.
+- Empty sync_log renders "Sünki pole veel tehtud" in the aggregator card.
+- Worker activity of zero still renders without crashing.
+- The ``/admin/health/aggregator`` detail page renders and includes a
+  Värskenda refresh button that does a plain GET back to itself.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+
+def _make_request(path: str = "/admin/health/aggregator") -> Request:
+    """Build a minimal ASGI Request carrying an admin ``auth`` scope.
+
+    Mirrors the ``tests/test_admin_audit_enhanced.py`` pattern — the
+    Beforeware that would normally populate ``scope['auth']`` is
+    bypassed so the handler can be invoked without a TestClient.
+    """
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": [],
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "auth": {
+            "role": "admin",
+            "id": "admin-health-test",
+            "email": "admin@seadusloome.ee",
+            "full_name": "Admin Test",
+        },
+    }
+    return Request(scope)
+
+
+# ---------------------------------------------------------------------------
+# _get_system_health — happy path and degraded variants
+# ---------------------------------------------------------------------------
+
+
+class TestGetSystemHealth:
+    @patch("app.admin.health._get_metrics_recent_count", return_value=42)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=3)
+    @patch("app.admin.health._get_last_sync")
+    @patch("app.admin.health._check_pgvector", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_all_green(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from app.admin.health import _get_system_health
+
+        mock_sync.return_value = {
+            "status": "success",
+            "started_at": datetime(2026, 5, 24, 9, 0, tzinfo=UTC),
+            "finished_at": datetime(2026, 5, 24, 9, 4, tzinfo=UTC),
+            "duration_s": 240.0,
+            "error_message": None,
+        }
+
+        result = _get_system_health()
+        assert result["postgres_ok"] is True
+        assert result["jena_ok"] is True
+        assert result["pgvector_ok"] is True
+        assert result["last_sync"] is not None
+        assert result["last_sync"]["status"] == "success"
+        assert result["worker_recent_activity"] == 3
+        assert result["metrics_recent_count"] == 42
+        assert result["overall_status"] == "ok"
+
+    @patch("app.admin.health._get_metrics_recent_count", return_value=10)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=0)
+    @patch("app.admin.health._get_last_sync", return_value=None)
+    @patch("app.admin.health._check_pgvector", return_value=False)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_pgvector_missing_marks_degraded(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from app.admin.health import _get_system_health
+
+        result = _get_system_health()
+        assert result["pgvector_ok"] is False
+        assert result["overall_status"] == "degraded"
+
+    @patch("app.admin.health._get_metrics_recent_count", return_value=10)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=0)
+    @patch("app.admin.health._get_last_sync", return_value=None)
+    @patch("app.admin.health._check_pgvector", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=False)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_jena_failing_marks_degraded(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from app.admin.health import _get_system_health
+
+        result = _get_system_health()
+        assert result["jena_ok"] is False
+        assert result["overall_status"] == "degraded"
+
+    @patch("app.admin.health._check_pgvector")
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=False)
+    def test_postgres_down_short_circuits(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+    ):
+        """When Postgres is unreachable the DB-backed probes must not run
+        (no point — they'd just fail and log noise) and overall_status
+        must be ``"down"``."""
+        from app.admin.health import _get_system_health
+
+        result = _get_system_health()
+        assert result["postgres_ok"] is False
+        assert result["overall_status"] == "down"
+        # pgvector / last_sync / worker activity / metrics counts must
+        # all collapse to their safe defaults without re-querying.
+        assert result["pgvector_ok"] is False
+        assert result["last_sync"] is None
+        assert result["worker_recent_activity"] == 0
+        assert result["metrics_recent_count"] == 0
+        mock_pgvector.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _health_aggregator_card — empty sync_log + zero-activity rendering
+# ---------------------------------------------------------------------------
+
+
+class TestHealthAggregatorCard:
+    @patch("app.admin.health._get_metrics_recent_count", return_value=12)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=0)
+    @patch("app.admin.health._get_last_sync", return_value=None)
+    @patch("app.admin.health._check_pgvector", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_empty_sync_log_renders_estonian_empty_state(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.health import _health_aggregator_card
+
+        html = to_xml(_health_aggregator_card())
+        assert "Sünki pole veel tehtud" in html
+        # The Estonian section labels should all be present.
+        assert "Postgres" in html
+        assert "Jena" in html
+        assert "pgvector" in html
+        assert "Viimane sünk" in html
+        assert "Töötaja aktiivsus (5m)" in html
+        assert "Metrics (5m)" in html
+        # Link to the detail page.
+        assert "/admin/health/aggregator" in html
+        assert "Vaata üksikasju" in html
+
+    @patch("app.admin.health._get_metrics_recent_count", return_value=0)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=0)
+    @patch("app.admin.health._get_last_sync", return_value=None)
+    @patch("app.admin.health._check_pgvector", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_zero_worker_activity_renders_without_crash(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        """PR #835 may not have landed yet — the aggregator must still
+        cope with a ``job_execution_ms`` metric stream that's empty."""
+        from fasthtml.common import to_xml
+
+        from app.admin.health import _health_aggregator_card
+
+        html = to_xml(_health_aggregator_card())
+        # The card must render the row label even when count is 0.
+        assert "Töötaja aktiivsus (5m)" in html
+        # Zero counts render as the muted "Ootel" status text (StatusBadge "pending").
+        assert "Ootel" in html
+
+    @patch("app.admin.health._get_metrics_recent_count", return_value=0)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=0)
+    @patch("app.admin.health._get_last_sync", return_value=None)
+    @patch("app.admin.health._check_pgvector", return_value=False)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_degraded_overall_badge_renders_warning(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.health import _health_aggregator_card
+
+        html = to_xml(_health_aggregator_card())
+        # The overall_status="degraded" → StatusBadge("warning") → "Hoiatus"
+        assert "Hoiatus" in html
+
+
+# ---------------------------------------------------------------------------
+# admin_health_page — detail page renders + refresh button
+# ---------------------------------------------------------------------------
+
+
+class TestAdminHealthPage:
+    @patch("app.admin.health._get_metrics_recent_count", return_value=99)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=5)
+    @patch("app.admin.health._get_last_sync")
+    @patch("app.admin.health._check_pgvector", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_detail_page_renders_full_data(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.health import admin_health_page
+
+        mock_sync.return_value = {
+            "status": "success",
+            "started_at": datetime(2026, 5, 24, 9, 0, tzinfo=UTC),
+            "finished_at": datetime(2026, 5, 24, 9, 4, tzinfo=UTC),
+            "duration_s": 240.0,
+            "error_message": None,
+        }
+
+        result = admin_health_page(_make_request())
+        html = to_xml(result)
+        # Page chrome
+        assert "Süsteemi tervis" in html
+        # Refresh button → plain GET back to the same URL
+        assert "Värskenda" in html
+        # The refresh link must point to the same detail URL (plain GET reload).
+        assert 'href="/admin/health/aggregator"' in html
+        # Back-link to /admin
+        assert "Tagasi adminipaneelile" in html
+        # Activity counts surface as their numeric strings.
+        assert ">5<" in html
+        assert ">99<" in html
+
+    @patch("app.admin.health._get_metrics_recent_count", return_value=0)
+    @patch("app.admin.health._get_worker_recent_activity", return_value=0)
+    @patch("app.admin.health._get_last_sync")
+    @patch("app.admin.health._check_pgvector", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    @patch("app.admin.health._check_postgres", return_value=True)
+    def test_detail_page_renders_sync_error_message(
+        self,
+        mock_pg: MagicMock,
+        mock_jena: MagicMock,
+        mock_pgvector: MagicMock,
+        mock_sync: MagicMock,
+        mock_worker: MagicMock,
+        mock_metrics: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.health import admin_health_page
+
+        mock_sync.return_value = {
+            "status": "failed",
+            "started_at": datetime(2026, 5, 24, 9, 0, tzinfo=UTC),
+            "finished_at": datetime(2026, 5, 24, 9, 4, tzinfo=UTC),
+            "duration_s": 240.0,
+            "error_message": "SHACL validation failed: malformed Provision",
+        }
+
+        result = admin_health_page(_make_request())
+        html = to_xml(result)
+        # Error message must be surfaced inside the Details disclosure.
+        assert "Veateade" in html
+        assert "SHACL validation failed" in html
+
+    def test_detail_route_requires_auth(self):
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/admin/health/aggregator")
+        assert response.status_code == 303
+        assert response.headers["location"] == "/auth/login"
+
+    @patch("app.admin.health._get_system_health")
+    def test_detail_page_renders_error_fallback_on_failure(self, mock_health: MagicMock):
+        """If the aggregator itself crashes, the handler must return a
+        styled PageShell error banner rather than a raw 500."""
+        from fasthtml.common import to_xml
+
+        from app.admin.health import admin_health_page
+
+        mock_health.side_effect = RuntimeError("unexpected boom")
+        result = admin_health_page(_make_request())
+        html = to_xml(result)
+        assert "Süsteemi tervis" in html
+        # The shared error banner copy.
+        assert "Andmete laadimine ebaõnnestus" in html

--- a/tests/test_admin_job_monitor.py
+++ b/tests/test_admin_job_monitor.py
@@ -1,26 +1,32 @@
-"""Tests for the admin job monitor page (#543).
+"""Tests for the admin job monitor page (#543 + #188 polish).
 
 Covers: status counts, type breakdown, recent failed jobs, retry action,
-purge action, page rendering, and route-level auth checks.
+purge action, page rendering, route-level auth, the new filterable +
+paginated jobs table (#188), per-handler 24h stats card (with and
+without metrics rows), and the HTMX-loaded detail fragment.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from unittest.mock import MagicMock, patch
 
 from starlette.requests import Request
 from starlette.testclient import TestClient
 
 
-def _make_request(path: str = "/admin/jobs", method: str = "GET") -> Request:
+def _make_request(
+    path: str = "/admin/jobs",
+    method: str = "GET",
+    query_string: str = "",
+) -> Request:
     """Build a minimal Starlette Request for unit testing."""
     scope = {
         "type": "http",
         "method": method,
         "path": path,
         "headers": [],
-        "query_string": b"",
+        "query_string": query_string.encode(),
         "scheme": "http",
         "server": ("testserver", 80),
         "client": ("127.0.0.1", 12345),
@@ -208,19 +214,262 @@ class TestPurgeCompleted:
 
 
 # ---------------------------------------------------------------------------
+# Filter parsing + WHERE clause builder (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestParseDateHelper:
+    def test_valid_date(self):
+        from app.admin.job_monitor import _parse_date
+
+        assert _parse_date("2025-03-15") == date(2025, 3, 15)
+
+    def test_invalid_returns_none(self):
+        from app.admin.job_monitor import _parse_date
+
+        assert _parse_date("not-a-date") is None
+
+    def test_empty_returns_none(self):
+        from app.admin.job_monitor import _parse_date
+
+        assert _parse_date("") is None
+        assert _parse_date(None) is None
+
+
+class TestNormaliseStatus:
+    def test_valid_status_passes_through(self):
+        from app.admin.job_monitor import _normalise_status
+
+        assert _normalise_status("pending") == "pending"
+        assert _normalise_status("running") == "running"
+        assert _normalise_status("failed") == "failed"
+        assert _normalise_status("success") == "success"
+
+    def test_completed_alias_maps_to_success(self):
+        from app.admin.job_monitor import _normalise_status
+
+        assert _normalise_status("completed") == "success"
+
+    def test_unknown_returns_none(self):
+        from app.admin.job_monitor import _normalise_status
+
+        assert _normalise_status("garbage") is None
+        assert _normalise_status("") is None
+        assert _normalise_status(None) is None
+
+
+class TestBuildJobsWhere:
+    def test_no_filters_returns_true(self):
+        from app.admin.job_monitor import _build_jobs_where
+
+        where, params = _build_jobs_where()
+        assert where == "TRUE"
+        assert params == []
+
+    def test_handler_uses_any(self):
+        from app.admin.job_monitor import _build_jobs_where
+
+        where, params = _build_jobs_where(handlers=["parse_draft", "extract_entities"])
+        assert "job_type = ANY(%s)" in where
+        assert params == [["parse_draft", "extract_entities"]]
+
+    def test_status_filter(self):
+        from app.admin.job_monitor import _build_jobs_where
+
+        where, params = _build_jobs_where(status="failed")
+        assert "status = %s" in where
+        assert "failed" in params
+
+    def test_date_range_filter(self):
+        from app.admin.job_monitor import _build_jobs_where
+
+        where, params = _build_jobs_where(date_from=date(2025, 1, 1), date_to=date(2025, 1, 31))
+        assert "started_at >= %s" in where
+        assert "started_at < %s" in where
+        assert len(params) == 2
+
+    def test_combined_filters(self):
+        from app.admin.job_monitor import _build_jobs_where
+
+        where, params = _build_jobs_where(
+            handlers=["parse_draft"],
+            status="failed",
+            date_from=date(2025, 6, 1),
+            date_to=date(2025, 6, 30),
+        )
+        assert "job_type = ANY(%s)" in where
+        assert "status = %s" in where
+        assert "started_at >= %s" in where
+        assert "started_at < %s" in where
+        assert len(params) == 4
+
+
+class TestExtractFilters:
+    def test_multi_select_handler(self):
+        from app.admin.job_monitor import _extract_filters
+
+        req = _make_request(query_string="handler=parse_draft&handler=extract_entities")
+        filters = _extract_filters(req)
+        assert filters["handlers"] == ["parse_draft", "extract_entities"]
+
+    def test_status_and_dates(self):
+        from app.admin.job_monitor import _extract_filters
+
+        req = _make_request(query_string="status=failed&from=2025-01-01&to=2025-01-31")
+        filters = _extract_filters(req)
+        assert filters["status"] == "failed"
+        assert filters["from"] == "2025-01-01"
+        assert filters["to"] == "2025-01-31"
+
+    def test_empty_query_string(self):
+        from app.admin.job_monitor import _extract_filters
+
+        req = _make_request()
+        filters = _extract_filters(req)
+        assert filters["handlers"] == []
+        assert filters["status"] == ""
+
+
+class TestFilterQueryString:
+    def test_round_trip_handler_status(self):
+        from app.admin.job_monitor import _filter_query_string
+
+        qs = _filter_query_string(
+            {
+                "handlers": ["parse_draft", "extract_entities"],
+                "status": "failed",
+                "from": "",
+                "to": "",
+            }
+        )
+        assert "handler=parse_draft" in qs
+        assert "handler=extract_entities" in qs
+        assert "status=failed" in qs
+        # No page key — Pagination owns that.
+        assert "page=" not in qs
+
+    def test_skips_empty_values(self):
+        from app.admin.job_monitor import _filter_query_string
+
+        qs = _filter_query_string({"handlers": [], "status": "", "from": "", "to": ""})
+        assert qs == ""
+
+
+# ---------------------------------------------------------------------------
+# Filtered jobs page DB helper (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestGetFilteredJobsPage:
+    @patch("app.admin.job_monitor._connect")
+    def test_returns_jobs_and_total(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _get_filtered_jobs_page
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        now = datetime(2025, 6, 15, 14, 30, tzinfo=UTC)
+        # Two execute calls: count + page rows.
+        mock_conn.execute.return_value.fetchone.return_value = (42,)
+        mock_conn.execute.return_value.fetchall.return_value = [
+            (1, "parse_draft", "failed", "boom", 3, 3, now, now, now),
+            (2, "extract_entities", "success", None, 1, 3, now, now, now),
+        ]
+
+        jobs, total = _get_filtered_jobs_page(
+            page=1,
+            per_page=20,
+            handlers=["parse_draft", "extract_entities"],
+            status="failed",
+            date_from=date(2025, 6, 1),
+            date_to=date(2025, 6, 30),
+        )
+        assert total == 42
+        assert len(jobs) == 2
+        assert jobs[0]["id"] == 1
+        assert jobs[0]["status"] == "failed"
+        # error_message defaults to '' for nulls.
+        assert jobs[1]["error_message"] == ""
+
+    @patch("app.admin.job_monitor._connect")
+    def test_returns_empty_on_error(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _get_filtered_jobs_page
+
+        mock_connect.side_effect = Exception("DB down")
+        jobs, total = _get_filtered_jobs_page()
+        assert jobs == []
+        assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-handler 24h aggregate stats (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestGetHandlerStats24h:
+    @patch("app.admin.job_monitor._connect")
+    def test_aggregates_per_handler(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _get_handler_stats_24h
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchall.return_value = [
+            ("parse_draft", 10, 0.9, 1500.0),
+            ("extract_entities", 5, 1.0, 800.0),
+        ]
+
+        stats = _get_handler_stats_24h()
+        assert len(stats) == 2
+        parse = next(s for s in stats if s["handler"] == "parse_draft")
+        assert parse["count"] == 10
+        assert parse["success_rate"] == 0.9
+        assert parse["p95_ms"] == 1500.0
+
+        # SQL must use the metrics table with the correct metric name.
+        sql = mock_conn.execute.call_args[0][0]
+        assert "FROM metrics" in sql
+        assert "name = 'job_execution_ms'" in sql
+        assert "percentile_cont(0.95)" in sql
+
+    @patch("app.admin.job_monitor._connect")
+    def test_returns_empty_when_no_rows(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _get_handler_stats_24h
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchall.return_value = []
+
+        stats = _get_handler_stats_24h()
+        assert stats == []
+
+    @patch("app.admin.job_monitor._connect")
+    def test_returns_empty_on_error(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _get_handler_stats_24h
+
+        mock_connect.side_effect = Exception("DB down")
+        stats = _get_handler_stats_24h()
+        assert stats == []
+
+
+# ---------------------------------------------------------------------------
 # Page rendering
 # ---------------------------------------------------------------------------
 
 
 class TestJobMonitorPageRendering:
-    @patch("app.admin.job_monitor._get_recent_failed")
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
     @patch("app.admin.job_monitor._get_type_breakdown")
     @patch("app.admin.job_monitor._get_status_counts")
     def test_page_renders_summary_badges(
         self,
         mock_counts: MagicMock,
         mock_breakdown: MagicMock,
-        mock_failed: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
     ):
         from fasthtml.common import to_xml
 
@@ -228,27 +477,29 @@ class TestJobMonitorPageRendering:
 
         mock_counts.return_value = {"pending": 5, "running": 2, "failed": 3, "success": 100}
         mock_breakdown.return_value = []
-        mock_failed.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
 
         req = _make_request()
         result = admin_jobs_page(req)
 
         html = to_xml(result)
         assert "5 ootel" in html
-        assert "2 t\u00f6\u00f6tab" in html
-        assert "3 eba\u00f5nnestunud" in html
-        assert "100 \u00f5nnestunud" in html
-        # Page title
-        assert "T\u00f6\u00f6de monitor" in html
+        assert "2 töötab" in html
+        assert "3 ebaõnnestunud" in html
+        assert "100 õnnestunud" in html
+        assert "Tööde monitor" in html
 
-    @patch("app.admin.job_monitor._get_recent_failed")
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
     @patch("app.admin.job_monitor._get_type_breakdown")
     @patch("app.admin.job_monitor._get_status_counts")
     def test_page_renders_type_breakdown(
         self,
         mock_counts: MagicMock,
         mock_breakdown: MagicMock,
-        mock_failed: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
     ):
         from fasthtml.common import to_xml
 
@@ -264,23 +515,26 @@ class TestJobMonitorPageRendering:
                 "success": 5,
             }
         ]
-        mock_failed.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
 
         req = _make_request()
         result = admin_jobs_page(req)
 
         html = to_xml(result)
         assert "parse_draft" in html
-        assert "T\u00f6\u00f6de t\u00fc\u00fcbi kaupa" in html
+        assert "Tööde tüübi kaupa" in html
 
-    @patch("app.admin.job_monitor._get_recent_failed")
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
     @patch("app.admin.job_monitor._get_type_breakdown")
     @patch("app.admin.job_monitor._get_status_counts")
     def test_page_renders_failed_jobs_with_retry(
         self,
         mock_counts: MagicMock,
         mock_breakdown: MagicMock,
-        mock_failed: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
     ):
         from fasthtml.common import to_xml
 
@@ -288,18 +542,24 @@ class TestJobMonitorPageRendering:
 
         mock_counts.return_value = {"pending": 0, "running": 0, "failed": 1, "success": 0}
         mock_breakdown.return_value = []
-        now = datetime(2025, 6, 15, 14, 30)
-        mock_failed.return_value = [
-            {
-                "id": 42,
-                "job_type": "parse_draft",
-                "error_message": "Connection timeout",
-                "attempts": 3,
-                "max_attempts": 3,
-                "finished_at": now,
-                "created_at": now,
-            }
-        ]
+        mock_stats.return_value = []
+        now = datetime(2025, 6, 15, 14, 30, tzinfo=UTC)
+        mock_jobs.return_value = (
+            [
+                {
+                    "id": 42,
+                    "job_type": "parse_draft",
+                    "status": "failed",
+                    "error_message": "Connection timeout",
+                    "attempts": 3,
+                    "max_attempts": 3,
+                    "finished_at": now,
+                    "started_at": now,
+                    "created_at": now,
+                }
+            ],
+            1,
+        )
 
         req = _make_request()
         result = admin_jobs_page(req)
@@ -310,14 +570,16 @@ class TestJobMonitorPageRendering:
         assert "Proovi uuesti" in html
         assert "/admin/jobs/42/retry" in html
 
-    @patch("app.admin.job_monitor._get_recent_failed")
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
     @patch("app.admin.job_monitor._get_type_breakdown")
     @patch("app.admin.job_monitor._get_status_counts")
     def test_page_renders_purge_button(
         self,
         mock_counts: MagicMock,
         mock_breakdown: MagicMock,
-        mock_failed: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
     ):
         from fasthtml.common import to_xml
 
@@ -325,14 +587,275 @@ class TestJobMonitorPageRendering:
 
         mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
         mock_breakdown.return_value = []
-        mock_failed.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
 
         req = _make_request()
         result = admin_jobs_page(req)
 
         html = to_xml(result)
-        assert "Puhasta vanad t\u00f6\u00f6d" in html
+        assert "Puhasta vanad tööd" in html
         assert "/admin/jobs/purge" in html
+
+
+# ---------------------------------------------------------------------------
+# Filtering + pagination (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestJobMonitorFiltering:
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
+    @patch("app.admin.job_monitor._get_type_breakdown")
+    @patch("app.admin.job_monitor._get_status_counts")
+    def test_filters_propagate_to_query(
+        self,
+        mock_counts: MagicMock,
+        mock_breakdown: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
+    ):
+        """Multi-select handler + status + date range reach the DB helper."""
+        from app.admin.job_monitor import admin_jobs_page
+
+        mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
+        mock_breakdown.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
+
+        qs = (
+            "handler=parse_draft&handler=extract_entities"
+            "&status=failed&from=2025-06-01&to=2025-06-30"
+        )
+        req = _make_request(query_string=qs)
+        admin_jobs_page(req)
+
+        call = mock_jobs.call_args
+        assert call.kwargs["handlers"] == ["parse_draft", "extract_entities"]
+        assert call.kwargs["status"] == "failed"
+        assert call.kwargs["date_from"] == date(2025, 6, 1)
+        assert call.kwargs["date_to"] == date(2025, 6, 30)
+
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
+    @patch("app.admin.job_monitor._get_type_breakdown")
+    @patch("app.admin.job_monitor._get_status_counts")
+    def test_completed_alias_normalises_to_success(
+        self,
+        mock_counts: MagicMock,
+        mock_breakdown: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
+    ):
+        from app.admin.job_monitor import admin_jobs_page
+
+        mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
+        mock_breakdown.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
+
+        req = _make_request(query_string="status=completed")
+        admin_jobs_page(req)
+        assert mock_jobs.call_args.kwargs["status"] == "success"
+
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
+    @patch("app.admin.job_monitor._get_type_breakdown")
+    @patch("app.admin.job_monitor._get_status_counts")
+    def test_pagination_page_param_persists_filters(
+        self,
+        mock_counts: MagicMock,
+        mock_breakdown: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
+    ):
+        """?page=3 reaches the DB helper AND filters survive in pagination links."""
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import admin_jobs_page
+
+        mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
+        mock_breakdown.return_value = []
+        # 65 total -> 4 pages at 20/page; we request page 3.
+        mock_jobs.return_value = ([], 65)
+        mock_stats.return_value = []
+
+        req = _make_request(query_string="handler=parse_draft&status=failed&page=3")
+        result = admin_jobs_page(req)
+
+        assert mock_jobs.call_args.kwargs["page"] == 3
+        html = to_xml(result)
+        # The pagination links must carry the active filters forward so
+        # paging back/forward keeps the filtered view.
+        assert "handler=parse_draft" in html
+        assert "status=failed" in html
+        # And the pagination wrapper is present.
+        assert "pagination" in html
+
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
+    @patch("app.admin.job_monitor._get_type_breakdown")
+    @patch("app.admin.job_monitor._get_status_counts")
+    def test_invalid_page_defaults_to_one(
+        self,
+        mock_counts: MagicMock,
+        mock_breakdown: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
+    ):
+        from app.admin.job_monitor import admin_jobs_page
+
+        mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
+        mock_breakdown.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
+
+        req = _make_request(query_string="page=garbage")
+        admin_jobs_page(req)
+        assert mock_jobs.call_args.kwargs["page"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-handler stats card rendering (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerStatsCard:
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
+    @patch("app.admin.job_monitor._get_type_breakdown")
+    @patch("app.admin.job_monitor._get_status_counts")
+    def test_empty_state_when_no_metrics(
+        self,
+        mock_counts: MagicMock,
+        mock_breakdown: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import admin_jobs_page
+
+        mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
+        mock_breakdown.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
+
+        req = _make_request()
+        result = admin_jobs_page(req)
+
+        html = to_xml(result)
+        assert "Aktiivsuse statistikat pole veel kogutud" in html
+        assert "Töötlejate statistika (viimased 24h)" in html
+
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
+    @patch("app.admin.job_monitor._get_type_breakdown")
+    @patch("app.admin.job_monitor._get_status_counts")
+    def test_renders_metrics_rows(
+        self,
+        mock_counts: MagicMock,
+        mock_breakdown: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import admin_jobs_page
+
+        mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
+        mock_breakdown.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = [
+            {
+                "handler": "parse_draft",
+                "count": 42,
+                "success_rate": 0.95,
+                "p95_ms": 1234.0,
+            }
+        ]
+
+        req = _make_request()
+        result = admin_jobs_page(req)
+
+        html = to_xml(result)
+        assert "parse_draft" in html
+        assert "42" in html
+        assert "95.0%" in html
+        assert "1234 ms" in html
+        # Empty-state copy must NOT appear when we have rows.
+        assert "Aktiivsuse statistikat pole veel kogutud" not in html
+
+
+# ---------------------------------------------------------------------------
+# Detail expand fragment (#188)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminJobDetailFragment:
+    @patch("app.admin.job_monitor._get_job_detail")
+    def test_detail_renders_payload_and_history(self, mock_get: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import admin_job_detail
+
+        now = datetime(2025, 6, 15, 14, 30, tzinfo=UTC)
+        mock_get.return_value = {
+            "id": 7,
+            "job_type": "parse_draft",
+            "status": "failed",
+            "payload": {"draft_id": "d-1", "owner": "u-2"},
+            "error_message": "Traceback (most recent call last):\n  KeyError: 'doc'",
+            "attempts": 3,
+            "max_attempts": 3,
+            "started_at": now,
+            "finished_at": now,
+            "created_at": now,
+            "scheduled_for": now,
+            "claimed_by": "worker-1",
+            "claimed_at": now,
+            "result": None,
+        }
+
+        req = _make_request("/admin/jobs/7/detail")
+        result = admin_job_detail(req, id=7)
+        html = to_xml(result)
+
+        # Payload pretty-printed
+        assert '"draft_id"' in html
+        assert "d-1" in html
+        # Estonian section headings
+        assert "Päringu sisu" in html
+        assert "Katsete ajalugu" in html
+        assert "Veateade" in html
+        # Traceback / error appears
+        assert "KeyError" in html
+        # Worker info shows up in the history
+        assert "worker-1" in html
+
+    @patch("app.admin.job_monitor._get_job_detail")
+    def test_detail_missing_row(self, mock_get: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import admin_job_detail
+
+        mock_get.return_value = None
+        req = _make_request("/admin/jobs/999/detail")
+        result = admin_job_detail(req, id=999)
+        html = to_xml(result)
+        assert "Tööd ei leitud" in html
+
+    @patch("app.admin.job_monitor._get_job_detail")
+    def test_detail_handles_internal_error(self, mock_get: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import admin_job_detail
+
+        mock_get.side_effect = Exception("DB went away")
+        req = _make_request("/admin/jobs/1/detail")
+        result = admin_job_detail(req, id=1)
+        html = to_xml(result)
+        assert "Detailide laadimine ebaõnnestus" in html
 
 
 # ---------------------------------------------------------------------------
@@ -341,7 +864,8 @@ class TestJobMonitorPageRendering:
 
 
 class TestAdminJobRetryHandler:
-    @patch("app.admin.job_monitor._get_recent_failed")
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
     @patch("app.admin.job_monitor._get_type_breakdown")
     @patch("app.admin.job_monitor._get_status_counts")
     @patch("app.admin.job_monitor._retry_job")
@@ -350,7 +874,8 @@ class TestAdminJobRetryHandler:
         mock_retry: MagicMock,
         mock_counts: MagicMock,
         mock_breakdown: MagicMock,
-        mock_failed: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
     ):
         from fasthtml.common import to_xml
 
@@ -359,7 +884,8 @@ class TestAdminJobRetryHandler:
         mock_retry.return_value = True
         mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
         mock_breakdown.return_value = []
-        mock_failed.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
 
         req = _make_request("/admin/jobs/42/retry", method="POST")
         result = admin_job_retry(req, id=42)
@@ -387,7 +913,8 @@ class TestAdminJobRetryHandler:
 
 
 class TestAdminJobsPurgeHandler:
-    @patch("app.admin.job_monitor._get_recent_failed")
+    @patch("app.admin.job_monitor._get_handler_stats_24h")
+    @patch("app.admin.job_monitor._get_filtered_jobs_page")
     @patch("app.admin.job_monitor._get_type_breakdown")
     @patch("app.admin.job_monitor._get_status_counts")
     @patch("app.admin.job_monitor._purge_completed")
@@ -396,7 +923,8 @@ class TestAdminJobsPurgeHandler:
         mock_purge: MagicMock,
         mock_counts: MagicMock,
         mock_breakdown: MagicMock,
-        mock_failed: MagicMock,
+        mock_jobs: MagicMock,
+        mock_stats: MagicMock,
     ):
         from fasthtml.common import to_xml
 
@@ -405,7 +933,8 @@ class TestAdminJobsPurgeHandler:
         mock_purge.return_value = 10
         mock_counts.return_value = {"pending": 0, "running": 0, "failed": 0, "success": 0}
         mock_breakdown.return_value = []
-        mock_failed.return_value = []
+        mock_jobs.return_value = ([], 0)
+        mock_stats.return_value = []
 
         req = _make_request("/admin/jobs/purge", method="POST")
         result = admin_jobs_purge(req)
@@ -442,5 +971,13 @@ class TestJobMonitorAuth:
 
         client = TestClient(app, follow_redirects=False)
         response = client.post("/admin/jobs/purge")
+        assert response.status_code == 303
+        assert response.headers["location"] == "/auth/login"
+
+    def test_job_detail_redirects_unauthenticated(self):
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/admin/jobs/42/detail")
         assert response.status_code == 303
         assert response.headers["location"] == "/auth/login"

--- a/tests/test_admin_job_monitor.py
+++ b/tests/test_admin_job_monitor.py
@@ -432,6 +432,11 @@ class TestGetHandlerStats24h:
         assert "FROM metrics" in sql
         assert "name = 'job_execution_ms'" in sql
         assert "percentile_cont(0.95)" in sql
+        # Backward compat: success_rate must accept BOTH the current
+        # ``'success'`` label (emitted post-#835) and the historical
+        # ``'ok'`` label (pre-2026-05-25 rows in production). Otherwise
+        # historical successful jobs would appear as failures.
+        assert "'ok'" in sql and "'success'" in sql
 
     @patch("app.admin.job_monitor._connect")
     def test_returns_empty_when_no_rows(self, mock_connect: MagicMock):

--- a/tests/test_admin_sentry_panel.py
+++ b/tests/test_admin_sentry_panel.py
@@ -1,0 +1,358 @@
+"""Tests for the admin Sentry errors panel (#324).
+
+Covers:
+    * Env-var gating: missing token/org/project yields ``None`` from the
+      helper and an "ei ole konfigureeritud" card.
+    * Empty-list case: Sentry returned 0 issues → green tick + Estonian
+      "Hiljutisi vigu pole." copy.
+    * Populated case: 3 issues → DataTable rendered, link to Sentry
+      project page included.
+    * 5xx response: graceful "Sentry API ei vasta" fallback (empty card).
+    * Timeout / connection error: same graceful fallback.
+    * ``/admin/sentry`` page renders 200 under ``require_role("admin")``.
+    * Unauthenticated request to ``/admin/sentry`` 303-redirects to
+      ``/auth/login``.
+
+External HTTP is mocked via ``monkeypatch.setattr("httpx.get", ...)`` so
+no real network traffic ever leaves the test process.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Populate the three Sentry env vars with throwaway values."""
+    monkeypatch.setenv("SENTRY_API_TOKEN", "sentry-test-token-do-not-log")
+    monkeypatch.setenv("SENTRY_ORG_SLUG", "seadusloome-test")
+    monkeypatch.setenv("SENTRY_PROJECT_SLUG", "seadusloome-app")
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all three Sentry env vars to simulate missing configuration."""
+    monkeypatch.delenv("SENTRY_API_TOKEN", raising=False)
+    monkeypatch.delenv("SENTRY_ORG_SLUG", raising=False)
+    monkeypatch.delenv("SENTRY_PROJECT_SLUG", raising=False)
+
+
+def _mock_response(status_code: int, payload: Any) -> MagicMock:
+    """Build a fake ``httpx.Response`` with ``status_code`` and ``.json()``."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json = MagicMock(return_value=payload)
+    return response
+
+
+def _admin_user() -> dict[str, Any]:
+    return {
+        "id": "admin-sentry",
+        "email": "admin@seadusloome.ee",
+        "full_name": "Sentry Admin",
+        "role": "admin",
+        "org_id": None,
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _admin_user()
+    return provider
+
+
+def _admin_client() -> TestClient:
+    from app.main import app
+
+    client = TestClient(app, follow_redirects=False)
+    client.cookies.set("access_token", "stub-admin-token")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _get_recent_sentry_errors — env-var gating
+# ---------------------------------------------------------------------------
+
+
+class TestEnvGating:
+    def test_returns_none_when_env_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin.sentry_panel import _get_recent_sentry_errors
+
+        _clear_env(monkeypatch)
+        assert _get_recent_sentry_errors() is None
+
+    def test_returns_none_when_only_token_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin.sentry_panel import _get_recent_sentry_errors
+
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("SENTRY_API_TOKEN", "x")
+        assert _get_recent_sentry_errors() is None
+
+    def test_returns_none_when_project_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin.sentry_panel import _get_recent_sentry_errors
+
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("SENTRY_API_TOKEN", "x")
+        monkeypatch.setenv("SENTRY_ORG_SLUG", "y")
+        assert _get_recent_sentry_errors() is None
+
+
+# ---------------------------------------------------------------------------
+# _get_recent_sentry_errors — HTTP behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSentryApiCall:
+    def test_empty_list_when_sentry_returns_zero_issues(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        mock_get = MagicMock(return_value=_mock_response(200, []))
+        monkeypatch.setattr(sentry_panel.httpx, "get", mock_get)
+
+        result = sentry_panel._get_recent_sentry_errors()
+        assert result == []
+        # Token is sent in the Authorization header, NOT URL params, and
+        # we must not leak it via logging — the test asserts that the
+        # call shape is correct, not the log output.
+        call_kwargs = mock_get.call_args.kwargs
+        assert call_kwargs["headers"]["Authorization"].startswith("Bearer ")
+
+    def test_returns_three_normalised_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        payload = [
+            {
+                "title": "AssertionError in sync_orchestrator",
+                "lastSeen": "2026-05-23T14:30:00Z",
+                "count": "12",
+                "level": "error",
+                "permalink": "https://sentry.io/issues/1/",
+            },
+            {
+                "title": "Timeout calling Voyage API",
+                "lastSeen": "2026-05-23T11:00:00Z",
+                "count": "3",
+                "level": "warning",
+                "permalink": "https://sentry.io/issues/2/",
+            },
+            {
+                "title": "KeyError in chat handler",
+                "lastSeen": "2026-05-22T20:15:00Z",
+                "count": "1",
+                "level": "fatal",
+                "permalink": "https://sentry.io/issues/3/",
+            },
+        ]
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(200, payload))
+        )
+
+        issues = sentry_panel._get_recent_sentry_errors()
+        assert issues is not None
+        assert len(issues) == 3
+        assert issues[0]["title"] == "AssertionError in sync_orchestrator"
+        assert issues[0]["count"] == "12"
+        assert issues[0]["level"] == "error"
+        assert issues[0]["link"] == "https://sentry.io/issues/1/"
+        assert issues[2]["level"] == "fatal"
+
+    def test_caps_at_five_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        payload = [
+            {"title": f"Error {i}", "lastSeen": "", "count": "1", "level": "error"}
+            for i in range(20)
+        ]
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(200, payload))
+        )
+        issues = sentry_panel._get_recent_sentry_errors()
+        assert issues is not None
+        assert len(issues) == 5
+
+    def test_returns_empty_list_on_500(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(500, None))
+        )
+        # Graceful fallback: NOT None (which means "unconfigured") and
+        # NOT a raised exception (which would 500 the admin page).
+        assert sentry_panel._get_recent_sentry_errors() == []
+
+    def test_returns_empty_list_on_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+
+        def _raise_timeout(*args: object, **kwargs: object) -> None:
+            raise httpx.TimeoutException("simulated timeout")
+
+        monkeypatch.setattr(sentry_panel.httpx, "get", _raise_timeout)
+        assert sentry_panel._get_recent_sentry_errors() == []
+
+    def test_returns_empty_list_on_connect_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+
+        def _raise_connect(*args: object, **kwargs: object) -> None:
+            raise httpx.ConnectError("simulated dns failure")
+
+        monkeypatch.setattr(sentry_panel.httpx, "get", _raise_connect)
+        assert sentry_panel._get_recent_sentry_errors() == []
+
+    def test_returns_empty_list_on_non_json_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        bad_response = MagicMock()
+        bad_response.status_code = 200
+        bad_response.json = MagicMock(side_effect=ValueError("not json"))
+        monkeypatch.setattr(sentry_panel.httpx, "get", MagicMock(return_value=bad_response))
+        assert sentry_panel._get_recent_sentry_errors() == []
+
+
+# ---------------------------------------------------------------------------
+# _sentry_panel_card — render branches
+# ---------------------------------------------------------------------------
+
+
+class TestSentryPanelCard:
+    def test_card_empty_state_when_env_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fasthtml.common import to_xml
+
+        from app.admin.sentry_panel import _sentry_panel_card
+
+        _clear_env(monkeypatch)
+        html = to_xml(_sentry_panel_card())
+        assert "Sentry vead" in html
+        assert "Sentry pole konfigureeritud" in html
+        # The setup-doc pointer must appear so admins can find the spec.
+        assert "SENTRY_API_TOKEN" in html
+
+    def test_card_green_tick_when_no_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fasthtml.common import to_xml
+
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(200, []))
+        )
+        html = to_xml(sentry_panel._sentry_panel_card())
+        # Green StatusBadge ("ok") + Estonian copy
+        assert "Hiljutisi vigu pole." in html
+        assert "status-ok" in html
+
+    def test_card_renders_table_for_three_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fasthtml.common import to_xml
+
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        payload = [
+            {
+                "title": "AssertionError in sync_orchestrator",
+                "lastSeen": "2026-05-23T14:30:00Z",
+                "count": "12",
+                "level": "error",
+                "permalink": "https://sentry.io/issues/1/",
+            },
+            {
+                "title": "Timeout calling Voyage API",
+                "lastSeen": "2026-05-23T11:00:00Z",
+                "count": "3",
+                "level": "warning",
+                "permalink": "https://sentry.io/issues/2/",
+            },
+            {
+                "title": "KeyError in chat handler",
+                "lastSeen": "2026-05-22T20:15:00Z",
+                "count": "1",
+                "level": "fatal",
+                "permalink": "https://sentry.io/issues/3/",
+            },
+        ]
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(200, payload))
+        )
+        html = to_xml(sentry_panel._sentry_panel_card())
+        # All three titles + counts present
+        assert "AssertionError in sync_orchestrator" in html
+        assert "Timeout calling Voyage API" in html
+        assert "KeyError in chat handler" in html
+        # Per-issue Sentry permalinks (rendered as anchor hrefs)
+        assert 'href="https://sentry.io/issues/1/"' in html
+        assert 'href="https://sentry.io/issues/2/"' in html
+        # Footer "Vaata Sentrys" link uses only the org + project slug
+        assert "seadusloome-test.sentry.io" in html
+        assert "Vaata Sentrys" in html
+        # Token MUST NEVER appear in rendered HTML
+        assert "sentry-test-token" not in html
+
+    def test_card_renders_empty_state_on_api_5xx(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fasthtml.common import to_xml
+
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(500, None))
+        )
+        html = to_xml(sentry_panel._sentry_panel_card())
+        # Same UX as the "no issues" branch — empty list yields the green tick
+        # because the data helper degrades to []. Admins still see the card,
+        # never a raw 500.
+        assert "Hiljutisi vigu pole." in html
+
+
+# ---------------------------------------------------------------------------
+# /admin/sentry route
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSentryRoute:
+    def test_route_renders_under_admin_role(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.admin import sentry_panel
+
+        _set_env(monkeypatch)
+        monkeypatch.setattr(
+            sentry_panel.httpx, "get", MagicMock(return_value=_mock_response(200, []))
+        )
+
+        with patch("app.auth.middleware._get_provider") as mock_provider:
+            mock_provider.return_value = _stub_provider()
+            client = _admin_client()
+            resp = client.get("/admin/sentry")
+
+        assert resp.status_code == 200, (
+            f"/admin/sentry returned {resp.status_code}; expected 200. Body: {resp.text[:300]!r}"
+        )
+        assert "text/html" in resp.headers.get("content-type", "")
+        # Page title + refresh button + "no issues" copy
+        assert "Sentry vead" in resp.text
+        assert "Värskenda" in resp.text
+        assert "Hiljutisi vigu pole." in resp.text
+
+    def test_route_redirects_unauthenticated(self) -> None:
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/admin/sentry")
+        assert response.status_code == 303
+        assert response.headers["location"] == "/auth/login"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -61,8 +61,8 @@ class TestDashboardAuth:
 
 
 class TestHealthCheck:
-    @patch("app.templates.admin_dashboard.jena_check_health")
-    @patch("app.templates.admin_dashboard._check_postgres")
+    @patch("app.admin.health.jena_check_health")
+    @patch("app.admin.health._check_postgres")
     def test_health_returns_json(self, mock_pg: MagicMock, mock_jena: MagicMock):
         mock_pg.return_value = True
         mock_jena.return_value = True
@@ -77,8 +77,8 @@ class TestHealthCheck:
         assert data["jena"] is True
         assert data["postgres"] is True
 
-    @patch("app.templates.admin_dashboard.jena_check_health")
-    @patch("app.templates.admin_dashboard._check_postgres")
+    @patch("app.admin.health.jena_check_health")
+    @patch("app.admin.health._check_postgres")
     def test_health_degraded_when_service_down(self, mock_pg: MagicMock, mock_jena: MagicMock):
         mock_pg.return_value = True
         mock_jena.return_value = False
@@ -150,8 +150,8 @@ class TestAdminDashboard:
         assert response.status_code == 303
         assert response.headers["location"] == "/auth/login"
 
-    @patch("app.templates.admin_dashboard._insert_running_row", return_value=99)
-    @patch("app.templates.admin_dashboard._get_sync_logs")
+    @patch("app.admin.sync._insert_running_row", return_value=99)
+    @patch("app.admin.sync._get_sync_logs")
     @patch("threading.Thread")
     def test_admin_sync_triggers_thread(
         self,
@@ -164,13 +164,13 @@ class TestAdminDashboard:
         banner. Asserts the lock state is reset via the `finally`."""
         from starlette.requests import Request
 
-        from app.templates import admin_dashboard
-        from app.templates.admin_dashboard import trigger_sync
+        from app.admin import sync as admin_sync
+        from app.admin.sync import trigger_sync
 
         mock_logs.return_value = []
 
         # Ensure a clean lock state so the test is deterministic.
-        admin_dashboard._sync_in_progress = False
+        admin_sync._sync_in_progress = False
         mock_thread = MagicMock()
         mock_thread_cls.return_value = mock_thread
 
@@ -195,7 +195,7 @@ class TestAdminDashboard:
         mock_thread.start.assert_called_once()
 
         # Handler should have flipped the in-progress flag on entry.
-        assert admin_dashboard._sync_in_progress is True
+        assert admin_sync._sync_in_progress is True
 
         # Result is a FastTag we can convert to XML to look for the banner.
         from fasthtml.common import to_xml
@@ -204,7 +204,7 @@ class TestAdminDashboard:
         assert "sünkroniseerimine käivitati" in html.lower()
 
         # Clean up: simulate the thread finishing and clearing the flag.
-        admin_dashboard._sync_in_progress = False
+        admin_sync._sync_in_progress = False
 
 
 # ---------------------------------------------------------------------------
@@ -600,9 +600,9 @@ class TestBookmarkRemove:
 
 
 class TestSyncLogs:
-    @patch("app.templates.admin_dashboard._connect")
+    @patch("app.admin.sync._connect")
     def test_get_sync_logs_returns_list(self, mock_connect: MagicMock):
-        from app.templates.admin_dashboard import _get_sync_logs
+        from app.admin.sync import _get_sync_logs
 
         mock_conn = MagicMock()
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
@@ -618,9 +618,9 @@ class TestSyncLogs:
         # Migration 013 adds current_step — helper must surface it.
         assert "current_step" in result[0]
 
-    @patch("app.templates.admin_dashboard._connect")
+    @patch("app.admin.sync._connect")
     def test_get_sync_logs_returns_empty_on_error(self, mock_connect: MagicMock):
-        from app.templates.admin_dashboard import _get_sync_logs
+        from app.admin.sync import _get_sync_logs
 
         mock_connect.side_effect = Exception("DB unavailable")
         result = _get_sync_logs()
@@ -721,13 +721,13 @@ class TestSyncCardLiveProgress:
         # Reingesting is still pending
         assert "sync-step-pending" in html
 
-    @patch("app.templates.admin_dashboard._get_sync_logs")
+    @patch("app.admin.sync._get_sync_logs")
     def test_sync_status_endpoint_renders_card(self, mock_logs: MagicMock):
         """GET /admin/sync/status returns the same card fragment the
         polling loop expects to swap in-place."""
         from starlette.requests import Request
 
-        from app.templates.admin_dashboard import sync_status_card
+        from app.admin.sync import sync_status_card
 
         mock_logs.return_value = [self._running_log()]
 
@@ -752,8 +752,8 @@ class TestSyncCardLiveProgress:
         assert 'id="sync-card"' in html
         assert "every 3s" in html
 
-    @patch("app.templates.admin_dashboard._insert_running_row", return_value=99)
-    @patch("app.templates.admin_dashboard._get_sync_logs")
+    @patch("app.admin.sync._insert_running_row", return_value=99)
+    @patch("app.admin.sync._get_sync_logs")
     def test_post_sync_inserts_running_row_before_thread(
         self,
         mock_logs: MagicMock,
@@ -765,10 +765,10 @@ class TestSyncCardLiveProgress:
         hasn't landed when the main thread queries sync_log."""
         from starlette.requests import Request
 
-        from app.templates import admin_dashboard
-        from app.templates.admin_dashboard import trigger_sync
+        from app.admin import sync as admin_sync
+        from app.admin.sync import trigger_sync
 
-        admin_dashboard._sync_in_progress = False
+        admin_sync._sync_in_progress = False
         # Simulate the worker landing the INSERT: the log helper returns
         # the row we pretend was just inserted.
         mock_logs.return_value = [
@@ -817,10 +817,10 @@ class TestSyncCardLiveProgress:
         assert "/admin/sync/status" in html
         assert "every 3s" in html
 
-        admin_dashboard._sync_in_progress = False
+        admin_sync._sync_in_progress = False
 
-    @patch("app.templates.admin_dashboard._get_sync_logs")
-    @patch("app.templates.admin_dashboard.has_recent_running_row", return_value=True)
+    @patch("app.admin.sync._get_sync_logs")
+    @patch("app.admin.sync.has_recent_running_row", return_value=True)
     def test_post_sync_detects_running_via_db(
         self,
         mock_has_running: MagicMock,
@@ -830,11 +830,11 @@ class TestSyncCardLiveProgress:
         spawn a second thread and must show the 'already running' banner."""
         from starlette.requests import Request
 
-        from app.templates import admin_dashboard
-        from app.templates.admin_dashboard import trigger_sync
+        from app.admin import sync as admin_sync
+        from app.admin.sync import trigger_sync
 
         mock_logs.return_value = [self._running_log()]
-        admin_dashboard._sync_in_progress = False
+        admin_sync._sync_in_progress = False
 
         scope = {
             "type": "http",
@@ -855,13 +855,13 @@ class TestSyncCardLiveProgress:
 
         # In-memory flag must be released again so a real subsequent sync
         # (after the other one finishes) can proceed.
-        assert admin_dashboard._sync_in_progress is False
+        assert admin_sync._sync_in_progress is False
 
 
 class TestUserStats:
-    @patch("app.templates.admin_dashboard._connect")
+    @patch("app.admin.users._connect")
     def test_get_user_stats_returns_dict(self, mock_connect: MagicMock):
-        from app.templates.admin_dashboard import _get_user_stats
+        from app.admin.users import _get_user_stats
 
         mock_conn = MagicMock()
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
@@ -880,9 +880,9 @@ class TestUserStats:
         assert len(result["users_per_org"]) == 2
         assert result["active_sessions"] == 2
 
-    @patch("app.templates.admin_dashboard._connect")
+    @patch("app.admin.users._connect")
     def test_get_user_stats_returns_defaults_on_error(self, mock_connect: MagicMock):
-        from app.templates.admin_dashboard import _get_user_stats
+        from app.admin.users import _get_user_stats
 
         mock_connect.side_effect = Exception("DB unavailable")
         result = _get_user_stats()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -129,17 +129,17 @@ class TestHealthEndpointIncludesVersion:
     def test_health_payload_has_version_block(self):
         # Using importlib avoids shadowing the ``app`` package name with
         # the ASGI ``app`` object. We import the main module first (which
-        # registers admin routes and transitively imports the shim), then
-        # pull out the ASGI callable by attribute access.
+        # registers admin routes), then pull out the ASGI callable by
+        # attribute access.
         import importlib
 
         main_mod = importlib.import_module("app.main")
-        importlib.import_module("app.templates.admin_dashboard")
+        importlib.import_module("app.admin.health")
         asgi_app = main_mod.app
 
         with (
-            patch("app.templates.admin_dashboard.jena_check_health", return_value=True),
-            patch("app.templates.admin_dashboard._check_postgres", return_value=True),
+            patch("app.admin.health.jena_check_health", return_value=True),
+            patch("app.admin.health._check_postgres", return_value=True),
         ):
             client = TestClient(asgi_app)
             response = client.get("/api/health")


### PR DESCRIPTION
## Summary

Sprint 3 of the post-2026-05-24-audit roadmap. Lands the **#182 admin shim refactor** (the load-bearing rebind machinery is gone — adding a new admin route is now a single `rt(...)` line) plus three admin panels that build on top of it: **#183 system health aggregator**, **#188 job monitor polish**, **#324 Sentry errors link panel**.

The shim refactor is the headline — `app/templates/admin_dashboard.py` went from 291 lines of `_rebind()` machinery + `_EXPECTED_PAGE_HANDLERS` invariant + module state to 37 lines of back-compat re-exports. 14 test patch sites repointed at the real modules.

PRs #835 (Sprint 1) and #837 (Sprint 2) are in review; this PR runs in parallel per the roadmap's execution policy.

## Commits

| SHA | Issue | Files | Headline |
|---|---|---|---|
| `0f825d7` | **#182** | shim + routes + 14 test sites | 291→37 line shim; routes.py is the new home; `_rebind()` + `_EXPECTED_PAGE_HANDLERS` deleted; 44 dashboard tests + 3466 full-repo tests pass |
| `32d8b3e` | **#183 + #188 + #324** | 8 files | Health aggregator card + page; job-monitor filtering + per-handler stats + HTMX detail expand; Sentry env-gated card + page |

## What's in each issue

### #182 — admin shim refactor
- `app/admin/routes.py`: 5 → 58 lines (real home of `register_admin_routes`)
- `app/templates/admin_dashboard.py`: **291 → 37 lines** (pure back-compat re-export)
- `app/admin/__init__.py`: re-import switched to the real path
- 14 patch sites in `tests/test_dashboard.py` + 2 in `tests/test_version.py` repointed
- `_EXPECTED_PAGE_HANDLERS` + `_rebind()` deleted — no longer needed since tests patch the real modules
- Obsoletes the `project_admin_shim` memory note; new rule documented in `app/admin/routes.py` docstring

### #183 — System health aggregator
- `_get_system_health()` rolls up postgres + jena + pgvector + last sync + worker activity + metrics count
- `overall_status: down/degraded/ok` with sensible short-circuit
- Card on `/admin` dashboard + detail page at `/admin/health/aggregator`
- 11 new tests

### #188 — Job monitor polish
- Filtering: handler multi-select + status dropdown + date range
- Per-handler 24h stats card (queries `job_execution_ms` metric with p95)
- Pagination with filter persistence
- HTMX detail expand at `/admin/jobs/{id}/detail` (lazy load on `<details>` toggle)
- Estonian copy throughout
- 21 → 52 tests

### #324 — Sentry errors link panel
- New module `app/admin/sentry_panel.py` (~245 lines)
- Env-gated on `SENTRY_API_TOKEN` + `SENTRY_ORG_SLUG` + `SENTRY_PROJECT_SLUG`
- Three render modes: not-configured / no-errors / populated
- Token only in `Authorization: Bearer` header, never logged
- Graceful degradation on timeout/5xx/non-JSON → empty list, not 500
- 16 tests
- No new dependencies (httpx already pinned)

## Numbers

- 13 files changed: +2,744 / -441
- 128 tests pass on the consolidated Sprint 3 surface (`test_admin_health` + `test_admin_job_monitor` + `test_admin_sentry_panel` + `test_dashboard` + `test_admin_quick_links_smoke` with `TestStubHandlers` excluded)
- Full repo: 3466 passed / 35 skipped / 0 failures (as of the #182 commit)
- `ruff check` clean; `pyright` clean (0 errors)

## Sprint dependencies

- #183 health aggregator's "Töötaja aktiivsus (5m)" + #188's per-handler stats card both query the `job_execution_ms` metric that PR #835 (Sprint 1) emits. Until #835 merges, those cards show the empty state ("Aktiivsuse statistikat pole veel kogutud") cleanly — by design.
- All `metrics`-querying admin panels also benefit from PR #835's other collectors (sparql, rag). Sentry panel is independent.

## Deferred from Sprint 3 (next wave)

- **#309** finish — needs Sprint 2 (#837) draft fixtures to merge first.
- **#102, #316, #317** VCR cassettes — need an interactive recording session with API keys.

## Test plan

- [x] `uv run pytest tests/test_admin_health.py tests/test_admin_job_monitor.py tests/test_admin_sentry_panel.py tests/test_dashboard.py tests/test_admin_quick_links_smoke.py -k "not TestStubHandlers"` → 128 pass.
- [x] `uv run ruff check app/admin/ tests/test_admin_*.py` → clean.
- [x] `uv run pyright app/admin/ tests/test_admin_*.py` → 0 errors.
- [x] Full repo (run after #182): 3466 pass / 35 skipped / 0 failures.
- [ ] Spot-check `/admin` dashboard, `/admin/health/aggregator`, `/admin/jobs` (filters + detail expand), `/admin/sentry` (3 env-var modes).
- [ ] After PR #835 merges + a job run, confirm health aggregator + job monitor stats cards fill in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)