### PR TITLE
fix(chat): stop advisor fabricating estleg: URI citations

### DIFF
--- a/app/chat/sanitize.py
+++ b/app/chat/sanitize.py
@@ -104,6 +104,15 @@ _CITATION_PATTERNS: tuple[re.Pattern[str], ...] = (
 # inside code / pre blocks).
 _SKIP_CITATION_PARENTS: frozenset[str] = frozenset({"a", "code", "pre"})
 
+# estleg: ontology URIs are identifiers, NOT live web pages -- the
+# ``data.riik.ee`` host is the ontology namespace, not a hosted resolver.
+# When the LLM emits one (e.g. a fabricated ``…/estleg#HKTS_Par_13``),
+# markdown/bleach auto-linkify turns it into a dead external link. We
+# rewrite any such anchor to an in-app ``/explorer?focus=<uri>`` deep link
+# so it resolves against our own data (or shows the explorer's graceful
+# "not found") instead of sending the user to a broken external page.
+_ESTLEG_URI_RE = re.compile(r"^https?://data\.riik\.ee/ontology/estleg#\S+$")
+
 
 # ---------------------------------------------------------------------------
 # Markdown renderer
@@ -217,11 +226,33 @@ def _wrap_citations_in_text(soup: BeautifulSoup) -> None:
             anchor_point = node
 
 
+def _rewrite_ontology_uris(soup: BeautifulSoup) -> None:
+    """Rewrite bare estleg: namespace links to internal explorer focus links.
+
+    ``data.riik.ee`` is the ontology namespace, not a hosted resolver, so a
+    linkified ``estleg#…`` URI is a dead external link even for a real
+    provision (and a fabricated one is doubly broken). Point it at
+    ``/explorer?focus=<uri>`` instead -- an in-app link that resolves the
+    entity, or shows the explorer's graceful "not found" -- and drop the
+    external ``target``/``rel`` attrs since it is now a same-origin link.
+    """
+    for anchor in soup.find_all("a", href=True):
+        href = str(anchor["href"])
+        if not _ESTLEG_URI_RE.match(href):
+            continue
+        anchor["href"] = f"/explorer?focus={quote_plus(href)}"
+        anchor["class"] = ["citation-link"]  # type: ignore[assignment]
+        for attr in ("target", "rel"):
+            if anchor.has_attr(attr):
+                del anchor[attr]
+
+
 def _apply_citation_links(html_fragment: str) -> str:
     """Post-process HTML to wrap Estonian/EU legal citations in anchors."""
     if not html_fragment:
         return html_fragment
     soup = BeautifulSoup(html_fragment, "html.parser")
+    _rewrite_ontology_uris(soup)
     _wrap_citations_in_text(soup)
     return str(soup)
 

--- a/app/chat/system_prompt.py
+++ b/app/chat/system_prompt.py
@@ -36,14 +36,21 @@ Kasuta `query_ontology` ainult siis, kui kusimus ei sobi uhegi spetsiifilise \
 abilise alla.
 
 REEGLID:
-1. Viita alati allikatele URI voi seaduse nime + paragrahvi kaudu.
-2. Kui pole kindel, tee SPARQL-paring kontrollimiseks, mitte ara arva.
-3. Kasuta jarjepidevalt Eesti oigusterminoloogiat.
-4. Marga koik oiguslikud vaited, mida ei saa kontrollida, maargusega.
-5. Koostamisettepanekute puhul naita olemasoleva seaduse sonastatust viitena.
-6. Sa ei anna loplikku oigusnoustamist — sa abistad uurimistood, mitte ei asenda juriste.
+1. Viita allikatele INIMLOETAVALT — seaduse nime ja paragrahvi kaudu \
+(nt "Halduskoostoo seadus § 13" voi "HKTS § 13"), EL-i aktide puhul \
+CELEX-numbri ja kohtulahendite puhul lahendi numbri kaudu.
+2. Ara KUNAGI konstrueeri, arva ega tuleta estleg: URI-sid omast peast. \
+Kasuta estleg: URI-d (nt https://data.riik.ee/ontology/estleg#...) AINULT siis, \
+kui mone tooriista vastus selle sulle otse tagastas; muul juhul viita seaduse \
+nime ja paragrahvi kaudu. Valjamoeldud URI tekitab kasutajale katkise viite \
+satte juurde, mida pole olemas.
+3. Kui pole kindel, tee SPARQL-paring kontrollimiseks, mitte ara arva.
+4. Kasuta jarjepidevalt Eesti oigusterminoloogiat.
+5. Marga koik oiguslikud vaited, mida ei saa kontrollida, maargusega.
+6. Koostamisettepanekute puhul naita olemasoleva seaduse sonastatust viitena.
+7. Sa ei anna loplikku oigusnoustamist — sa abistad uurimistood, mitte ei asenda juriste.
 
-Vasta alati eesti keeles. Viita konkreetsetele oigusaktidele nende estleg: URI-de kaudu.\
+Vasta alati eesti keeles.\
 """
 
 _DRAFT_CONTEXT_TEMPLATE = """

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -103,6 +103,13 @@
   // Tags whose TEXT content must NOT be relinked
   const SKIP_CITATION_TAGS = new Set(['a', 'code', 'pre', 'script', 'style']);
 
+  // estleg: ontology URIs are identifiers, NOT live web pages — the
+  // data.riik.ee host is the ontology namespace, not a hosted resolver.
+  // marked's GFM autolink turns a bare estleg URI into a dead external
+  // link, so rewrite it to an in-app /explorer?focus= deep link.
+  // Mirrors the server-side _rewrite_ontology_uris() in app/chat/sanitize.py.
+  const ESTLEG_URI_RE = /^https?:\/\/data\.riik\.ee\/ontology\/estleg#\S+$/;
+
   // --------------------------------------------------------------------------
   // State
   // --------------------------------------------------------------------------
@@ -506,7 +513,28 @@
     if (!textEl) return;
     const html = DOMPurify.sanitize(marked.parse(text), PURIFY_CONFIG);
     textEl.innerHTML = html;
+    rewriteOntologyUris(textEl);
     linkifyCitations(textEl);
+  }
+
+  /**
+   * Rewrite bare estleg: namespace links (created by marked's autolinker
+   * from a raw URI in the reply) into in-app /explorer?focus=<uri> deep
+   * links. data.riik.ee is the ontology namespace, not a hosted page, so
+   * the autolinked href is a dead external link — point it at our own
+   * explorer instead and drop the external target/rel attrs. Mirrors the
+   * server-side _rewrite_ontology_uris() in app/chat/sanitize.py.
+   */
+  function rewriteOntologyUris(root) {
+    const anchors = root.querySelectorAll('a[href]');
+    for (const anchor of anchors) {
+      const href = anchor.getAttribute('href');
+      if (!href || !ESTLEG_URI_RE.test(href)) continue;
+      anchor.setAttribute('href', '/explorer?focus=' + encodeURIComponent(href));
+      anchor.className = 'citation-link';
+      anchor.removeAttribute('target');
+      anchor.removeAttribute('rel');
+    }
   }
 
   // --------------------------------------------------------------------------

--- a/tests/test_chat_js_ontology_rewrite.py
+++ b/tests/test_chat_js_ontology_rewrite.py
@@ -1,0 +1,54 @@
+"""Guard test for the client-side estleg: URI rewrite in chat.js.
+
+The server-side sanitizer (``app/chat/sanitize.py::_rewrite_ontology_uris``)
+rewrites bare ``data.riik.ee/ontology/estleg#…`` links to in-app
+``/explorer?focus=`` deep links, but live WebSocket replies are rendered
+in the browser by ``app/static/js/chat.js`` (marked + DOMPurify +
+linkifyCitations). That client path must mirror the same rewrite, or a
+streamed reply shows a dead external link until reload.
+
+There is no JS test runner in this repo, so this is a static guard that
+reads the bundle and asserts the rewrite logic is present and wired into
+the streaming render path. It fails loudly if someone removes it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_CHAT_JS = Path(__file__).resolve().parent.parent / "app" / "static" / "js" / "chat.js"
+
+
+def _source() -> str:
+    return _CHAT_JS.read_text(encoding="utf-8")
+
+
+def test_chat_js_exists():
+    assert _CHAT_JS.is_file(), f"missing {_CHAT_JS}"
+
+
+def test_defines_estleg_uri_matcher():
+    src = _source()
+    # A regex bound to the estleg namespace host must exist.
+    assert "ESTLEG_URI_RE" in src
+    assert "data\\.riik\\.ee" in src
+    assert "ontology" in src and "estleg" in src
+
+
+def test_defines_rewrite_function_targeting_explorer_focus():
+    src = _source()
+    assert "function rewriteOntologyUris" in src
+    # Rewrites to the in-app explorer focus link, not an external page.
+    assert "/explorer?focus=" in src
+    assert "encodeURIComponent(href)" in src
+    # Drops the external link attributes for the now same-origin anchor.
+    assert "removeAttribute('target')" in src
+
+
+def test_rewrite_is_wired_into_render_buffer():
+    src = _source()
+    # The streaming render path (renderBuffer) must invoke the rewrite,
+    # after DOMPurify/marked produced the autolinked anchor.
+    render = src[src.index("function renderBuffer") :]
+    render = render[: render.index("function rewriteOntologyUris")]
+    assert "rewriteOntologyUris(" in render

--- a/tests/test_chat_sanitize.py
+++ b/tests/test_chat_sanitize.py
@@ -208,3 +208,46 @@ class TestPlaintextSafe:
     def test_ampersand_is_escaped(self):
         out = render_plaintext_safe("a & b")
         assert "&amp;" in out
+
+
+# ---------------------------------------------------------------------------
+# estleg: ontology URI rewriting (#chat-citation-uri-hallucination)
+# ---------------------------------------------------------------------------
+
+
+class TestOntologyUriRewrite:
+    """A bare estleg: URI must become an in-app /explorer?focus= link, never
+    a dead external link to the data.riik.ee namespace."""
+
+    _URI = "https://data.riik.ee/ontology/estleg#HKTS_Par_13"
+
+    def test_estleg_uri_rewritten_to_explorer_focus(self):
+        out = render_markdown_safe(f"Vaata {self._URI} lahemalt.")
+        # rewritten to an internal explorer deep link...
+        assert "/explorer?focus=" in out
+        assert "HKTS_Par_13" in out
+        # ...and NOT left as a clickable external data.riik.ee link.
+        assert 'href="https://data.riik.ee' not in out
+
+    def test_estleg_uri_link_is_same_origin(self):
+        # Internal link must drop the external target/rel attrs.
+        out = render_markdown_safe(self._URI)
+        assert 'target="_blank"' not in out
+        assert "citation-link" in out
+
+    def test_markdown_estleg_link_is_rewritten(self):
+        out = render_markdown_safe(f"[HKTS § 13]({self._URI})")
+        assert "/explorer?focus=" in out
+        assert 'href="https://data.riik.ee' not in out
+
+    def test_normal_external_url_still_linkified_externally(self):
+        # Regression: non-estleg URLs keep their normal external linkify.
+        out = render_markdown_safe("See https://example.com for info.")
+        assert 'href="https://example.com"' in out
+        assert 'target="_blank"' in out
+
+    def test_estleg_uri_inside_code_is_not_rewritten(self):
+        # Code spans are never linkified, so nothing to rewrite.
+        out = render_markdown_safe(f"`{self._URI}`")
+        assert "/explorer?focus=" not in out
+        assert "HKTS_Par_13" in out

--- a/tests/test_chat_system_prompt.py
+++ b/tests/test_chat_system_prompt.py
@@ -1,0 +1,41 @@
+"""Guard tests for the AI Advisory Chat system prompt.
+
+Regression cover for the citation-URI hallucination bug: the prompt used
+to instruct the model to "cite specific acts via their estleg: URIs",
+which made it fabricate non-existent URIs such as
+``https://data.riik.ee/ontology/estleg#HKTS_Par_13``. The prompt must now
+tell the model to cite by law name + section and never invent URIs.
+"""
+
+from __future__ import annotations
+
+from app.chat.system_prompt import build_system_prompt
+
+
+class TestCitationRules:
+    def test_does_not_order_url_citation(self):
+        prompt = build_system_prompt()
+        # The old blanket directive must be gone.
+        assert "URI-de kaudu" not in prompt
+
+    def test_forbids_inventing_uris(self):
+        prompt = build_system_prompt()
+        # An explicit "never construct/guess estleg: URIs" rule must exist.
+        assert "KUNAGI" in prompt
+        assert "estleg:" in prompt
+        assert "konstrueeri" in prompt
+
+    def test_prefers_name_and_paragraph_citation(self):
+        prompt = build_system_prompt()
+        # The model is told to cite human-readably (name + section).
+        assert "§" in prompt
+        assert "CELEX" in prompt
+
+    def test_still_responds_in_estonian(self):
+        prompt = build_system_prompt()
+        assert "Vasta alati eesti keeles." in prompt
+
+    def test_draft_context_still_appended(self):
+        prompt = build_system_prompt(draft_context_id="abc123", impact_summary="Mingi kokkuvõte.")
+        assert "abc123" in prompt
+        assert "Mingi kokkuvõte." in prompt


### PR DESCRIPTION
## Problem

The **Nõustaja** advisor gave a law reference as
`https://data.riik.ee/ontology/estleg#HKTS_Par_13` — an entity that doesn't exist.

## Root cause (two compounding bugs)

1. **Prompt invites fabrication.** `app/chat/system_prompt.py` ordered the model to *"Viita konkreetsetele õigusaktidele nende estleg: URI-de kaudu"* (cite specific acts via their estleg: URIs). The model can only know a real provision URI if a **tool returned it** — otherwise it invents a plausible one following the visible `#TOKEN_Par_N` pattern (e.g. "Halduskoostöö seadus § 13" → `#HKTS_Par_13`). Rule 2 ("don't guess") lost to this directive.
2. **Renderer makes it a dead link.** `app/chat/sanitize.py` runs `bleach.linkify`, which turns the bare URI into a clickable link to `data.riik.ee` — but that host is the ontology **namespace**, not a hosted resolver, so it's a broken external link *even for real provisions*.

(`reference_resolver.py` is **not** at fault — it `ASK`s Jena before returning a guessed URI. This bug is purely the LLM free-text citation path.)

## Fix

- **`system_prompt.py`** — cite **human-readably** by law name + § (and CELEX / case number); an explicit rule: *never construct, guess, or derive estleg: URIs* — use a URI only when a tool returned it verbatim.
- **`sanitize.py`** — `_rewrite_ontology_uris()` rewrites any bare `data.riik.ee/ontology/estleg#…` anchor to an in-app `/explorer?focus=<uri>` deep link (same-origin, drops `target`/`rel`), so even a stray/real URI lands in our explorer (which resolves it or shows a graceful "not found") instead of a dead external page.
- **tests** — system-prompt guards (no URI directive, forbids inventing URIs, prefers name+§) + sanitize URI-rewrite cases (rewrite to focus link, same-origin, markdown-link form, regression: normal URLs still linkify externally, code spans untouched).

## Verification

- `ruff format`/`check` ✓ · `pyright app/chat/*` → 0 errors ✓
- `pytest` chat suite (`sanitize` + `system_prompt` + `handlers` + `actions` + `tools_c4`) → **164 passed**
- End-to-end: the reported URI now renders as
  `<a class="citation-link" href="/explorer?focus=…HKTS_Par_13">` — no `data.riik.ee` external link.

## Related (separate follow-up, not in this PR)

The **Koostaja** drafter has a sibling anti-pattern: `app/drafter/prompts.py` tells the model to emit `[estleg:ActName/par/X]` citations, which land **unvalidated** in the generated `.docx` "Citation index" (`docx_builder.py`). Different format + surface than the reported chat bug; worth its own focused fix + review. Happy to take it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)