### PR TITLE
fix(security): scrub tokens and Estonian PII from Sentry telemetry (#846)

### DIFF
--- a/app/llm/scrubber.py
+++ b/app/llm/scrubber.py
@@ -1,11 +1,12 @@
 """PII / secret scrubbing for LLM prompt payloads.
 
-NFR §7.1 requires emails, phone numbers, UUIDs, and secret-like tokens
-to be redacted *before* prompts are sent to third-party LLM providers
-such as Anthropic. This module is the single source of truth for that
-regex set — ``app.observability._scrub_pii`` (Sentry ``before_send``)
-also consumes :data:`SCRUB_PATTERNS` so we never drift between the two
-egress paths.
+NFR §7.1 requires emails, phone numbers, UUIDs, Estonian personal
+identification codes (isikukood), Estonian IBANs, and secret-like
+tokens to be redacted *before* prompts are sent to third-party LLM
+providers such as Anthropic. This module is the single source of truth
+for that regex set — ``app.observability._scrub_pii`` (Sentry
+``before_send`` / ``before_send_transaction``) also consumes
+:data:`SCRUB_PATTERNS` so we never drift between the two egress paths.
 
 Public surface
 ==============
@@ -76,13 +77,32 @@ _PEM_RE = re.compile(r"-----BEGIN [A-Z0-9 ]+-----[\s\S]+?-----END [A-Z0-9 ]+----
 _JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
 _TOKEN_RE = re.compile(r"\b(?:sk|pk)[-_][A-Za-z0-9_-]{16,}\b")
 
+# Estonian personal identification code (isikukood): GYYMMDDSSSC —
+# first digit 1-6 encodes century + sex, then birth date (YYMMDD),
+# 3-digit serial, 1 checksum digit. 11 digits total. The month/day
+# constraints ([01]\d and [0-3]\d) keep random 11-digit numbers from
+# matching. For a system processing Estonian legal text this is the
+# primary PII class reaching third parties (issue #846).
+_ISIKUKOOD_RE = re.compile(r"\b[1-6]\d{2}[01]\d[0-3]\d{5}\b")
+
+# Estonian IBAN: ``EE`` + 2 check digits + 16-digit BBAN (20 chars).
+# Tolerates the conventional 4-digit grouping (``EE38 2200 2210 2014
+# 5685``) as well as the compact form required by issue #846.
+_EE_IBAN_RE = re.compile(r"\bEE\d{2}(?:\s?\d{4}){4}\b")
+
 
 SCRUB_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # PEM first so inner lines aren't nibbled by other patterns.
     (_PEM_RE, "[REDACTED_KEY]"),
     (_JWT_RE, "[REDACTED_TOKEN]"),
     (_TOKEN_RE, "[REDACTED_TOKEN]"),
+    # Email before isikukood so ``38501010002@example.com`` collapses
+    # to a single [REDACTED_EMAIL] instead of a half-redacted local part.
     (_EMAIL_RE, "[REDACTED_EMAIL]"),
+    (_EE_IBAN_RE, "[REDACTED_IBAN]"),
+    # Isikukood before phone: a bare ``372…``-prefixed isikukood would
+    # otherwise be mislabelled as an Estonian phone number.
+    (_ISIKUKOOD_RE, "[REDACTED_ISIKUKOOD]"),
     (_PHONE_RE, "[REDACTED_PHONE]"),
     (_UUID_RE, "[REDACTED_UUID]"),
 ]

--- a/app/observability.py
+++ b/app/observability.py
@@ -56,11 +56,13 @@ _QUERY_PAIR_RE = re.compile(r"(^|[?&;\s])([A-Za-z0-9_.\-]+)=([^&;#\s]+)")
 # param, form field, header, breadcrumb-data key or stack-frame local.
 # Suffix matching requires a separator (``api_key``, ``x-auth-token``)
 # or exact match (``token``) so benign names like ``status_code`` or
-# ``monkey`` survive.
+# ``monkey`` survive. Plural forms (``tokens``, ``keys``…) are covered
+# because bulk-credential collections are a real payload shape.
 _SENSITIVE_NAME_RE = re.compile(
     r"(?i)(?:^|[._\-])"
-    r"(?:token|secret|password|passwd|pwd|key|apikey|auth|authorization"
-    r"|session|sessionid|signature|sig|jwt|bearer|otp|credentials?)$"
+    r"(?:tokens?|secrets?|passwords?|passwd|pwd|keys?|apikeys?|auth"
+    r"|authorization|sessions?|sessionid|signatures?|sig|jwt|bearer"
+    r"|otp|credentials?)$"
 )
 
 # Query-param-only sensitive names: OAuth/OIDC ``code`` + ``state`` and
@@ -122,13 +124,63 @@ def _scrub_text(value: str) -> str:
     return scrub_prompt(value)
 
 
-def _scrub_str_dict(data: dict[str, Any]) -> None:
-    """In-place: redact sensitive keys, scrub remaining string values."""
-    for key in list(data.keys()):
-        if _is_sensitive_key(key):
-            data[key] = _REDACTED_KEY
-        elif isinstance(data[key], str):
-            data[key] = _scrub_text(data[key])
+# Containers nested deeper than this are replaced wholesale: we cannot
+# verify they are clean, so fail closed. Sentry's own serializer
+# truncates well before this depth, so real telemetry is unaffected.
+_MAX_SCRUB_DEPTH = 20
+
+
+def _deep_scrub(value: Any, _depth: int = 0, _seen: set[int] | None = None) -> Any:
+    """Recursively scrub *value*: dicts, lists, tuples and strings.
+
+    Review finding on #846: a shallow helper only rewrote *top-level*
+    string values, so nested JSON-like payloads (request bodies,
+    breadcrumb/span data, stack-frame locals) still shipped tokens and
+    Estonian PII verbatim. This walks the whole structure:
+
+    - ``str`` values run through :func:`_scrub_text`.
+    - Dict entries whose key matches the sensitive-name rules are
+      redacted wholesale, regardless of the value's type or depth.
+    - Dicts and lists are mutated in place (and returned) so shared
+      references inside cyclic payloads observe the scrubbed content;
+      tuples are immutable and therefore rebuilt.
+    - An ``id()``-based visited guard stops infinite recursion on
+      self-referential structures. Skipping a revisit is sound because
+      mutable containers are scrubbed in place exactly once. Tuples
+      are deliberately *not* guarded (a reference cycle cannot consist
+      of tuples alone) so a tuple shared between two branches is still
+      rebuilt scrubbed at each site.
+    - Containers nested beyond ``_MAX_SCRUB_DEPTH`` are replaced with
+      the redaction marker — fail closed rather than ship unverified
+      data.
+    """
+    if isinstance(value, str):
+        return _scrub_text(value)
+    if not isinstance(value, (dict, list, tuple)):
+        return value
+    if _depth >= _MAX_SCRUB_DEPTH:
+        return _REDACTED_KEY
+    if _seen is None:
+        _seen = set()
+
+    if isinstance(value, tuple):
+        return tuple(_deep_scrub(item, _depth + 1, _seen) for item in value)
+
+    if id(value) in _seen:
+        return value
+    _seen.add(id(value))
+
+    if isinstance(value, dict):
+        for key in list(value.keys()):
+            if isinstance(key, str) and _is_sensitive_key(key):
+                value[key] = _REDACTED_KEY
+            else:
+                value[key] = _deep_scrub(value[key], _depth + 1, _seen)
+        return value
+
+    for index in range(len(value)):
+        value[index] = _deep_scrub(value[index], _depth + 1, _seen)
+    return value
 
 
 def _scrub_request(event: dict[str, Any]) -> None:
@@ -155,13 +207,13 @@ def _scrub_request(event: dict[str, Any]) -> None:
         # Authorization / Cookie / X-Api-Key → redacted via the key
         # check; Referer and friends get URL scrubbing via the value
         # branch so token-bearing referrers don't slip through.
-        _scrub_str_dict(headers)
+        _deep_scrub(headers)
 
+    # Body can be a form dict, nested JSON structure, list-of-dicts or
+    # a raw string — deep-scrub handles every shape.
     data = request.get("data")
-    if isinstance(data, dict):
-        _scrub_str_dict(data)
-    elif isinstance(data, str):
-        request["data"] = _scrub_text(data)
+    if data is not None:
+        request["data"] = _deep_scrub(data)
 
 
 def _scrub_breadcrumbs(event: dict[str, Any]) -> None:
@@ -177,8 +229,8 @@ def _scrub_breadcrumbs(event: dict[str, Any]) -> None:
         if not isinstance(breadcrumb, dict):
             continue
         data = breadcrumb.get("data")
-        if isinstance(data, dict):
-            _scrub_str_dict(data)
+        if data is not None:
+            breadcrumb["data"] = _deep_scrub(data)
         message = breadcrumb.get("message")
         if isinstance(message, str):
             breadcrumb["message"] = _scrub_text(message)
@@ -196,23 +248,44 @@ def _scrub_spans(event: dict[str, Any]) -> None:
         if isinstance(description, str):
             span["description"] = _scrub_text(description)
         data = span.get("data")
-        if isinstance(data, dict):
-            _scrub_str_dict(data)
+        if data is not None:
+            span["data"] = _deep_scrub(data)
 
 
-def _scrub_exception(event: dict[str, Any]) -> None:
-    """Scrub stack-frame local variables on exception events."""
-    exception_info = event.get("exception")
-    if not exception_info:
-        return
-    for exc_value in exception_info.get("values", []):
-        stacktrace = exc_value.get("stacktrace")
-        if not stacktrace:
+def _scrub_stack_vars(event: dict[str, Any]) -> None:
+    """Scrub captured frame locals — the classic Sentry leak vector.
+
+    The SDK captures local variables by default, so any token /
+    isikukood / IBAN held in a variable at crash time ships with the
+    event. Covers both ``exception.values[*]`` and the
+    ``threads.values[*]`` equivalent, in dict-with-``values`` and
+    bare-list protocol shapes.
+    """
+    for section in ("exception", "threads"):
+        info = event.get(section)
+        if isinstance(info, dict):
+            entries = info.get("values", [])
+        elif isinstance(info, list):
+            entries = info
+        else:
             continue
-        for frame in stacktrace.get("frames", []):
-            local_vars = frame.get("vars")
-            if isinstance(local_vars, dict):
-                _scrub_str_dict(local_vars)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            stacktrace = entry.get("stacktrace")
+            if not isinstance(stacktrace, dict):
+                continue
+            frames = stacktrace.get("frames", [])
+            if not isinstance(frames, list):
+                continue
+            for frame in frames:
+                if not isinstance(frame, dict):
+                    continue
+                local_vars = frame.get("vars")
+                if local_vars is not None:
+                    frame["vars"] = _deep_scrub(local_vars)
 
 
 def _scrub_logentry(event: dict[str, Any]) -> None:
@@ -225,12 +298,8 @@ def _scrub_logentry(event: dict[str, Any]) -> None:
         if isinstance(value, str):
             logentry[field] = _scrub_text(value)
     params = logentry.get("params")
-    if isinstance(params, list):
-        logentry["params"] = [
-            _scrub_text(param) if isinstance(param, str) else param for param in params
-        ]
-    elif isinstance(params, dict):
-        _scrub_str_dict(params)
+    if params is not None:
+        logentry["params"] = _deep_scrub(params)
 
 
 def _get_git_sha() -> str:
@@ -263,12 +332,14 @@ def _scrub_pii(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | 
     ``before_send_transaction`` (performance events) so the two egress
     paths share one implementation (issue #846). Strips ``user``
     context entirely, scrubs the request envelope (URL, query string,
-    headers, cookies, body), redacts sensitive keys in breadcrumb
-    data / span data / stack-frame locals, and runs every free-form
-    string through :func:`app.llm.scrubber.scrub_prompt` so emails,
-    phone numbers, UUIDs, Estonian isikukoodid, EE IBANs and
-    secret-like tokens are redacted with the same regex set the LLM
-    egress path uses (NFR §7.1).
+    headers, cookies, body), deep-scrubs every arbitrary structure the
+    protocol carries (breadcrumb data, span data, ``extra``,
+    ``contexts``, exception/thread stack-frame locals — at any nesting
+    depth), and runs every free-form string through
+    :func:`app.llm.scrubber.scrub_prompt` so emails, phone numbers,
+    UUIDs, Estonian isikukoodid, EE IBANs and secret-like tokens are
+    redacted with the same regex set the LLM egress path uses
+    (NFR §7.1).
     """
     # Remove top-level user context so emails/names never reach Sentry.
     event.pop("user", None)
@@ -276,8 +347,16 @@ def _scrub_pii(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | 
     _scrub_request(event)
     _scrub_breadcrumbs(event)
     _scrub_spans(event)
-    _scrub_exception(event)
+    _scrub_stack_vars(event)
     _scrub_logentry(event)
+
+    # Free-form attachment points: ``extra`` is arbitrary user data,
+    # ``contexts`` carries trace/runtime metadata whose identifiers
+    # (32-hex trace_id, 16-hex span_id) survive _scrub_text untouched.
+    for section in ("extra", "contexts"):
+        value = event.get(section)
+        if isinstance(value, (dict, list)):
+            _deep_scrub(value)
 
     return event
 

--- a/app/observability.py
+++ b/app/observability.py
@@ -12,10 +12,225 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request / URL scrubbing (issue #846)
+# ---------------------------------------------------------------------------
+#
+# With ``traces_sample_rate=0.1`` roughly 10% of requests ship to Sentry
+# SaaS as transaction events carrying the full request URL — including
+# ``/auth/reset/<token_hex(32)>`` clicks and ``?token=`` signed report
+# downloads. The helpers below redact bearer credentials from URLs,
+# query strings, headers, cookies and form bodies while keeping the
+# route context (host, path, benign params) intact so events stay
+# debuggable. They are shared by ``before_send`` (error events),
+# ``before_send_transaction`` (performance events) and the breadcrumb /
+# span / stack-frame scrubbers so all egress paths use one
+# implementation.
+
+# Placeholder for values redacted inside free-form strings (paths,
+# query-param values). Dict-key redaction keeps the pre-existing
+# ``[Redacted]`` marker for backwards compatibility.
+_REDACTED_VALUE = "[redacted]"
+_REDACTED_KEY = "[Redacted]"
+
+# Path segments following these route prefixes are single-use bearer
+# credentials (password-reset tokens are ``secrets.token_hex(32)``).
+_TOKEN_PATH_RE = re.compile(r"(/auth/reset/)[^/?#\s]+")
+
+# Any path segment of 32+ hex chars is token-shaped — UUIDs keep their
+# dashes and Estonian slugs are not hex, so this never hits a segment
+# we need for debugging. Catch-all for future token-in-path routes.
+_HEX_SEGMENT_RE = re.compile(r"(/)[0-9a-fA-F]{32,}(?=[/?#.,\s]|$)")
+
+# ``name=value`` pairs in query strings / form bodies / log lines.
+_QUERY_PAIR_RE = re.compile(r"(^|[?&;\s])([A-Za-z0-9_.\-]+)=([^&;#\s]+)")
+
+# Names whose values are credentials when they appear as a query
+# param, form field, header, breadcrumb-data key or stack-frame local.
+# Suffix matching requires a separator (``api_key``, ``x-auth-token``)
+# or exact match (``token``) so benign names like ``status_code`` or
+# ``monkey`` survive.
+_SENSITIVE_NAME_RE = re.compile(
+    r"(?i)(?:^|[._\-])"
+    r"(?:token|secret|password|passwd|pwd|key|apikey|auth|authorization"
+    r"|session|sessionid|signature|sig|jwt|bearer|otp|credentials?)$"
+)
+
+# Query-param-only sensitive names: OAuth/OIDC ``code`` + ``state`` and
+# the single-use chat-seed token. Kept out of the shared regex so a
+# stack-frame local called ``state`` or ``code`` is not nuked.
+_SENSITIVE_PARAMS_EXACT = frozenset({"code", "state", "seed"})
+
+# Dict-key-only sensitive names (headers, frame vars, form fields).
+_SENSITIVE_KEYS_EXACT = frozenset(
+    {
+        "email",
+        "full_name",
+        "isikukood",
+        "cookie",
+        "set-cookie",
+        "x-csrftoken",
+        "x-csrf-token",
+        "x-xsrf-token",
+    }
+)
+
+
+def _is_sensitive_param(name: str) -> bool:
+    """True when a query/form param *name* carries a credential."""
+    lowered = name.lower()
+    return lowered in _SENSITIVE_PARAMS_EXACT or bool(_SENSITIVE_NAME_RE.search(lowered))
+
+
+def _is_sensitive_key(name: str) -> bool:
+    """True when a dict key (header, frame var, body field) is sensitive."""
+    lowered = name.lower()
+    return lowered in _SENSITIVE_KEYS_EXACT or bool(_SENSITIVE_NAME_RE.search(lowered))
+
+
+def _redact_sensitive_params(text: str) -> str:
+    """Redact values of sensitive ``name=value`` pairs inside *text*."""
+
+    def _sub(match: re.Match[str]) -> str:
+        if _is_sensitive_param(match.group(2)):
+            return f"{match.group(1)}{match.group(2)}={_REDACTED_VALUE}"
+        return match.group(0)
+
+    return _QUERY_PAIR_RE.sub(_sub, text)
+
+
+def _scrub_text(value: str) -> str:
+    """Scrub one free-form string: token paths, query params, PII regexes.
+
+    This is the single implementation shared by request URLs, query
+    strings, headers, form bodies, breadcrumb messages/data, span
+    descriptions and stack-frame locals — for both error events and
+    transaction events.
+    """
+    from app.llm.scrubber import scrub_prompt
+
+    value = _TOKEN_PATH_RE.sub(rf"\g<1>{_REDACTED_VALUE}", value)
+    value = _HEX_SEGMENT_RE.sub(rf"\g<1>{_REDACTED_VALUE}", value)
+    value = _redact_sensitive_params(value)
+    return scrub_prompt(value)
+
+
+def _scrub_str_dict(data: dict[str, Any]) -> None:
+    """In-place: redact sensitive keys, scrub remaining string values."""
+    for key in list(data.keys()):
+        if _is_sensitive_key(key):
+            data[key] = _REDACTED_KEY
+        elif isinstance(data[key], str):
+            data[key] = _scrub_text(data[key])
+
+
+def _scrub_request(event: dict[str, Any]) -> None:
+    """Scrub ``event["request"]`` — url, query_string, headers, cookies, data."""
+    request = event.get("request")
+    if not isinstance(request, dict):
+        return
+
+    url = request.get("url")
+    if isinstance(url, str):
+        request["url"] = _scrub_text(url)
+
+    query_string = request.get("query_string")
+    if isinstance(query_string, str):
+        request["query_string"] = _scrub_text(query_string)
+
+    # Cookies are session credentials wholesale (JWT cookie auth) —
+    # there is no debugging value in any individual cookie.
+    if request.get("cookies"):
+        request["cookies"] = _REDACTED_KEY
+
+    headers = request.get("headers")
+    if isinstance(headers, dict):
+        # Authorization / Cookie / X-Api-Key → redacted via the key
+        # check; Referer and friends get URL scrubbing via the value
+        # branch so token-bearing referrers don't slip through.
+        _scrub_str_dict(headers)
+
+    data = request.get("data")
+    if isinstance(data, dict):
+        _scrub_str_dict(data)
+    elif isinstance(data, str):
+        request["data"] = _scrub_text(data)
+
+
+def _scrub_breadcrumbs(event: dict[str, Any]) -> None:
+    """Scrub breadcrumb messages and data (httpx/log crumbs carry URLs)."""
+    crumbs = event.get("breadcrumbs")
+    if isinstance(crumbs, dict):
+        values = crumbs.get("values", [])
+    elif isinstance(crumbs, list):  # older SDK shape
+        values = crumbs
+    else:
+        values = []
+    for breadcrumb in values:
+        if not isinstance(breadcrumb, dict):
+            continue
+        data = breadcrumb.get("data")
+        if isinstance(data, dict):
+            _scrub_str_dict(data)
+        message = breadcrumb.get("message")
+        if isinstance(message, str):
+            breadcrumb["message"] = _scrub_text(message)
+
+
+def _scrub_spans(event: dict[str, Any]) -> None:
+    """Scrub span descriptions/data — outbound httpx URLs in transactions."""
+    spans = event.get("spans")
+    if not isinstance(spans, list):
+        return
+    for span in spans:
+        if not isinstance(span, dict):
+            continue
+        description = span.get("description")
+        if isinstance(description, str):
+            span["description"] = _scrub_text(description)
+        data = span.get("data")
+        if isinstance(data, dict):
+            _scrub_str_dict(data)
+
+
+def _scrub_exception(event: dict[str, Any]) -> None:
+    """Scrub stack-frame local variables on exception events."""
+    exception_info = event.get("exception")
+    if not exception_info:
+        return
+    for exc_value in exception_info.get("values", []):
+        stacktrace = exc_value.get("stacktrace")
+        if not stacktrace:
+            continue
+        for frame in stacktrace.get("frames", []):
+            local_vars = frame.get("vars")
+            if isinstance(local_vars, dict):
+                _scrub_str_dict(local_vars)
+
+
+def _scrub_logentry(event: dict[str, Any]) -> None:
+    """Scrub log-derived events — providers log reset links verbatim."""
+    logentry = event.get("logentry")
+    if not isinstance(logentry, dict):
+        return
+    for field in ("message", "formatted"):
+        value = logentry.get(field)
+        if isinstance(value, str):
+            logentry[field] = _scrub_text(value)
+    params = logentry.get("params")
+    if isinstance(params, list):
+        logentry["params"] = [
+            _scrub_text(param) if isinstance(param, str) else param for param in params
+        ]
+    elif isinstance(params, dict):
+        _scrub_str_dict(params)
 
 
 def _get_git_sha() -> str:
@@ -42,48 +257,27 @@ def _get_git_sha() -> str:
 
 
 def _scrub_pii(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
-    """Remove PII (emails, names, tokens) from Sentry events before send.
+    """Remove PII and bearer credentials from Sentry events before send.
 
-    Strips ``user`` context entirely, redacts any ``email`` /
-    ``full_name`` / ``password`` / ``token`` keys in breadcrumb data
-    and stack-frame locals, and additionally runs :func:`scrub_prompt`
-    over all free-form string values so emails, phone numbers, UUIDs
-    and secret-like tokens that leaked into logs are redacted using
-    the same regex set the LLM egress path uses (NFR §7.1).
+    Registered as both ``before_send`` (error events) and
+    ``before_send_transaction`` (performance events) so the two egress
+    paths share one implementation (issue #846). Strips ``user``
+    context entirely, scrubs the request envelope (URL, query string,
+    headers, cookies, body), redacts sensitive keys in breadcrumb
+    data / span data / stack-frame locals, and runs every free-form
+    string through :func:`app.llm.scrubber.scrub_prompt` so emails,
+    phone numbers, UUIDs, Estonian isikukoodid, EE IBANs and
+    secret-like tokens are redacted with the same regex set the LLM
+    egress path uses (NFR §7.1).
     """
-    from app.llm.scrubber import scrub_prompt
-
     # Remove top-level user context so emails/names never reach Sentry.
     event.pop("user", None)
 
-    # Scrub breadcrumb data values.
-    for breadcrumb in event.get("breadcrumbs", {}).get("values", []):
-        data = breadcrumb.get("data")
-        if isinstance(data, dict):
-            for key in list(data.keys()):
-                if key in ("email", "full_name", "password", "token"):
-                    data[key] = "[Redacted]"
-                elif isinstance(data[key], str):
-                    data[key] = scrub_prompt(data[key])
-        message = breadcrumb.get("message")
-        if isinstance(message, str):
-            breadcrumb["message"] = scrub_prompt(message)
-
-    # Scrub exception frame local variables.
-    exception_info = event.get("exception")
-    if exception_info:
-        for exc_value in exception_info.get("values", []):
-            stacktrace = exc_value.get("stacktrace")
-            if not stacktrace:
-                continue
-            for frame in stacktrace.get("frames", []):
-                local_vars = frame.get("vars")
-                if isinstance(local_vars, dict):
-                    for key in list(local_vars.keys()):
-                        if key in ("email", "full_name", "password", "token"):
-                            local_vars[key] = "[Redacted]"
-                        elif isinstance(local_vars[key], str):
-                            local_vars[key] = scrub_prompt(local_vars[key])
+    _scrub_request(event)
+    _scrub_breadcrumbs(event)
+    _scrub_spans(event)
+    _scrub_exception(event)
+    _scrub_logentry(event)
 
     return event
 
@@ -107,5 +301,8 @@ def init_sentry() -> None:
         release=_get_git_sha(),
         environment=os.environ.get("APP_ENV", "development"),
         before_send=_scrub_pii,  # type: ignore[arg-type]  # Sentry stubs define Event as TypedDict
+        # Transactions sample real request URLs (reset links, signed
+        # download tokens) — scrub them with the same function (#846).
+        before_send_transaction=_scrub_pii,  # type: ignore[arg-type]
     )
     logger.info("Sentry initialized (release=%s)", _get_git_sha())

--- a/tests/test_llm_scrubber.py
+++ b/tests/test_llm_scrubber.py
@@ -1,8 +1,9 @@
 """Unit tests for :mod:`app.llm.scrubber`.
 
 Covers the pattern set required by NFR §7.1 (emails, Estonian / E.164
-phone numbers, UUIDs, PEM keys, JWT and ``sk-``/``pk_`` tokens), the
-``allow_raw`` opt-out, and the message-shape preservation contract of
+phone numbers, UUIDs, PEM keys, JWT and ``sk-``/``pk_`` tokens,
+Estonian isikukoodid and EE IBANs per issue #846), the ``allow_raw``
+opt-out, and the message-shape preservation contract of
 :func:`scrub_messages`.
 """
 
@@ -88,6 +89,65 @@ class TestScrubPromptPatterns:
         plain = "See on tavaline lause ilma isikuandmeteta."
         assert scrub_prompt(plain) == plain
 
+    # --- Estonian isikukood (#846) -------------------------------------
+
+    def test_isikukood_male_redacted(self) -> None:
+        out = scrub_prompt("kaebaja isikukood 38501010002 esitas taotluse")
+        assert "38501010002" not in out
+        assert out == "kaebaja isikukood [REDACTED_ISIKUKOOD] esitas taotluse"
+
+    def test_isikukood_female_2000s_redacted(self) -> None:
+        out = scrub_prompt("isik 60002290003 on registreeritud")
+        assert out == "isik [REDACTED_ISIKUKOOD] on registreeritud"
+
+    def test_isikukood_372_prefix_not_mislabelled_as_phone(self) -> None:
+        # A bare isikukood starting with 372 (male born 1972) must win
+        # over the Estonian phone pattern via list ordering.
+        out = scrub_prompt("isikukood 37201010002")
+        assert out == "isikukood [REDACTED_ISIKUKOOD]"
+
+    def test_invalid_isikukood_first_digit_unchanged(self) -> None:
+        # First digit 9 is not a valid century/sex digit.
+        plain = "number 99901010002 ei ole isikukood"
+        assert scrub_prompt(plain) == plain
+
+    def test_invalid_isikukood_month_unchanged(self) -> None:
+        # Month 91 fails the [01]\d constraint.
+        plain = "number 48191010002 ei ole isikukood"
+        assert scrub_prompt(plain) == plain
+
+    def test_isikukood_inside_longer_digit_run_unchanged(self) -> None:
+        plain = "viitenumber 3850101000212345 jääb alles"
+        assert scrub_prompt(plain) == plain
+
+    def test_isikukood_in_email_redacted_as_email(self) -> None:
+        out = scrub_prompt("kiri 38501010002@example.com saadetud")
+        assert out == "kiri [REDACTED_EMAIL] saadetud"
+
+    # --- Estonian IBAN (#846) ------------------------------------------
+
+    def test_ee_iban_compact_redacted(self) -> None:
+        out = scrub_prompt("konto EE382200221020145685 makse")
+        assert out == "konto [REDACTED_IBAN] makse"
+
+    def test_ee_iban_grouped_redacted(self) -> None:
+        out = scrub_prompt("konto EE38 2200 2210 2014 5685 makse")
+        assert out == "konto [REDACTED_IBAN] makse"
+
+    def test_short_ee_prefix_unchanged(self) -> None:
+        plain = "direktiiv EE12 3456 ei ole IBAN"
+        assert scrub_prompt(plain) == plain
+
+    def test_foreign_iban_unchanged(self) -> None:
+        # Only Estonian IBANs are in scope for the EE pattern.
+        plain = "konto SE3550000000054910000003"
+        assert scrub_prompt(plain) == plain
+
+    def test_phone_still_redacted_alongside_isikukood(self) -> None:
+        out = scrub_prompt("isik 38501010002, tel +37256789012")
+        assert "[REDACTED_ISIKUKOOD]" in out
+        assert "[REDACTED_PHONE]" in out
+
 
 class TestAllowRaw:
     def test_allow_raw_preserves_prompt(self) -> None:
@@ -169,4 +229,6 @@ class TestPatternList:
             "[REDACTED_UUID]",
             "[REDACTED_TOKEN]",
             "[REDACTED_KEY]",
+            "[REDACTED_ISIKUKOOD]",
+            "[REDACTED_IBAN]",
         }

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,4 +1,4 @@
-"""Tests for app.observability — Sentry init and PII scrubbing (#544)."""
+"""Tests for app.observability — Sentry init and PII scrubbing (#544, #846)."""
 
 from __future__ import annotations
 
@@ -107,6 +107,262 @@ class TestScrubPii:
         assert result is not None
 
 
+_RESET_TOKEN = "ab12cd34" * 8  # token_hex(32) → 64 hex chars
+
+
+class TestRequestScrubbing:
+    """#846 — event["request"] must never ship bearer credentials."""
+
+    def test_reset_path_redacted_in_url(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                "url": f"https://seadusloome.sixtyfour.ee/auth/reset/{_RESET_TOKEN}",
+                "method": "GET",
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["url"] == (
+            "https://seadusloome.sixtyfour.ee/auth/reset/[redacted]"
+        )
+        # Route context survives for debugging.
+        assert result["request"]["method"] == "GET"
+
+    def test_generic_hex_path_segment_redacted(self):
+        from app.observability import _scrub_pii
+
+        event = {"request": {"url": f"https://x.ee/files/{'deadbeef' * 4}/view"}}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["url"] == "https://x.ee/files/[redacted]/view"
+
+    def test_sensitive_query_params_redacted_in_url(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                # Home-grown signed download token: 2 b64url segments —
+                # the JWT regex does NOT match it, so param-name
+                # redaction is the only line of defence.
+                "url": ("https://x.ee/docs/raport?token=eyJkcmFmdF9pZCJ9.c2lnbmF0dXJl&vaade=koik")
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["url"] == ("https://x.ee/docs/raport?token=[redacted]&vaade=koik")
+
+    def test_query_string_field_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                "query_string": (
+                    "token=abc123&seed=550e8400-e29b-41d4-a716-446655440000&focus=estleg%3AKarS"
+                )
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["query_string"] == (
+            "token=[redacted]&seed=[redacted]&focus=estleg%3AKarS"
+        )
+
+    def test_auth_headers_redacted_benign_headers_kept(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                "headers": {
+                    "Authorization": "Bearer abc.def",
+                    "Cookie": "access_token=xyz",
+                    "X-Api-Key": "k-123456",
+                    "Referer": f"https://x.ee/auth/reset/{_RESET_TOKEN}?token=abc",
+                    "Accept": "text/html",
+                }
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        headers = result["request"]["headers"]
+        assert headers["Authorization"] == "[Redacted]"
+        assert headers["Cookie"] == "[Redacted]"
+        assert headers["X-Api-Key"] == "[Redacted]"
+        # Referer keeps the route but loses both credentials.
+        assert headers["Referer"] == ("https://x.ee/auth/reset/[redacted]?token=[redacted]")
+        assert headers["Accept"] == "text/html"
+
+    def test_cookies_redacted_wholesale(self):
+        from app.observability import _scrub_pii
+
+        event = {"request": {"cookies": {"access_token": "ey.x", "theme": "dark"}}}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["cookies"] == "[Redacted]"
+
+    def test_form_data_dict_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                "data": {
+                    "password": "hunter2",
+                    "email": "mari@example.ee",
+                    "comment": "isikukood 38501010002",
+                }
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        data = result["request"]["data"]
+        assert data["password"] == "[Redacted]"
+        assert data["email"] == "[Redacted]"
+        assert data["comment"] == "isikukood [REDACTED_ISIKUKOOD]"
+
+    def test_form_data_string_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {"request": {"data": "password=hunter2&note=ok"}}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["data"] == "password=[redacted]&note=ok"
+
+    def test_benign_request_kept_intact(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                "url": "https://x.ee/analyysikeskus/normi-mojuahel",
+                "query_string": "sisend=PS+%C2%A7+12&vaade=koik",
+                "method": "GET",
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["url"] == ("https://x.ee/analyysikeskus/normi-mojuahel")
+        assert result["request"]["query_string"] == "sisend=PS+%C2%A7+12&vaade=koik"
+
+
+class TestTransactionScrubbing:
+    """#846 — the same function must scrub transaction events and spans."""
+
+    def test_transaction_request_and_spans_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "type": "transaction",
+            "transaction": "/auth/reset/{token}",
+            "request": {"url": f"https://x.ee/auth/reset/{_RESET_TOKEN}"},
+            "spans": [
+                {
+                    "description": ("GET https://api.example.ee/callback?access_token=abc123"),
+                    "data": {
+                        "url": "https://api.example.ee/callback?access_token=abc123",
+                        "status_code": 200,
+                    },
+                }
+            ],
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["request"]["url"] == "https://x.ee/auth/reset/[redacted]"
+        span = result["spans"][0]
+        assert span["description"] == (
+            "GET https://api.example.ee/callback?access_token=[redacted]"
+        )
+        assert span["data"]["url"] == ("https://api.example.ee/callback?access_token=[redacted]")
+        # Useful telemetry survives.
+        assert span["data"]["status_code"] == 200
+        assert result["transaction"] == "/auth/reset/{token}"
+
+
+class TestBreadcrumbScrubbing:
+    """#846 — httpx/log breadcrumbs carry the same token-bearing URLs."""
+
+    def test_httpx_breadcrumb_url_redacted(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "breadcrumbs": {
+                "values": [
+                    {
+                        "category": "httplib",
+                        "data": {
+                            "url": "https://x.ee/download?token=tok-123",
+                            "method": "GET",
+                            "status_code": 200,
+                        },
+                    }
+                ]
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        data = result["breadcrumbs"]["values"][0]["data"]
+        assert data["url"] == "https://x.ee/download?token=[redacted]"
+        assert data["method"] == "GET"
+        assert data["status_code"] == 200
+
+    def test_breadcrumb_message_reset_link_redacted(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "breadcrumbs": {
+                "values": [
+                    {
+                        "message": (
+                            f"Password reset link sent: https://x.ee/auth/reset/{_RESET_TOKEN}"
+                        )
+                    }
+                ]
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        message = result["breadcrumbs"]["values"][0]["message"]
+        assert _RESET_TOKEN not in message
+        assert message == ("Password reset link sent: https://x.ee/auth/reset/[redacted]")
+
+    def test_breadcrumb_estonian_pii_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "breadcrumbs": {
+                "values": [{"message": ("klient 38501010002 maksis kontolt EE382200221020145685")}]
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        message = result["breadcrumbs"]["values"][0]["message"]
+        assert message == ("klient [REDACTED_ISIKUKOOD] maksis kontolt [REDACTED_IBAN]")
+
+    def test_breadcrumbs_as_list_shape_supported(self):
+        from app.observability import _scrub_pii
+
+        event = {"breadcrumbs": [{"message": "token=abc123"}]}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["breadcrumbs"][0]["message"] == "token=[redacted]"
+
+
+class TestLogentryScrubbing:
+    def test_logentry_message_and_params_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "logentry": {
+                "message": "reset url %s for mari@example.ee",
+                "params": [f"https://x.ee/auth/reset/{_RESET_TOKEN}"],
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        logentry = result["logentry"]
+        assert logentry["message"] == "reset url %s for [REDACTED_EMAIL]"
+        assert logentry["params"] == ["https://x.ee/auth/reset/[redacted]"]
+
+
 class TestInitSentry:
     def test_noop_without_dsn(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("SENTRY_DSN", raising=False)
@@ -133,6 +389,11 @@ class TestInitSentry:
             assert call_kwargs["release"] == "test123"
             assert call_kwargs["environment"] == "testing"
             assert call_kwargs["before_send"] is not None
+            # #846: transactions must run through the SAME scrubber so
+            # sampled request URLs (reset links, ?token= downloads)
+            # never ship unscrubbed.
+            assert call_kwargs["before_send_transaction"] is not None
+            assert call_kwargs["before_send_transaction"] is call_kwargs["before_send"]
 
         # Restore module
         importlib.reload(importlib.import_module("app.observability"))

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -363,6 +363,190 @@ class TestLogentryScrubbing:
         assert logentry["params"] == ["https://x.ee/auth/reset/[redacted]"]
 
 
+class TestDeepScrubbing:
+    """#846 review — nested payloads must be scrubbed at any depth."""
+
+    def test_nested_request_data_three_levels_deep(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {
+                "data": {
+                    "payload": {
+                        "users": [
+                            {
+                                "kirjeldus": "isik 38501010002 esitas taotluse",
+                                "konto": "EE382200221020145685",
+                                "api_key": "sk-abcdefghijklmnop123456",
+                            }
+                        ],
+                        "pair": ("EE382200221020145685", 200),
+                    }
+                }
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        user = result["request"]["data"]["payload"]["users"][0]
+        assert user["kirjeldus"] == "isik [REDACTED_ISIKUKOOD] esitas taotluse"
+        assert user["konto"] == "[REDACTED_IBAN]"
+        # Sensitive key at depth 3 → wholesale redaction.
+        assert user["api_key"] == "[Redacted]"
+        # Tuples are rebuilt scrubbed, shape and non-str members kept.
+        pair = result["request"]["data"]["payload"]["pair"]
+        assert isinstance(pair, tuple)
+        assert pair == ("[REDACTED_IBAN]", 200)
+
+    def test_request_data_as_list_of_dicts(self):
+        from app.observability import _scrub_pii
+
+        event = {"request": {"data": [{"token": "abc123"}, {"note": "isik 38501010002"}]}}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        data = result["request"]["data"]
+        assert data[0]["token"] == "[Redacted]"
+        assert data[1]["note"] == "isik [REDACTED_ISIKUKOOD]"
+
+    def test_breadcrumb_data_list_of_dicts(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "breadcrumbs": {
+                "values": [
+                    {
+                        "data": {
+                            "results": [
+                                {"url": "https://x.ee/f?token=abc", "status": 200},
+                                {"url": f"https://x.ee/auth/reset/{_RESET_TOKEN}"},
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        results = result["breadcrumbs"]["values"][0]["data"]["results"]
+        assert results[0]["url"] == "https://x.ee/f?token=[redacted]"
+        assert results[0]["status"] == 200
+        assert results[1]["url"] == "https://x.ee/auth/reset/[redacted]"
+
+    def test_nested_frame_vars_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "vars": {
+                                        "payload": {
+                                            "reset_token": f"'{_RESET_TOKEN}'",
+                                            "saaja": {"isikukood": "38501010002"},
+                                        },
+                                        "rows": [["EE382200221020145685"]],
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        local_vars = result["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]
+        # Sensitive key nested one level down → wholesale redaction.
+        assert local_vars["payload"]["reset_token"] == "[Redacted]"
+        # Sensitive key two levels down, exact-name rule.
+        assert local_vars["payload"]["saaja"]["isikukood"] == "[Redacted]"
+        # PII value inside list-of-lists.
+        assert local_vars["rows"] == [["[REDACTED_IBAN]"]]
+
+    def test_threads_frame_vars_scrubbed(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "threads": {
+                "values": [
+                    {"stacktrace": {"frames": [{"vars": {"ctx": {"klient": "isik 38501010002"}}}]}}
+                ]
+            }
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        local_vars = result["threads"]["values"][0]["stacktrace"]["frames"][0]["vars"]
+        assert local_vars["ctx"]["klient"] == "isik [REDACTED_ISIKUKOOD]"
+
+    def test_sensitive_key_wholesale_at_depth_regardless_of_type(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "request": {"data": {"outer": {"auth": {"nested": "structure"}, "tokens": [1, 2, 3]}}}
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        outer = result["request"]["data"]["outer"]
+        # Dict-valued sensitive key → redacted wholesale, not recursed.
+        assert outer["auth"] == "[Redacted]"
+        # "tokens" matches the suffix rule → list value redacted too.
+        assert outer["tokens"] == "[Redacted]"
+
+    def test_self_referential_structure_no_infinite_loop(self):
+        from app.observability import _scrub_pii
+
+        data: dict = {"kirjeldus": "isik 38501010002"}
+        data["self"] = data
+        cyclic_list: list = ["EE382200221020145685"]
+        cyclic_list.append(cyclic_list)
+        data["loop"] = cyclic_list
+
+        event = {"request": {"data": data}}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        scrubbed = result["request"]["data"]
+        assert scrubbed["kirjeldus"] == "isik [REDACTED_ISIKUKOOD]"
+        # In-place mutation means the cyclic reference sees scrubbed data.
+        assert scrubbed["self"] is scrubbed
+        assert scrubbed["loop"][0] == "[REDACTED_IBAN]"
+        assert scrubbed["loop"][1] is scrubbed["loop"]
+
+    def test_depth_cap_fails_closed(self):
+        from app.observability import _scrub_pii
+
+        node: dict = {"kirjeldus": "isik 38501010002"}
+        for _ in range(25):
+            node = {"child": node}
+        event = {"request": {"data": node}}
+        result = _scrub_pii(event, {})
+        assert result is not None
+        # The over-deep container is replaced, the PII never ships.
+        assert "38501010002" not in repr(result)
+        assert "[Redacted]" in repr(result)
+
+    def test_extra_and_contexts_scrubbed_trace_ids_survive(self):
+        from app.observability import _scrub_pii
+
+        event = {
+            "extra": {"debug": {"link": f"https://x.ee/auth/reset/{_RESET_TOKEN}"}},
+            "contexts": {
+                "trace": {"trace_id": "4c79f60c11214eb38604f4ae0781bfb2", "op": "http.server"},
+                "runtime": {"name": "CPython", "version": "3.13.2"},
+                "leak": {"konto": "EE382200221020145685"},
+            },
+        }
+        result = _scrub_pii(event, {})
+        assert result is not None
+        assert result["extra"]["debug"]["link"] == "https://x.ee/auth/reset/[redacted]"
+        assert result["contexts"]["leak"]["konto"] == "[REDACTED_IBAN]"
+        # Trace correlation and runtime metadata stay intact.
+        assert result["contexts"]["trace"]["trace_id"] == "4c79f60c11214eb38604f4ae0781bfb2"
+        assert result["contexts"]["trace"]["op"] == "http.server"
+        assert result["contexts"]["runtime"] == {"name": "CPython", "version": "3.13.2"}
+
+
 class TestInitSentry:
     def test_noop_without_dsn(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("SENTRY_DSN", raising=False)


### PR DESCRIPTION
## Summary

With `traces_sample_rate=0.1`, ~10% of requests shipped to Sentry SaaS as transaction events carrying full request URLs — including `/auth/reset/<token_hex(32)>` clicks and `?token=` signed report downloads — because `_scrub_pii` never touched `event["request"]` and no `before_send_transaction` was registered (`app/observability.py:104` on main).

**`app/observability.py`** — one shared scrub implementation (`_scrub_text` + `_scrub_str_dict`) now feeds every egress path:

- **Request envelope**: `url` + `query_string` (token-bearing path segments → `/auth/reset/[redacted]`, generic 32+-hex segments redacted, sensitive params `token`/`access_token`/`code`/`seed`/`state`/`*_key`/`*_secret`/… → `[redacted]`), `cookies` redacted wholesale (JWT cookie auth — no debugging value), `headers` (`Authorization`/`Cookie`/`X-Api-Key`/CSRF redacted by name; `Referer` URL-scrubbed so token-bearing referrers don't slip through), `data` (dict and string form bodies).
- **Transactions**: `_scrub_pii` registered as `before_send_transaction` — same function as `before_send`. Span descriptions/data (outbound httpx URLs) scrubbed too.
- **Breadcrumbs** (review-comment gap 1): messages + data run through the same path/param/PII scrubbing, both dict (`values`) and legacy list shapes.
- Stack-frame locals and `logentry` route through the same helpers; everything still finishes with the shared NFR §7.1 `scrub_prompt` regex set.
- **Context preserved**: host, path, benign params (`vaade`, `sisend`, `focus`…), `method`, `status_code`, route templates survive — verified by tests. (Confirmed against all query-param names used in the app: only `seed` and `token` match the sensitive rules, both credentials by design.)

**`app/llm/scrubber.py`** (review-comment gap 2 — shared with the Anthropic egress path):

- Estonian **isikukood**: `\b[1-6]\d{2}[01]\d[0-3]\d{5}\b` → `[REDACTED_ISIKUKOOD]`, ordered after email (so `isikukood@host` collapses to one `[REDACTED_EMAIL]`) and before phone (so bare `372…`-prefixed codes aren't mislabelled).
- **EE IBAN** → `[REDACTED_IBAN]`: `\bEE\d{2}(?:\s?\d{4}){4}\b` — matches the issue's compact `EE\d{18}` form **plus** the conventional `EE38 2200 2210 2014 5685` grouping (deliberate superset; see deviations).

## DoD status

- [x] `event["request"]` scrubbed in `_scrub_pii`: url, query_string, data, cookies, headers (incl. Authorization/Cookie)
- [x] Token-bearing path segments redacted (`/auth/reset/<hex>` → `/auth/reset/[redacted]`, plus generic 32+-hex segment catch-all)
- [x] Sensitive query params redacted (`token`, `access_token`, `code`, `authorization`, `seed`, `state`, `*_secret`, `*_key`, …)
- [x] Same function registered as `before_send_transaction`
- [x] Breadcrumbs scrubbed with the same patterns in both event and transaction paths (review comment, gap 1)
- [x] Isikukood + EE IBAN added to shared `SCRUB_PATTERNS` — protects Sentry **and** Anthropic egress (review comment, gap 2)
- [x] Centralized: events, transactions, breadcrumbs, spans, frame vars, logentry share one implementation

## Test evidence

`uv run pytest -q` → **3824 passed, 45 skipped** (~28s) · `uv run ruff check .` → clean · `uv run pyright` → 0 errors

New coverage (`tests/test_observability.py` +16, `tests/test_llm_scrubber.py` +13):
- Reset-path redaction (URL, Referer header, breadcrumb message, logentry params)
- Query-param redaction (URL + `query_string`, incl. the 2-segment home-grown signed download token the JWT regex can't catch)
- Header/cookie redaction (Authorization/Cookie/X-Api-Key redacted, Accept kept)
- Transaction-event scrubbing (request + spans; `before_send_transaction is before_send` asserted)
- Breadcrumb scrubbing (httpx data URL, dict + list shapes, Estonian PII in messages)
- Isikukood (valid male/female, invalid first-digit/month, longer-digit-run and email-embedding non-matches, 372-prefix ordering vs phone) + IBAN (compact, grouped, short/foreign non-matches)
- Scrubbed payloads keep useful route context (host/path/benign params/method/status_code/route template)

## Deviations from issue text

- IBAN regex is a superset of the specified `\bEE\d{18}\b`: it also matches the standard space-grouped print form (`EE38 2200 2210 2014 5685`) common in legal documents. Compact form matches exactly as specified.
- Added beyond the letter of the DoD (same leak class, same helper): transaction **span** data/descriptions and `logentry` scrubbing.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)