### PR TITLE
fix(sync): install git-lfs so ontology clone materialises LFS content

### DIFF
--- a/app/sync/converter.py
+++ b/app/sync/converter.py
@@ -8,6 +8,19 @@ from rdflib import Graph
 
 logger = logging.getLogger(__name__)
 
+# Git LFS pointer files begin with this magic line. When the ontology repo's
+# LFS-tracked files (combined_ontology.jsonld and the curia/eurlex combined
+# graphs, LFS since 2026-05-27) are cloned without git-lfs, these ~130-byte
+# pointer stubs land on disk instead of real content. Parsing one as JSON-LD
+# yields the cryptic orjson error "unexpected character: line 1 column 1
+# (char 0)"; detecting it here lets us raise an actionable message instead.
+_LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+
+
+class UnresolvedLfsPointerError(RuntimeError):
+    """Raised when an ontology file on disk is an unresolved Git LFS pointer."""
+
+
 DOMAINS = {
     "riigiteataja": "Enacted laws (Riigi Teataja)",
     "eelnoud": "Draft legislation (eelnõud)",
@@ -27,8 +40,31 @@ def load_index(repo_path: Path) -> list[dict]:  # type: ignore[type-arg]
     return data.get("laws", [])  # type: ignore[no-any-return]
 
 
+def _assert_not_lfs_pointer(path: Path) -> None:
+    """Raise :class:`UnresolvedLfsPointerError` if *path* is a Git LFS pointer.
+
+    Pointer files are tiny text stubs beginning with the LFS magic prefix; we
+    read only the first bytes so a real multi-hundred-MB JSON-LD file is never
+    slurped into memory by this check.
+    """
+    try:
+        with open(path, "rb") as f:
+            head = f.read(len(_LFS_POINTER_PREFIX))
+    except OSError:
+        # Unreadable here -> let the normal parse path surface the error.
+        return
+    if head == _LFS_POINTER_PREFIX:
+        raise UnresolvedLfsPointerError(
+            f"{path.name} is an unresolved Git LFS pointer — git-lfs is not "
+            f"installed or 'git lfs pull' did not run in the sync environment. "
+            f"The ontology repo stores this file via Git LFS; install git-lfs "
+            f"so the clone materialises real content (see docker/Dockerfile)."
+        )
+
+
 def parse_jsonld_file(path: Path) -> Graph:
     """Parse a single JSON-LD file into an rdflib Graph."""
+    _assert_not_lfs_pointer(path)
     g = Graph()
     g.parse(str(path), format="json-ld")
     return g

--- a/app/sync/converter.py
+++ b/app/sync/converter.py
@@ -106,6 +106,11 @@ def convert_ontology(repo_path: Path) -> Graph:
                 g = parse_jsonld_file(peep_file)
                 merged += g
                 total += len(g)
+            except UnresolvedLfsPointerError:
+                # An unresolved LFS pointer is an environment failure (git-lfs
+                # didn't materialise the file), not a single-file data problem.
+                # Abort rather than silently publishing a partial graph.
+                raise
             except Exception:
                 logger.exception("Failed to parse %s", peep_file.name)
         entity_counts["enacted_laws"] = total
@@ -129,6 +134,10 @@ def convert_ontology(repo_path: Path) -> Graph:
                 g = parse_jsonld_file(path)
                 merged += g
                 domain_count += len(g)
+            except UnresolvedLfsPointerError:
+                # See note above: an unresolved LFS pointer must abort the
+                # whole sync, not silently drop this domain's data.
+                raise
             except Exception:
                 logger.exception("Failed to parse %s/%s", domain_dir, path.name)
 

--- a/app/sync/orchestrator.py
+++ b/app/sync/orchestrator.py
@@ -266,23 +266,37 @@ def has_recent_running_row(max_age_minutes: int = 30) -> bool:
         return False
 
 
+class GitCommandError(RuntimeError):
+    """A git/git-lfs subprocess failed. The message includes decoded stderr.
+
+    ``subprocess.CalledProcessError.__str__`` reports only the exit status and
+    drops the captured stderr, so the sync's outer handler would otherwise
+    record a useless "returned non-zero exit status N" for Git-LFS bandwidth /
+    auth / network failures. This wrapper surfaces the actual git output.
+    """
+
+
+def _run_git(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run a git command, raising GitCommandError with decoded output on failure."""
+    try:
+        return subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+    except FileNotFoundError as e:
+        raise GitCommandError(f"`{' '.join(args)}` failed: {e}") from e
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or b"").decode("utf-8", errors="replace").strip()
+        stdout = (e.stdout or b"").decode("utf-8", errors="replace").strip()
+        detail = stderr or stdout or "(no output)"
+        raise GitCommandError(f"`{' '.join(args)}` failed (exit {e.returncode}): {detail}") from e
+
+
 def clone_or_pull(target_dir: Path) -> None:
     """Clone or pull the ontology repo, then materialise Git LFS objects."""
     if (target_dir / ".git").exists():
         logger.info("Pulling latest changes...")
-        subprocess.run(
-            ["git", "pull", "--ff-only"],
-            cwd=target_dir,
-            check=True,
-            capture_output=True,
-        )
+        _run_git(["git", "pull", "--ff-only"], cwd=target_dir)
     else:
         logger.info("Cloning ontology repo...")
-        subprocess.run(
-            ["git", "clone", "--depth", "1", ONTOLOGY_REPO, str(target_dir)],
-            check=True,
-            capture_output=True,
-        )
+        _run_git(["git", "clone", "--depth", "1", ONTOLOGY_REPO, str(target_dir)])
     # Since the 2026-05-27 corpus refresh the big JSON-LD files are stored
     # via Git LFS. Materialise them on both the clone and pull paths so the
     # converter sees real content rather than 130-byte pointer stubs.
@@ -323,7 +337,7 @@ def _fetch_lfs_objects(target_dir: Path) -> None:
         )
         return
     logger.info("Fetching Git LFS objects...")
-    subprocess.run(["git", "lfs", "pull"], cwd=target_dir, check=True, capture_output=True)
+    _run_git(["git", "lfs", "pull"], cwd=target_dir)
     logger.info("Git LFS objects fetched")
 
 

--- a/app/sync/orchestrator.py
+++ b/app/sync/orchestrator.py
@@ -267,7 +267,7 @@ def has_recent_running_row(max_age_minutes: int = 30) -> bool:
 
 
 def clone_or_pull(target_dir: Path) -> None:
-    """Clone or pull the ontology repo."""
+    """Clone or pull the ontology repo, then materialise Git LFS objects."""
     if (target_dir / ".git").exists():
         logger.info("Pulling latest changes...")
         subprocess.run(
@@ -283,6 +283,48 @@ def clone_or_pull(target_dir: Path) -> None:
             check=True,
             capture_output=True,
         )
+    # Since the 2026-05-27 corpus refresh the big JSON-LD files are stored
+    # via Git LFS. Materialise them on both the clone and pull paths so the
+    # converter sees real content rather than 130-byte pointer stubs.
+    _fetch_lfs_objects(target_dir)
+
+
+def _git_lfs_available() -> bool:
+    """Return True if the ``git lfs`` subcommand is usable in this environment."""
+    try:
+        subprocess.run(["git", "lfs", "version"], check=True, capture_output=True)
+        return True
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+
+def _fetch_lfs_objects(target_dir: Path) -> None:
+    """Materialise Git LFS objects for the freshly cloned/pulled repo.
+
+    Since the 2026-05-27 corpus refresh the ontology repo stores its large
+    JSON-LD files (``combined_ontology.jsonld`` ~179 MB, plus the curia/eurlex
+    combined graphs) via Git LFS. A plain ``git clone`` in an environment
+    without git-lfs leaves 130-byte pointer files on disk, which rdflib then
+    fails to parse ("unexpected character: line 1 column 1 (char 0)"). The
+    runtime image installs git-lfs (docker/Dockerfile); we still fetch
+    explicitly here so the GIT_LFS_SKIP_SMUDGE / pull-existing-clone paths
+    also materialise content.
+
+    If git-lfs is unavailable we log an actionable error but do NOT raise —
+    the converter detects the leftover pointer files and fails with a message
+    that names the offending file. A genuine fetch failure (network, LFS
+    bandwidth quota) raises so the sync aborts at a clearly-named step.
+    """
+    if not _git_lfs_available():
+        logger.error(
+            "git-lfs is not available in this environment; LFS-tracked "
+            "ontology files will remain as pointers and conversion will fail. "
+            "Install git-lfs in the runtime image."
+        )
+        return
+    logger.info("Fetching Git LFS objects...")
+    subprocess.run(["git", "lfs", "pull"], cwd=target_dir, check=True, capture_output=True)
+    logger.info("Git LFS objects fetched")
 
 
 def run_sync(

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,15 +43,27 @@ RUN printf '{"app": "0.1.0", "sha": "%s", "built_at": "%s"}\n' \
 # Runtime stage
 FROM python:3.13-slim
 
-# Install curl for HEALTHCHECK and git for the sync pipeline.
+# Install curl for HEALTHCHECK, git for the sync pipeline, and git-lfs for
+# large ontology files.
 # curl: used by the /api/ping HEALTHCHECK below.
 # git: app/sync/orchestrator.py clones/pulls the Estonian Legal Ontology repo
 #      via subprocess. Without git the sync silently fails and Jena stays
 #      empty, which is how we debugged the "Jena has no data" issue at the
 #      end of Phase 1.5.
+# git-lfs: as of the 2026-05-27 corpus refresh, the ontology repo stores its
+#      large JSON-LD files (combined_ontology.jsonld ~179 MB, plus curia/eurlex
+#      combined graphs) via Git LFS. Without git-lfs, `git clone` writes
+#      130-byte LFS pointer files to disk instead of real content, and the
+#      JSON-LD parser crashes with "unexpected character: line 1 column 1".
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl git && \
+    apt-get install -y --no-install-recommends curl git git-lfs && \
     rm -rf /var/lib/apt/lists/*
+
+# Register the LFS smudge filter system-wide so that every subsequent
+# `git clone` or `git lfs pull` in the container (including the ones
+# called by app/sync/orchestrator.py) materialises LFS content
+# automatically. Must run as root, before the USER appuser switch below.
+RUN git lfs install --system
 
 # §4.3 LibreOffice base image (Eelnõud sprint plan 2026-05-02).
 # Installed here so the deploy risk is validated independently before any

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3,7 +3,11 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from app.sync.converter import (
+    UnresolvedLfsPointerError,
+    _assert_not_lfs_pointer,
     load_index,
     parse_jsonld_file,
     serialize_to_turtle,
@@ -15,6 +19,29 @@ FIXTURES = Path(__file__).parent / "fixtures"
 def test_parse_jsonld_file():
     g = parse_jsonld_file(FIXTURES / "sample_peep.json")
     assert len(g) > 0
+
+
+def test_parse_jsonld_real_fixture_passes_lfs_check():
+    # The pointer check is a no-op for real content; parsing still works.
+    g = parse_jsonld_file(FIXTURES / "sample_peep.json")
+    assert len(g) > 0
+
+
+def test_parse_jsonld_lfs_pointer_raises(tmp_path: Path):
+    pointer = tmp_path / "combined_ontology.jsonld"
+    pointer.write_bytes(
+        b"version https://git-lfs.github.com/spec/v1\noid sha256:abc123\nsize 187819360\n"
+    )
+    with pytest.raises(UnresolvedLfsPointerError, match="Git LFS pointer") as exc_info:
+        parse_jsonld_file(pointer)
+    assert "combined_ontology.jsonld" in str(exc_info.value)
+
+
+def test_assert_not_lfs_pointer_allows_normal_json(tmp_path: Path):
+    normal = tmp_path / "real.jsonld"
+    normal.write_text('{"@context": {}, "@graph": []}', encoding="utf-8")
+    # Should not raise for a normal JSON document starting with '{'.
+    _assert_not_lfs_pointer(normal)
 
 
 def test_parse_jsonld_contains_expected_subjects():

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -8,6 +8,7 @@ import pytest
 from app.sync.converter import (
     UnresolvedLfsPointerError,
     _assert_not_lfs_pointer,
+    convert_ontology,
     load_index,
     parse_jsonld_file,
     serialize_to_turtle,
@@ -35,6 +36,32 @@ def test_parse_jsonld_lfs_pointer_raises(tmp_path: Path):
     with pytest.raises(UnresolvedLfsPointerError, match="Git LFS pointer") as exc_info:
         parse_jsonld_file(pointer)
     assert "combined_ontology.jsonld" in str(exc_info.value)
+
+
+def test_convert_ontology_aborts_on_lfs_pointer_domain_file(tmp_path: Path):
+    # Regression (PR #840): a domain subdirectory file that is an unresolved LFS
+    # pointer must abort the whole sync, not be swallowed by the guarded loop's
+    # broad `except Exception`. Otherwise a partial graph (combined only, no
+    # curia/eurlex) could still be published.
+    krr = tmp_path / "krr_outputs"
+    krr.mkdir()
+
+    # Valid combined file (reuse the real JSON-LD fixture) so the unguarded
+    # combined parse succeeds and contributes triples *before* the domain loop.
+    (krr / "combined_ontology.jsonld").write_bytes((FIXTURES / "sample_peep.json").read_bytes())
+
+    # curia domain file is an unresolved Git LFS pointer.
+    curia = krr / "curia"
+    curia.mkdir()
+    (curia / "curia_combined.jsonld").write_bytes(
+        b"version https://git-lfs.github.com/spec/v1\noid sha256:abc123\nsize 27756872\n"
+    )
+
+    with pytest.raises(UnresolvedLfsPointerError, match="Git LFS pointer") as exc_info:
+        convert_ontology(tmp_path)
+    # Aborted on the domain pointer (after the valid combined file parsed) —
+    # confirms no partial publish path was taken.
+    assert "curia_combined.jsonld" in str(exc_info.value)
 
 
 def test_assert_not_lfs_pointer_allows_normal_json(tmp_path: Path):

--- a/tests/test_sync_orchestrator.py
+++ b/tests/test_sync_orchestrator.py
@@ -21,6 +21,7 @@ never touch the network, the DB, or Jena.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,7 @@ from app.sync.orchestrator import (
     PHASE_REINGESTING,
     PHASE_UPLOADING,
     PHASE_VALIDATING,
+    GitCommandError,
     _parse_violation_count,
     clone_or_pull,
     run_sync,
@@ -116,6 +118,61 @@ class TestCloneOrPullLfs:
 
         argvs = [_argv_of(call) for call in mock_run.call_args_list]
         assert ["git", "lfs", "pull"] not in argvs
+
+    @patch("app.sync.orchestrator.subprocess.run")
+    def test_lfs_pull_failure_surfaces_stderr(self, mock_run: MagicMock, tmp_path: Path):
+        """A failing ``git lfs pull`` (e.g. LFS bandwidth quota) must raise
+        GitCommandError whose message carries the real git stderr, not the
+        useless "returned non-zero exit status N" that CalledProcessError emits.
+
+        No .git dir exists here, so clone_or_pull takes the clone path and then
+        reaches the LFS pull.
+        """
+
+        def _side_effect(argv, *args, **kwargs):
+            argv = list(argv)
+            if argv == ["git", "lfs", "version"]:
+                # Probe succeeds so _git_lfs_available() is True and we reach
+                # the actual ``git lfs pull``.
+                return MagicMock()
+            if argv == ["git", "lfs", "pull"]:
+                raise subprocess.CalledProcessError(
+                    returncode=2,
+                    cmd=argv,
+                    stderr=b"batch response: This repository is over its data quota.",
+                )
+            # The clone itself succeeds.
+            return MagicMock()
+
+        mock_run.side_effect = _side_effect
+
+        with pytest.raises(GitCommandError, match="data quota") as excinfo:
+            clone_or_pull(tmp_path)
+
+        # The argv of the failing command is echoed so operators can tell
+        # which git invocation blew up.
+        assert "git lfs pull" in str(excinfo.value)
+
+    @patch("app.sync.orchestrator.subprocess.run")
+    def test_clone_failure_surfaces_stderr(self, mock_run: MagicMock, tmp_path: Path):
+        """A failing ``git clone`` must raise GitCommandError containing the
+        real git stderr — LFS smudge can fail during the clone itself when
+        git-lfs is installed system-wide (prod)."""
+
+        def _side_effect(argv, *args, **kwargs):
+            argv = list(argv)
+            if argv[:2] == ["git", "clone"]:
+                raise subprocess.CalledProcessError(
+                    returncode=128,
+                    cmd=argv,
+                    stderr=b"fatal: could not read from remote",
+                )
+            return MagicMock()
+
+        mock_run.side_effect = _side_effect
+
+        with pytest.raises(GitCommandError, match="could not read from remote"):
+            clone_or_pull(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_orchestrator.py
+++ b/tests/test_sync_orchestrator.py
@@ -28,12 +28,14 @@ import pytest
 from rdflib import Graph
 
 from app.sync.orchestrator import (
+    ONTOLOGY_REPO,
     PHASE_CLONING,
     PHASE_CONVERTING,
     PHASE_REINGESTING,
     PHASE_UPLOADING,
     PHASE_VALIDATING,
     _parse_violation_count,
+    clone_or_pull,
     run_sync,
 )
 
@@ -51,6 +53,69 @@ class TestParseViolationCount:
     def test_zero_on_unparseable(self):
         # pyshacl will never emit Results (abc), but handle it gracefully
         assert _parse_violation_count("Results (abc)") == 0
+
+
+# ---------------------------------------------------------------------------
+# clone_or_pull + Git LFS materialisation
+#
+# Since the 2026-05-27 corpus refresh the ontology repo stores its large
+# JSON-LD files via Git LFS. clone_or_pull must materialise that content
+# (``git lfs pull``) on both the clone and pull paths, and must degrade
+# gracefully — never raise — when git-lfs is absent from the environment.
+# ---------------------------------------------------------------------------
+
+
+def _argv_of(call) -> list[str]:
+    """Return the argv list that a ``subprocess.run`` call was invoked with.
+
+    ``subprocess.run`` is always called positionally with the argv list as
+    the first argument in this module, so ``call.args[0]`` is the command.
+    """
+    return list(call.args[0])
+
+
+class TestCloneOrPullLfs:
+    @patch("app.sync.orchestrator.subprocess.run")
+    def test_clone_path_clones_then_fetches_lfs(self, mock_run: MagicMock, tmp_path: Path):
+        """On a path with no .git, clone_or_pull must run ``git clone
+        --depth 1 <repo> <dir>`` AND then ``git lfs pull``."""
+        # git-lfs probe (``git lfs version``) succeeds by default.
+        clone_or_pull(tmp_path)
+
+        argvs = [_argv_of(call) for call in mock_run.call_args_list]
+        assert ["git", "clone", "--depth", "1", ONTOLOGY_REPO, str(tmp_path)] in argvs
+        assert ["git", "lfs", "pull"] in argvs
+
+    @patch("app.sync.orchestrator.subprocess.run")
+    def test_pull_path_pulls_then_fetches_lfs(self, mock_run: MagicMock, tmp_path: Path):
+        """On an existing clone (a .git dir present), clone_or_pull must run
+        ``git pull --ff-only`` AND then ``git lfs pull``."""
+        (tmp_path / ".git").mkdir()
+
+        clone_or_pull(tmp_path)
+
+        argvs = [_argv_of(call) for call in mock_run.call_args_list]
+        assert ["git", "pull", "--ff-only"] in argvs
+        assert ["git", "lfs", "pull"] in argvs
+
+    @patch("app.sync.orchestrator.subprocess.run")
+    def test_skips_lfs_pull_when_git_lfs_unavailable(self, mock_run: MagicMock, tmp_path: Path):
+        """When git-lfs is missing, clone_or_pull must NOT raise and must NOT
+        attempt ``git lfs pull`` — the converter handles the leftover pointer
+        files with a file-named error instead."""
+
+        def _side_effect(argv, *args, **kwargs):
+            if list(argv) == ["git", "lfs", "version"]:
+                raise FileNotFoundError("git-lfs not installed")
+            return MagicMock()
+
+        mock_run.side_effect = _side_effect
+
+        # Must not propagate the FileNotFoundError from the probe.
+        clone_or_pull(tmp_path)
+
+        argvs = [_argv_of(call) for call in mock_run.call_args_list]
+        assert ["git", "lfs", "pull"] not in argvs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Admin **Sünkroniseerimine** failed on 2026-06-08 with:

> Ebaõnnestus — `unexpected character: line 1 column 1 (char 0)`

## Root cause

Since the **2026-05-27 corpus refresh (#232)**, the `estonian-legal-ontology` source repo stores 6 large files via **Git LFS** — including `krr_outputs/combined_ontology.jsonld` (~179 MB), the first file the converter parses.

The app container's `docker/Dockerfile` installed `curl` and `git` but **not `git-lfs`**. So the sync's `git clone --depth 1` wrote a 130-byte **LFS pointer stub** to disk instead of the real JSON-LD:

```
version https://git-lfs.github.com/spec/v1
oid sha256:2564e027…deb9b9
size 187819360
```

`convert_ontology` fed that stub straight to rdflib, whose JSON-LD parser (via orjson) raised the exact error above. The combined-file parse was the one unguarded parse in `converter.py`, so it bubbled up and failed the whole sync at the **converting** phase.

This is the same class of bug as the earlier "Jena has no data → missing `git`" incident already documented in `docker/Dockerfile`, one layer deeper.

**Live data was never at risk:** the crash happens *before* any Jena write, and the staged-publish flow (#573) leaves the default graph untouched on failure. Õiguskaart/Nõustaja kept serving the pre-05-27 snapshot — stale, not broken.

## Changes

- **`docker/Dockerfile`** — add `git-lfs` to the apt install and `RUN git lfs install --system` (as root, before `USER appuser`) so clones materialise LFS content. Comment updated.
- **`app/sync/orchestrator.py`** — `clone_or_pull` now runs `git lfs pull` on both the clone and pull paths, guarded by a `_git_lfs_available()` probe. A genuine fetch failure (network / LFS bandwidth) raises so the sync aborts at a clearly-named step; a missing binary logs an actionable error and defers to the converter's diagnostic.
- **`app/sync/converter.py`** — `parse_jsonld_file` detects an unresolved LFS pointer and raises `UnresolvedLfsPointerError` with a message naming the file, instead of the cryptic orjson error.
- **tests** — `clone_or_pull` LFS fetch (clone path, pull path, git-lfs-unavailable path) and converter pointer detection.

## Verification

- `ruff format --check` ✓ · `ruff check` ✓ · `pyright app/sync/*` → 0 errors ✓
- `pytest tests/test_converter.py tests/test_sync_orchestrator.py tests/test_admin_sync.py` → **34 passed** ✓
- End-to-end: feeding the *actual* production pointer bytes through `parse_jsonld_file` now yields the clear `UnresolvedLfsPointerError` (was: orjson `unexpected character…`).

## Known tradeoff / follow-up (your call)

`git lfs pull` fetches **all 6 LFS files (~380 MB)** on every sync, and `run_sync` does a fresh shallow clone to a new tempdir each time. GitHub's **free LFS tier is 1 GB bandwidth/month** → ~2–3 syncs before throttling. If syncs are frequent and the repo isn't on a paid LFS data pack, options for a follow-up PR:
- persist the clone on a volume and `git pull` + `git lfs pull` (the code already supports the pull-if-`.git`-exists path — just needs a stable `repo_dir`);
- targeted `git lfs pull --include=…` for only the files the converter reads (~251 MB; the new pointer-detection guard makes this safe — a missed file fails loudly);
- or move the big files off LFS.

LFS storage/retrieval itself is healthy (the object downloads fine today), so this PR unblocks the sync as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)