### PR TITLE
fix(impact): accept versioned draft graph URIs + restore burden C6 section (#849, #855)

### DIFF
--- a/app/analyysikeskus/burden.py
+++ b/app/analyysikeskus/burden.py
@@ -373,6 +373,14 @@ def _build_draft_affected_provisions_query() -> str:
     provision" in non-AmendmentEvent contexts). The UNION arm guards
     against the half-populated corpus where some drafts have references
     but no AmendmentEvent rows yet.
+
+    This is the **default-graph** variant: the draft subject is supplied
+    by the caller as a ``?draftUri`` URI binding and the triples are
+    expected in the default graph. It remains the public ontology path
+    (e.g. an enacted-Act draft already merged into the default graph).
+    For an *uploaded* draft whose triples live at ``<graph_uri>#self``
+    inside a named graph, use :func:`_build_draft_affected_provisions_graph_query`
+    instead (see #855).
     """
     return (
         PREFIXES
@@ -386,6 +394,53 @@ WHERE {{
   }}
   UNION
   {{ ?draftUri <{PREDICATES.REFERENCES}> ?provision }}
+}}
+LIMIT {_MAX_BURDEN_ROWS_PER_ACT}
+"""
+    )
+
+
+def _build_draft_affected_provisions_graph_query(graph_uri: str) -> str:
+    """Return the GRAPH-scoped affected-provisions SPARQL for an uploaded draft.
+
+    #855 — the C6 burden section was silently always zero. An uploaded
+    draft's triples are written by :func:`app.docs.graph_builder.build_draft_graph`
+    as ``<graph_uri>#self estleg:references <provision>`` **inside the
+    named graph** ``<graph_uri>``. The default-graph variant above (which
+    binds ``?draftUri`` to the bare ``graph_uri`` and matches the default
+    graph) therefore never matched: wrong subject (missing ``#self``) AND
+    wrong graph (Fuseki has no ``unionDefaultGraph`` — see
+    ``docker/fuseki-config/ontology.ttl``). The whole burden delta came
+    back empty and nothing errored.
+
+    This variant fixes both:
+
+    * the draft-side patterns are wrapped in ``GRAPH <graph_uri> {…}`` so
+      they read the named graph where the draft triples actually live;
+    * the subject is the ``<graph_uri>#self`` IRI, bound by the caller via
+      ``uri_bindings={"draftSelf": "<graph_uri>#self"}`` (the SparqlClient
+      URI allowlist admits ``#``).
+
+    ``graph_uri`` is interpolated directly into the ``GRAPH`` clause and
+    MUST already be validated by :func:`app.sync.jena_loader._validate_graph_uri`
+    — the caller (:func:`burden_delta_for_draft`) does this before calling.
+    The amendment-event arm reads the AmendmentEvent → Provision hop from
+    the default graph (enacted ontology) since AmendmentEvents are public
+    ontology nodes, while the draft → event hop stays inside the graph.
+    """
+    return (
+        PREFIXES
+        + f"""
+SELECT DISTINCT ?provision
+WHERE {{
+  {{
+    GRAPH <{graph_uri}> {{ ?draftSelf ?p ?ev . }}
+    ?ev <{PREDICATES.AMENDS}> ?provision .
+  }}
+  UNION
+  {{
+    GRAPH <{graph_uri}> {{ ?draftSelf <{PREDICATES.REFERENCES}> ?provision . }}
+  }}
 }}
 LIMIT {_MAX_BURDEN_ROWS_PER_ACT}
 """
@@ -495,6 +550,7 @@ def list_burden_for_provision(
 def burden_delta_for_draft(
     draft_uri: str,
     *,
+    graph_uri: str | None = None,
     sparql_client: SparqlClient | None = None,
 ) -> BurdenDelta:
     """Return the burden delta for a draft URI vs. the prior-law baseline.
@@ -509,6 +565,17 @@ def burden_delta_for_draft(
     Args:
         draft_uri: A ``DraftLegislation`` URI. Empty / whitespace input
             yields an empty delta with ``affected_count=0``.
+        graph_uri: The draft's Jena **named graph** URI (#855). When
+            provided, the affected-provision lookup is GRAPH-scoped to
+            that graph and addresses the ``<graph_uri>#self`` subject the
+            graph builder actually wrote — the only shape that works for
+            an *uploaded* draft (its triples never reach the default
+            graph). When ``None`` (the legacy/default-graph path, used by
+            callers that pre-merged the draft into the default graph and
+            by the existing unit tests), the default-graph variant binds
+            ``?draftUri`` to *draft_uri* as before. Must match the draft
+            graph allowlist when supplied; an invalid value degrades to an
+            empty delta rather than raising.
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -520,15 +587,31 @@ def burden_delta_for_draft(
         return BurdenDelta(before=_empty_summary(), after=None, affected_count=0)
 
     client = sparql_client if sparql_client is not None else SparqlClient()
+    scoped_graph = (graph_uri or "").strip()
     try:
-        rows = client.query(
-            _build_draft_affected_provisions_query(),
-            uri_bindings={"draftUri": uri},
-        )
+        if scoped_graph:
+            # #855: GRAPH-scoped lookup against the draft's named graph,
+            # addressing the ``#self`` subject. Validate the graph URI
+            # before it is interpolated into the GRAPH clause (the same
+            # allowlist the GSP transport + impact builders use; widened
+            # for ``/v<n>`` in #849).
+            from app.sync.jena_loader import _validate_graph_uri
+
+            safe_graph = _validate_graph_uri(scoped_graph)
+            rows = client.query(
+                _build_draft_affected_provisions_graph_query(safe_graph),
+                uri_bindings={"draftSelf": f"{safe_graph}#self"},
+            )
+        else:
+            rows = client.query(
+                _build_draft_affected_provisions_query(),
+                uri_bindings={"draftUri": uri},
+            )
     except Exception:
         logger.warning(
-            "burden_delta_for_draft: affected-provision query failed for %r",
+            "burden_delta_for_draft: affected-provision query failed for %r (graph=%r)",
             uri,
+            scoped_graph or None,
             exc_info=True,
         )
         return BurdenDelta(before=_empty_summary(), after=None, affected_count=0)

--- a/app/docs/impact/analyzer.py
+++ b/app/docs/impact/analyzer.py
@@ -311,6 +311,18 @@ class ImpactAnalyzer:
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_uri(value: str) -> bool:
+    """Return ``True`` when *value* is shaped like an http(s) URI.
+
+    Used to filter act-title LITERAL rows (``estleg:referencesAct``) out of
+    the affected-provision list before they reach a URI-only SPARQL
+    binding (#855). A bare title such as ``"Riigieelarve seadus"`` returns
+    ``False``; a provision IRI returns ``True``.
+    """
+    v = (value or "").strip()
+    return v.startswith("http://") or v.startswith("https://")
+
+
 @dataclass(frozen=True)
 class SanctionsDeltaRow:
     """One sanction row in the impact report's sanctions-delta section.
@@ -513,6 +525,19 @@ def analyze_sanctions_delta(
         provision_uri = (raw_uri or "").strip()
         if not provision_uri:
             continue
+        # #855: the affected-entities pass surfaces act-level partial
+        # matches as ``estleg:referencesAct "<title>"`` LITERAL rows whose
+        # ``uri`` field is the act title (e.g. ``"Riigieelarve seadus"``),
+        # not a provision URI. Those flow into ``affected_uris`` in
+        # ``analyze_handler`` and, if handed to
+        # ``list_sanctions_for_provision`` → ``uri_bindings``, trip the
+        # SparqlClient's strict URI allowlist with a ``ValueError`` that
+        # was caught + logged once PER TITLE PER RUN (warning spam, never a
+        # real lookup). Sanctions attach to provision URIs only, so a
+        # non-URI value can never have sanctions — skip it before the call
+        # rather than letting it raise-and-log.
+        if not _looks_like_uri(provision_uri):
+            continue
         try:
             sanction_rows = list_sanctions_for_provision(
                 provision_uri, sparql_client=sparql_client
@@ -568,7 +593,7 @@ def _sanction_to_delta_row(sanction: SanctionRow) -> SanctionsDeltaRow:
 
 
 def analyze_burden_delta(
-    draft_uri: str,
+    draft_graph_uri: str,
     *,
     sparql_client: SparqlClient | None = None,
 ) -> BurdenDeltaReport:
@@ -579,8 +604,15 @@ def analyze_burden_delta(
     counts in JSON-friendly form, a burden score, and a percent-delta).
 
     Args:
-        draft_uri: The ``DraftLegislation`` URI. An empty URI yields an
-            empty :class:`BurdenDeltaReport` with all zero counters.
+        draft_graph_uri: The draft's Jena **named graph** URI (the same
+            value :func:`app.docs.analyze_handler.analyze_impact` passes
+            for every other pass). #855: an uploaded draft's triples live
+            at ``<graph_uri>#self`` *inside* this named graph, so the
+            burden lookup is GRAPH-scoped to it and addresses the ``#self``
+            subject. Passing the bare graph URI to the default-graph query
+            (the old behaviour) matched nothing, so the C6 section was
+            silently always zero. An empty URI yields an empty
+            :class:`BurdenDeltaReport` with all zero counters.
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -589,15 +621,23 @@ def analyze_burden_delta(
         not yet carry their own ``normativeType`` edges — see the
         :class:`BurdenDelta` docstring for the v2 backfill dependency.
     """
-    uri = (draft_uri or "").strip()
-    if not uri:
+    graph_uri = (draft_graph_uri or "").strip()
+    if not graph_uri:
         return BurdenDeltaReport(counts=_empty_burden_counts())
 
     # Lazy import — see TYPE_CHECKING block above.
     from app.analyysikeskus.burden import burden_delta_for_draft
 
     try:
-        delta = burden_delta_for_draft(uri, sparql_client=sparql_client)
+        # The draft subject the graph builder wrote is ``<graph_uri>#self``;
+        # pass it as the ``draft_uri`` (used for the default-graph fallback
+        # arm + logging) and the graph URI as ``graph_uri`` so the
+        # GRAPH-scoped lookup reads the named graph (#855).
+        delta = burden_delta_for_draft(
+            f"{graph_uri}#self",
+            graph_uri=graph_uri,
+            sparql_client=sparql_client,
+        )
     except Exception as exc:  # noqa: BLE001 — pass-level isolation
         logger.warning("analyze_burden_delta: burden_delta_for_draft failed: %s", exc)
         return BurdenDeltaReport(counts=_empty_burden_counts())

--- a/app/docs/impact/queries.py
+++ b/app/docs/impact/queries.py
@@ -250,16 +250,24 @@ SELECT DISTINCT ?draftRef ?conflictEntity ?conflictLabel ?reason ?relation ?othe
   GRAPH <{graph_uri}> {{ ?draft estleg:references ?draftRef . }}
   {{
     # Another draft references the same entity.
+    #
+    # #855: the other draft's ``rdfs:label`` triple lives INSIDE its own
+    # named graph (the draft graph builder writes ``<g>#self rdfs:label
+    # "<title>"`` into ``<g>``). On Fuseki there is no ``unionDefaultGraph``
+    # so the label OPTIONAL must sit INSIDE ``GRAPH ?otherGraph`` — when it
+    # was outside, ``?conflictEntity rdfs:label ?conflictLabel`` matched
+    # only the default graph, never bound, and the UI fell back to raw
+    # draft URIs. Keeping it inside the GRAPH block binds the title.
     GRAPH ?otherGraph {{
       ?otherDraft a estleg:DraftLegislation ;
                   estleg:references ?draftRef .
+      BIND(?otherDraft AS ?conflictEntity)
+      OPTIONAL {{ ?conflictEntity rdfs:label ?conflictLabel }}
     }}
     # A5: exclude this draft's own (current + prior-version) graphs.
     FILTER(!STRSTARTS(str(?otherGraph), "{draft_prefix}"))
     # A3(c): exclude ephemeral adhoc probe graphs.
     FILTER(!STRSTARTS(str(?otherGraph), "{adhoc_prefix}"))
-    BIND(?otherDraft AS ?conflictEntity)
-    OPTIONAL {{ ?conflictEntity rdfs:label ?conflictLabel }}
     BIND("Teine eelnõu viitab juba sellele sättele" AS ?reason)
     BIND(estleg:references AS ?relation)
   }} UNION {{

--- a/app/sync/jena_loader.py
+++ b/app/sync/jena_loader.py
@@ -107,13 +107,38 @@ def _admin_auth() -> tuple[str, str]:
 # this regex (the UUID is server-generated), but the allowlist stays a
 # defence-in-depth guard against any future code path assembling a URI
 # from user-supplied data.
+#
+# #849: draft *versions* mint per-version graph URIs of the shape
+# ``…/estleg/drafts/<uuid>/v<n>`` (see ``app.docs.upload`` §9.5 — v1 is
+# the bare ``…/drafts/<uuid>``, v2+ append ``/v<n>``). Before this fix the
+# allowlist only admitted the bare-UUID form, so every v2+ upload's
+# analyze + cleanup tripped ``ValueError("Unsafe graph URI")``, retries
+# exhausted, and the draft flipped to ``failed``. The optional
+# ``(?:/v\d+)?`` arm is attached to the **drafts** alternative only — the
+# adhoc probe graphs are single-shot and never versioned, so they keep the
+# bare-UUID shape. This is the ONE canonical regex (re-exported from
+# ``app.docs.impact.queries``); the version widening therefore lands in
+# the GSP transport, the lineage writer, and the impact query builders
+# simultaneously, with no second definition to drift. We deliberately do
+# NOT widen the character class or admit ``#``/``?`` — the version segment
+# is a literal ``/v`` followed by one-or-more ASCII digits, nothing else.
 _SAFE_GRAPH_URI = re.compile(
-    r"^https://data\.riik\.ee/ontology/estleg/(?:drafts|adhoc)/[0-9a-f-]{36}$"
+    r"^https://data\.riik\.ee/ontology/estleg/"
+    r"(?:drafts/[0-9a-f-]{36}(?:/v\d+)?|adhoc/[0-9a-f-]{36})$"
 )
 
 
 def _validate_graph_uri(uri: str) -> str:
     """Return *uri* unchanged after asserting it matches the allowlist.
+
+    Accepted shapes (#849):
+
+    * ``…/estleg/drafts/<uuid>`` — a draft's v1 graph;
+    * ``…/estleg/drafts/<uuid>/v<n>`` — a draft's v2+ version graph;
+    * ``…/estleg/adhoc/<uuid>`` — an ephemeral Normi-mõjuahel probe.
+
+    Anything else (non-estleg host, malformed UUID, a stray suffix, an
+    injection-shaped string) is rejected.
 
     Raises:
         ValueError: When *uri* doesn't fit the safe pattern. Callers

--- a/tests/test_docs_graph_builder.py
+++ b/tests/test_docs_graph_builder.py
@@ -596,3 +596,41 @@ class TestWriteDocLineageGraphScope:
         text = mock_update.call_args.args[0]
         # Both the DELETE WHERE and INSERT DATA blocks must be GRAPH-scoped.
         assert text.count(f"GRAPH <{draft.graph_uri}>") == 2
+
+
+class TestWriteDocLineageVersionedGraph:
+    """#849: the lineage writer must accept a draft's ``/v<n>`` version graph.
+
+    v2+ uploads mint ``…/drafts/<uuid>/v<n>`` graph URIs. ``write_doc_lineage``
+    runs in the analyze pipeline right after the Turtle PUT, so a v2+ upload
+    would raise ``ValueError("Unsafe graph URI")`` here before the fix —
+    one of the paths that flipped v2 drafts to ``failed``.
+    """
+
+    def _make_v2_eelnou(self) -> Draft:
+        draft = _make_eelnou(parent_vtk_id=None)
+        draft.graph_uri = f"https://data.riik.ee/ontology/estleg/drafts/{_EELNOU_ID}/v2"
+        return draft
+
+    def test_accepts_v2_graph_uri_and_writes_self_subject(self):
+        draft = self._make_v2_eelnou()
+        with patch("app.docs.graph_builder._sparql_update", return_value=True) as mock_update:
+            write_doc_lineage(draft, None)
+
+        assert mock_update.call_count == 1
+        text = mock_update.call_args.args[0]
+        draft_iri = f"{draft.graph_uri}#self"
+        # The class assertion lands on the versioned ``#self`` subject…
+        assert f"<{draft_iri}> a <https://data.riik.ee/ontology/estleg#DraftLegislation> ." in text
+        # …GRAPH-scoped to the versioned graph URI (both DELETE + INSERT).
+        assert text.count(f"GRAPH <{draft.graph_uri}>") == 2
+
+    def test_accepts_versioned_parent_vtk_graph(self):
+        """A versioned parent VTK graph must also pass validation."""
+        draft = self._make_v2_eelnou()
+        parent = _make_vtk()
+        parent.graph_uri = f"https://data.riik.ee/ontology/estleg/drafts/{_VTK_A_ID}/v2"
+        with patch("app.docs.graph_builder._sparql_update", return_value=True) as mock_update:
+            write_doc_lineage(draft, parent)
+        text = mock_update.call_args.args[0]
+        assert f"<{parent.graph_uri}#self>" in text

--- a/tests/test_impact_report_c6_sanctions_burden_summary.py
+++ b/tests/test_impact_report_c6_sanctions_burden_summary.py
@@ -58,6 +58,11 @@ _USER_ID = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
 _ORG_ID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
 
 _NS = "https://data.riik.ee/ontology/estleg#"
+# #855: analyze_burden_delta now takes the draft's *named graph* URI (its
+# triples live at ``<graph_uri>#self`` inside the graph). Use a valid
+# drafts/<uuid> graph URI so the GRAPH-scoped lookup's URI validation
+# passes.
+_DRAFT_GRAPH_URI = f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}"
 _KARS_URI = f"{_NS}karistusseadustik"
 _KARS_P211_URI = f"{_NS}KarS-p211"
 _KARS_P211_SANCTION_URI = f"{_NS}KarS-p211-Sanction"
@@ -249,7 +254,9 @@ class TestAnalyzeBurdenDelta:
             [_burden_sparql_row(provision_uri=f"{_NS}P1", norm_type=_OBLIGATION_URI)],
             [_burden_sparql_row(provision_uri=f"{_NS}P2", norm_type=_PROHIBITION_URI)],
         ]
-        report = analyze_burden_delta(f"{_NS}Draft_1", sparql_client=stub)
+        # #855: pass the draft's *named graph* URI; the helper now
+        # GRAPH-scopes the affected-provision lookup to it.
+        report = analyze_burden_delta(_DRAFT_GRAPH_URI, sparql_client=stub)
         assert report.affected_count == 2
         assert report.counts["obligation"] == 1
         assert report.counts["prohibition"] == 1
@@ -264,10 +271,21 @@ class TestAnalyzeBurdenDelta:
         assert "Kohustused" in labels
         assert "Keelud" in labels
 
+        # #855 regression: the first (affected-provisions) query must be
+        # GRAPH-scoped to the draft's named graph and address the ``#self``
+        # subject — proving the C6 burden lookup reads the named graph
+        # where the draft triples actually live, not the (empty) default
+        # graph.
+        first_query = stub.query.call_args_list[0]
+        sent_sparql = first_query.args[0]
+        assert f"GRAPH <{_DRAFT_GRAPH_URI}>" in sent_sparql
+        self_subject = first_query.kwargs.get("uri_bindings", {}).get("draftSelf")
+        assert self_subject == f"{_DRAFT_GRAPH_URI}#self"
+
     def test_jena_failure_returns_empty_report(self) -> None:
         stub = MagicMock()
         stub.query.side_effect = RuntimeError("jena down")
-        report = analyze_burden_delta(f"{_NS}Draft_1", sparql_client=stub)
+        report = analyze_burden_delta(_DRAFT_GRAPH_URI, sparql_client=stub)
         assert report.affected_count == 0
         assert report.before_score == 0
 

--- a/tests/test_sync_jena_loader_named_graphs.py
+++ b/tests/test_sync_jena_loader_named_graphs.py
@@ -199,6 +199,137 @@ class TestGraphUriValidation:
         assert queries._SAFE_GRAPH_URI is jena_loader._SAFE_GRAPH_URI
 
 
+class TestVersionedGraphUriValidation:
+    """#849: the allowlist must accept ``drafts/<uuid>/v<n>`` version graphs.
+
+    v1 uploads mint ``…/drafts/<uuid>``; v2+ uploads mint
+    ``…/drafts/<uuid>/v<n>`` (``app.docs.upload`` §9.5). Before this fix the
+    allowlist rejected the versioned shape, so every v2+ upload's analyze
+    + cleanup raised ``ValueError("Unsafe graph URI")``, retries
+    exhausted, and the draft flipped to ``failed``.
+    """
+
+    _UUID = "11111111-1111-1111-1111-111111111111"
+    _PREFIX = "https://data.riik.ee/ontology/estleg/"
+    _V1 = f"{_PREFIX}drafts/{_UUID}"
+    _V2 = f"{_PREFIX}drafts/{_UUID}/v2"
+    _V10 = f"{_PREFIX}drafts/{_UUID}/v10"
+    _ADHOC = f"{_PREFIX}adhoc/22222222-2222-2222-2222-222222222222"
+
+    # --- acceptance matrix -------------------------------------------------
+
+    def test_accepts_v1_bare_uuid(self):
+        assert jena_loader._validate_graph_uri(self._V1) == self._V1
+
+    def test_accepts_v2_version_graph(self):
+        assert jena_loader._validate_graph_uri(self._V2) == self._V2
+        assert jena_loader._SAFE_GRAPH_URI.fullmatch(self._V2)
+
+    def test_accepts_v10_double_digit_version_graph(self):
+        assert jena_loader._validate_graph_uri(self._V10) == self._V10
+
+    def test_accepts_adhoc(self):
+        assert jena_loader._validate_graph_uri(self._ADHOC) == self._ADHOC
+
+    # --- rejection matrix (malformed / external / injection) ---------------
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "urn:not-a-draft",
+            "http://jena.apache.org/Default",
+            # non-estleg host with an otherwise valid-looking path
+            "https://evil.com/ontology/estleg/drafts/11111111-1111-1111-1111-111111111111",
+            # bad uuid
+            "https://data.riik.ee/ontology/estleg/drafts/not-a-uuid",
+            # version arm with no digits
+            "https://data.riik.ee/ontology/estleg/drafts/11111111-1111-1111-1111-111111111111/v",
+            # extra path segment after the version
+            "https://data.riik.ee/ontology/estleg/drafts/11111111-1111-1111-1111-111111111111/v2/extra",
+            # adhoc graphs are never versioned
+            "https://data.riik.ee/ontology/estleg/adhoc/22222222-2222-2222-2222-222222222222/v2",
+            # fragment at the graph level is not allowed
+            "https://data.riik.ee/ontology/estleg/drafts/11111111-1111-1111-1111-111111111111#self",
+            # query-string injection
+            f"{_PREFIX}drafts/{_UUID}/v2?x=1",
+            # SPARQL-injection-shaped tail (angle-bracket break-out attempt)
+            f"{_PREFIX}drafts/{_UUID}/v2> }} GRAPH ?g {{",
+        ],
+    )
+    def test_rejects_malformed_external_and_injection(self, bad: str):
+        with pytest.raises(ValueError, match="Unsafe graph URI"):
+            jena_loader._validate_graph_uri(bad)
+
+    # --- transport accepts the versioned URI end to end --------------------
+
+    @patch("app.sync.jena_loader.httpx.put")
+    def test_put_accepts_v2_graph(self, mock_put: MagicMock):
+        response = MagicMock()
+        response.status_code = 204
+        mock_put.return_value = response
+        assert jena_loader.put_named_graph(self._V2, "# turtle") is True
+        mock_put.assert_called_once()
+        # The versioned URI is URL-encoded into the ?graph= param.
+        called_url = mock_put.call_args.args[0]
+        assert "graph=" in called_url
+
+    @patch("app.sync.jena_loader.httpx.delete")
+    def test_delete_accepts_v2_graph(self, mock_delete: MagicMock):
+        """#849: version-graph cleanup deletes must pass validation."""
+        response = MagicMock()
+        response.status_code = 204
+        mock_delete.return_value = response
+        assert jena_loader.delete_named_graph(self._V2) is True
+        mock_delete.assert_called_once()
+
+    @patch("app.sync.jena_loader.httpx.post")
+    def test_named_graph_exists_accepts_v2_graph(self, mock_post: MagicMock):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"head": {}, "boolean": True}
+        response.raise_for_status.return_value = None
+        mock_post.return_value = response
+        assert jena_loader.named_graph_exists(self._V2) is True
+
+    # --- impact builders + lineage writer share the one regula -------------
+
+    def test_impact_builders_accept_v2_graph(self):
+        """All four impact query builders must accept a versioned graph URI.
+
+        They re-use the canonical ``_validate_graph_uri`` (re-exported in
+        ``app.docs.impact.queries``), so the #849 widening must reach them
+        without a second edit. A versioned URI that previously raised must
+        now build a query string containing the GRAPH clause.
+        """
+        from app.docs.impact.queries import (
+            build_affected_entities_query,
+            build_conflicts_query,
+            build_eu_compliance_query,
+            build_gaps_query,
+        )
+
+        for builder in (
+            build_affected_entities_query,
+            build_gaps_query,
+            build_eu_compliance_query,
+            build_conflicts_query,
+        ):
+            q = builder(self._V2)
+            assert f"GRAPH <{self._V2}>" in q
+
+    def test_conflicts_builder_excludes_own_prior_versions_for_v2(self):
+        """#849 + #868 (A5): a v2 graph's conflict query must exclude the
+        whole ``…/drafts/<uuid>`` namespace so it never self-conflicts
+        against its own v1."""
+        from app.docs.impact.queries import build_conflicts_query
+
+        q = build_conflicts_query(self._V2)
+        # The version-agnostic prefix (no ``/v2``) is what the exclusion
+        # keys on, so v1 and any other version are excluded.
+        assert f'!STRSTARTS(str(?otherGraph), "{self._V1}")' in q
+        assert "/v2" not in q.split("!STRSTARTS")[1].split("\n")[0]
+
+
 class TestNamedGraphExists:
     @patch("app.sync.jena_loader.httpx.post")
     def test_named_graph_exists_true(self, mock_post: MagicMock):

--- a/tests/test_versioned_graph_and_burden_c6.py
+++ b/tests/test_versioned_graph_and_burden_c6.py
@@ -1,0 +1,345 @@
+"""Integration-style tests for #849 (versioned draft graph URIs) + #855
+(silently-zero C6 burden section, conflict-label binding, sanctions
+warning spam).
+
+These exercise the real code paths end to end, mocking only the Jena
+transport (``httpx``) / the SPARQL client, so they prove the fixes hold
+across module seams rather than at a single function:
+
+#849
+    * A v2 upload's analyze path (Turtle PUT → impact query builders →
+      lineage writer) passes graph-URI validation instead of raising
+      ``ValueError("Unsafe graph URI")``.
+    * The version-graph cleanup DELETE passes validation too.
+    * #868's A5 self-version exclusion still holds for a v2 graph (the
+      draft does not report its own v1 graph as a conflict).
+
+#855
+    * The C6 burden lookup is GRAPH-scoped to the draft's named graph and
+      addresses the ``#self`` subject, so a synthetic draft graph yields
+      non-zero burden rows (the section was silently always zero before).
+    * Other-draft conflict labels bind (the OPTIONAL now lives inside the
+      ``GRAPH ?otherGraph`` block).
+    * Act-title literal rows (``estleg:referencesAct``) are skipped before
+      sanctions URI validation, so no ``invalid URI`` warnings are logged.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rdflib import Dataset, Literal, Namespace, URIRef
+from rdflib.namespace import RDF, RDFS
+
+from app.analyysikeskus.burden import (
+    _build_draft_affected_provisions_graph_query,
+    burden_delta_for_draft,
+)
+from app.docs.impact.analyzer import analyze_burden_delta, analyze_sanctions_delta
+from app.docs.impact.queries import (
+    build_affected_entities_query,
+    build_conflicts_query,
+    build_eu_compliance_query,
+    build_gaps_query,
+)
+from app.sync import jena_loader
+
+EST = Namespace("https://data.riik.ee/ontology/estleg#")
+
+_PREFIX = "https://data.riik.ee/ontology/estleg/"
+_UUID = "44444444-4444-4444-4444-444444444444"
+_V1_GRAPH = f"{_PREFIX}drafts/{_UUID}"
+_V2_GRAPH = f"{_PREFIX}drafts/{_UUID}/v2"
+_V2_SELF = f"{_V2_GRAPH}#self"
+
+
+def _rows(ds: Dataset, query: str) -> list[dict[str, str]]:
+    """Run *query* against *ds* and flatten each binding to a str dict.
+
+    Mirrors the helper in ``tests/test_tenant_scoping_conflicts.py`` — the
+    ``# type: ignore`` annotations paper over rdflib's wide
+    ``Result``/``ResultRow`` union types (``query`` may return a bool for
+    ASK; SELECT rows expose ``.labels`` + ``__getitem__``).
+    """
+    out: list[dict[str, str]] = []
+    for row in ds.query(query):
+        d: dict[str, str] = {}
+        for var in row.labels:  # type: ignore[attr-defined,union-attr]
+            value = row[var]  # type: ignore[index]
+            d[str(var)] = str(value) if value is not None else ""
+        out.append(d)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# #849 — versioned graph URIs flow through every gate
+# ---------------------------------------------------------------------------
+
+
+class TestVersionedUploadAnalyzeAndCleanup:
+    """Every gate a v2 upload crosses must accept ``…/drafts/<uuid>/v<n>``."""
+
+    @patch("app.sync.jena_loader.httpx.put")
+    @patch("app.sync.jena_loader.httpx.delete")
+    def test_v2_put_then_cleanup_delete_pass_validation(
+        self, mock_delete: MagicMock, mock_put: MagicMock
+    ):
+        """A v2 graph survives the PUT (analyze) → DELETE (cleanup) round-trip
+        without raising the allowlist ``ValueError``."""
+        put_resp = MagicMock()
+        put_resp.status_code = 204
+        mock_put.return_value = put_resp
+        del_resp = MagicMock()
+        del_resp.status_code = 204
+        mock_delete.return_value = del_resp
+
+        # Analyze-side write.
+        assert jena_loader.put_named_graph(_V2_GRAPH, "# turtle") is True
+        # Cleanup-side delete (the version-graph cleanup path #849 calls).
+        assert jena_loader.delete_named_graph(_V2_GRAPH) is True
+        mock_put.assert_called_once()
+        mock_delete.assert_called_once()
+
+    def test_all_impact_builders_accept_v2_graph(self):
+        """The four impact query builders must not raise on a v2 graph and
+        must GRAPH-scope to it."""
+        for builder in (
+            build_affected_entities_query,
+            build_gaps_query,
+            build_eu_compliance_query,
+            build_conflicts_query,
+        ):
+            q = builder(_V2_GRAPH)
+            assert f"GRAPH <{_V2_GRAPH}>" in q
+
+    def test_lineage_writer_accepts_v2_graph(self):
+        """``write_doc_lineage`` (analyze pipeline) must accept a v2 graph."""
+        from datetime import UTC, datetime
+
+        from app.docs.draft_model import Draft
+        from app.docs.graph_builder import write_doc_lineage
+
+        now = datetime.now(UTC)
+        draft = Draft(
+            id=uuid.UUID(_UUID),
+            user_id=uuid.UUID("55555555-5555-5555-5555-555555555555"),
+            org_id=uuid.UUID("66666666-6666-6666-6666-666666666666"),
+            title="v2 eelnõu",
+            filename="eelnou_v2.docx",
+            content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            file_size=1024,
+            storage_path="/tmp/c.enc",
+            graph_uri=_V2_GRAPH,
+            status="analyzing",
+            parsed_text_encrypted=None,
+            entity_count=None,
+            error_message=None,
+            created_at=now,
+            updated_at=now,
+            doc_type="eelnou",  # type: ignore[arg-type]
+            parent_vtk_id=None,
+        )
+        with patch("app.docs.graph_builder._sparql_update", return_value=True) as mock_update:
+            write_doc_lineage(draft, None)
+        text = mock_update.call_args.args[0]
+        assert f"GRAPH <{_V2_GRAPH}>" in text
+        assert f"<{_V2_SELF}> a " in text
+
+    def test_a5_self_version_exclusion_holds_for_v2(self):
+        """#868 sequencing guard: a v2 analyze must NOT report this draft's
+        own v1 graph as a conflict (the whole ``…/drafts/<uuid>`` namespace
+        is excluded)."""
+        from app.docs.impact.queries import CONFLICTS
+        from app.ontology.scoping import ADHOC_GRAPH_PREFIX, draft_graph_prefix_for
+
+        q = CONFLICTS.format(
+            graph_uri=_V2_GRAPH,
+            draft_prefix=draft_graph_prefix_for(_V2_GRAPH),
+            adhoc_prefix=ADHOC_GRAPH_PREFIX,
+        )
+        ds = Dataset()
+        prov = EST.Provision_Shared
+        cur = ds.graph(URIRef(_V2_GRAPH))
+        cur.add((URIRef(_V2_SELF), RDF.type, EST.DraftLegislation))
+        cur.add((URIRef(_V2_SELF), EST.references, prov))
+        # The same draft's own v1 graph references the same provision.
+        v1 = ds.graph(URIRef(_V1_GRAPH))
+        v1.add((URIRef(f"{_V1_GRAPH}#self"), RDF.type, EST.DraftLegislation))
+        v1.add((URIRef(f"{_V1_GRAPH}#self"), EST.references, prov))
+        v1.add((URIRef(f"{_V1_GRAPH}#self"), RDFS.label, Literal("MY OWN V1")))
+
+        leaked = [x for x in _rows(ds, q) if x.get("conflictEntity")]
+        assert leaked == [], f"A5: v2 reported its own v1 graph as a conflict: {leaked!r}"
+
+
+# ---------------------------------------------------------------------------
+# #855 — C6 burden section is no longer silently zero
+# ---------------------------------------------------------------------------
+
+
+class TestBurdenGraphScoping:
+    def test_graph_scoped_query_finds_provisions_in_named_graph(self):
+        """The GRAPH-scoped affected-provisions query returns the draft's
+        referenced provisions when its triples live in a named graph."""
+        ds = Dataset()
+        g = ds.graph(URIRef(_V2_GRAPH))
+        g.add((URIRef(_V2_SELF), RDF.type, EST.DraftLegislation))
+        g.add((URIRef(_V2_SELF), EST.references, EST.TLS_p12))
+        g.add((URIRef(_V2_SELF), EST.references, EST.TLS_p20))
+
+        q = _build_draft_affected_provisions_graph_query(_V2_GRAPH)
+        # Mirror SparqlClient's VALUES injection for the ``#self`` subject.
+        cut = q.rstrip().rfind("}")
+        q_bound = (
+            q.rstrip()[:cut] + f"\n  VALUES ?draftSelf {{ <{_V2_SELF}> }}\n" + q.rstrip()[cut:]
+        )
+        rows = sorted(r["provision"] for r in _rows(ds, q_bound))
+        assert rows == [str(EST.TLS_p12), str(EST.TLS_p20)]
+
+    def test_default_graph_query_misses_named_graph_triples(self):
+        """Regression guard: the OLD default-graph variant returns nothing
+        against named-graph triples — the exact #855 root cause."""
+        from app.analyysikeskus.burden import _build_draft_affected_provisions_query
+
+        ds = Dataset()
+        g = ds.graph(URIRef(_V2_GRAPH))
+        g.add((URIRef(_V2_SELF), EST.references, EST.TLS_p12))
+
+        q = _build_draft_affected_provisions_query()
+        cut = q.rstrip().rfind("}")
+        q_bound = (
+            q.rstrip()[:cut] + f"\n  VALUES ?draftUri {{ <{_V2_GRAPH}> }}\n" + q.rstrip()[cut:]
+        )
+        assert _rows(ds, q_bound) == []
+
+    def test_burden_delta_for_draft_graph_scoped_yields_rows(self):
+        """``burden_delta_for_draft(graph_uri=…)`` GRAPH-scopes the lookup and
+        addresses ``#self``; a stubbed client returns non-zero rows."""
+        stub = MagicMock()
+        stub.query.side_effect = [
+            # affected-provisions list
+            [{"provision": f"{EST}P1"}, {"provision": f"{EST}P2"}],
+            # per-provision burden
+            [
+                {
+                    "provision": f"{EST}P1",
+                    "provisionLabel": "P1",
+                    "normType": f"{EST}NormType_Obligation",
+                    "dutyHolder": "Tööandja",
+                }
+            ],
+            [
+                {
+                    "provision": f"{EST}P2",
+                    "provisionLabel": "P2",
+                    "normType": f"{EST}NormType_Prohibition",
+                    "dutyHolder": "Riik",
+                }
+            ],
+        ]
+        delta = burden_delta_for_draft(_V2_SELF, graph_uri=_V2_GRAPH, sparql_client=stub)
+        assert delta.affected_count == 2
+        assert delta.before.counts["obligation"] == 1
+        assert delta.before.counts["prohibition"] == 1
+        # The first query must be GRAPH-scoped + bind the ``#self`` subject.
+        first = stub.query.call_args_list[0]
+        assert f"GRAPH <{_V2_GRAPH}>" in first.args[0]
+        assert first.kwargs["uri_bindings"]["draftSelf"] == _V2_SELF
+
+    def test_analyze_burden_delta_threads_graph_uri(self):
+        """``analyze_burden_delta(draft_graph_uri)`` must GRAPH-scope the
+        burden lookup to the named graph (non-zero C6 section)."""
+        stub = MagicMock()
+        stub.query.side_effect = [
+            [{"provision": f"{EST}P1"}],
+            [
+                {
+                    "provision": f"{EST}P1",
+                    "provisionLabel": "P1",
+                    "normType": f"{EST}NormType_Obligation",
+                    "dutyHolder": "Tööandja",
+                }
+            ],
+        ]
+        report = analyze_burden_delta(_V2_GRAPH, sparql_client=stub)
+        assert report.affected_count == 1
+        assert report.counts["obligation"] == 1
+        assert report.before_score == 1
+        first = stub.query.call_args_list[0]
+        assert f"GRAPH <{_V2_GRAPH}>" in first.args[0]
+        assert first.kwargs["uri_bindings"]["draftSelf"] == _V2_SELF
+
+
+class TestConflictLabelBinding:
+    def test_other_draft_label_binds_from_inside_named_graph(self):
+        """#855: the other draft's ``rdfs:label`` lives inside its own named
+        graph; the conflict query must bind it (no raw-URI fallback)."""
+        cur_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        other_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        cur_graph = f"{_PREFIX}drafts/{cur_uuid}"
+        other_graph = f"{_PREFIX}drafts/{other_uuid}"
+
+        q = build_conflicts_query(cur_graph)
+        ds = Dataset()
+        prov = EST.Provision_X
+        cur = ds.graph(URIRef(cur_graph))
+        cur.add((URIRef(f"{cur_graph}#self"), RDF.type, EST.DraftLegislation))
+        cur.add((URIRef(f"{cur_graph}#self"), EST.references, prov))
+        oth = ds.graph(URIRef(other_graph))
+        oth.add((URIRef(f"{other_graph}#self"), RDF.type, EST.DraftLegislation))
+        oth.add((URIRef(f"{other_graph}#self"), EST.references, prov))
+        oth.add((URIRef(f"{other_graph}#self"), RDFS.label, Literal("OTHER ORG DRAFT")))
+
+        hits = [x for x in _rows(ds, q) if x.get("conflictEntity")]
+        assert hits, "expected a cross-draft conflict row"
+        assert any(h.get("conflictLabel") == "OTHER ORG DRAFT" for h in hits), (
+            f"conflict label did not bind from the named graph: {hits!r}"
+        )
+
+
+class TestSanctionsActTitleNoWarningSpam:
+    def test_act_title_literals_skipped_no_invalid_uri_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        """#855: act-title literal rows must be skipped before sanctions URI
+        validation, so no ``invalid URI`` / ``Unsafe URI`` warning is logged
+        and the SPARQL client is never called for them."""
+        stub = MagicMock()
+        # A mix: one real provision URI + two act-title literals (the shape
+        # ``estleg:referencesAct`` rows leave in ``affected_uris``).
+        affected = [
+            f"{EST}KarS_p211",
+            "Riigieelarve seadus",
+            "Töölepingu seadus",
+        ]
+        # The single valid provision returns no sanctions (empty list).
+        stub.query.return_value = []
+
+        with caplog.at_level(logging.WARNING):
+            delta = analyze_sanctions_delta("urn:draft:1", affected, sparql_client=stub)
+
+        # No sanctions found (empty), and crucially no warning spam.
+        assert delta.rows == []
+        # The act-title literals never reached list_sanctions_for_provision,
+        # so the client was called at most once (for the one real URI).
+        assert stub.query.call_count <= 1
+        spammy = [
+            rec
+            for rec in caplog.records
+            if "invalid uri" in rec.getMessage().lower()
+            or "unsafe uri" in rec.getMessage().lower()
+            or "list_sanctions_for_provision" in rec.getMessage().lower()
+        ]
+        assert spammy == [], (
+            f"unexpected URI-validation warning spam: {[r.getMessage() for r in spammy]}"
+        )
+
+    def test_valid_provision_uri_still_queried(self):
+        """A real provision URI must still be passed through to the lookup."""
+        stub = MagicMock()
+        stub.query.return_value = []
+        analyze_sanctions_delta("urn:draft:1", [f"{EST}KarS_p211"], sparql_client=stub)
+        stub.query.assert_called_once()


### PR DESCRIPTION
Two correctness fixes in the same draft-impact subsystem, building on the merged wave-1 PRs (#868's A5 self-version exclusion + masking + `app/ontology/scoping.py`).

## #849 — accept versioned draft graph URIs

**Root cause.** v2+ uploads mint per-version graph URIs `…/drafts/<uuid>/v<n>` (`app/docs/upload.py` §9.5), but the single canonical allowlist regex `_SAFE_GRAPH_URI` (in `app/sync/jena_loader.py`, re-exported from `app/docs/impact/queries.py`) only admitted the bare-UUID form. Every v2+ upload's analyze raised `ValueError("Unsafe graph URI")`; retries exhausted; the draft flipped to `failed`. Version-graph cleanup deletes raised too.

**Fix.** One shared validator — widen the **single** regex to accept an optional `/v\d+` arm on the **drafts** alternative only (adhoc probes are single-shot, never versioned). Because the GSP transport (`put`/`delete`/`named_graph_exists`/`get_named_graph_triple_count`), the lineage writer (`app/docs/graph_builder.write_doc_lineage`), and all four impact query builders import the same `_validate_graph_uri`/`_SAFE_GRAPH_URI`, the widening reaches every gate with no second definition to drift. Malformed / external / path-traversal / injection-shaped URIs are still rejected.

### DoD — #849
- [x] Single shared safe-graph-URI validator used by loader, lineage writer, impact query builder, and cleanup paths (the one `_SAFE_GRAPH_URI`).
- [x] Validator accepts draft, adhoc, and versioned-draft (`/v\d+`) URIs.
- [x] Still rejects malformed / external / path-traversal / injection-bearing URIs.
- [x] v1/v2/later re-uploads use compatible graph-URI generation, analysis, cleanup, impact-query behaviour.
- [x] Error messages stay actionable (`Unsafe graph URI rejected: <uri>`).
- [x] Unit tests for accepted `drafts/{uuid}`, `drafts/{uuid}/v2`, `/v10`, `adhoc/{uuid}`.
- [x] Unit tests for rejected non-estleg, malformed UUID, bad suffix, SPARQL-injection-like values.
- [x] Integration/workflow test: a v2 upload's analyze (PUT + lineage + impact builders) does not fail on graph-URI validation.
- [x] Cleanup test: versioned graph DELETE accepts the same safe URI.
- [x] Lint/type/test baseline green.

## #855 — restore the silently-zero burden (C6) section

**Root cause(s).**
1. `analyze_burden_delta(draft.graph_uri)` passed the **bare** graph URI while the draft's triples live at `{graph_uri}#self` **inside** the named graph, and `_build_draft_affected_provisions_query` matched only the default graph (no `unionDefaultGraph`). The section rendered, reported zero, nothing errored.
2. The other-draft `?conflictLabel` OPTIONAL sat **outside** `GRAPH ?otherGraph`, so labels never bound → UI fell back to raw draft URIs.
3. Act-title literal rows (`estleg:referencesAct "<title>"`) flowed into `analyze_sanctions_delta` → `list_sanctions_for_provision` → URI-only binding, raising-and-logging a warning **per title per analyze run**.

**Fix.**
1. New GRAPH-scoped variant `_build_draft_affected_provisions_graph_query(graph_uri)` that wraps the draft-side patterns in `GRAPH <graph_uri> {…}` and addresses the `<graph_uri>#self` subject. `analyze_burden_delta` now threads the graph URI through `burden_delta_for_draft` via a new optional `graph_uri=` kwarg. **The Halduskoormus route path (`burden_delta_for_draft(entity_uri)` for corpus drafts in the default graph) is unchanged** — `graph_uri` defaults to `None` → legacy default-graph query.
2. Moved the `?conflictLabel` OPTIONAL inside the `GRAPH ?otherGraph` block.
3. `analyze_sanctions_delta` skips non-URI provision values before the lookup.

### DoD — #855
- [x] Burden-delta query addresses the draft's named graph explicitly (GRAPH clause) and uses the `{graph_uri}#self` subject.
- [x] C6 section produces non-zero rows for a fixture draft (integration test + negative control proving the old default-graph variant matched nothing).
- [x] Conflict-label OPTIONAL moved inside `GRAPH ?otherGraph` so labels bind.
- [x] `referencesAct` act-title rows skipped before sanction URI validation (no warning spam).
- [x] Lint/type/test baseline green.

### Sequencing guard (#868)
- [x] A v2 analysis does **not** report the same draft's v1 graph as a conflict — `TestVersionedUploadAnalyzeAndCleanup::test_a5_self_version_exclusion_holds_for_v2` (the whole `…/drafts/<uuid>` namespace stays excluded via `!STRSTARTS`).

## Recovery for drafts already flipped to `failed` by #849

Affected drafts are identifiable via `error_debug` containing `Unsafe graph URI`. They are all v2+ versions (v1 graph URIs always passed). The existing user-facing retry endpoint (`app/docs/retry_handler.py`) re-runs the pipeline once a draft is back in `uploaded`; the snippet below mirrors `_reset_draft_for_retry` so owners can re-run without manual support.

```sql
-- 1) IDENTIFY affected drafts (run first; notify owners).
SELECT d.id, d.title, d.org_id, d.user_id, d.updated_at, d.error_message
FROM drafts d
WHERE d.status = 'failed'
  AND d.error_debug ILIKE '%Unsafe graph URI%';

-- 2) RESET them to a re-runnable state (clears error columns, mirrors
--    retry_handler._reset_draft_for_retry). Run inside a transaction.
BEGIN;

UPDATE drafts
SET status = 'uploaded',
    error_message = NULL,
    error_debug = NULL,
    processing_completed_at = NULL,
    updated_at = now()
WHERE status = 'failed'
  AND error_debug ILIKE '%Unsafe graph URI%';

-- Keep the per-version mirror consistent for the latest (failed) version.
UPDATE draft_versions v
SET status = 'uploaded'
WHERE v.status = 'failed'
  AND v.draft_id IN (
    SELECT id FROM drafts
    WHERE status = 'uploaded' AND error_message IS NULL
  );

COMMIT;
```

After the reset, owners click **Proovi uuesti** (the existing retry button) on each draft, or an operator enqueues `parse_draft` for each affected id. (No migration ships with this PR; this is a one-off operational snippet.)

## Test evidence

- Full suite: `4307 passed, 45 skipped`.
- `uv run ruff check .` — all checks passed. `uv run pyright` — 0 errors.
- New file `tests/test_versioned_graph_and_burden_c6.py` (11 tests): v2 PUT+DELETE round-trip, all impact builders + lineage writer accept v2, A5 self-version exclusion for v2, GRAPH-scoped burden query yields rows, default-graph negative control, `burden_delta_for_draft`/`analyze_burden_delta` graph-scoping, conflict-label binding, sanctions no-warning-spam.
- Extended `tests/test_sync_jena_loader_named_graphs.py` with `TestVersionedGraphUriValidation` (parametrized accept/reject matrix + transport).
- Extended `tests/test_docs_graph_builder.py` with `TestWriteDocLineageVersionedGraph`.
- Updated `tests/test_impact_report_c6_sanctions_burden_summary.py::TestAnalyzeBurdenDelta` for the corrected GRAPH-scoped contract (now asserts the GRAPH clause + `#self` binding).

## Scope notes / deviations
- `app/docs/graph_builder.py` and `app/docs/upload.py` were intentionally **not** edited: the lineage writer inherits the regex widening via its existing `_validate_graph_uri` import, and upload.py already mints the correct `…/v{n}` shape — no source change needed for either.
- `burden.py` edits are confined to the draft-delta region (`_build_draft_affected_provisions_query` + the new graph variant + `burden_delta_for_draft`); the act-level/temporal helpers are untouched.
- No migration (none required).

Closes #849
Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)