### PR TITLE
fix(config): stub gating fails closed and providers enforce it (#847)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,11 +1,13 @@
 """Central environment configuration and stub-mode gating.
 
-Phase 2 introduces three external services that the app degrades to
-local stubs for when their environment variables are missing:
+The app degrades to local stubs for several external services when
+their environment variables are missing:
 
-    - Apache Tika      (``TIKA_URL``)
-    - Anthropic Claude (``ANTHROPIC_API_KEY``)
+    - Apache Tika            (``TIKA_URL``)
+    - Anthropic Claude       (``ANTHROPIC_API_KEY``)
+    - Voyage AI embeddings   (``VOYAGE_API_KEY``)
     - Encrypted file storage (``STORAGE_ENCRYPTION_KEY``)
+    - Postmark email         (``POSTMARK_API_TOKEN``)
 
 Each used to ship its own dev/prod gate (``app/storage/encrypted.py``,
 ``app/llm/claude.py``, ``app/docs/tika_client.py``) with subtly
@@ -16,32 +18,87 @@ allowed any ``APP_ENV != "production"``, and the third hard-coded a
 crashing on missing credentials, depending on which file you looked
 at first (#449).
 
-This module is the single source of truth for that gate. The rule is
-deliberately simple: stubs are allowed unless ``APP_ENV=production``.
-That means dev, test, ci, and staging all default to stub mode; only
-an explicit production deployment forces real credentials. Operators
-who want production-like staging just set ``APP_ENV=production`` plus
-the matching credentials.
+This module is the single source of truth for that gate. Since #847
+the gate **fails closed**: stubs are only permitted when the
+normalized ``APP_ENV`` is on the explicit :data:`STUB_ALLOWED_ENVS`
+allowlist (``development``, ``test``, ``ci``, ``staging``). A missing
+or empty ``APP_ENV`` defaults to ``development`` so a freshly-cloned
+repo stays runnable, but any *unrecognized* non-empty value
+(``prod``, ``Production`` typos that survive normalization, etc.) is
+treated like production — stubs are disabled and consumers raise a
+clear error instead of silently serving canned data.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
+
+# Environments in which external-service stubs (Tika, Claude, Voyage,
+# storage encryption, email) are permitted. Anything else — including
+# unknown/typo'd values — fails closed (#847).
+STUB_ALLOWED_ENVS = frozenset({"development", "test", "ci", "staging"})
+
+# Unknown APP_ENV values we have already warned about, so the
+# fail-closed path logs once per distinct value instead of per call.
+_warned_unknown_envs: set[str] = set()
+
+
+def _normalized_env(name: str, default: str) -> str:
+    """Return ``os.environ[name]`` normalized with ``.strip().lower()``.
+
+    Missing, empty, and whitespace-only values all return *default*.
+    Shared by :func:`get_app_env` and :func:`get_worker_mode` (#847)
+    so the two env gates cannot drift apart in how they parse their
+    variables again.
+    """
+    raw = os.environ.get(name, "").strip().lower()
+    return raw or default
+
+
+def get_app_env() -> str:
+    """Return the normalized ``APP_ENV`` value.
+
+    Missing/empty/whitespace-only values default to ``"development"``,
+    which keeps a freshly-cloned repo (and the test suite, which runs
+    with ``APP_ENV`` unset) runnable without any setup beyond
+    ``uv sync``.
+    """
+    return _normalized_env("APP_ENV", "development")
 
 
 def is_stub_allowed() -> bool:
-    """Return True when Phase 2 service stubs are permitted.
+    """Return True when external service stubs are permitted.
 
-    The rule is: stubs allowed UNLESS ``APP_ENV=production``. The
-    default of ``"development"`` means an unset env var also allows
-    stubs, which keeps a freshly-cloned repo runnable without any
-    setup beyond ``uv sync``.
+    Fail-closed allowlist (#847): stubs are allowed only when the
+    normalized ``APP_ENV`` is in :data:`STUB_ALLOWED_ENVS`. Both
+    ``production`` and any unrecognized value disable stubs; unknown
+    values additionally log a one-time warning so a typo'd
+    ``APP_ENV=prod`` is diagnosable from the logs while the consumers
+    (which raise on missing credentials when stubs are disabled)
+    refuse to serve canned data.
 
-    Used by :mod:`app.storage.encrypted`, :mod:`app.llm.claude`, and
-    :mod:`app.docs.tika_client` to keep their stub-mode gating in
+    Used by :mod:`app.storage.encrypted`, :mod:`app.llm.claude`,
+    :mod:`app.rag.embedding`, :mod:`app.docs.tika_client`,
+    :mod:`app.docs.signed_urls`, :mod:`app.docs.reference_resolver`,
+    and :mod:`app.email.service` to keep their stub-mode gating in
     lock-step with each other.
     """
-    return os.environ.get("APP_ENV", "development") != "production"
+    env = get_app_env()
+    if env in STUB_ALLOWED_ENVS:
+        return True
+    if env != "production" and env not in _warned_unknown_envs:
+        _warned_unknown_envs.add(env)
+        logger.warning(
+            "APP_ENV=%r is not a recognised environment "
+            "(allowed stub envs: %s, or 'production'); failing closed — "
+            "service stubs are DISABLED and missing credentials will raise.",
+            env,
+            sorted(STUB_ALLOWED_ENVS),
+        )
+    return False
 
 
 def is_chat_auto_title_enabled() -> bool:
@@ -84,11 +141,13 @@ def get_worker_mode() -> str:
     """Return the configured worker mode (``"inproc"`` | ``"standalone"``).
 
     Defaults to ``"inproc"`` to preserve the historical single-container
-    behaviour. Unknown values raise ``ValueError`` so a typo in Coolify
-    env vars surfaces loudly at startup instead of silently disabling
-    the worker.
+    behaviour; empty/whitespace-only values are treated as unset.
+    Unknown values raise ``ValueError`` so a typo in Coolify env vars
+    surfaces loudly at startup instead of silently disabling the
+    worker. Normalization goes through the same :func:`_normalized_env`
+    helper as the ``APP_ENV`` stub gate (#847).
     """
-    raw = os.environ.get("WORKER_MODE", "inproc").strip().lower()
+    raw = _normalized_env("WORKER_MODE", "inproc")
     if raw not in _VALID_WORKER_MODES:
         raise ValueError(
             f"WORKER_MODE={raw!r} is invalid; expected one of {sorted(_VALID_WORKER_MODES)}"

--- a/app/llm/claude.py
+++ b/app/llm/claude.py
@@ -1,9 +1,14 @@
 """Anthropic Claude concrete ``LLMProvider`` implementation.
 
 Phase 2 shipped only the scaffolding; Phase 3A fills in real Anthropic
-API calls. When ``ANTHROPIC_API_KEY`` is unset, the provider switches to
+API calls. When ``ANTHROPIC_API_KEY`` is unset AND
+:func:`app.config.is_stub_allowed` permits it (``APP_ENV`` in
+development/test/ci/staging), the provider switches to
 ``_stubbed = True`` and returns canned responses so tests, local dev,
-and CI never make network calls.
+and CI never make network calls. In production or any unrecognized
+``APP_ENV`` (#847) a missing key raises ``RuntimeError`` at
+construction instead — a prod key loss must never silently serve
+canned advice.
 
 The real implementation path (when the SDK is installed and a key is
 set) calls the Anthropic Messages API and logs token usage via
@@ -21,6 +26,7 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any
 
+from app.config import STUB_ALLOWED_ENVS, get_app_env, is_stub_allowed
 from app.llm.provider import LLMProvider, StreamEvent
 from app.llm.retry import retry_async, retry_sync
 from app.llm.scrubber import scrub_messages, scrub_prompt
@@ -35,16 +41,31 @@ class ClaudeProvider(LLMProvider):
     """Anthropic Claude backend with a dev-mode stub path.
 
     Attributes:
-        _stubbed: True when running with no API key; methods return
-            canned responses instead of calling Anthropic.
+        _stubbed: True when running with no API key in a stub-allowed
+            environment; methods return canned responses instead of
+            calling Anthropic.
         _api_key: The ``ANTHROPIC_API_KEY`` value (empty when stubbed).
         _model: Model identifier, from ``CLAUDE_MODEL`` env var.
+
+    Raises:
+        RuntimeError: When ``ANTHROPIC_API_KEY`` is missing and
+            :func:`app.config.is_stub_allowed` is False (production or
+            an unrecognized ``APP_ENV``) — the fail-closed gate of #847.
     """
 
     def __init__(self) -> None:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
 
         if not api_key:
+            if not is_stub_allowed():
+                raise RuntimeError(
+                    "ANTHROPIC_API_KEY is not set and stub mode is disabled "
+                    f"for APP_ENV={get_app_env()!r} (stubs are only allowed in "
+                    f"{sorted(STUB_ALLOWED_ENVS)}). Refusing to serve canned "
+                    "LLM responses — set ANTHROPIC_API_KEY in the Coolify "
+                    "environment, or fix APP_ENV if this is not a production "
+                    "deployment (#847)."
+                )
             logger.warning(
                 "ANTHROPIC_API_KEY not set — ClaudeProvider running in STUB mode. "
                 "All completions return canned responses. Set ANTHROPIC_API_KEY "

--- a/app/rag/embedding.py
+++ b/app/rag/embedding.py
@@ -5,10 +5,14 @@ the same pattern as :class:`app.llm.provider.LLMProvider`. The default
 concrete implementation uses Voyage AI's ``voyage-multilingual-2`` model
 (1024 dimensions), which excels at multilingual text including Estonian.
 
-When ``VOYAGE_API_KEY`` is unset the provider switches to stub mode and
-returns random vectors of the correct dimensionality. This mirrors the
-``ClaudeProvider`` pattern: never crash due to a missing optional key,
-even in production.
+When ``VOYAGE_API_KEY`` is unset AND :func:`app.config.is_stub_allowed`
+permits it (``APP_ENV`` in development/test/ci/staging), the provider
+switches to stub mode and returns random vectors of the correct
+dimensionality. This mirrors the ``ClaudeProvider`` pattern. In
+production or any unrecognized ``APP_ENV`` (#847) a missing key raises
+``RuntimeError`` at construction instead — random stub vectors must
+never be persisted over real embeddings (the ingestion pipeline writes
+with ``ON CONFLICT DO UPDATE``).
 """
 
 from __future__ import annotations
@@ -19,6 +23,8 @@ import random
 import threading
 from abc import ABC, abstractmethod
 from typing import Any
+
+from app.config import STUB_ALLOWED_ENVS, get_app_env, is_stub_allowed
 
 logger = logging.getLogger(__name__)
 
@@ -51,17 +57,33 @@ class VoyageProvider(EmbeddingProvider):
     """Voyage AI embedding backend with a dev-mode stub path.
 
     Attributes:
-        _stubbed: True when running with no API key; methods return
-            random vectors instead of calling Voyage AI.
+        _stubbed: True when running with no API key in a stub-allowed
+            environment; methods return random vectors instead of
+            calling Voyage AI.
         _api_key: The ``VOYAGE_API_KEY`` value (empty when stubbed).
         _model: Model identifier, from ``VOYAGE_MODEL`` env var.
         _dimensions: Vector dimensionality for the selected model.
+
+    Raises:
+        RuntimeError: When ``VOYAGE_API_KEY`` is missing and
+            :func:`app.config.is_stub_allowed` is False (production or
+            an unrecognized ``APP_ENV``) — the fail-closed gate of #847.
     """
 
     def __init__(self) -> None:
         api_key = os.environ.get("VOYAGE_API_KEY", "").strip()
 
         if not api_key:
+            if not is_stub_allowed():
+                raise RuntimeError(
+                    "VOYAGE_API_KEY is not set and stub mode is disabled "
+                    f"for APP_ENV={get_app_env()!r} (stubs are only allowed in "
+                    f"{sorted(STUB_ALLOWED_ENVS)}). Refusing to generate "
+                    "random stub embeddings — they would be persisted over "
+                    "real vectors by the ingestion pipeline. Set "
+                    "VOYAGE_API_KEY, or fix APP_ENV if this is not a "
+                    "production deployment (#847)."
+                )
             logger.warning(
                 "VOYAGE_API_KEY not set — VoyageProvider running in STUB mode. "
                 "All embeddings return random vectors. Set VOYAGE_API_KEY "

--- a/scripts/migrate_chat_encryption.py
+++ b/scripts/migrate_chat_encryption.py
@@ -152,8 +152,17 @@ def migrate() -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    if not os.environ.get("STORAGE_ENCRYPTION_KEY") and os.environ.get("APP_ENV") == "production":
-        logger.error("STORAGE_ENCRYPTION_KEY must be set in production")
+    # #847 ride-along: the key is required UNCONDITIONALLY, not just when
+    # APP_ENV=production. Running the backfill in any environment without
+    # an explicit key would silently encrypt rows with the ephemeral
+    # dev-mode Fernet key, which is lost on process exit — making every
+    # backfilled ciphertext permanently undecryptable.
+    if not os.environ.get("STORAGE_ENCRYPTION_KEY"):
+        logger.error(
+            "STORAGE_ENCRYPTION_KEY must be set to run the chat encryption "
+            "backfill (in EVERY environment — without it the rows would be "
+            "encrypted with an ephemeral key and lost on exit)."
+        )
         return 1
 
     database_url = _get_database_url()

--- a/tests/test_drafter_guards.py
+++ b/tests/test_drafter_guards.py
@@ -18,18 +18,20 @@ class TestRequireRealLlm:
             require_real_llm()
 
     def test_stubbed_provider_in_prod_raises(self, monkeypatch: pytest.MonkeyPatch):
-        """Even in production, if the key is missing, drafter should block.
+        """Even in production, if the key is missing, drafter must block.
 
-        Phase 2 hotfix a3e4430 exempted Claude from is_stub_allowed() so
-        the extraction pipeline could run in stub mode in prod. But the
-        drafter MUST NOT run in stub mode — so this guard catches it
-        regardless of APP_ENV.
+        Since #847 the provider itself fails closed: ``ClaudeProvider``
+        refuses to instantiate without a key when stubs are disallowed,
+        so the guard surfaces a ``RuntimeError`` from provider
+        construction instead of a ``DrafterNotAvailableError`` from the
+        ``_stubbed`` check. Either way the drafter cannot run on canned
+        responses in production.
         """
         _reset_default_provider()
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-        with pytest.raises(DrafterNotAvailableError, match="ANTHROPIC_API_KEY"):
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
             require_real_llm()
 
     def test_real_provider_passes(self, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -66,22 +66,29 @@ class TestClaudeStubMode:
 
 
 class TestClaudeProdMode:
-    def test_claude_stubs_in_prod_without_key(self, monkeypatch: pytest.MonkeyPatch):
-        """APP_ENV=production + no key -> stub mode (NOT RuntimeError).
+    def test_claude_raises_in_prod_without_key(self, monkeypatch: pytest.MonkeyPatch):
+        """APP_ENV=production + no key -> RuntimeError (fail closed, #847).
 
-        Unlike STORAGE_ENCRYPTION_KEY (data-loss risk) and TIKA_URL
-        (hard dep for parsing), the Anthropic key is explicitly optional
-        per README Phase 2 Step 5.
+        Phase 2 hotfix a3e4430 had exempted Claude from is_stub_allowed()
+        so a prod deploy without a key silently served canned responses.
+        #847 reversed that: a production key loss must raise, never stub.
         """
         monkeypatch.setenv("APP_ENV", "production")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-        provider = ClaudeProvider()
-        assert provider._stubbed is True
-        assert provider.complete("test").startswith("[STUB Claude]")
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            ClaudeProvider()
+
+    def test_claude_raises_on_unknown_env_without_key(self, monkeypatch: pytest.MonkeyPatch):
+        """Unknown APP_ENV values fail closed like production (#847)."""
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            ClaudeProvider()
 
     def test_claude_stubbed_in_staging(self, monkeypatch: pytest.MonkeyPatch):
-        """#449: APP_ENV=staging is now explicitly stub-mode-eligible."""
+        """#449: APP_ENV=staging is explicitly stub-mode-eligible."""
         monkeypatch.setenv("APP_ENV", "staging")
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 

--- a/tests/test_stub_gating.py
+++ b/tests/test_stub_gating.py
@@ -1,0 +1,532 @@
+"""Fail-closed stub gating tests (#847, review IDs C-a / C-b).
+
+Covers, in one place:
+
+- ``app.config.get_app_env`` / ``is_stub_allowed`` normalization and the
+  explicit allowlist (development / test / ci / staging). Unknown
+  non-empty ``APP_ENV`` values fail closed; missing/empty values default
+  to ``development`` so local dev and the test suite keep working.
+- ``get_worker_mode`` sharing the same normalization helper.
+- ``ClaudeProvider`` / ``VoyageProvider`` refusing to instantiate
+  without API keys when stubs are disallowed (C-b), including the
+  module singletons and the RAG ingestion path that would otherwise
+  persist random stub embeddings via ``ON CONFLICT DO UPDATE``.
+- The consumer matrix from the ticket review: storage encryption
+  (ephemeral-key fallback), Tika, email, signed download URLs, and the
+  reference-resolver hash secret all gate on ``is_stub_allowed()`` —
+  these tests pin their behavior across the env matrix WITHOUT any
+  code change in those modules.
+- ``scripts/migrate_chat_encryption.py`` requiring
+  ``STORAGE_ENCRYPTION_KEY`` unconditionally (ride-along).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from app.config import STUB_ALLOWED_ENVS, get_app_env, get_worker_mode, is_stub_allowed
+
+# Values that must allow stubs: the allowlist plus normalization
+# variants plus the unset/empty default. ``None`` means "delete APP_ENV".
+STUB_ALLOWED_VALUES: list[str | None] = [
+    None,
+    "",
+    "   ",
+    "development",
+    "test",
+    "ci",
+    "staging",
+    "Development",
+    "TEST",
+    " staging ",
+    "CI",
+    "  Test  ",
+]
+
+# Values that must fail closed: production in any spelling/spacing, and
+# every unrecognized value (typos, aliases the allowlist does not name).
+STUB_DENIED_VALUES: list[str] = [
+    "production",
+    "Production",
+    "PRODUCTION",
+    " production ",
+    "production ",
+    "prod",
+    "Prod",
+    "produciton",
+    "live",
+    "qa",
+    "testing",
+]
+
+
+def _set_app_env(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    if value is None:
+        monkeypatch.delenv("APP_ENV", raising=False)
+    else:
+        monkeypatch.setenv("APP_ENV", value)
+
+
+# ---------------------------------------------------------------------------
+# C-a: config normalization + allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestGetAppEnv:
+    def test_unset_defaults_to_development(self, monkeypatch: pytest.MonkeyPatch):
+        """Missing APP_ENV must keep defaulting to development (local dev)."""
+        monkeypatch.delenv("APP_ENV", raising=False)
+        assert get_app_env() == "development"
+
+    @pytest.mark.parametrize("raw", ["", "   ", "\t"])
+    def test_empty_and_whitespace_default_to_development(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ):
+        monkeypatch.setenv("APP_ENV", raw)
+        assert get_app_env() == "development"
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (" Production ", "production"),
+            ("TEST", "test"),
+            ("Staging", "staging"),
+            ("ci ", "ci"),
+            ("pRoD", "prod"),
+        ],
+    )
+    def test_strip_lower_normalization(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, expected: str
+    ):
+        monkeypatch.setenv("APP_ENV", raw)
+        assert get_app_env() == expected
+
+
+class TestIsStubAllowedMatrix:
+    @pytest.mark.parametrize("value", STUB_ALLOWED_VALUES)
+    def test_allowlisted_envs_permit_stubs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        _set_app_env(monkeypatch, value)
+        assert is_stub_allowed() is True
+
+    @pytest.mark.parametrize("value", STUB_DENIED_VALUES)
+    def test_production_and_unknown_envs_fail_closed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        _set_app_env(monkeypatch, value)
+        assert is_stub_allowed() is False
+
+    def test_allowlist_is_the_documented_set(self):
+        """The allowlist itself is part of the contract (#847 DoD)."""
+        assert STUB_ALLOWED_ENVS == frozenset({"development", "test", "ci", "staging"})
+
+    def test_unknown_env_warns_once(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """Unknown values log a single diagnosable warning, then stay quiet."""
+        # Unique value so other tests' warnings cannot interfere.
+        monkeypatch.setenv("APP_ENV", "qa-847-warn-once")
+        with caplog.at_level(logging.WARNING, logger="app.config"):
+            assert is_stub_allowed() is False
+            assert is_stub_allowed() is False
+        warnings = [r for r in caplog.records if "qa-847-warn-once" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "failing closed" in warnings[0].getMessage()
+
+    def test_production_does_not_warn(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """production is a recognised env — fail closed without noise."""
+        monkeypatch.setenv("APP_ENV", "production")
+        with caplog.at_level(logging.WARNING, logger="app.config"):
+            assert is_stub_allowed() is False
+        assert not [r for r in caplog.records if r.name == "app.config"]
+
+
+class TestWorkerModeSharedNormalization:
+    """get_worker_mode goes through the same _normalized_env helper."""
+
+    def test_empty_value_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("WORKER_MODE", "")
+        assert get_worker_mode() == "inproc"
+
+    def test_whitespace_and_case_normalized(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("WORKER_MODE", "  InProc ")
+        assert get_worker_mode() == "inproc"
+
+    def test_unknown_value_still_raises(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("WORKER_MODE", " Bogus ")
+        with pytest.raises(ValueError, match="WORKER_MODE"):
+            get_worker_mode()
+
+
+# ---------------------------------------------------------------------------
+# C-b: ClaudeProvider fail-closed gate
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeProviderFailClosed:
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        from app.llm import _reset_default_provider
+
+        _reset_default_provider()
+        yield
+        _reset_default_provider()
+
+    @pytest.mark.parametrize("value", ["production", "Production", "production ", "prod", "live"])
+    def test_missing_key_raises_when_stubs_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        from app.llm import ClaudeProvider
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            ClaudeProvider()
+
+    @pytest.mark.parametrize("value", STUB_ALLOWED_VALUES)
+    def test_missing_key_stubs_in_allowed_envs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        from app.llm import ClaudeProvider
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        provider = ClaudeProvider()
+        assert provider._stubbed is True
+        assert provider.complete("test").startswith("[STUB Claude]")
+
+    def test_key_present_in_production_instantiates_real_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.llm import ClaudeProvider
+
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+        provider = ClaudeProvider()
+        assert provider._stubbed is False
+
+    def test_error_names_env_and_allowlist(self, monkeypatch: pytest.MonkeyPatch):
+        """The fail-closed error must be self-diagnosing for operators."""
+        from app.llm import ClaudeProvider
+
+        monkeypatch.setenv("APP_ENV", "produciton")  # typo on purpose
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            ClaudeProvider()
+        message = str(exc_info.value)
+        assert "produciton" in message
+        assert "staging" in message  # allowlist is spelled out
+
+    def test_default_provider_singleton_raises_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.llm import get_default_provider
+
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            get_default_provider()
+
+
+# ---------------------------------------------------------------------------
+# C-b: VoyageProvider fail-closed gate
+# ---------------------------------------------------------------------------
+
+
+class TestVoyageProviderFailClosed:
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        from app.rag.embedding import _reset_default_embedding_provider
+
+        _reset_default_embedding_provider()
+        yield
+        _reset_default_embedding_provider()
+
+    @pytest.mark.parametrize("value", ["production", "PRODUCTION", "prod", "qa"])
+    def test_missing_key_raises_when_stubs_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        from app.rag.embedding import VoyageProvider
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+            VoyageProvider()
+
+    @pytest.mark.parametrize("value", STUB_ALLOWED_VALUES)
+    def test_missing_key_stubs_in_allowed_envs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        from app.rag.embedding import VoyageProvider
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+        provider = VoyageProvider()
+        assert provider._stubbed is True
+        vectors = asyncio.run(provider.embed(["Tsiviilseadustik"]))
+        assert len(vectors) == 1
+        assert len(vectors[0]) == provider.dimensions
+
+    def test_key_present_in_production_instantiates_real_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.rag.embedding import VoyageProvider
+
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("VOYAGE_API_KEY", "voyage-test-key")
+
+        provider = VoyageProvider()
+        assert provider._stubbed is False
+
+    def test_default_provider_singleton_raises_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.rag.embedding import get_default_embedding_provider
+
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+            get_default_embedding_provider()
+
+    def test_ingestion_cannot_embed_with_stub_in_production(self, monkeypatch: pytest.MonkeyPatch):
+        """The RAG ingestion path (ON CONFLICT DO UPDATE writer) must
+        blow up BEFORE producing random vectors in production-like envs.
+        """
+        from app.rag.chunker import RagChunk
+        from scripts.ingest_rag import _embed_chunks
+
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+        chunk = RagChunk(
+            content="Tsiviilseadustik § 1",
+            metadata={"source_type": "provision", "source_uri": "estleg:TsMS_Par_1"},
+            chunk_index=0,
+        )
+        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+            asyncio.run(_embed_chunks([chunk]))
+
+
+# ---------------------------------------------------------------------------
+# Consumer matrix (review comment item 1) — NO code changes in these
+# modules; the tests pin their behavior under the fail-closed gate.
+# ---------------------------------------------------------------------------
+
+
+class TestStorageEncryptionConsumer:
+    """app.storage.encrypted ephemeral-key fallback across the matrix."""
+
+    @pytest.mark.parametrize("value", ["development", "test", "ci", "staging", None])
+    def test_ephemeral_key_in_allowed_envs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        import app.storage.encrypted as encrypted
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("STORAGE_ENCRYPTION_KEY", raising=False)
+
+        key = encrypted._load_encryption_key()
+        assert isinstance(key, bytes) and key
+
+    @pytest.mark.parametrize("value", ["production", "prod", "Production ", "live"])
+    def test_missing_key_raises_when_stubs_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        import app.storage.encrypted as encrypted
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("STORAGE_ENCRYPTION_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="STORAGE_ENCRYPTION_KEY"):
+            encrypted._load_encryption_key()
+
+    def test_explicit_key_wins_in_any_env(self, monkeypatch: pytest.MonkeyPatch):
+        from cryptography.fernet import Fernet
+
+        import app.storage.encrypted as encrypted
+
+        explicit = Fernet.generate_key().decode()
+        monkeypatch.setenv("APP_ENV", "prod")  # even an unknown env
+        monkeypatch.setenv("STORAGE_ENCRYPTION_KEY", explicit)
+
+        assert encrypted._load_encryption_key() == explicit.encode()
+
+
+class TestTikaConsumer:
+    """app.docs.tika_client stub mode across the matrix."""
+
+    @pytest.mark.parametrize("value", ["development", "test", "ci", "staging", None])
+    def test_stub_mode_in_allowed_envs(self, monkeypatch: pytest.MonkeyPatch, value: str | None):
+        from app.docs.tika_client import TikaClient
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("TIKA_URL", raising=False)
+
+        client = TikaClient()
+        assert client._stub_mode is True
+        text = client.extract_text(b"fake docx bytes", "application/pdf")
+        assert isinstance(text, str) and text
+
+    @pytest.mark.parametrize("value", ["production", "prod", "qa"])
+    def test_no_stub_and_call_time_error_when_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        from app.docs.tika_client import TikaClient
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("TIKA_URL", raising=False)
+
+        client = TikaClient()
+        assert client._stub_mode is False
+        with pytest.raises(RuntimeError, match="TIKA_URL"):
+            client.extract_text(b"fake docx bytes", "application/pdf")
+
+
+class TestEmailConsumer:
+    """app.email.service provider selection across the matrix."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        from app.email.service import _reset_provider_for_tests
+
+        _reset_provider_for_tests()
+        yield
+        _reset_provider_for_tests()
+
+    @pytest.mark.parametrize("value", ["development", "test", "ci", "staging", None])
+    def test_stub_provider_in_allowed_envs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        from app.email.service import get_email_provider
+        from app.email.stub_provider import StubProvider
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("POSTMARK_API_TOKEN", raising=False)
+
+        assert isinstance(get_email_provider(), StubProvider)
+
+    @pytest.mark.parametrize("value", ["production", "prod", "live"])
+    def test_missing_token_raises_when_stubs_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        from app.email.service import get_email_provider
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("POSTMARK_API_TOKEN", raising=False)
+
+        with pytest.raises(RuntimeError, match="POSTMARK_API_TOKEN"):
+            get_email_provider()
+
+
+class TestSignedUrlsConsumer:
+    """app.docs.signed_urls dev signing-key fallback across the matrix."""
+
+    @pytest.mark.parametrize("value", ["development", "test", "ci", "staging", None])
+    def test_dev_sentinel_in_allowed_envs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        from app.docs import signed_urls
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("DOWNLOAD_TOKEN_SECRET", raising=False)
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+
+        assert signed_urls._load_signing_key() == signed_urls._DEV_SIGNING_KEY
+
+    @pytest.mark.parametrize("value", ["production", "prod", "qa"])
+    def test_missing_secret_raises_when_stubs_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        from app.docs import signed_urls
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("DOWNLOAD_TOKEN_SECRET", raising=False)
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="DOWNLOAD_TOKEN_SECRET"):
+            signed_urls._load_signing_key()
+
+
+class TestReferenceResolverConsumer:
+    """app.docs.reference_resolver ref-hash secret across the matrix."""
+
+    @pytest.mark.parametrize("value", ["development", "test", "ci", "staging", None])
+    def test_dev_sentinel_in_allowed_envs(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        from app.docs import reference_resolver
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("RESOLVER_REF_HASH_SECRET", raising=False)
+
+        assert reference_resolver._get_ref_hash_secret() == b"dev-only-resolver-ref-id-secret"
+
+    @pytest.mark.parametrize("value", ["production", "prod", "live"])
+    def test_missing_secret_raises_when_stubs_disallowed(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        from app.docs import reference_resolver
+
+        monkeypatch.setenv("APP_ENV", value)
+        monkeypatch.delenv("RESOLVER_REF_HASH_SECRET", raising=False)
+
+        with pytest.raises(RuntimeError, match="RESOLVER_REF_HASH_SECRET"):
+            reference_resolver._get_ref_hash_secret()
+
+
+# ---------------------------------------------------------------------------
+# Ride-along: scripts/migrate_chat_encryption.py key guard
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateChatEncryptionKeyGuard:
+    @pytest.mark.parametrize("value", [None, "development", "staging", "production", "prod"])
+    def test_missing_key_exits_1_in_every_env(
+        self, monkeypatch: pytest.MonkeyPatch, value: str | None
+    ):
+        """The backfill must refuse to run without an explicit key,
+        regardless of APP_ENV — an ephemeral key would permanently
+        destroy every backfilled row.
+        """
+        import scripts.migrate_chat_encryption as mce
+
+        _set_app_env(monkeypatch, value)
+        monkeypatch.delenv("STORAGE_ENCRYPTION_KEY", raising=False)
+
+        def _no_connect(*args: object, **kwargs: object) -> object:
+            raise AssertionError("migrate() must not touch the DB without a key")
+
+        monkeypatch.setattr(mce.psycopg, "connect", _no_connect)
+
+        assert mce.migrate() == 1
+
+    def test_key_present_passes_guard(self, monkeypatch: pytest.MonkeyPatch):
+        """With the key set the guard lets the run proceed to the DB."""
+        from cryptography.fernet import Fernet
+
+        import scripts.migrate_chat_encryption as mce
+
+        monkeypatch.delenv("APP_ENV", raising=False)
+        monkeypatch.setenv("STORAGE_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        def _sentinel_connect(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("DB-CONNECT-ATTEMPTED")
+
+        monkeypatch.setattr(mce.psycopg, "connect", _sentinel_connect)
+
+        with pytest.raises(RuntimeError, match="DB-CONNECT-ATTEMPTED"):
+            mce.migrate()


### PR DESCRIPTION
## Summary

`is_stub_allowed()` failed **open**: any unrecognized `APP_ENV` (`prod`, `Production`, trailing whitespace) enabled service stubs in what is really production, and the LLM/embedding providers never consulted the central policy at all — a production key loss silently served canned advice and random-vector embeddings (which `scripts/ingest_rag.py` would persist over real vectors via `ON CONFLICT DO UPDATE`).

- **C-a** — `app/config.py`: `APP_ENV` is normalized (`.strip().lower()`) and checked against an explicit allowlist `STUB_ALLOWED_ENVS = {development, test, ci, staging}`. Unknown non-empty values fail closed with a one-time diagnosable warning; missing/empty values still default to `development` (local dev + the 3,968-test suite keep working with no env setup). `get_worker_mode()` now routes through the same `_normalized_env()` helper so the two gates can't drift apart (review-comment item 2).
- **C-b** — `ClaudeProvider` / `VoyageProvider` raise a clear `RuntimeError` at construction when the API key is missing and `not is_stub_allowed()`. The error names the offending `APP_ENV` value and the allowlist. Module + class docstrings (including config's false claim that providers already consulted the gate) corrected.
- **Consumer matrix** (review-comment item 1) — **no code changes** in `app/storage/encrypted.py`, `app/docs/tika_client.py`, `app/email/service.py`, `app/docs/signed_urls.py`, `app/docs/reference_resolver.py`; new tests pin each consumer's behavior across the env matrix under the fail-closed gate (none crashes in a legitimate env; all refuse stubs in production/unknown envs).
- **Ride-along** — `scripts/migrate_chat_encryption.py` now requires `STORAGE_ENCRYPTION_KEY` unconditionally (error + exit 1); previously a staging run silently encrypted rows with an ephemeral key lost on process exit.

## Env matrix

| `APP_ENV` | `is_stub_allowed()` | Provider w/o key | Storage w/o key | Tika w/o URL | Email w/o token |
|---|---|---|---|---|---|
| unset / `""` / `"   "` | True (→ development) | stub | ephemeral key | stub | stub |
| `development` / `test` / `ci` / `staging` (any case/spacing) | True | stub | ephemeral key | stub | stub |
| `production` / `Production` / `PRODUCTION` / `" production "` | **False** | **RuntimeError** | RuntimeError | call-time RuntimeError | RuntimeError |
| `prod` / `produciton` / `live` / `qa` / `testing` (unknown) | **False** + one-time warning | **RuntimeError** | RuntimeError | call-time RuntimeError | RuntimeError |

## DoD status

- [x] Normalize `APP_ENV` with `.strip().lower()` before policy checks
- [x] Explicit allowlist (`development`, `test`, `ci`, `staging`)
- [x] Unknown env values fail closed with a clear runtime error where stubs would otherwise be used (provider `RuntimeError` names the env value + allowlist; `app.config` logs a one-time warning)
- [x] `ClaudeProvider` refuses to instantiate without a key in non-stub-allowed envs
- [x] `VoyageProvider` refuses to instantiate without a key in non-stub-allowed envs
- [x] Config docs/docstrings match actual behavior (config module + both providers)
- [x] Existing tests that relied on permissive envs updated: `tests/test_llm_provider.py::test_claude_stubs_in_prod_without_key` → `test_claude_raises_in_prod_without_key`; `tests/test_drafter_guards.py::test_stubbed_provider_in_prod_raises` now expects the provider's `RuntimeError`
- [x] Review comment: all `is_stub_allowed()` consumers covered by a verification matrix (tests only, no consumer code changed)
- [x] Review comment: both env gates share one normalization helper (`_normalized_env`)
- [x] Review comment ride-along: `migrate_chat_encryption.py` key required unconditionally
- [ ] Review comment optional: refuse boot on `.env.example` placeholder `SECRET_KEY`/`STORAGE_ENCRYPTION_KEY` — **not done**, out of this ticket's file scope (touches boot path / `app/main.py`); suggest a follow-up issue

## Verification

- [x] Unit tests cover `production`, `prod`, `Production`, trailing-whitespace, unknown, and allowed dev/test/ci/staging values (`tests/test_stub_gating.py`, 89 tests)
- [x] Provider tests prove missing keys raise in production-like/unknown envs and stub only in allowed envs (direct construction + `get_default_provider` / `get_default_embedding_provider` singletons)
- [x] Embedding-sync proof: `scripts/ingest_rag._embed_chunks` raises `RuntimeError` before producing any vector under `APP_ENV=production` without a key (`test_ingestion_cannot_embed_with_stub_in_production`)
- [x] Baseline green: `uv run ruff check .` ✓ · `uv run ruff format --check .` ✓ · `uv run pyright` ✓ (0 errors) · `uv run pytest -q` → **3923 passed, 45 skipped** (was 3,792 + 131 new/updated)

## Notes

- `.github/workflows/ci.yml` intentionally **unchanged**: CI leaves `APP_ENV` unset, which now explicitly normalizes to `development`. Setting `APP_ENV=test` there would break `tests/test_prod_middleware.py:129`, which asserts the suite runs with `APP_ENV` unset/development.
- `get_worker_mode("")` previously raised `ValueError`; via the shared helper an empty/whitespace `WORKER_MODE` is now treated as unset → `inproc` (consistent with `APP_ENV` handling; documented + tested).
- A pre-existing order-dependent flake in `tests/test_docs_reference_resolver.py::test_resolve_refs_top_level_helper` (live-SPARQL connection attempt under certain file orderings) reproduces on the base commit and is unrelated; the full suite passes.

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)