### PR TITLE
feat(drafter): resolve citations against ontology, mark unverified (#842)

### DIFF
--- a/app/drafter/_step_renderers.py
+++ b/app/drafter/_step_renderers.py
@@ -38,13 +38,13 @@ import json
 import logging
 import uuid
 from typing import Any
-from urllib.parse import quote as url_quote
 
 from fasthtml.common import *  # noqa: F403
 
 from app.auth.provider import UserDict
 from app.db import get_connection as _connect
 from app.docs.report_routes import explorer_focus_url
+from app.drafter.citations import coerce_citation, unverified_label
 from app.drafter.session_model import DraftingSession
 from app.drafter.state_machine import STEP_LABELS_ET, Step
 from app.ontology.relations import legal_phrase
@@ -784,16 +784,25 @@ def _render_clause_card(
     citations = clause.get("citations", [])
     notes = clause.get("notes", "")
 
+    # #842: clause citations are enriched dicts (or legacy raw strings).
+    # Render verified ones as in-app same-origin /explorer?focus= links;
+    # mark unverified ones (incl. legacy strings) as "kontrollimata viide"
+    # non-links so fabricated citations never become clickable dead links.
     citation_links: list[Any] = []
     for cit in citations:
-        citation_links.append(
-            A(
-                cit,
-                href=f"/explorer?search={url_quote(cit)}",
-                cls="citation-link",
-                target="_blank",
-            )  # noqa: F405
-        )
+        c = coerce_citation(cit)
+        if c["verified"] and c["explorer_url"]:
+            citation_links.append(
+                A(  # noqa: F405
+                    c["label"],
+                    href=c["explorer_url"],
+                    cls="citation-link",
+                )
+            )
+        else:
+            citation_links.append(
+                Span(unverified_label(c["text"]), cls="citation-unverified")  # noqa: F405
+            )
 
     return Div(  # noqa: F405
         H4(f"{para} {title}", cls="clause-heading"),  # noqa: F405

--- a/app/drafter/citations.py
+++ b/app/drafter/citations.py
@@ -26,13 +26,26 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import Any, Protocol
 
 from app.docs.entity_extractor import ExtractedRef
 from app.docs.reference_resolver import ReferenceResolver
 from app.docs.report_routes import explorer_focus_url
 
 logger = logging.getLogger(__name__)
+
+
+class _ResolverLike(Protocol):
+    """Structural type for the resolver dependency.
+
+    The real :class:`ReferenceResolver` satisfies this, and so does any test
+    double — ``resolve_citations`` only needs a ``resolve(refs)`` method, so
+    typing the parameter structurally keeps it injectable without coupling
+    callers (or tests) to the concrete class.
+    """
+
+    def resolve(self, refs: list[ExtractedRef]) -> list[Any]: ...
+
 
 # Legacy pseudo-URI forms the OLD drafter prompt asked the model to emit,
 # e.g. "[estleg:TsiviilS/par/3]" and "[eu:2016-679/art/6]". The resolver's
@@ -135,7 +148,7 @@ def coerce_citation(item: Any) -> dict[str, Any]:
 def resolve_citations(
     raw_citations: list[Any] | None,
     *,
-    resolver: ReferenceResolver | None = None,
+    resolver: _ResolverLike | None = None,
 ) -> list[dict[str, Any]]:
     """Resolve raw drafter citation strings into enriched citation dicts.
 

--- a/app/drafter/citations.py
+++ b/app/drafter/citations.py
@@ -29,7 +29,7 @@ import re
 from typing import Any, Protocol
 
 from app.docs.entity_extractor import ExtractedRef
-from app.docs.reference_resolver import ReferenceResolver
+from app.docs.reference_resolver import get_default_resolver
 from app.docs.report_routes import explorer_focus_url
 
 logger = logging.getLogger(__name__)
@@ -106,15 +106,39 @@ def _classify(raw: str) -> tuple[str, str]:
     return "law", text
 
 
+def _is_ontology_uri(uri: object) -> bool:
+    """True only for a real http(s) ontology URI.
+
+    Guards the ``verified`` flag and the rendered href against pseudo-URIs or
+    hostile values (``javascript:…``, ``estleg:Fake``): only a genuine
+    http(s) URI returned by the resolver counts as a verified citation.
+    """
+    return isinstance(uri, str) and uri.startswith(("http://", "https://"))
+
+
 def _enriched(text: str, *, resolved_uri: str | None, label: str | None) -> dict[str, Any]:
-    """Build the canonical enriched-citation dict."""
-    verified = bool(resolved_uri)
+    """Build the canonical enriched-citation dict.
+
+    A citation is *verified* only when ``resolved_uri`` is a real http(s)
+    ontology URI. ``explorer_url`` is ALWAYS recomputed from it via
+    ``explorer_focus_url`` (URL-encoded) — never taken from caller input — so
+    a hostile stored ``explorer_url`` can never reach a rendered href.
+    """
+    uri = resolved_uri if _is_ontology_uri(resolved_uri) else None
+    if uri is None:
+        return {
+            "text": text,
+            "resolved_uri": None,
+            "label": text,
+            "verified": False,
+            "explorer_url": None,
+        }
     return {
         "text": text,
-        "resolved_uri": resolved_uri if verified else None,
-        "label": (label or text) if verified else text,
-        "verified": verified,
-        "explorer_url": explorer_focus_url(resolved_uri) if verified else None,
+        "resolved_uri": uri,
+        "label": label or text,
+        "verified": True,
+        "explorer_url": explorer_focus_url(uri),
     }
 
 
@@ -123,26 +147,32 @@ def coerce_citation(item: Any) -> dict[str, Any]:
     canonical enriched shape WITHOUT re-resolving against Jena.
 
     Render paths use this so they read old sessions (``list[str]``) and new
-    ones (``list[dict]``) uniformly. A legacy string is surfaced as
-    *unverified* — never authoritative — per #842.
+    ones (``list[dict]``) uniformly. It **never trusts** a stored ``verified``
+    or ``explorer_url`` — both are recomputed from ``resolved_uri`` (which
+    must be a real http(s) ontology URI to count as verified). A legacy
+    string is always unverified. So a hostile persisted citation (a fake
+    ``verified=True`` or a ``javascript:`` ``explorer_url``) can never be
+    surfaced as authoritative or as a live link.
     """
     if isinstance(item, dict):
         text = str(item.get("text") or item.get("label") or "")
-        resolved_uri = item.get("resolved_uri") or None
-        verified = bool(item.get("verified")) and resolved_uri is not None
-        return {
-            "text": text,
-            "resolved_uri": resolved_uri if verified else None,
-            "label": str(item.get("label") or text) if verified else text,
-            "verified": verified,
-            "explorer_url": (
-                item.get("explorer_url")
-                or (explorer_focus_url(resolved_uri) if resolved_uri else None)
-            )
-            if verified
-            else None,
-        }
+        raw_label = item.get("label")
+        label = str(raw_label) if raw_label else None
+        return _enriched(text, resolved_uri=item.get("resolved_uri"), label=label)
     return _enriched(str(item), resolved_uri=None, label=None)
+
+
+def _raw_text(item: Any) -> str:
+    """Extract the human-readable citation text from a raw LLM citation.
+
+    The model is asked for plain strings, but a response could contain dicts.
+    We use ONLY the ``text``/``label`` and ignore any caller-supplied
+    verification fields — those are (re)computed by resolution, never trusted
+    from input.
+    """
+    if isinstance(item, dict):
+        return str(item.get("text") or item.get("label") or "")
+    return str(item)
 
 
 def resolve_citations(
@@ -150,56 +180,47 @@ def resolve_citations(
     *,
     resolver: _ResolverLike | None = None,
 ) -> list[dict[str, Any]]:
-    """Resolve raw drafter citation strings into enriched citation dicts.
+    """Resolve raw drafter citations into enriched citation dicts.
 
-    Each raw string is classified, converted to an :class:`ExtractedRef`,
-    and resolved in one batch via :class:`ReferenceResolver`. Verified
-    entries carry the ontology URI + an ``/explorer?focus=`` link; the rest
-    come back unverified so callers can mark them "kontrollimata".
+    Every entry is treated as UNTRUSTED model output: only its text is used
+    (via :func:`_raw_text`), then classified, converted to an
+    :class:`ExtractedRef`, and resolved in one batch via the shared
+    :func:`~app.docs.reference_resolver.get_default_resolver` (a process-wide
+    singleton — the abbreviation map is warmed once, not per clause). A
+    citation is marked ``verified`` only when the ontology returns a real
+    http(s) URI, so a model **cannot** persist a fake "verified" citation by
+    returning a dict with ``verified=True``.
 
     Fails open: any resolver error (e.g. Jena down) downgrades *every*
     citation to unverified rather than raising — drafting and export must
-    never crash on a citation lookup. Already-enriched dicts pass through
-    :func:`coerce_citation` unchanged, so re-running is idempotent.
+    never crash on a citation lookup.
     """
     if not raw_citations:
         return []
 
-    # Collect the raw strings that still need resolution (preserve order).
-    texts = [str(c) for c in raw_citations if not isinstance(c, dict)]
+    texts = [_raw_text(c) for c in raw_citations]
+    refs = [
+        ExtractedRef(ref_text=ref_text, ref_type=ref_type, confidence=1.0)
+        for ref_type, ref_text in (_classify(t) for t in texts)
+    ]
+    runner = resolver if resolver is not None else get_default_resolver()
+    try:
+        results = runner.resolve(refs)
+    except Exception:
+        logger.warning(
+            "drafter citation resolution failed; marking all unverified",
+            exc_info=True,
+        )
+        results = []
 
-    resolved_by_text: dict[str, dict[str, Any]] = {}
-    if texts:
-        refs = [
-            ExtractedRef(ref_text=ref_text, ref_type=ref_type, confidence=1.0)
-            for ref_type, ref_text in (_classify(t) for t in texts)
-        ]
-        runner = resolver if resolver is not None else ReferenceResolver()
-        try:
-            results = runner.resolve(refs)
-        except Exception:
-            logger.warning(
-                "drafter citation resolution failed; marking all unverified",
-                exc_info=True,
-            )
-            results = []
-        for raw_text, res in zip(texts, results):
-            resolved_by_text[raw_text] = _enriched(
-                raw_text,
+    out: list[dict[str, Any]] = []
+    for i, text in enumerate(texts):
+        res = results[i] if i < len(results) else None
+        out.append(
+            _enriched(
+                text,
                 resolved_uri=getattr(res, "entity_uri", None),
                 label=getattr(res, "matched_label", None),
             )
-        # Any text the resolver didn't return (failure / length mismatch).
-        for raw_text in texts:
-            resolved_by_text.setdefault(
-                raw_text, _enriched(raw_text, resolved_uri=None, label=None)
-            )
-
-    # Reassemble in original order, preserving already-enriched dicts.
-    out: list[dict[str, Any]] = []
-    for c in raw_citations:
-        if isinstance(c, dict):
-            out.append(coerce_citation(c))
-        else:
-            out.append(resolved_by_text[str(c)])
+        )
     return out

--- a/app/drafter/citations.py
+++ b/app/drafter/citations.py
@@ -1,0 +1,192 @@
+"""Resolve drafter LLM citation strings against the Estonian Legal Ontology.
+
+The AI law drafter (Koostaja) asks the model to cite existing provisions.
+Previously those citations were stored and rendered as raw, unvalidated
+strings — often fabricated ``estleg:`` pseudo-URIs — and presented as
+authoritative in the exported DOCX and the step-5 UI (issue #842). This
+module turns each raw citation into an enriched, *verified-or-marked*
+object so downstream surfaces only present a citation as authoritative
+when the ontology actually contains it.
+
+Mirrors the chat-advisor fix in PR #841: never trust an LLM-emitted URI —
+resolve by law name + § / CELEX / case number via the shared
+:class:`~app.docs.reference_resolver.ReferenceResolver`.
+
+The enriched citation is a plain JSON-serialisable dict (it persists in
+the drafting-session blob) with these keys:
+
+    text:         human-readable citation text (always present)
+    resolved_uri: ontology URI when verified, else None
+    label:        display label (resolver match label when verified, else text)
+    verified:     True iff the ontology resolved it to a real entity
+    explorer_url: /explorer?focus=<uri> when verified, else None
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from app.docs.entity_extractor import ExtractedRef
+from app.docs.reference_resolver import ReferenceResolver
+from app.docs.report_routes import explorer_focus_url
+
+logger = logging.getLogger(__name__)
+
+# Legacy pseudo-URI forms the OLD drafter prompt asked the model to emit,
+# e.g. "[estleg:TsiviilS/par/3]" and "[eu:2016-679/art/6]". The resolver's
+# provision path expects an "Act § N" form (not the slash form), so these
+# must be normalised before resolution.
+_LEGACY_ESTLEG_RE = re.compile(
+    r"^estleg:\s*([A-Za-zÕÄÖÜõäöü0-9_]+)\s*/\s*par\s*/\s*(\d+)$",
+    re.IGNORECASE,
+)
+_LEGACY_EU_RE = re.compile(r"^eu:\s*(.+?)\s*/\s*art\s*/\s*\w+$", re.IGNORECASE)
+
+# CELEX number, e.g. 32016R0679 / 32019L0790.
+_CELEX_RE = re.compile(r"\b\d{5}[A-Z]{1,2}\d{4}\b")
+# Estonian Supreme Court case numbers (3-2-1-100-15) or CJEU (C-123/45).
+_CASE_RE = re.compile(r"\b(?:\d+-\d+-\d+-\d+-\d+|[CT]-\d+/\d+)\b")
+
+_UNVERIFIED_PREFIX = "kontrollimata viide"
+
+
+def unverified_label(text: str) -> str:
+    """Estonian label for a citation the ontology could not verify.
+
+    Shared by every render surface so the wording stays consistent.
+    """
+    return f"{_UNVERIFIED_PREFIX}: {text}"
+
+
+def _strip_brackets(text: str) -> str:
+    t = text.strip()
+    if t.startswith("[") and t.endswith("]"):
+        t = t[1:-1].strip()
+    return t
+
+
+def _classify(raw: str) -> tuple[str, str]:
+    """Map a raw citation string to ``(ref_type, ref_text)`` for the resolver.
+
+    Handles both the new human-readable forms (post-#842 prompt: ``Act § N``,
+    CELEX, case number) and the legacy ``estleg:``/``eu:`` pseudo-URIs left
+    in older drafting sessions. Misclassification is safe: an unmatched ref
+    simply stays unresolved (marked "kontrollimata"), never a crash.
+    """
+    text = _strip_brackets(raw)
+
+    m = _LEGACY_ESTLEG_RE.match(text)
+    if m:
+        return "provision", f"{m.group(1)} § {m.group(2)}"
+    m = _LEGACY_EU_RE.match(text)
+    if m:
+        return "eu_act", m.group(1)
+
+    if "§" in text:
+        return "provision", text
+    if _CELEX_RE.search(text):
+        return "eu_act", text
+    if _CASE_RE.search(text):
+        return "court_decision", text
+    return "law", text
+
+
+def _enriched(text: str, *, resolved_uri: str | None, label: str | None) -> dict[str, Any]:
+    """Build the canonical enriched-citation dict."""
+    verified = bool(resolved_uri)
+    return {
+        "text": text,
+        "resolved_uri": resolved_uri if verified else None,
+        "label": (label or text) if verified else text,
+        "verified": verified,
+        "explorer_url": explorer_focus_url(resolved_uri) if verified else None,
+    }
+
+
+def coerce_citation(item: Any) -> dict[str, Any]:
+    """Coerce a *stored* citation (legacy ``str`` OR enriched ``dict``) to the
+    canonical enriched shape WITHOUT re-resolving against Jena.
+
+    Render paths use this so they read old sessions (``list[str]``) and new
+    ones (``list[dict]``) uniformly. A legacy string is surfaced as
+    *unverified* — never authoritative — per #842.
+    """
+    if isinstance(item, dict):
+        text = str(item.get("text") or item.get("label") or "")
+        resolved_uri = item.get("resolved_uri") or None
+        verified = bool(item.get("verified")) and resolved_uri is not None
+        return {
+            "text": text,
+            "resolved_uri": resolved_uri if verified else None,
+            "label": str(item.get("label") or text) if verified else text,
+            "verified": verified,
+            "explorer_url": (
+                item.get("explorer_url")
+                or (explorer_focus_url(resolved_uri) if resolved_uri else None)
+            )
+            if verified
+            else None,
+        }
+    return _enriched(str(item), resolved_uri=None, label=None)
+
+
+def resolve_citations(
+    raw_citations: list[Any] | None,
+    *,
+    resolver: ReferenceResolver | None = None,
+) -> list[dict[str, Any]]:
+    """Resolve raw drafter citation strings into enriched citation dicts.
+
+    Each raw string is classified, converted to an :class:`ExtractedRef`,
+    and resolved in one batch via :class:`ReferenceResolver`. Verified
+    entries carry the ontology URI + an ``/explorer?focus=`` link; the rest
+    come back unverified so callers can mark them "kontrollimata".
+
+    Fails open: any resolver error (e.g. Jena down) downgrades *every*
+    citation to unverified rather than raising — drafting and export must
+    never crash on a citation lookup. Already-enriched dicts pass through
+    :func:`coerce_citation` unchanged, so re-running is idempotent.
+    """
+    if not raw_citations:
+        return []
+
+    # Collect the raw strings that still need resolution (preserve order).
+    texts = [str(c) for c in raw_citations if not isinstance(c, dict)]
+
+    resolved_by_text: dict[str, dict[str, Any]] = {}
+    if texts:
+        refs = [
+            ExtractedRef(ref_text=ref_text, ref_type=ref_type, confidence=1.0)
+            for ref_type, ref_text in (_classify(t) for t in texts)
+        ]
+        runner = resolver if resolver is not None else ReferenceResolver()
+        try:
+            results = runner.resolve(refs)
+        except Exception:
+            logger.warning(
+                "drafter citation resolution failed; marking all unverified",
+                exc_info=True,
+            )
+            results = []
+        for raw_text, res in zip(texts, results):
+            resolved_by_text[raw_text] = _enriched(
+                raw_text,
+                resolved_uri=getattr(res, "entity_uri", None),
+                label=getattr(res, "matched_label", None),
+            )
+        # Any text the resolver didn't return (failure / length mismatch).
+        for raw_text in texts:
+            resolved_by_text.setdefault(
+                raw_text, _enriched(raw_text, resolved_uri=None, label=None)
+            )
+
+    # Reassemble in original order, preserving already-enriched dicts.
+    out: list[dict[str, Any]] = []
+    for c in raw_citations:
+        if isinstance(c, dict):
+            out.append(coerce_citation(c))
+        else:
+            out.append(resolved_by_text[str(c)])
+    return out

--- a/app/drafter/docx_builder.py
+++ b/app/drafter/docx_builder.py
@@ -163,7 +163,12 @@ def build_drafter_docx(
     for clause in clauses:
         for raw in clause.get("citations", []):
             cit = coerce_citation(raw)
-            coerced.setdefault(cit["text"], cit)
+            existing = coerced.get(cit["text"])
+            # Prefer a verified entry when the same citation text appears
+            # more than once (e.g. a legacy/unverified copy before a
+            # verified one) so we never downgrade a confirmed citation.
+            if existing is None or (cit["verified"] and not existing["verified"]):
+                coerced[cit["text"]] = cit
 
     if coerced:
         doc.add_section(WD_SECTION.NEW_PAGE)

--- a/app/drafter/docx_builder.py
+++ b/app/drafter/docx_builder.py
@@ -30,6 +30,7 @@ from docx import Document
 from docx.enum.section import WD_SECTION
 from docx.shared import Pt
 
+from app.drafter.citations import coerce_citation, unverified_label
 from app.ui.time import format_tallinn
 
 logger = logging.getLogger(__name__)
@@ -152,17 +153,29 @@ def build_drafter_docx(
     else:
         _build_law_doc(doc, title, structure, clause_map)
 
-    # Appendix A: Citation index
-    all_citations: list[str] = []
+    # Appendix A: Citation index.
+    # Stored citations may be NEW enriched dicts or LEGACY raw strings;
+    # coerce_citation() normalises both (legacy strings -> unverified).
+    # A verified citation renders as authoritative (resolver label, plus the
+    # confirmed provision reference); an unverified one is explicitly marked
+    # "kontrollimata viide: ..." so it is never presented as authoritative.
+    coerced: dict[str, dict[str, Any]] = {}
     for clause in clauses:
-        all_citations.extend(clause.get("citations", []))
+        for raw in clause.get("citations", []):
+            cit = coerce_citation(raw)
+            coerced.setdefault(cit["text"], cit)
 
-    if all_citations:
+    if coerced:
         doc.add_section(WD_SECTION.NEW_PAGE)
         doc.add_heading("Lisa A: Viidete register", level=1)
-        unique_citations = sorted(set(all_citations))
-        for i, cit in enumerate(unique_citations, 1):
-            doc.add_paragraph(f"{i}. {cit}")
+        for i, text in enumerate(sorted(coerced), 1):
+            cit = coerced[text]
+            if cit["verified"]:
+                label = cit.get("label") or text
+                line = label if label == text else f"{label} ({text})"
+            else:
+                line = unverified_label(text)
+            doc.add_paragraph(f"{i}. {line}")
 
     # Appendix B: Impact summary (if available)
     if impact_summary:

--- a/app/drafter/handlers.py
+++ b/app/drafter/handlers.py
@@ -26,6 +26,7 @@ from uuid import UUID
 
 from app.chat.rate_limiter import check_org_cost_budget
 from app.db import get_connection
+from app.drafter.citations import resolve_citations
 from app.drafter.prompts import (
     CLARIFY_PROMPT,
     DRAFT_PROMPT,
@@ -910,7 +911,10 @@ def drafter_draft(
                         "paragraph": section.get("paragraph", ""),
                         "title": section_title,
                         "text": result.get("text", ""),
-                        "citations": result.get("citations", []),
+                        # #842: resolve LLM citations against the ontology so
+                        # only verified ones are later shown as authoritative;
+                        # fabricated/unresolved ones are marked "kontrollimata".
+                        "citations": resolve_citations(result.get("citations", [])),
                         "notes": result.get("notes", ""),
                     }
                 )
@@ -1027,7 +1031,10 @@ def drafter_regenerate_clause(
             org_id=session.org_id,
         )
         clause["text"] = result.get("text", clause.get("text", ""))
-        clause["citations"] = result.get("citations", clause.get("citations", []))
+        # #842: resolve citations through the ontology (see drafter_draft).
+        clause["citations"] = resolve_citations(
+            result.get("citations", clause.get("citations", []))
+        )
         clause["notes"] = result.get("notes", clause.get("notes", ""))
     except Exception as exc:
         if attempt >= max_attempts:

--- a/app/drafter/prompts.py
+++ b/app/drafter/prompts.py
@@ -121,8 +121,12 @@ Research findings relevant to this section:
 Requirements:
 - Write in formal Estonian legislative style
 - Follow Oigustehnika reeglid (Estonian legislative drafting rules)
-- Cite specific existing provisions being amended or referenced using the
-  format [estleg:ActName/par/X] (e.g., [estleg:TsiviilS/par/3])
+- Cite existing provisions by law name and section — e.g. "Halduskoostoo seadus
+  § 13" or "HKTS § 13" — EU acts by CELEX number, and court decisions by case
+  number.
+- NEVER construct, guess, or invent estleg: identifiers or URIs. Cite only what
+  you can name in human-readable form; an invented identifier produces a broken,
+  non-existent reference to a provision that does not exist.
 - If transposing an EU directive, cite the specific article
 - Use clear, unambiguous language appropriate for legislation
 - Paragraphs should be numbered with (1), (2), etc. within the section
@@ -131,7 +135,7 @@ Requirements:
 Return a JSON object:
 {{
   "text": "The full section text in Estonian legislative style",
-  "citations": ["estleg:ActName/par/X", "eu:DirectiveNumber/art/Y"],
+  "citations": ["Halduskoostoo seadus § 13", "32016R0679"],
   "notes": "Optional drafting notes about choices made, in Estonian"
 }}
 """

--- a/app/drafter/prompts.py
+++ b/app/drafter/prompts.py
@@ -194,6 +194,14 @@ VTK_STRUCTURE = {
     ],
 }
 
+_VTK_CITATION_GUIDANCE = (
+    "When citing existing law, cite human-readably by law name and section "
+    '(e.g. "Halduskoostoo seadus § 13" or "HKTS § 13"), EU acts by CELEX '
+    "number, and court decisions by case number. NEVER construct, guess, or "
+    "invent estleg: identifiers or URIs — an invented identifier is a broken "
+    "reference to a provision that does not exist.\n\n"
+)
+
 VTK_SECTION_PROMPTS: dict[str, str] = {
     "Probleemi olemus": _PROMPT_INJECTION_PREAMBLE
     + """\
@@ -395,4 +403,14 @@ Describe:
 
 Return JSON: {{"text": "...", "citations": [...], "notes": "..."}}
 """,
+}
+
+# Inject the citation guardrail into every VTK section prompt immediately
+# before its ``Return JSON:`` line. Each prompt contains exactly one
+# ``Return JSON:`` substring, so ``str.replace`` hits each one once. The
+# guidance text contains no ``{`` / ``}`` characters, so the ``{intent}`` /
+# ``{relevant_research}`` / ``{{...}}`` format placeholders are untouched.
+VTK_SECTION_PROMPTS = {
+    name: prompt.replace("Return JSON:", _VTK_CITATION_GUIDANCE + "Return JSON:")
+    for name, prompt in VTK_SECTION_PROMPTS.items()
 }

--- a/tests/test_drafter_citations.py
+++ b/tests/test_drafter_citations.py
@@ -118,25 +118,61 @@ class TestResolveCitations:
         assert all(c["explorer_url"] is None for c in out)
 
     def test_order_preserved_across_mixed_results(self):
-        resolver = _FakeResolver({"A § 1": "uri:a", "B § 2": None, "C § 3": "uri:c"})
+        ua = "https://data.riik.ee/ontology/estleg#A_Par_1"
+        uc = "https://data.riik.ee/ontology/estleg#C_Par_3"
+        resolver = _FakeResolver({"A § 1": ua, "B § 2": None, "C § 3": uc})
         out = resolve_citations(["A § 1", "B § 2", "C § 3"], resolver=resolver)
         assert [c["text"] for c in out] == ["A § 1", "B § 2", "C § 3"]
         assert [c["verified"] for c in out] == [True, False, True]
 
-    def test_already_enriched_dict_passes_through(self):
-        enriched = {
-            "text": "X § 1",
-            "resolved_uri": "uri:x",
-            "label": "X paragrahv 1",
+    def test_defaults_to_shared_resolver_singleton(self, monkeypatch):
+        # P2a: no resolver passed -> uses the process-wide
+        # get_default_resolver (warms the abbreviation map once), NOT a fresh
+        # ReferenceResolver per clause.
+        calls = []
+        sentinel = _FakeResolver({"HKTS § 13": "https://data.riik.ee/ontology/estleg#HKTS_Par_13"})
+
+        def fake_default():
+            calls.append(1)
+            return sentinel
+
+        monkeypatch.setattr("app.drafter.citations.get_default_resolver", fake_default)
+        out = resolve_citations(["HKTS § 13"])
+        assert calls == [1]
+        assert out[0]["verified"] is True
+
+    def test_dict_input_is_reresolved_from_text_not_trusted(self):
+        # P1 (security): a model could return a dict claiming verified=True
+        # with a hostile href. resolve_citations IGNORES those fields and
+        # re-resolves from the text; here the resolver doesn't know it, so it
+        # stays unverified and the javascript: href is gone.
+        evil = {
+            "text": "Made up § 1",
             "verified": True,
-            "explorer_url": "/explorer?focus=uri%3Ax",
+            "resolved_uri": "estleg:Fake",
+            "label": "Totally Real § 1",
+            "explorer_url": "javascript:alert(1)",
         }
         resolver = _FakeResolver({})
-        out = resolve_citations([enriched], resolver=resolver)
-        assert out[0]["verified"] is True
-        assert out[0]["resolved_uri"] == "uri:x"
-        # Resolver was never asked about an already-enriched dict.
-        assert resolver.seen == []
+        out = resolve_citations([evil], resolver=resolver)
+        assert resolver.seen == [("provision", "Made up § 1")]
+        c = out[0]
+        assert c["verified"] is False
+        assert c["resolved_uri"] is None
+        assert c["explorer_url"] is None
+        assert c["label"] == "Made up § 1"
+
+    def test_dict_input_resolved_when_text_is_real(self):
+        # The same untrusted dict, but its TEXT genuinely resolves -> verified
+        # via the ontology, with a recomputed link (never the input's href).
+        uri = "https://data.riik.ee/ontology/estleg#HKTS_Par_13"
+        evil = {"text": "HKTS § 13", "verified": False, "explorer_url": "javascript:x"}
+        resolver = _FakeResolver({"HKTS § 13": uri})
+        c = resolve_citations([evil], resolver=resolver)[0]
+        assert c["verified"] is True
+        assert c["resolved_uri"] == uri
+        assert (c["explorer_url"] or "").startswith("/explorer?focus=")
+        assert "javascript" not in (c["explorer_url"] or "")
 
 
 # --------------------------------------------------------------------------
@@ -145,16 +181,41 @@ class TestResolveCitations:
 
 
 class TestCoerceCitation:
+    _X_URI = "https://data.riik.ee/ontology/estleg#X_Par_1"
+    _X_FOCUS = "/explorer?focus=https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23X_Par_1"
+
     def test_legacy_string_is_unverified(self):
         c = coerce_citation("estleg:Foo/par/1")
         assert c["verified"] is False
         assert c["text"] == "estleg:Foo/par/1"
         assert c["explorer_url"] is None
 
-    def test_enriched_dict_preserved(self):
-        c = coerce_citation({"text": "X § 1", "resolved_uri": "uri:x", "verified": True})
+    def test_enriched_dict_with_real_uri_is_verified(self):
+        c = coerce_citation({"text": "X § 1", "resolved_uri": self._X_URI, "verified": True})
         assert c["verified"] is True
-        assert c["explorer_url"] == "/explorer?focus=uri%3Ax"
+        assert c["explorer_url"] == self._X_FOCUS
+
+    def test_coerce_ignores_stored_explorer_url_and_recomputes(self):
+        # P1 (security): a hostile stored explorer_url is never used — it is
+        # recomputed from the (validated) resolved_uri.
+        c = coerce_citation(
+            {
+                "text": "X § 1",
+                "resolved_uri": self._X_URI,
+                "verified": True,
+                "explorer_url": "javascript:alert(1)",
+            }
+        )
+        assert c["explorer_url"] == self._X_FOCUS
+        assert "javascript" not in c["explorer_url"]
+
+    def test_coerce_rejects_non_http_uri_as_unverified(self):
+        # P1: a fake "verified" dict whose resolved_uri is not a real http(s)
+        # URI (pseudo-URI / javascript:) is downgraded to unverified.
+        for bad in ("javascript:alert(1)", "estleg:Fake", "uri:x", ""):
+            c = coerce_citation({"text": "X § 1", "resolved_uri": bad, "verified": True})
+            assert c["verified"] is False
+            assert c["explorer_url"] is None
 
     def test_dict_without_uri_is_unverified(self):
         c = coerce_citation({"text": "X § 1", "verified": True})

--- a/tests/test_drafter_citations.py
+++ b/tests/test_drafter_citations.py
@@ -1,0 +1,166 @@
+"""Tests for the drafter citation resolver pipeline (issue #842)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.drafter.citations import (
+    _classify,
+    coerce_citation,
+    resolve_citations,
+    unverified_label,
+)
+
+
+class _FakeResolver:
+    """Returns a ResolvedRef-shaped object per ref, keyed by ref_text.
+
+    ``mapping`` maps an expected ``ref_text`` to an ``entity_uri`` (or None
+    for "act resolved but provision missing" / unresolved).
+    """
+
+    def __init__(self, mapping: dict[str, str | None], *, raises: bool = False):
+        self.mapping = mapping
+        self.raises = raises
+        self.seen: list[tuple[str, str]] = []
+
+    def resolve(self, refs):
+        if self.raises:
+            raise RuntimeError("jena down")
+        out = []
+        for r in refs:
+            self.seen.append((r.ref_type, r.ref_text))
+            uri = self.mapping.get(r.ref_text)
+            out.append(
+                SimpleNamespace(
+                    entity_uri=uri,
+                    matched_label=(f"label::{uri}" if uri else None),
+                )
+            )
+        return out
+
+
+# --------------------------------------------------------------------------
+# _classify
+# --------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_legacy_estleg_pseudo_uri_normalised_to_provision(self):
+        assert _classify("estleg:TsiviilS/par/3") == ("provision", "TsiviilS § 3")
+
+    def test_legacy_estleg_with_brackets(self):
+        assert _classify("[estleg:HKTS/par/13]") == ("provision", "HKTS § 13")
+
+    def test_legacy_eu_pseudo_uri(self):
+        rt, _ = _classify("eu:2016-679/art/6")
+        assert rt == "eu_act"
+
+    def test_human_paragraph_is_provision(self):
+        assert _classify("Halduskoostöö seadus § 13") == (
+            "provision",
+            "Halduskoostöö seadus § 13",
+        )
+
+    def test_celex_is_eu_act(self):
+        assert _classify("32016R0679")[0] == "eu_act"
+
+    def test_case_number_is_court_decision(self):
+        assert _classify("3-2-1-100-15")[0] == "court_decision"
+
+    def test_bare_name_is_law(self):
+        assert _classify("Karistusseadustik")[0] == "law"
+
+
+# --------------------------------------------------------------------------
+# resolve_citations
+# --------------------------------------------------------------------------
+
+
+class TestResolveCitations:
+    def test_empty_and_none(self):
+        assert resolve_citations(None) == []
+        assert resolve_citations([]) == []
+
+    def test_verified_citation_gets_uri_and_explorer_link(self):
+        uri = "https://data.riik.ee/ontology/estleg#HKTS_Par_13"
+        resolver = _FakeResolver({"HKTS § 13": uri})
+        out = resolve_citations(["HKTS § 13"], resolver=resolver)
+        assert len(out) == 1
+        c = out[0]
+        assert c["verified"] is True
+        assert c["resolved_uri"] == uri
+        assert c["label"] == f"label::{uri}"
+        assert c["explorer_url"] == "/explorer?focus=" + (
+            "https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23HKTS_Par_13"
+        )
+
+    def test_unresolved_citation_is_unverified(self):
+        resolver = _FakeResolver({"HKTS § 99": None})
+        out = resolve_citations(["HKTS § 99"], resolver=resolver)
+        c = out[0]
+        assert c["verified"] is False
+        assert c["resolved_uri"] is None
+        assert c["explorer_url"] is None
+        assert c["text"] == "HKTS § 99"
+
+    def test_fabricated_pseudo_uri_resolved_via_normalised_form(self):
+        # Legacy fabricated id -> normalised to "TsiviilS § 3" before resolve.
+        resolver = _FakeResolver({"TsiviilS § 3": None})
+        out = resolve_citations(["estleg:TsiviilS/par/3"], resolver=resolver)
+        assert resolver.seen == [("provision", "TsiviilS § 3")]
+        assert out[0]["verified"] is False
+
+    def test_resolver_failure_fails_open_all_unverified(self):
+        resolver = _FakeResolver({}, raises=True)
+        out = resolve_citations(["HKTS § 13", "KarS § 5"], resolver=resolver)
+        assert [c["verified"] for c in out] == [False, False]
+        assert all(c["explorer_url"] is None for c in out)
+
+    def test_order_preserved_across_mixed_results(self):
+        resolver = _FakeResolver({"A § 1": "uri:a", "B § 2": None, "C § 3": "uri:c"})
+        out = resolve_citations(["A § 1", "B § 2", "C § 3"], resolver=resolver)
+        assert [c["text"] for c in out] == ["A § 1", "B § 2", "C § 3"]
+        assert [c["verified"] for c in out] == [True, False, True]
+
+    def test_already_enriched_dict_passes_through(self):
+        enriched = {
+            "text": "X § 1",
+            "resolved_uri": "uri:x",
+            "label": "X paragrahv 1",
+            "verified": True,
+            "explorer_url": "/explorer?focus=uri%3Ax",
+        }
+        resolver = _FakeResolver({})
+        out = resolve_citations([enriched], resolver=resolver)
+        assert out[0]["verified"] is True
+        assert out[0]["resolved_uri"] == "uri:x"
+        # Resolver was never asked about an already-enriched dict.
+        assert resolver.seen == []
+
+
+# --------------------------------------------------------------------------
+# coerce_citation  (read path — never re-resolves)
+# --------------------------------------------------------------------------
+
+
+class TestCoerceCitation:
+    def test_legacy_string_is_unverified(self):
+        c = coerce_citation("estleg:Foo/par/1")
+        assert c["verified"] is False
+        assert c["text"] == "estleg:Foo/par/1"
+        assert c["explorer_url"] is None
+
+    def test_enriched_dict_preserved(self):
+        c = coerce_citation({"text": "X § 1", "resolved_uri": "uri:x", "verified": True})
+        assert c["verified"] is True
+        assert c["explorer_url"] == "/explorer?focus=uri%3Ax"
+
+    def test_dict_without_uri_is_unverified(self):
+        c = coerce_citation({"text": "X § 1", "verified": True})
+        assert c["verified"] is False
+        assert c["explorer_url"] is None
+
+
+def test_unverified_label():
+    assert unverified_label("HKTS § 13") == "kontrollimata viide: HKTS § 13"

--- a/tests/test_drafter_docx_builder.py
+++ b/tests/test_drafter_docx_builder.py
@@ -1,0 +1,107 @@
+"""Tests for the drafter DOCX builder's citation rendering (issue #842, part 2).
+
+The "Lisa A: Viidete register" appendix must NOT print raw, unverified
+citation strings as authoritative legal references. Verified enriched
+citations render as authoritative (resolver label); unverified ones —
+including legacy raw strings from old sessions — are explicitly marked
+"kontrollimata viide: ...".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from docx import Document
+
+from app.drafter.docx_builder import build_drafter_docx
+
+
+def _appendix_texts(path: Path) -> list[str]:
+    """Reopen the saved .docx and return all paragraph texts."""
+    doc = Document(str(path))
+    return [p.text for p in doc.paragraphs]
+
+
+def _build_with_citations(tmp_path: Path, monkeypatch) -> list[str]:
+    """Build a minimal full_law doc whose single clause carries a mix of
+    verified / unverified / legacy citations, then return its paragraph texts.
+    """
+    monkeypatch.setenv("EXPORT_DIR", str(tmp_path))
+
+    clauses = [
+        {
+            "chapter": "1",
+            "paragraph": "§ 1",
+            "text": "Klausli tekst.",
+            "citations": [
+                # Verified enriched dict -> authoritative.
+                {
+                    "text": "HKTS § 13",
+                    "verified": True,
+                    "label": "HKTS § 13",
+                    "resolved_uri": "https://example.org/hkts/13",
+                    "explorer_url": "/explorer?focus=https://example.org/hkts/13",
+                },
+                # Unverified enriched dict -> marked kontrollimata.
+                {
+                    "text": "Foo § 9",
+                    "verified": False,
+                    "label": "Foo § 9",
+                    "resolved_uri": None,
+                    "explorer_url": None,
+                },
+                # Legacy raw string -> coerced to unverified -> kontrollimata.
+                "estleg:Bar/par/1",
+            ],
+        },
+    ]
+    structure = {
+        "chapters": [
+            {
+                "number": "1",
+                "title": "Üldsätted",
+                "sections": [{"paragraph": "§ 1", "title": "Reguleerimisala"}],
+            }
+        ]
+    }
+
+    out_path = build_drafter_docx(
+        session_id="test-session",
+        title="Testeelnõu",
+        workflow_type="full_law",
+        structure=structure,
+        clauses=clauses,
+    )
+    return _appendix_texts(out_path)
+
+
+def test_verified_citation_is_authoritative(tmp_path, monkeypatch):
+    texts = _build_with_citations(tmp_path, monkeypatch)
+    blob = "\n".join(texts)
+
+    # The verified label appears...
+    assert any("HKTS § 13" in t for t in texts)
+    # ...and is NOT marked as unverified.
+    verified_lines = [t for t in texts if "HKTS § 13" in t]
+    assert verified_lines, "verified citation line missing"
+    for line in verified_lines:
+        assert "kontrollimata" not in line, (
+            f"verified citation must not carry the kontrollimata prefix: {line!r}"
+        )
+
+    # Sanity: the appendix heading is present.
+    assert "Lisa A: Viidete register" in blob
+
+
+def test_unverified_dict_is_marked(tmp_path, monkeypatch):
+    texts = _build_with_citations(tmp_path, monkeypatch)
+    assert any("kontrollimata viide: Foo § 9" in t for t in texts), (
+        "unverified dict citation must be marked kontrollimata"
+    )
+
+
+def test_legacy_string_is_marked(tmp_path, monkeypatch):
+    texts = _build_with_citations(tmp_path, monkeypatch)
+    assert any("kontrollimata viide: estleg:Bar/par/1" in t for t in texts), (
+        "legacy raw-string citation must be marked kontrollimata"
+    )

--- a/tests/test_drafter_docx_builder.py
+++ b/tests/test_drafter_docx_builder.py
@@ -105,3 +105,69 @@ def test_legacy_string_is_marked(tmp_path, monkeypatch):
     assert any("kontrollimata viide: estleg:Bar/par/1" in t for t in texts), (
         "legacy raw-string citation must be marked kontrollimata"
     )
+
+
+def test_verified_wins_when_unverified_duplicate_comes_first(tmp_path, monkeypatch):
+    """A verified citation must stay authoritative even when an unverified
+    copy with the same text appears earlier (regression for PR #843 review):
+    the appendix dedupe keyed on citation text must prefer the verified entry
+    regardless of clause/citation order, so it never downgrades to the
+    "kontrollimata viide: ..." form.
+    """
+    monkeypatch.setenv("EXPORT_DIR", str(tmp_path))
+
+    clauses = [
+        {
+            "chapter": "1",
+            "paragraph": "§ 1",
+            "text": "Esimene klausel.",
+            "citations": [
+                # Unverified copy of "HKTS § 13" appears FIRST.
+                {"text": "HKTS § 13", "verified": False},
+            ],
+        },
+        {
+            "chapter": "1",
+            "paragraph": "§ 2",
+            "text": "Teine klausel.",
+            "citations": [
+                # Verified copy of the SAME text appears later.
+                {
+                    "text": "HKTS § 13",
+                    "verified": True,
+                    "label": "HKTS § 13",
+                    "resolved_uri": "https://data.riik.ee/ontology/estleg#HKTS_Par_13",
+                },
+            ],
+        },
+    ]
+    structure = {
+        "chapters": [
+            {
+                "number": "1",
+                "title": "Üldsätted",
+                "sections": [
+                    {"paragraph": "§ 1", "title": "Reguleerimisala"},
+                    {"paragraph": "§ 2", "title": "Mõisted"},
+                ],
+            }
+        ]
+    }
+
+    out_path = build_drafter_docx(
+        session_id="test-session-dupe",
+        title="Testeelnõu",
+        workflow_type="full_law",
+        structure=structure,
+        clauses=clauses,
+    )
+    texts = _appendix_texts(out_path)
+
+    hkts_lines = [t for t in texts if "HKTS § 13" in t]
+    assert hkts_lines, "HKTS § 13 citation line missing from appendix"
+    # The merged entry must be authoritative — never downgraded by the
+    # earlier unverified duplicate.
+    for line in hkts_lines:
+        assert "kontrollimata" not in line, (
+            f"verified citation must win over an earlier unverified duplicate: {line!r}"
+        )

--- a/tests/test_drafter_prompts.py
+++ b/tests/test_drafter_prompts.py
@@ -164,3 +164,24 @@ class TestCitationGuidanceIsHumanReadable:
         # Sanity: neither legacy scheme prefix appears in the example line.
         assert "estleg:ActName" not in DRAFT_PROMPT
         assert "eu:DirectiveNumber" not in DRAFT_PROMPT
+
+    def test_every_vtk_prompt_carries_citation_guardrail(self):
+        """Each VTK section prompt must carry the same human-readable citation
+        guardrail as DRAFT_PROMPT (#843): VTK generation uses these prompts, so
+        they must instruct the model to cite human-readably and never invent
+        ``estleg:`` identifiers.
+        """
+        for title, prompt in VTK_SECTION_PROMPTS.items():
+            # The 'never invent identifiers' instruction is present.
+            assert "NEVER construct, guess, or invent estleg:" in prompt, (
+                f"VTK prompt for '{title}' is missing the citation guardrail"
+            )
+            # Human-readable section symbol is shown.
+            assert "§" in prompt, f"VTK prompt for '{title}' is missing the '§' symbol"
+            # Neither fabricated pseudo-URI form may appear.
+            assert "[estleg:" not in prompt, (
+                f"VTK prompt for '{title}' contains a fabricated '[estleg:...]' citation"
+            )
+            assert "/par/" not in prompt, (
+                f"VTK prompt for '{title}' contains a '/par/' pseudo-URI path"
+            )

--- a/tests/test_drafter_prompts.py
+++ b/tests/test_drafter_prompts.py
@@ -16,6 +16,14 @@ from app.drafter.prompts import (
     VTK_STRUCTURE,
 )
 
+# Every prompt template that can instruct the model to emit citations.
+_ALL_CITATION_PROMPTS = {
+    "CLARIFY_PROMPT": CLARIFY_PROMPT,
+    "STRUCTURE_PROMPT": STRUCTURE_PROMPT,
+    "DRAFT_PROMPT": DRAFT_PROMPT,
+    **{f"VTK[{title}]": prompt for title, prompt in VTK_SECTION_PROMPTS.items()},
+}
+
 
 class TestClarifyPrompt:
     def test_has_intent_placeholder(self):
@@ -110,3 +118,49 @@ class TestVtkSectionPrompts:
                 # Some prompts might not have {clarifications}, that's OK
                 if "clarifications" not in str(e):
                     raise
+
+
+class TestCitationGuidanceIsHumanReadable:
+    """Guard against regressing to fabricated estleg: pseudo-URI citations (#842).
+
+    The drafter must instruct the model to cite provisions human-readably
+    (law name + section / CELEX / case number), never to construct estleg:
+    identifiers. Downstream (``app/drafter/citations.py``) resolves these
+    human-readable strings against the ontology.
+    """
+
+    def test_no_estleg_pseudo_uri_in_any_prompt(self):
+        """No prompt may demonstrate or instruct the bracketed estleg: form."""
+        for name, prompt in _ALL_CITATION_PROMPTS.items():
+            assert "[estleg:" not in prompt, (
+                f"{name} still contains a fabricated '[estleg:...]' citation example"
+            )
+
+    def test_no_par_slash_path_in_any_prompt(self):
+        """The old ``/par/N`` pseudo-path must not appear anywhere."""
+        for name, prompt in _ALL_CITATION_PROMPTS.items():
+            assert "/par/" not in prompt, f"{name} still contains a '/par/' pseudo-URI path"
+
+    def test_draft_prompt_uses_human_readable_citations(self):
+        """DRAFT_PROMPT cites by law name + section symbol, not a pseudo-URI."""
+        assert "[estleg:" not in DRAFT_PROMPT
+        assert "/par/" not in DRAFT_PROMPT
+        # Human-readable guidance: section symbol + a named example law.
+        assert "§" in DRAFT_PROMPT
+        assert "Halduskoostoo seadus § 13" in DRAFT_PROMPT
+        # CELEX / case-number guidance is present (the literal phrase may be
+        # line-wrapped, so assert on stable single tokens).
+        assert "CELEX" in DRAFT_PROMPT
+        assert "court decisions by case" in DRAFT_PROMPT
+
+    def test_draft_prompt_forbids_inventing_identifiers(self):
+        """The 'never invent identifiers' instruction must be present."""
+        assert "NEVER construct, guess, or invent estleg: identifiers" in DRAFT_PROMPT
+
+    def test_draft_prompt_example_citations_are_human_readable(self):
+        """The JSON ``citations`` example shows resolvable human-readable strings."""
+        # The exact example values written into the prompt.
+        assert '"citations": ["Halduskoostoo seadus § 13", "32016R0679"]' in DRAFT_PROMPT
+        # Sanity: neither legacy scheme prefix appears in the example line.
+        assert "estleg:ActName" not in DRAFT_PROMPT
+        assert "eu:DirectiveNumber" not in DRAFT_PROMPT

--- a/tests/test_drafter_step_renderers.py
+++ b/tests/test_drafter_step_renderers.py
@@ -1,0 +1,89 @@
+"""Tests for drafter step-5 clause-card citation rendering (#842, part 3).
+
+The clause card (`_render_clause_card`) must render *verified* enriched
+citations as in-app same-origin ``/explorer?focus=`` anchors and mark
+*unverified* citations (enriched dicts that did not resolve, plus legacy
+raw strings) as ``kontrollimata viide:`` non-links — so fabricated
+citations never become clickable dead ``/explorer?search=`` links.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fasthtml.common import to_xml
+
+from app.drafter._step_renderers import _render_clause_card
+
+
+def _clause_with_mixed_citations() -> dict:
+    """Minimal valid step-5 clause whose citations mix all three forms."""
+    return {
+        "chapter": "1",
+        "chapter_title": "Üldsätted",
+        "paragraph": "§ 1",
+        "title": "Reguleerimisala",
+        "text": "Käesolev seadus reguleerib midagi.",
+        "notes": "",
+        "citations": [
+            # Verified enriched dict → in-app /explorer?focus= anchor.
+            {
+                "text": "HKTS § 13",
+                "verified": True,
+                "label": "HKTS § 13",
+                "resolved_uri": "https://data.riik.ee/ontology/estleg#HKTS_Par_13",
+                "explorer_url": (
+                    "/explorer?focus=https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23HKTS_Par_13"
+                ),
+            },
+            # Unverified enriched dict → "kontrollimata viide:" Span, no link.
+            {
+                "text": "Väljamõeldud seadus § 99",
+                "verified": False,
+                "label": "Väljamõeldud seadus § 99",
+                "resolved_uri": None,
+                "explorer_url": None,
+            },
+            # Legacy raw string → coerced to unverified Span.
+            "estleg:TsiviilS/par/3",
+        ],
+    }
+
+
+def test_verified_citation_renders_in_app_focus_anchor():
+    html = to_xml(_render_clause_card(_clause_with_mixed_citations(), uuid.uuid4(), 0))
+
+    # The verified citation is a clickable /explorer?focus= anchor.
+    assert "/explorer?focus=" in html
+    # ...and it is in-app (no new-tab target).
+    assert 'target="_blank"' not in html
+
+
+def test_no_search_anchor_is_rendered():
+    html = to_xml(_render_clause_card(_clause_with_mixed_citations(), uuid.uuid4(), 0))
+
+    # Fabricated citations must NOT become /explorer?search= dead links.
+    assert "/explorer?search=" not in html
+
+
+def test_unverified_citations_are_marked_and_not_links():
+    html = to_xml(_render_clause_card(_clause_with_mixed_citations(), uuid.uuid4(), 0))
+
+    # Both the unverified dict and the legacy string get the marker text.
+    assert html.count("kontrollimata viide:") == 2
+    assert "kontrollimata viide: Väljamõeldud seadus § 99" in html
+    assert "kontrollimata viide: estleg:TsiviilS/par/3" in html
+
+    # The unverified marker text never sits inside an <a ...> href element —
+    # the element wrapping each marker must be a <span ...>, not an anchor.
+    for marker in (
+        "kontrollimata viide: Väljamõeldud seadus § 99",
+        "kontrollimata viide: estleg:TsiviilS/par/3",
+    ):
+        # Locate the element wrapping the marker; it must be a <span ...>,
+        # not an <a ...> anchor.
+        idx = html.index(marker)
+        open_tag_start = html.rfind("<", 0, idx)
+        open_tag = html[open_tag_start : html.index(">", open_tag_start) + 1]
+        assert open_tag.startswith("<span")
+        assert not open_tag.startswith("<a")


### PR DESCRIPTION
Closes #842. Drafter counterpart to the merged chat fix (#841): the **Koostaja** drafter asked the LLM to emit `[estleg:ActName/par/X]` pseudo-URI citations and then surfaced them **verbatim as authoritative** — fabricated references to provisions that don't exist.

## Approach — a drafter citation pipeline
A new keystone module resolves every LLM citation against the ontology before it is ever shown as authoritative; the four consumer surfaces read its output.

**`app/drafter/citations.py` (new)**
- `resolve_citations(raw, *, resolver=None) -> list[dict]` — classifies each citation string (`Act § N` → provision, CELEX → eu_act, case number → court_decision, bare name → law), batch-resolves via the shared `ReferenceResolver`, and returns enriched `{text, resolved_uri, label, verified, explorer_url}`. **Fails open** — any resolver error (e.g. Jena down) downgrades everything to unverified, never crashes drafting/export.
- Legacy `estleg:ActName/par/X` / `eu:…/art/Y` pseudo-URIs (in old sessions) are **normalised to `Act § N`** before resolution.
- `coerce_citation(item)` — read-path coercion tolerant of legacy `list[str]` (shown unverified) and new `list[dict]`; never re-resolves.
- `unverified_label(text)` → `"kontrollimata viide: <text>"` (shared wording).

**Consumers**
- **`prompts.py`** — cite human-readably by law name + § / CELEX / case number; explicit rule: never construct/invent `estleg:` identifiers (mirrors #841).
- **`handlers.py`** — generate (`:913`) + regenerate (`:1030`) now persist `resolve_citations(...)` output.
- **`docx_builder.py`** — "Lisa A: Viidete register" prints verified citations as authoritative; unverified ones marked `kontrollimata viide:` (marked, **not** silently dropped).
- **`_step_renderers.py`** — step-5 verified → in-app `/explorer?focus=` link (label text); unverified → `kontrollimata` non-link. No more dead `/explorer?search=` links.

## Backward compatibility
Existing sessions store `list[str]`. Every read path goes through `coerce_citation`, so old drafts render unchanged except their (unvalidated) citations now show as `kontrollimata` rather than as authoritative links.

## Verification
- New tests: resolver pipeline (`test_drafter_citations.py`, 18), prompt guard (`test_drafter_prompts.py`), DOCX (`test_drafter_docx_builder.py`, 3), step-5 (`test_drafter_step_renderers.py`, 3).
- **Full drafter suite: 206 passed, 2 skipped** · worker handlers: 14 passed · `ruff format`/`check` ✓ · `pyright app/drafter/*` → 0 errors.
- End-to-end smoke: a fabricated `estleg:Fake/par/99` resolves to **unverified** → renders `kontrollimata` in step-5 (no `?search=` link); a real `HKTS § 13` → `/explorer?focus=…` link.

## DoD (from #842)
- [x] Prompt no longer instructs `[estleg:ActName/par/X]`; cites human-readably; forbids inventing ids.
- [x] `citations.py` resolver adapter (fail-open) → enriched objects.
- [x] handlers persist enriched citations; read paths tolerate legacy `list[str]`.
- [x] DOCX "Lisa A" shows only verified as authoritative; unverified `kontrollimata`.
- [x] step-5 uses `/explorer?focus=` for verified, `kontrollimata` for the rest; no `?search=` for fabricated ids.
- [x] Legacy pseudo-URIs normalised before resolution.
- [x] Tests pass; `ruff` + `pyright` clean; existing drafter tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)