### PR TITLE
fix(security): validate URI schemes for bookmarks, notification links, search deep-links (#848)

### DIFF
--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -32,6 +32,7 @@ from app.notifications.models import (
     mark_read,
 )
 from app.ui.layout import PageShell
+from app.ui.safe_url import is_safe_http_url
 from app.ui.theme import get_theme_from_request
 from app.ui.time import format_tallinn
 
@@ -94,7 +95,12 @@ def NotificationItem(notif: Any, *, compact: bool = False):  # noqa: ANN201, N80
         id=f"notification-{notif.id}",
     )
 
-    if notif.link and not notif.read:
+    # #848: only render an <a href> when the link passes the safe-link policy
+    # (same-origin relative path OR absolute http(s) URL). An unsafe value
+    # (javascript:/data:/protocol-relative/backslash) falls through to the
+    # non-link wrapper below so it is shown as plain, non-clickable content.
+    link_is_safe = _is_safe_link(notif.link)
+    if link_is_safe and not notif.read:
         # Wrap in a link and mark as read on click. The raw <a href> is
         # swallowed by HTMX's hx-post, so we pipe the destination through
         # a ``?redirect=`` query param — the handler validates same-origin
@@ -107,7 +113,7 @@ def NotificationItem(notif: Any, *, compact: bool = False):  # noqa: ANN201, N80
             hx_swap="none",
             cls="notification-link",
         )
-    if notif.link:
+    if link_is_safe:
         return A(content, href=notif.link, cls="notification-link")  # noqa: F405
     # Non-link notifications always render inside a wrapper with a stable
     # ID. The unread variant has a "Loe" button; the read variant does
@@ -208,16 +214,38 @@ def _is_safe_redirect(target: str) -> bool:
     We only allow relative paths beginning with a single ``/`` so the
     browser cannot be sent to an attacker-controlled host. ``//host`` is
     a protocol-relative URL and must be rejected.
+
+    #848: also reject any target containing a backslash. Browsers normalise
+    ``\\`` to ``/``, so ``/\\evil.com`` becomes ``//evil.com`` (a
+    protocol-relative off-site URL) after normalisation — an open redirect.
     """
     if not target or not target.startswith("/"):
         return False
     if target.startswith("//"):
+        return False
+    if "\\" in target:
         return False
     parsed = urlparse(target)
     # urlparse of a relative path should yield empty scheme and netloc.
     if parsed.scheme or parsed.netloc:
         return False
     return True
+
+
+def _is_safe_link(link: str | None) -> bool:
+    """Return True if *link* is safe to render as a notification ``href``.
+
+    A notification link is safe when it is **either** a same-origin relative
+    path (``/drafts/123`` — the shape every current ``notify()`` caller emits)
+    **or** an absolute ``http(s)://`` URL. This blocks ``javascript:`` /
+    ``data:`` / protocol-relative / backslash-normalised values from ever
+    landing in an ``href`` should a future caller pass a user-influenced link
+    (e.g. ``_annotation_target_link``). Unsafe links render as plain,
+    non-clickable content instead.
+    """
+    if not link:
+        return False
+    return _is_safe_redirect(link) or is_safe_http_url(link)
 
 
 def mark_single_read(req: Request, id: str):

--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -32,7 +32,7 @@ from app.notifications.models import (
     mark_read,
 )
 from app.ui.layout import PageShell
-from app.ui.safe_url import is_safe_http_url
+from app.ui.safe_url import has_unsafe_chars, is_safe_http_url
 from app.ui.theme import get_theme_from_request
 from app.ui.time import format_tallinn
 
@@ -218,12 +218,20 @@ def _is_safe_redirect(target: str) -> bool:
     #848: also reject any target containing a backslash. Browsers normalise
     ``\\`` to ``/``, so ``/\\evil.com`` becomes ``//evil.com`` (a
     protocol-relative off-site URL) after normalisation — an open redirect.
+
+    #848 (round-3 review): reject raw control/whitespace bytes too (NUL, DEL,
+    ``\\t`` / ``\\r`` / ``\\n``, space) via the shared ``has_unsafe_chars``
+    policy, so this relative-path gate matches the strictness of the absolute
+    URL helper and the two cannot drift. Estonian diacritic paths
+    (``/märkused``, raw or percent-encoded) are unaffected.
     """
     if not target or not target.startswith("/"):
         return False
     if target.startswith("//"):
         return False
     if "\\" in target:
+        return False
+    if has_unsafe_chars(target):
         return False
     parsed = urlparse(target)
     # urlparse of a relative path should yield empty scheme and netloc.

--- a/app/templates/dashboard.py
+++ b/app/templates/dashboard.py
@@ -28,7 +28,7 @@ from urllib.parse import urlencode
 
 from fasthtml.common import *
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse
+from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from app.analyysikeskus.eu_transposition import (
     DEFAULT_TRANSPOSITION_HORIZON_DAYS,
@@ -50,6 +50,7 @@ from app.ui.primitives.badge import Badge, BadgeVariant
 from app.ui.primitives.button import Button
 from app.ui.primitives.icon import Icon
 from app.ui.primitives.link_button import LinkButton
+from app.ui.safe_url import is_safe_http_url
 from app.ui.surfaces.card import Card, CardBody, CardHeader
 from app.ui.theme import get_theme_from_request
 from app.ui.time import format_tallinn
@@ -1292,7 +1293,15 @@ def _bookmarks_card(bookmarks: list[dict]):  # type: ignore[type-arg]
                 key="entity_uri",
                 label="URI",
                 sortable=False,
-                render=lambda r: A(r["entity_uri"], href=r["entity_uri"]),
+                # #848: render-side guard (defense in depth). Even though the
+                # POST handler now validates before insert, legacy rows may
+                # carry an unsafe ``javascript:`` / ``data:`` value — render
+                # those as plain text, never as a clickable ``href``.
+                render=lambda r: (
+                    A(r["entity_uri"], href=r["entity_uri"])
+                    if is_safe_http_url(r["entity_uri"])
+                    else Span(r["entity_uri"], cls="muted-text")
+                ),
             ),
             Column(
                 key="actions",
@@ -1447,6 +1456,11 @@ def _wants_json(req: Request) -> bool:
     return req.headers.get("x-requested-with", "").lower() == "xmlhttprequest"
 
 
+# #848: Estonian message for a rejected bookmark URI (shown to plain-form
+# callers as the 400 body and returned to XHR callers in the JSON payload).
+_INVALID_URI_MSG = "Vigane URI. Lubatud on ainult http:// või https:// aadressid."
+
+
 def add_bookmark(req: Request, entity_uri: str, label: str = ""):
     """POST /api/bookmarks — add a bookmark for the current user.
 
@@ -1461,10 +1475,23 @@ def add_bookmark(req: Request, entity_uri: str, label: str = ""):
             return JSONResponse({"ok": False, "error": "auth"}, status_code=401)
         return RedirectResponse(url="/auth/login", status_code=303)
 
+    clean_uri = entity_uri.strip()
+    # #848: validate the scheme server-side BEFORE insert — only absolute
+    # http(s):// URLs are allowed. Rejects javascript:/data:/protocol-relative/
+    # backslash-normalised/relative/empty values so a crafted bookmark can
+    # never become stored XSS on dashboard load. No row is persisted on reject.
+    if not is_safe_http_url(clean_uri):
+        if wants_json:
+            return JSONResponse(
+                {"ok": False, "error": "invalid_uri", "message": _INVALID_URI_MSG},
+                status_code=400,
+            )
+        return Response(_INVALID_URI_MSG, status_code=400)
+
     actual_label = label.strip() if label else None
-    bookmark = _add_bookmark(user_id, entity_uri.strip(), actual_label)
+    bookmark = _add_bookmark(user_id, clean_uri, actual_label)
     if bookmark:
-        log_action(user_id, "bookmark.add", {"entity_uri": entity_uri, "label": actual_label})
+        log_action(user_id, "bookmark.add", {"entity_uri": clean_uri, "label": actual_label})
     if wants_json:
         # ``bookmark`` is None when the row already existed (ON CONFLICT DO
         # NOTHING) — still "ok" from the caller's point of view.

--- a/app/ui/components/global_search.py
+++ b/app/ui/components/global_search.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 from fasthtml.common import *  # noqa: F403
 
 from app.ui.primitives.icon import Icon
+from app.ui.safe_url import quote_uri_param
 
 # Placeholder strings — kept module-level so the mobile full-screen page can
 # reuse the long form. Estonian-first; do not translate.
@@ -217,7 +218,10 @@ def _entity_group(entities: list[dict]):  # noqa: ANN202
             A(  # noqa: F405
                 Div(label, cls="global-search-row-label"),  # noqa: F405
                 Div(short_type, cls="global-search-row-meta") if short_type else "",  # noqa: F405
-                href=f"/explorer?focus={uri}",
+                # #848: URL-encode the focus param so ``&``/``#``/``?`` in a
+                # SPARQL-derived URI can't truncate the query string and land
+                # the deep link on the wrong (or no) focus.
+                href=f"/explorer?focus={quote_uri_param(uri)}",
                 role="option",
                 cls="global-search-row global-search-row--entity",
                 tabindex="-1",

--- a/app/ui/safe_url.py
+++ b/app/ui/safe_url.py
@@ -39,6 +39,33 @@ from urllib.parse import quote, urlsplit
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 
+def has_unsafe_chars(value: str) -> bool:
+    """Return ``True`` if *value* contains a raw control or whitespace byte.
+
+    "Unsafe" means any C0 control character or space (codepoint ``<= 0x20``,
+    which covers NUL / tab / newline / carriage-return / space) or the C1 DEL
+    byte (``0x7F``). Browsers strip ``\\t`` / ``\\r`` / ``\\n`` from URLs before
+    acting on them, so a raw control byte can smuggle an otherwise-blocked
+    scheme (``java\\tscript:``) past a naive prefix check, or hide an
+    off-origin target inside an apparently same-origin redirect path.
+
+    This is the single character-safety policy shared by both
+    :func:`is_safe_http_url` (absolute URLs) and the relative-path redirect /
+    link gate in ``app.notifications.routes`` — keeping it here means the two
+    cannot drift apart again (#848 round-3 review). It deliberately does **not**
+    reject non-ASCII: a legitimate Estonian path such as ``/märkused`` (raw or
+    percent-encoded) must still pass. Reserved/percent characters are fine too
+    — only raw control/whitespace bytes are blocked.
+
+    Args:
+        value: The candidate string (URL or relative path).
+
+    Returns:
+        ``True`` if any raw control/whitespace byte is present.
+    """
+    return any(ord(ch) <= 0x20 or ord(ch) == 0x7F for ch in value)
+
+
 def is_safe_http_url(value: str | None) -> bool:
     """Return ``True`` only for a safe, absolute ``http(s)://`` URL.
 
@@ -71,13 +98,12 @@ def is_safe_http_url(value: str | None) -> bool:
     if not value:
         return False
 
-    # Reject any control character (incl. tab / newline / NUL) or whitespace
-    # *anywhere* in the string. Browsers strip tab/CR/LF from URLs before
-    # acting on the scheme, so ``java\tscript:alert(1)`` would otherwise slip
-    # an unsafe scheme past a naive ``startswith`` check. A legitimate absolute
-    # http(s) URL never contains raw whitespace or control bytes (spaces are
-    # percent-encoded as ``%20``).
-    if any(ord(ch) <= 0x20 or ord(ch) == 0x7F for ch in value):
+    # Reject any raw control/whitespace byte *anywhere* in the string (shared
+    # policy — see ``has_unsafe_chars``). Browsers strip tab/CR/LF from URLs
+    # before acting on the scheme, so ``java\tscript:alert(1)`` would otherwise
+    # slip an unsafe scheme past a naive ``startswith`` check. A legitimate
+    # absolute http(s) URL never contains raw whitespace (spaces → ``%20``).
+    if has_unsafe_chars(value):
         return False
 
     # Backslashes are normalised to forward slashes by browsers, turning

--- a/app/ui/safe_url.py
+++ b/app/ui/safe_url.py
@@ -1,0 +1,126 @@
+"""Shared safe-URL helpers — block stored XSS and open-redirect vectors.
+
+Issue #848 (P0, review ID C4): ``/api/bookmarks`` stored a user-controlled
+``entity_uri`` without scheme validation and the dashboard rendered it as
+``A(uri, href=uri)``. FastHTML escapes attribute *values* but does **not**
+strip dangerous URL *schemes*, so a ``javascript:`` (or ``data:`` /
+``vbscript:``) href becomes stored XSS the moment the dashboard loads. The
+same class of bug lurks anywhere a stored/derived string lands in an ``href``
+(notification links) or a deep-link query param (global search ``?focus=``).
+
+This module is the single place that answers "is this URL safe to put in an
+``href`` we control?". It deliberately stands alone from
+``app.explorer.routes._validate_uri``:
+
+    * ``explorer._validate_uri`` answers a *different* question — "is this
+      string safe to interpolate into a ``<uri>`` slot inside a SPARQL query
+      string?" (it guards against SPARQL injection, e.g. ``>``, ``{``, quotes).
+      Its character allow-list happens to also reject ``javascript:`` because
+      a colon-with-no-``//`` won't match ``^https?://…``, but its purpose,
+      surface, and failure mode are SPARQL-shaped, not browser-href-shaped.
+    * ``is_safe_http_url`` answers the *href* question and is deliberately
+      stricter about the things browsers normalise (backslashes,
+      protocol-relative ``//host``, embedded control/whitespace characters)
+      which a SPARQL allow-list never has to think about.
+
+Keeping the two policies separate (and documented) is intentional: a future
+change to the SPARQL allow-list (e.g. to permit URN schemes) must not silently
+widen what we are willing to render as a clickable link, and vice versa.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote, urlsplit
+
+#: Schemes we are willing to emit into an ``href`` we control. Ontology /
+#: entity URIs are ``http(s)://…`` absolute URLs; nothing else is expected.
+#: ``http`` is allowed alongside ``https`` because the ontology source data
+#: (and many Riigi Teataja / EUR-Lex identifiers) use bare ``http://`` URIs.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def is_safe_http_url(value: str | None) -> bool:
+    """Return ``True`` only for a safe, absolute ``http(s)://`` URL.
+
+    Safe means: it has an explicit ``http``/``https`` scheme **and** a host,
+    contains no embedded whitespace/control characters, and uses no backslash
+    (which browsers silently normalise to ``/``). Everything else is rejected,
+    including:
+
+    * dangerous schemes — ``javascript:``, ``data:``, ``vbscript:``, ``file:``,
+      ``mailto:``, …;
+    * protocol-relative URLs — ``//evil.example`` (browsers inherit the page
+      scheme and navigate off-site);
+    * backslash variants — ``/\\evil.example``, ``\\\\evil.example``,
+      ``https:/\\evil.example`` (``\\`` → ``/`` in every major browser, so
+      these become protocol-relative / off-site after normalisation);
+    * relative or scheme-less values — ``/dashboard``, ``foo``, ``example.com``;
+    * empty / whitespace-only / ``None``.
+
+    The check is intentionally conservative: when in doubt, reject. Callers
+    that want to *render* an unsafe legacy value should fall back to plain text
+    rather than an anchor (defense in depth for data that predates this guard).
+
+    Args:
+        value: The candidate URL (typically user-controlled or derived from
+            stored data / SPARQL results).
+
+    Returns:
+        ``True`` if the value is safe to use as an ``href`` target.
+    """
+    if not value:
+        return False
+
+    # Reject any control character (incl. tab / newline / NUL) or whitespace
+    # *anywhere* in the string. Browsers strip tab/CR/LF from URLs before
+    # acting on the scheme, so ``java\tscript:alert(1)`` would otherwise slip
+    # an unsafe scheme past a naive ``startswith`` check. A legitimate absolute
+    # http(s) URL never contains raw whitespace or control bytes (spaces are
+    # percent-encoded as ``%20``).
+    if any(ord(ch) <= 0x20 or ord(ch) == 0x7F for ch in value):
+        return False
+
+    # Backslashes are normalised to forward slashes by browsers, turning
+    # ``/\evil`` and ``https:/\evil`` into protocol-relative / off-site URLs.
+    # No valid http(s) URL needs a literal backslash, so reject outright.
+    if "\\" in value:
+        return False
+
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        # Malformed (e.g. bad IPv6 literal / port) — treat as unsafe.
+        return False
+
+    scheme = parts.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        # Covers ``javascript:``, ``data:``, protocol-relative ``//host``
+        # (empty scheme), and bare relative paths (empty scheme).
+        return False
+
+    # Require a real host. ``http:///path`` or ``https://`` alone is not a
+    # navigable absolute URL and should not be rendered as a link.
+    if not parts.netloc or not parts.hostname:
+        return False
+
+    return True
+
+
+def quote_uri_param(uri: str) -> str:
+    """Percent-encode *uri* for safe use as a single URL query-param value.
+
+    Encodes every reserved character (``safe=""``) so ``&``, ``#``, ``?`` and
+    friends embedded in an entity URI cannot truncate or hijack the query
+    string of a deep link such as ``/explorer?focus=<uri>``. This is *not* a
+    security boundary on its own (FastHTML escapes attribute values), but it
+    keeps deep links pointing at the intended target.
+
+    Args:
+        uri: The raw URI to embed as a query-param value.
+
+    Returns:
+        The percent-encoded value (empty string for falsy input).
+    """
+    if not uri:
+        return ""
+    return quote(uri, safe="")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from starlette.testclient import TestClient
 
 # ---------------------------------------------------------------------------
@@ -988,6 +989,148 @@ class TestBookmarkRoute:
         resp = remove_bookmark(self._req(auth=self._AUTH, xhr=True), "bm-1")
         assert resp.status_code == 200
         assert _json.loads(bytes(resp.body)) == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# #848: bookmark URI scheme validation — reject XSS / open-redirect vectors
+# before insert, and never render unsafe legacy rows as a link.
+# ---------------------------------------------------------------------------
+
+
+_UNSAFE_BOOKMARK_URIS = [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "//evil.example",
+    "/\\evil.example",
+    "",
+    "   ",
+    "/relative/path",
+    "example.org/no-scheme",
+]
+
+
+class TestBookmarkUriValidation:
+    _AUTH = {"id": "u-1", "email": "u@x.ee", "full_name": "U", "role": "drafter", "org_id": None}
+
+    def _req(self, *, xhr: bool):  # type: ignore[type-arg]
+        from starlette.requests import Request
+
+        headers: list[tuple[bytes, bytes]] = []
+        if xhr:
+            headers.append((b"x-requested-with", b"XMLHttpRequest"))
+        return Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/api/bookmarks",
+                "query_string": b"",
+                "headers": headers,
+                "auth": self._AUTH,
+            }
+        )
+
+    @pytest.mark.parametrize("bad_uri", _UNSAFE_BOOKMARK_URIS)
+    @patch("app.templates.dashboard.log_action")
+    @patch("app.templates.dashboard._add_bookmark")
+    def test_xhr_unsafe_uri_returns_400_and_no_insert(
+        self, mock_add: MagicMock, mock_log: MagicMock, bad_uri: str
+    ):
+        import json as _json
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(xhr=True), bad_uri, "L")
+        assert resp.status_code == 400
+        payload = _json.loads(bytes(resp.body))
+        assert payload["ok"] is False
+        assert payload["error"] == "invalid_uri"
+        # No row persisted, no audit log entry for a rejected URI.
+        mock_add.assert_not_called()
+        mock_log.assert_not_called()
+
+    @pytest.mark.parametrize("bad_uri", _UNSAFE_BOOKMARK_URIS)
+    @patch("app.templates.dashboard.log_action")
+    @patch("app.templates.dashboard._add_bookmark")
+    def test_plain_form_unsafe_uri_returns_400_and_no_insert(
+        self, mock_add: MagicMock, mock_log: MagicMock, bad_uri: str
+    ):
+        from starlette.responses import Response
+
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(xhr=False), bad_uri, "L")
+        assert isinstance(resp, Response)
+        assert resp.status_code == 400
+        # Estonian message in the body, not an HTML escape of the bad URI.
+        assert "Vigane URI" in bytes(resp.body).decode()
+        mock_add.assert_not_called()
+        mock_log.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "good_uri",
+        [
+            "https://example.org/entity/1",
+            "http://www.riigiteataja.ee/akt/13201407",
+            "  https://example.org/trimmed  ",  # trimmed before validation
+        ],
+    )
+    @patch("app.templates.dashboard.log_action")
+    @patch(
+        "app.templates.dashboard._add_bookmark",
+        return_value={"id": "bm-1", "entity_uri": "x", "label": "L"},
+    )
+    def test_valid_uri_is_inserted(self, mock_add: MagicMock, mock_log: MagicMock, good_uri: str):
+        from app.templates.dashboard import add_bookmark
+
+        resp = add_bookmark(self._req(xhr=True), good_uri, "L")
+        assert resp.status_code == 200
+        # The trimmed URI is what gets persisted.
+        mock_add.assert_called_once()
+        assert mock_add.call_args.args[1] == good_uri.strip()
+
+
+class TestBookmarkRenderGuard:
+    """#848 regression: legacy unsafe bookmark rows must never render as a link."""
+
+    def test_unsafe_legacy_row_renders_as_plain_text_not_link(self):
+        from fasthtml.common import to_xml
+
+        from app.templates.dashboard import _bookmarks_card
+
+        html = to_xml(
+            _bookmarks_card(
+                [
+                    {
+                        "id": "bm-evil",
+                        "entity_uri": "javascript:alert(document.cookie)",
+                        "label": "Paha",
+                    }
+                ]
+            )
+        )
+        # The payload appears (as escaped text) but never inside an href.
+        assert 'href="javascript:' not in html
+        assert "href='javascript:" not in html
+        # It is rendered as plain text inside the muted span, not an anchor.
+        assert '<span class="muted-text">javascript:alert(document.cookie)</span>' in html
+
+    def test_safe_row_renders_as_link(self):
+        from fasthtml.common import to_xml
+
+        from app.templates.dashboard import _bookmarks_card
+
+        html = to_xml(
+            _bookmarks_card(
+                [
+                    {
+                        "id": "bm-1",
+                        "entity_uri": "https://example.org/entity/1",
+                        "label": "Hea",
+                    }
+                ]
+            )
+        )
+        assert 'href="https://example.org/entity/1"' in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -124,7 +124,9 @@ class TestGlobalSearchEndpoint:
         body = resp.text
         assert "Entiteedid" in body
         assert "Zzzzz seadus" in body
-        assert "/explorer?focus=https://data.riik.ee/ontology/estleg#Act_ZZZ" in body
+        # #848: the focus param is URL-encoded so ``#``/``&`` in the URI can't
+        # truncate the query string (``#`` → ``%23``).
+        assert "/explorer?focus=https%3A%2F%2Fdata.riik.ee%2Fontology%2Festleg%23Act_ZZZ" in body
 
     @patch("app.auth.middleware._get_provider")
     @patch("app.ui.components.search_routes._entity_matches")
@@ -316,6 +318,23 @@ class TestRenderDropdown:
         assert "X seadus" in rendered
         assert "/explorer?focus=" in rendered
         assert 'role="option"' in rendered
+
+    def test_entity_focus_param_is_url_encoded(self):
+        """#848: ``&``/``#``/``?`` in a SPARQL-derived URI must be
+        percent-encoded so they can't truncate the deep-link query."""
+        entities = [
+            {
+                "uri": "https://example.org/ns#A?evil=1&x=2",
+                "label": "Tricky",
+                "type": "https://example.org/ns#Act",
+            }
+        ]
+        rendered = to_xml(render_dropdown(entities=entities, capabilities=[], query="x"))
+        # The reserved characters must be encoded inside the href value.
+        assert "focus=https%3A%2F%2Fexample.org%2Fns%23A%3Fevil%3D1%26x%3D2" in rendered
+        # Raw reserved chars must not leak into the href, which would split
+        # the URI across multiple (spurious) query params.
+        assert "focus=https://example.org/ns#A?evil=1&x=2" not in rendered
 
     def test_capability_row_carries_icon_and_url(self):
         caps = [

--- a/tests/test_notifications_routes.py
+++ b/tests/test_notifications_routes.py
@@ -230,6 +230,37 @@ class TestMarkSingleRead:
 
     @patch("app.notifications.routes._require_auth")
     @patch("app.notifications.routes._connect")
+    def test_rejects_backslash_normalized_redirect_target(self, mock_connect, mock_auth):
+        """#848: ``/\\evil.com`` normalises to ``//evil.com`` in browsers —
+        it must not be forwarded as an HX-Redirect."""
+        mock_auth.return_value = _AUTH
+        conn = MagicMock()
+        mock_connect.return_value = _ConnectCM(conn)
+
+        fresh_notif = _make_notification(read=True)
+        with (
+            patch("app.notifications.routes.mark_read"),
+            patch(
+                "app.notifications.routes.get_notification",
+                return_value=fresh_notif,
+            ),
+        ):
+            req = _make_request(
+                path=f"/notifications/{_NOTIF_ID}/read",
+                method="POST",
+                # ``/\evil.com`` percent-encoded.
+                query_string=b"redirect=%2F%5Cevil.com",
+            )
+            result = mark_single_read(req, str(_NOTIF_ID))
+
+        if isinstance(result, Response):
+            assert result.headers.get("HX-Redirect") is None
+        else:
+            html = to_xml(result)
+            assert "evil.com" not in html
+
+    @patch("app.notifications.routes._require_auth")
+    @patch("app.notifications.routes._connect")
     def test_returns_rendered_read_state_item_when_no_redirect(self, mock_connect, mock_auth):
         """Bug 2: marking a non-link notification must return a re-rendered
         read-state notification item — not a bare Span that collapses the
@@ -316,6 +347,91 @@ class TestNotificationItemRendering:
         # No stale "Loe" button must remain.
         assert "Loe" not in html
         assert "notification-mark-btn" not in html
+
+
+# ---------------------------------------------------------------------------
+# #848: notification link gating — a user-influenced unsafe link must never
+# land in an <a href>; safe internal/absolute links still render as links.
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationLinkGating:
+    def test_unsafe_link_does_not_render_as_href(self):
+        """An unread notification with a ``javascript:`` link must NOT
+        produce an ``<a href>`` — it falls through to the non-link
+        wrapper so the scheme is never clickable."""
+        notif = _make_notification(read=False, link="javascript:alert(1)")
+
+        html = to_xml(NotificationItem(notif))
+
+        assert 'href="javascript:' not in html
+        assert "href='javascript:" not in html
+        # Falls through to the non-link wrapper (with the "Loe" button).
+        assert f'id="notification-wrapper-{_NOTIF_ID}"' in html
+
+    def test_unsafe_read_link_does_not_render_as_href(self):
+        """Even a read notification with an unsafe link renders non-link."""
+        notif = _make_notification(read=True, link="data:text/html,<script>1</script>")
+
+        html = to_xml(NotificationItem(notif))
+
+        assert "href=" not in html or 'href="data:' not in html
+        assert 'href="data:' not in html
+
+    def test_safe_relative_link_renders_as_href(self):
+        """Same-origin relative links (the shape every notify() caller
+        emits today) still render as a clickable anchor."""
+        notif = _make_notification(read=False, link="/drafts/abc")
+
+        html = to_xml(NotificationItem(notif))
+
+        assert 'href="/drafts/abc"' in html
+        assert "notification-link" in html
+
+    def test_safe_absolute_http_link_renders_as_href(self):
+        notif = _make_notification(read=True, link="https://example.org/x")
+
+        html = to_xml(NotificationItem(notif))
+
+        assert 'href="https://example.org/x"' in html
+
+
+class TestIsSafeRedirect:
+    """#848: the open-redirect guard must reject backslash variants that
+    browsers normalise to ``//evil.com``."""
+
+    def test_rejects_backslash_normalized_open_redirect(self):
+        from app.notifications.routes import _is_safe_redirect
+
+        assert _is_safe_redirect("/\\evil.com") is False
+        assert _is_safe_redirect("/\\\\evil.com") is False
+
+    def test_rejects_protocol_relative_and_absolute(self):
+        from app.notifications.routes import _is_safe_redirect
+
+        assert _is_safe_redirect("//evil.com") is False
+        assert _is_safe_redirect("https://evil.com") is False
+        assert _is_safe_redirect("javascript:alert(1)") is False
+        assert _is_safe_redirect("") is False
+
+    def test_accepts_same_origin_relative_path(self):
+        from app.notifications.routes import _is_safe_redirect
+
+        assert _is_safe_redirect("/drafts/abc") is True
+        assert _is_safe_redirect("/admin/costs") is True
+
+
+class TestIsSafeLink:
+    def test_combines_relative_and_absolute_policies(self):
+        from app.notifications.routes import _is_safe_link
+
+        assert _is_safe_link("/drafts/abc") is True
+        assert _is_safe_link("https://example.org/x") is True
+        assert _is_safe_link("javascript:alert(1)") is False
+        assert _is_safe_link("//evil.example") is False
+        assert _is_safe_link("/\\evil.example") is False
+        assert _is_safe_link(None) is False
+        assert _is_safe_link("") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notifications_routes.py
+++ b/tests/test_notifications_routes.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fasthtml.common import to_xml
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
@@ -395,6 +396,28 @@ class TestNotificationLinkGating:
 
         assert 'href="https://example.org/x"' in html
 
+    @pytest.mark.parametrize("ctrl", ["\x00", "\x7f", "\t", "\n", "\r"])
+    def test_control_byte_in_same_origin_path_not_rendered_as_href(self, ctrl: str):
+        """#848 round-3: a same-origin path with an embedded control byte
+        (NUL/DEL/tab/CR/LF) must fall through to the non-link wrapper, never
+        an ``<a href>`` — browsers strip these bytes and could be steered
+        off-origin."""
+        notif = _make_notification(read=False, link=f"/drafts/{ctrl}evil")
+
+        html = to_xml(NotificationItem(notif))
+
+        # No anchor link class — it rendered as the non-link wrapper instead.
+        assert "notification-link" not in html
+        assert f'id="notification-wrapper-{_NOTIF_ID}"' in html
+
+    def test_diacritic_relative_link_still_renders_as_href(self):
+        """Don't over-reject: a legitimate Estonian path renders as a link."""
+        notif = _make_notification(read=False, link="/märkused/123")
+
+        html = to_xml(NotificationItem(notif))
+
+        assert "notification-link" in html
+
 
 class TestIsSafeRedirect:
     """#848: the open-redirect guard must reject backslash variants that
@@ -414,11 +437,36 @@ class TestIsSafeRedirect:
         assert _is_safe_redirect("javascript:alert(1)") is False
         assert _is_safe_redirect("") is False
 
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "/foo\x00bar",  # NUL
+            "/foo\x7fbar",  # DEL
+            "/foo\tbar",  # tab
+            "/foo\nbar",  # newline
+            "/foo\rbar",  # carriage return
+            "/foo bar",  # space
+        ],
+    )
+    def test_rejects_control_bytes_in_same_origin_path(self, target: str):
+        """#848 round-3: align with the absolute-URL helper — raw
+        control/whitespace bytes in a redirect target are rejected."""
+        from app.notifications.routes import _is_safe_redirect
+
+        assert _is_safe_redirect(target) is False
+
     def test_accepts_same_origin_relative_path(self):
         from app.notifications.routes import _is_safe_redirect
 
         assert _is_safe_redirect("/drafts/abc") is True
         assert _is_safe_redirect("/admin/costs") is True
+
+    def test_accepts_estonian_diacritic_path(self):
+        """Don't over-reject legitimate non-ASCII (raw and percent-encoded)."""
+        from app.notifications.routes import _is_safe_redirect
+
+        assert _is_safe_redirect("/märkused") is True
+        assert _is_safe_redirect("/m%C3%A4rkused") is True
 
 
 class TestIsSafeLink:
@@ -432,6 +480,19 @@ class TestIsSafeLink:
         assert _is_safe_link("/\\evil.example") is False
         assert _is_safe_link(None) is False
         assert _is_safe_link("") is False
+
+    @pytest.mark.parametrize("ctrl", ["\x00", "\x7f", "\t", "\n", "\r", " "])
+    def test_rejects_control_bytes_in_relative_branch(self, ctrl: str):
+        """#848 round-3: the relative-path branch inherits the control-byte
+        rejection from ``_is_safe_redirect``."""
+        from app.notifications.routes import _is_safe_link
+
+        assert _is_safe_link(f"/drafts/{ctrl}evil") is False
+
+    def test_accepts_estonian_diacritic_path(self):
+        from app.notifications.routes import _is_safe_link
+
+        assert _is_safe_link("/märkused") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_safe_url.py
+++ b/tests/test_safe_url.py
@@ -9,7 +9,46 @@ from __future__ import annotations
 
 import pytest
 
-from app.ui.safe_url import is_safe_http_url, quote_uri_param
+from app.ui.safe_url import has_unsafe_chars, is_safe_http_url, quote_uri_param
+
+# ---------------------------------------------------------------------------
+# has_unsafe_chars — shared control/whitespace policy (#848 round-3 review)
+# ---------------------------------------------------------------------------
+
+
+class TestHasUnsafeChars:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "/foo\x00bar",  # NUL
+            "/foo\x7fbar",  # DEL
+            "/foo\tbar",  # tab
+            "/foo\nbar",  # newline
+            "/foo\rbar",  # carriage return
+            "/foo bar",  # space
+            "java\tscript:alert(1)",
+            "\x00",
+            "https://example.org/\x1f",  # C0 control
+        ],
+    )
+    def test_raw_control_or_whitespace_flagged(self, value: str):
+        assert has_unsafe_chars(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "/drafts/abc",
+            "/märkused",  # raw Estonian diacritics — must NOT be flagged
+            "/m%C3%A4rkused",  # percent-encoded diacritics
+            "https://example.org/entity/1",
+            "https://example.org/a?b=1&c#frag",  # reserved chars are fine
+            "õäöü",
+            "",
+        ],
+    )
+    def test_clean_values_not_flagged(self, value: str):
+        assert has_unsafe_chars(value) is False
+
 
 # ---------------------------------------------------------------------------
 # is_safe_http_url — accepted values

--- a/tests/test_safe_url.py
+++ b/tests/test_safe_url.py
@@ -1,0 +1,116 @@
+"""Tests for ``app.ui.safe_url`` — the shared safe-href / open-redirect guard.
+
+Issue #848 (P0, review ID C4): block stored XSS via ``javascript:`` (and
+friends) URLs landing in ``href`` attributes we control, plus the related
+protocol-relative / backslash-normalised open-redirect vectors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ui.safe_url import is_safe_http_url, quote_uri_param
+
+# ---------------------------------------------------------------------------
+# is_safe_http_url — accepted values
+# ---------------------------------------------------------------------------
+
+
+class TestIsSafeHttpUrlAccepts:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://example.org/entity/1",
+            "http://example.org/entity/1",
+            # Real ontology / legal identifiers use bare http and #fragments.
+            "https://www.riigiteataja.ee/akt/13201407",
+            "http://data.europa.eu/eli/dir/2016/680/oj",
+            "https://example.org/ns#HKTS_Par_13",
+            "https://example.org:8443/path?q=1&x=2#frag",
+            "HTTPS://EXAMPLE.ORG/UPPER",  # scheme is case-insensitive
+        ],
+    )
+    def test_valid_http_urls_accepted(self, url: str):
+        assert is_safe_http_url(url) is True
+
+
+# ---------------------------------------------------------------------------
+# is_safe_http_url — rejected values (the attack matrix from the DoD)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSafeHttpUrlRejects:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Dangerous schemes
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "  javascript:alert(1)",  # leading whitespace + scheme
+            "data:text/html,<script>alert(1)</script>",
+            "data:text/html;base64,PHNjcmlwdD4=",
+            "vbscript:msgbox(1)",
+            "file:///etc/passwd",
+            "mailto:evil@example.org",
+            # Protocol-relative — browsers inherit page scheme, navigate off-site
+            "//evil.example",
+            "//evil.example/path",
+            # Backslash variants — browsers normalise \ to /
+            "/\\evil.example",
+            "\\\\evil.example",
+            "https:/\\evil.example",
+            "https://good.example\\@evil.example",
+            # Embedded control/whitespace that browsers strip before acting
+            "java\tscript:alert(1)",
+            "java\nscript:alert(1)",
+            "http://exa mple.org/path",
+            "https://example.org/\x00",
+            # Relative / scheme-less
+            "/dashboard",
+            "dashboard",
+            "example.org/path",
+            "../../etc/passwd",
+            "#frag",
+            "?q=1",
+            # No host
+            "http://",
+            "https:///path",
+            # Empty-ish
+            "",
+            "   ",
+            None,
+        ],
+    )
+    def test_unsafe_values_rejected(self, url: str | None):
+        assert is_safe_http_url(url) is False
+
+
+# ---------------------------------------------------------------------------
+# quote_uri_param
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteUriParam:
+    def test_encodes_reserved_characters(self):
+        # &, #, ? must all be percent-encoded so they can't truncate a query.
+        encoded = quote_uri_param("https://example.org/a?b=1&c#frag")
+        assert "&" not in encoded
+        assert "#" not in encoded
+        assert "?" not in encoded
+        assert "%3F" in encoded  # ?
+        assert "%26" in encoded  # &
+        assert "%23" in encoded  # #
+
+    def test_encodes_slashes(self):
+        # safe="" means even '/' is encoded — it's a single param value.
+        assert quote_uri_param("https://example.org/x") == quote_uri_param("https://example.org/x")
+        assert "/" not in quote_uri_param("https://example.org/x")
+
+    def test_roundtrips_via_unquote(self):
+        from urllib.parse import unquote
+
+        uri = "https://example.org/ns#Par_13?x=1&y=2"
+        assert unquote(quote_uri_param(uri)) == uri
+
+    def test_empty_input_returns_empty(self):
+        assert quote_uri_param("") == ""


### PR DESCRIPTION
## Summary

Closes the P0 stored-XSS vector in `/api/bookmarks` (review ID C4) plus two same-class siblings flagged in the ticket review, behind one shared safe-href helper.

A user-controlled bookmark `entity_uri` was stored unvalidated and the dashboard rendered it as `A(uri, href=uri)`. FastHTML escapes attribute *values* but does not strip dangerous *schemes*, so a `javascript:` href became stored XSS on dashboard load. The same class of bug lurked in notification link rendering and the global-search deep link.

### Changes
- **New `app/ui/safe_url.py`** — the single place that answers "is this URL safe to put in an `href` we control?":
  - `is_safe_http_url(value)` — allows only absolute `http(s)://` URLs with a host; rejects `javascript:`/`data:`/`vbscript:`/`file:`/`mailto:`, protocol-relative `//host`, backslash variants (`/\evil`, `\\evil`, `https:/\evil` — browsers normalise `\` → `/`), embedded whitespace/control chars, and empty/relative values.
  - `quote_uri_param(uri)` — `quote(uri, safe="")` helper for deep-link query params.
  - Documented as deliberately separate from the SPARQL-shaped `explorer.routes._validate_uri` (different question: SPARQL-injection vs href-safety) so the two policies can't silently drift.
- **`app/templates/dashboard.py`** — bookmark POST validates `entity_uri` before insert → clear `400` with an Estonian message (`Vigane URI. Lubatud on ainult http:// või https:// aadressid.`) and no row persisted (XHR callers get `{"ok": false, "error": "invalid_uri", ...}`); the dashboard render path shows unsafe legacy rows as plain `<span>` text, never as an `href`.
- **`app/notifications/routes.py`** — notification links gated on a combined safe-link policy (same-origin relative path **or** absolute `http(s)://`) so a future user-influenced `notify()` link can't become a `javascript:` vector; `_is_safe_redirect` now rejects backslash-normalised open-redirect targets (`/\evil.com` → `//evil.com`).
- **`app/ui/components/global_search.py`** — `?focus=` deep link now URL-encodes the URI so `&`/`#`/`?` can't truncate the query string and land on the wrong focus.

## Definition of Done

- [x] Bookmark creation validates `entity_uri` server-side before insert.
- [x] Only safe URI schemes accepted (`http`/`https` only; `javascript:`/`data:`/protocol-relative/backslash/empty/relative rejected).
- [x] Validation centralized in `app/ui/safe_url.py`; explorer's SPARQL validator left untouched, with the two distinct policies documented so they don't drift.
- [x] Invalid submissions return a clear `4xx` (Estonian) and persist no row.
- [x] Dashboard rendering never emits an unsafe `href`, even for legacy bad data.
- [x] Tests: `javascript:alert(1)`, `data:text/html,...`, `//evil.example`, `/\evil.example`, blank, relative all rejected.
- [x] Tests: valid ontology/entity URLs still save and render.
- [x] Regression test proving pre-existing unsafe bookmark data is not rendered as an executable link.
- [x] Lint/type/test baseline green.

**Review siblings folded in (per the ticket review comment):**
- [x] `notifications/routes.py` — `notif.link` href gated on the new helper; `_is_safe_redirect` backslash rejection.
- [x] `global_search.py` — focus param URL-encoded.

## Test evidence

- New `tests/test_safe_url.py` — full accept/reject attack matrix for `is_safe_http_url` + `quote_uri_param` encoding/roundtrip.
- `tests/test_dashboard.py` — `TestBookmarkUriValidation` (XHR + plain-form reject → `400`, no insert, no audit log; valid URIs inserted with trim) and `TestBookmarkRenderGuard` (legacy `javascript:` row renders as muted `<span>`, safe row renders as link).
- `tests/test_notifications_routes.py` — `TestNotificationLinkGating` (unsafe link never rendered as href; safe relative/absolute links still render) + `TestIsSafeRedirect`/`TestIsSafeLink` + a `mark_single_read` backslash-redirect rejection test.
- `tests/test_global_search.py` — focus-param URL-encoding assertions (incl. an `&`/`#`/`?`-laden URI).

Full suite: **3868 passed, 45 skipped**. `ruff check .` and `pyright` both clean.

## Deviations

- The DoD says "prefer `https://` and, if needed, explicitly justified `http://`". Bare `http://` is allowed (alongside `https://`) because the ontology source data and many Riigi Teataja / EUR-Lex identifiers use bare `http://` URIs — rejecting it would break legitimate existing bookmarks. This is documented in `safe_url.py`.
- Notification links use a *combined* policy (relative-path OR absolute-http(s)) rather than `is_safe_http_url` alone, because every current `notify()` caller emits same-origin relative paths (`/drafts/...`); gating on `is_safe_http_url` alone would have broken all existing notification links.
- The optional "one-off cleanup of legacy non-http(s) bookmark rows" from the review was left out of scope; the render-side guard makes such rows safe, and a data migration is out of this PR's file scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)