### PR TITLE
fix(llm): correct pricing tables, retry transient errors, meter cancelled streams, attribute embedding spend (#854)

### DIFF
--- a/app/drafter/handlers.py
+++ b/app/drafter/handlers.py
@@ -670,7 +670,22 @@ def drafter_research(
     # Step 3 (the legacy act-label fallback in
     # :func:`_similar_provisions_text_for_prompt` keeps Step 4 working).
     try:
-        research["similar_provisions"] = _find_similar_provisions(research, sparql_client=client)
+        # #854: the similarity lookup may fire a Voyage embedding call
+        # deep inside ``analyysikeskus.similarity`` → ``Retriever`` —
+        # a chain we can't thread kwargs through. The contextvar-based
+        # attribution stamps that spend with this session's owner and a
+        # drafter-specific feature label instead of the old anonymous
+        # ``feature="embedding"`` / user_id=org_id=NULL rows.
+        from app.rag.embedding import embedding_attribution
+
+        with embedding_attribution(
+            user_id=session.user_id,
+            org_id=session.org_id,
+            feature="drafter_research_embedding",
+        ):
+            research["similar_provisions"] = _find_similar_provisions(
+                research, sparql_client=client
+            )
     except Exception:
         logger.warning(
             "drafter_research: similar-provision enrichment failed for session %s",

--- a/app/llm/claude.py
+++ b/app/llm/claude.py
@@ -17,6 +17,7 @@ set) calls the Anthropic Messages API and logs token usage via
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -100,7 +101,11 @@ class ClaudeProvider(LLMProvider):
                 "ClaudeProvider: the 'anthropic' package is not installed. "
                 "Run `uv add anthropic` to add it."
             ) from exc
-        self._client = anthropic.Anthropic(api_key=self._api_key)
+        # #854: max_retries=0 — app/llm/retry.py is the single retry
+        # authority. The SDK default of 2 internal retries would stack
+        # under the outer wrapper's 4 attempts (up to 12 HTTP calls and
+        # a multi-minute blocking worst case).
+        self._client = anthropic.Anthropic(api_key=self._api_key, max_retries=0)
         return self._client
 
     def _log_cost(
@@ -312,7 +317,9 @@ class ClaudeProvider(LLMProvider):
                 "ClaudeProvider: the 'anthropic' package is not installed. "
                 "Run `uv add anthropic` to add it."
             ) from exc
-        self._async_client = anthropic.AsyncAnthropic(api_key=self._api_key)
+        # #854: max_retries=0 — see _get_client; the outer retry wrapper
+        # in app/llm/retry.py is the single retry authority.
+        self._async_client = anthropic.AsyncAnthropic(api_key=self._api_key, max_retries=0)
         return self._async_client
 
     # -- async LLMProvider interface -------------------------------------------
@@ -478,8 +485,27 @@ class ClaudeProvider(LLMProvider):
             stream_obj.__stream_ctx__ = ctx  # type: ignore[attr-defined]
             return stream_obj
 
+        # #854: cost logging happens in the OUTER ``finally`` at the bottom
+        # of this method. Previously ``_log_cost`` ran in a ``finally``
+        # attached to the trailing ``yield stop``, which a mid-stream
+        # upstream error or a client-disconnect cancel (GeneratorExit via
+        # ``aclose()``) skipped entirely — already-billed output tokens
+        # never reached ``llm_usage``. Once the stream has *opened*,
+        # Anthropic bills the input tokens (and any streamed output), so
+        # we record whatever usage the events delivered. The counts are
+        # event-derived: on an early abort ``message_delta`` may not have
+        # arrived yet, so partial-but-honest numbers (often output=0) are
+        # logged rather than nothing.
+        stream_opened = False
         try:
-            stream = await retry_async(_open_stream, context="astream-open")
+            try:
+                stream = await retry_async(_open_stream, context="astream-open")
+            except Exception:
+                # Open never succeeded → nothing was billed; skip the
+                # usage row entirely (stream_opened stays False).
+                stream_status = "error"
+                raise
+            stream_opened = True
             ctx = stream.__stream_ctx__  # type: ignore[attr-defined]
             try:
                 async for event in stream:
@@ -548,13 +574,35 @@ class ClaudeProvider(LLMProvider):
                             usage = getattr(msg, "usage", None)
                             if usage:
                                 tokens_input = getattr(usage, "input_tokens", 0)
+            except (GeneratorExit, asyncio.CancelledError):
+                # Consumer cancelled mid-stream — client disconnect
+                # (``aclose()`` → GeneratorExit) or an enclosing
+                # ``wait_for`` timeout (CancelledError). The tokens
+                # streamed so far are still billed; the outer finally
+                # records them (#854).
+                stream_status = "cancelled"
+                raise
+            except Exception:
+                stream_status = "error"
+                raise
             finally:
                 # Close the context we manually entered above so the
-                # underlying httpx stream is released even on errors.
+                # underlying httpx stream is released on every path —
+                # clean stop, upstream error, and GeneratorExit from a
+                # consumer ``aclose()``.
                 await ctx.__aexit__(None, None, None)
-        except Exception:
-            stream_status = "error"
-            raise
+
+            # #662 / post-review fix: yield the stop event so the
+            # orchestrator can read the per-turn tokens off it and persist
+            # them on the assistant message row. The llm_usage row is
+            # recorded in the OUTER finally below, so a consumer cancel
+            # immediately after receiving the stop frame (or at any
+            # earlier point) still produces exactly one usage row.
+            yield StreamEvent(
+                type="stop",
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
+            )
         finally:
             _stream_duration_ms = (time.perf_counter() - _stream_start) * 1000
             record_metric(
@@ -567,29 +615,18 @@ class ClaudeProvider(LLMProvider):
                     "status": stream_status,
                 },
             )
-
-        # #662 / post-review fix: yield the stop event FIRST so the
-        # orchestrator can read the per-turn tokens off it and persist
-        # them on the assistant message row, then log_cost in a finally
-        # block so the llm_usage row is recorded even if the consumer
-        # cancels the generator immediately after receiving the stop
-        # frame. Previously cost was logged before the yield, so a
-        # cancel between the two left llm_usage incremented but the
-        # message row had NULL tokens — analytics drift across cancel.
-        try:
-            yield StreamEvent(
-                type="stop",
-                tokens_input=tokens_input,
-                tokens_output=tokens_output,
-            )
-        finally:
-            self._log_cost(
-                feature=feature,
-                tokens_input=tokens_input,
-                tokens_output=tokens_output,
-                user_id=user_id,
-                org_id=org_id,
-            )
+            if stream_opened:
+                # #854: meter the stream no matter how it ended — clean
+                # stop, mid-stream upstream error, or consumer cancel.
+                # ``log_usage`` swallows its own failures, so this never
+                # masks the in-flight exception.
+                self._log_cost(
+                    feature=feature,
+                    tokens_input=tokens_input,
+                    tokens_output=tokens_output,
+                    user_id=user_id,
+                    org_id=org_id,
+                )
 
 
 _default_provider: ClaudeProvider | None = None

--- a/app/llm/pricing.py
+++ b/app/llm/pricing.py
@@ -1,17 +1,89 @@
-"""LLM pricing table for cost calculation."""
+"""LLM and embedding pricing table for cost calculation.
+
+Prices are USD per million tokens, verified 2026-06-11 against the
+provider documentation (#854):
+
+* Anthropic: https://platform.claude.com/docs/en/docs/about-claude/pricing
+  (redirect target of https://docs.anthropic.com/en/docs/about-claude/pricing)
+* Voyage AI: https://docs.voyageai.com/docs/pricing
+
+The table covers every model the app actually configures (``CLAUDE_MODEL``
+defaults to ``claude-sonnet-4-6``; ``VOYAGE_MODEL`` defaults to
+``voyage-multilingual-2``) plus the plausible env-var overrides. When a
+new model is rolled out, add a row here in the same deploy — unknown
+models are *recorded with cost 0* and a loud warning (see
+:func:`calculate_cost`), so the usage row survives but budget
+enforcement undercounts until the row is added.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
 
 # Rates in USD per million tokens (input, output).
 PRICING: dict[tuple[str, str], dict[str, float]] = {
+    # -- Anthropic Claude --------------------------------------------------
+    # Opus 4.5 through 4.8 are all $5 in / $25 out. (The previous table's
+    # $15/$75 belonged to the retired Opus 4.0/4.1 generation — a 3x
+    # overcharge against opus-4-6; #854 / review E4.)
+    ("claude", "claude-fable-5"): {"input": 10.00, "output": 50.00},
+    ("claude", "claude-opus-4-8"): {"input": 5.00, "output": 25.00},
+    ("claude", "claude-opus-4-7"): {"input": 5.00, "output": 25.00},
+    ("claude", "claude-opus-4-6"): {"input": 5.00, "output": 25.00},
+    ("claude", "claude-opus-4-5"): {"input": 5.00, "output": 25.00},
     ("claude", "claude-sonnet-4-6"): {"input": 3.00, "output": 15.00},
-    ("claude", "claude-opus-4-6"): {"input": 15.00, "output": 75.00},
-    ("claude", "claude-haiku-4-5"): {"input": 0.80, "output": 4.00},
+    ("claude", "claude-sonnet-4-5"): {"input": 3.00, "output": 15.00},
+    # Haiku 4.5 is $1/$5 (the previous $0.80/$4.00 was Haiku 3.5 pricing).
+    ("claude", "claude-haiku-4-5"): {"input": 1.00, "output": 5.00},
+    # -- Voyage AI embeddings ----------------------------------------------
+    # Embeddings only consume input tokens; output rate is 0 so the same
+    # ``calculate_cost`` formula works for both providers.
+    ("voyage", "voyage-multilingual-2"): {"input": 0.12, "output": 0.0},
+    ("voyage", "voyage-law-2"): {"input": 0.12, "output": 0.0},
+    ("voyage", "voyage-3-large"): {"input": 0.18, "output": 0.0},
+    ("voyage", "voyage-3.5"): {"input": 0.06, "output": 0.0},
+    ("voyage", "voyage-3.5-lite"): {"input": 0.02, "output": 0.0},
 }
+
+# (provider, model) pairs we've already warned about — the warning fires
+# once per process per unknown model so a busy ingest doesn't flood logs.
+_warned_unknown: set[tuple[str, str]] = set()
+_warned_unknown_lock = threading.Lock()
+
+
+def _reset_unknown_model_warnings() -> None:
+    """Reset the warn-once state (for tests only)."""
+    with _warned_unknown_lock:
+        _warned_unknown.clear()
 
 
 def calculate_cost(provider: str, model: str, tokens_input: int, tokens_output: int) -> float:
-    """Return the estimated cost in USD for the given token counts."""
+    """Return the estimated cost in USD for the given token counts.
+
+    Unknown ``(provider, model)`` pairs follow the warn-and-record policy
+    chosen for #854: emit a loud ``logger.warning`` (once per model per
+    process) and return ``0.0`` so the caller still records the usage row.
+    Billing paths must never crash on a missing price — but the gap must
+    be visible in logs, not silent as before.
+    """
     key = (provider, model)
     rates = PRICING.get(key)
     if rates is None:
-        return 0.0  # unknown model — log but don't crash
+        with _warned_unknown_lock:
+            first_sighting = key not in _warned_unknown
+            if first_sighting:
+                _warned_unknown.add(key)
+        if first_sighting:
+            logger.warning(
+                "No pricing entry for provider=%r model=%r — usage will be "
+                "recorded with cost_usd=0, so budgets and cost dashboards "
+                "undercount until a row is added to app/llm/pricing.py "
+                "PRICING (#854).",
+                provider,
+                model,
+            )
+        return 0.0
     return (tokens_input * rates["input"] + tokens_output * rates["output"]) / 1_000_000

--- a/app/llm/pricing.py
+++ b/app/llm/pricing.py
@@ -43,6 +43,11 @@ PRICING: dict[tuple[str, str], dict[str, float]] = {
     # ``calculate_cost`` formula works for both providers.
     ("voyage", "voyage-multilingual-2"): {"input": 0.12, "output": 0.0},
     ("voyage", "voyage-law-2"): {"input": 0.12, "output": 0.0},
+    # Voyage 4 series (current generation) — plausible VOYAGE_MODEL upgrades;
+    # verified against docs.voyageai.com/docs/pricing 2026-06-11 (review P3).
+    ("voyage", "voyage-4-large"): {"input": 0.12, "output": 0.0},
+    ("voyage", "voyage-4"): {"input": 0.06, "output": 0.0},
+    ("voyage", "voyage-4-lite"): {"input": 0.02, "output": 0.0},
     ("voyage", "voyage-3-large"): {"input": 0.18, "output": 0.0},
     ("voyage", "voyage-3.5"): {"input": 0.06, "output": 0.0},
     ("voyage", "voyage-3.5-lite"): {"input": 0.02, "output": 0.0},

--- a/app/llm/retry.py
+++ b/app/llm/retry.py
@@ -26,7 +26,18 @@ Cost-tracking caveat
 Retries here wrap the SDK call only. ``log_usage`` is invoked *after*
 the wrapped call returns successfully (in the existing call sites in
 ``app.llm.claude``), so a retried-then-succeeded request still logs
-exactly one usage row, and a fully failed request logs none.
+exactly one usage row, and a fully failed non-streaming request logs
+none. Streams are different (#854): once the stream *opened*, tokens
+are billed even if it dies or is cancelled mid-flight, so
+``ClaudeProvider.astream`` logs whatever usage it captured in an outer
+``finally`` instead of only on clean completion.
+
+SDK-internal retries are disabled
+---------------------------------
+This module is the *single* retry authority (#854). The Anthropic
+clients are constructed with ``max_retries=0`` (SDK default is 2, which
+would stack under our 4 attempts → up to 12 HTTP calls) and the Voyage
+client pins its tenacity-based ``max_retries=0`` likewise.
 """
 
 from __future__ import annotations
@@ -39,7 +50,11 @@ from collections.abc import Awaitable, Callable
 logger = logging.getLogger(__name__)
 
 # Status codes that warrant retry — transient server / rate-limit conditions.
-_RETRYABLE_HTTP: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+# #854: includes the full transient set both SDKs treat as retryable —
+# 408 (request timeout), 409 (conflict; Anthropic's SDK retries it),
+# 429 (rate limit), 5xx, and 529 (Anthropic ``overloaded_error``, its
+# most common transient failure).
+_RETRYABLE_HTTP: frozenset[int] = frozenset({408, 409, 429, 500, 502, 503, 504, 529})
 
 # Status codes that must fail fast — broken request / auth / permissions.
 _NON_RETRYABLE_HTTP: frozenset[int] = frozenset({400, 401, 403})
@@ -55,13 +70,23 @@ def _http_status(exc: BaseException) -> int | None:
     """Best-effort extraction of an HTTP status code from an exception.
 
     Anthropic SDK ``APIStatusError`` subclasses expose ``.status_code``
-    directly; we also check ``.response.status_code`` for httpx-shaped
-    errors. Returns ``None`` when the exception isn't tied to an HTTP
-    response (e.g. ``ConnectionError``, ``TimeoutError``).
+    directly; voyageai's ``VoyageError`` hierarchy exposes ``.http_status``
+    (#854 — previously missed, so Voyage 429/5xx never retried and a
+    single rate-limit hit aborted a whole ingest); we also check
+    ``.response.status_code`` for httpx-shaped errors. Returns ``None``
+    when the exception isn't tied to an HTTP response (e.g.
+    ``ConnectionError``, ``TimeoutError``).
     """
     status = getattr(exc, "status_code", None)
     if isinstance(status, int):
         return status
+    # voyageai stores the response status verbatim on ``http_status``;
+    # it is normally an int but tolerate numeric strings defensively.
+    status = getattr(exc, "http_status", None)
+    if isinstance(status, int):
+        return status
+    if isinstance(status, str) and status.isdigit():
+        return int(status)
     response = getattr(exc, "response", None)
     if response is not None:
         status = getattr(response, "status_code", None)
@@ -74,10 +99,10 @@ def _is_retryable(exc: BaseException) -> bool:
     """Decide whether *exc* represents a transient failure worth retrying.
 
     Policy:
-    * HTTP status in ``_RETRYABLE_HTTP`` → retry.
+    * HTTP status in ``_RETRYABLE_HTTP`` (408/409/429/5xx/529) → retry.
     * HTTP status in ``_NON_RETRYABLE_HTTP`` → never retry.
     * No HTTP status (network/timeout) → retry.
-    * Other HTTP statuses (e.g. 404, 409, 422) → don't retry; the caller's
+    * Other HTTP statuses (e.g. 404, 422) → don't retry; the caller's
       payload is wrong, not the server.
     """
     # Network / timeout errors carry no status code.

--- a/app/rag/embedding.py
+++ b/app/rag/embedding.py
@@ -17,11 +17,15 @@ with ``ON CONFLICT DO UPDATE``).
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 import random
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Any
 
 from app.config import STUB_ALLOWED_ENVS, get_app_env, is_stub_allowed
@@ -32,15 +36,80 @@ DEFAULT_MODEL = "voyage-multilingual-2"
 DEFAULT_DIMENSIONS = 1024
 
 
+# ---------------------------------------------------------------------------
+# Embedding cost attribution (#854)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _EmbeddingAttribution:
+    """User/org/feature labels to stamp on embedding ``llm_usage`` rows."""
+
+    user_id: Any = None
+    org_id: Any = None
+    feature: str | None = None
+
+
+_attribution_ctx: contextvars.ContextVar[_EmbeddingAttribution | None] = contextvars.ContextVar(
+    "embedding_attribution", default=None
+)
+
+
+@contextmanager
+def embedding_attribution(
+    *,
+    user_id: Any = None,
+    org_id: Any = None,
+    feature: str | None = None,
+) -> Iterator[None]:
+    """Attribute embedding spend made anywhere inside the ``with`` block.
+
+    Some call chains cross modules whose signatures we can't extend
+    (e.g. drafter research → ``app.analyysikeskus.similarity.find_similar``
+    → :class:`app.rag.retriever.Retriever` → :meth:`VoyageProvider.embed`),
+    so the attribution rides a :mod:`contextvars` context variable
+    instead of explicit kwargs. Values set here take precedence over the
+    kwargs threaded into :meth:`VoyageProvider.embed`, because the
+    outermost caller knows the business context best.
+
+    ContextVars propagate into ``asyncio.run`` / tasks started inside
+    the block, which covers the sync→async bridge in
+    ``find_embedding_similar``. They do NOT propagate into worker
+    threads — in that fallback path the spend is logged with whatever
+    the explicit kwargs carried (never wrongly attributed, at worst
+    unattributed).
+    """
+    token = _attribution_ctx.set(
+        _EmbeddingAttribution(user_id=user_id, org_id=org_id, feature=feature)
+    )
+    try:
+        yield
+    finally:
+        _attribution_ctx.reset(token)
+
+
 class EmbeddingProvider(ABC):
     """Abstract base class for text embedding providers."""
 
     @abstractmethod
-    async def embed(self, texts: list[str]) -> list[list[float]]:
+    async def embed(
+        self,
+        texts: list[str],
+        *,
+        user_id: Any = None,
+        org_id: Any = None,
+        feature: str = "embedding",
+    ) -> list[list[float]]:
         """Embed a batch of texts into dense vectors.
 
         Args:
             texts: List of text strings to embed.
+            user_id: Optional user to attribute the embedding spend to
+                in ``llm_usage`` (#854). ``None`` = unattributed.
+            org_id: Optional org to attribute the embedding spend to —
+                this is what per-org budget enforcement keys on.
+            feature: Cost-attribution label for the ``llm_usage`` row
+                (e.g. ``"chat_embedding"``, ``"drafter_research_embedding"``).
 
         Returns:
             List of embedding vectors, one per input text. Each vector
@@ -118,19 +187,47 @@ class VoyageProvider(EmbeddingProvider):
                 "VoyageProvider: the 'voyageai' package is not installed. "
                 "Run `uv add voyageai` to add it."
             ) from exc
-        self._client = voyageai.AsyncClient(api_key=self._api_key)  # type: ignore[attr-defined]
+        # #854: pin max_retries=0 (it IS the voyageai 0.3.7 default, but
+        # pinning guards against an SDK default bump) — app/llm/retry.py
+        # is the single retry authority; tenacity-internal retries would
+        # stack under the outer wrapper's 4 attempts.
+        self._client = voyageai.AsyncClient(  # type: ignore[attr-defined]
+            api_key=self._api_key, max_retries=0
+        )
         return self._client
 
-    def _log_cost(self, token_count: int) -> None:
-        """Log embedding usage via cost_tracker."""
+    def _log_cost(
+        self,
+        token_count: int,
+        *,
+        user_id: Any = None,
+        org_id: Any = None,
+        feature: str = "embedding",
+    ) -> None:
+        """Log embedding usage via cost_tracker.
+
+        Attribution precedence (#854): an active
+        :func:`embedding_attribution` context overrides the explicit
+        kwargs field-by-field — the outermost business caller (e.g. the
+        drafter research handler) wins over generic plumbing defaults.
+        """
         from app.llm.cost_tracker import log_usage
 
+        ctx = _attribution_ctx.get()
+        if ctx is not None:
+            if ctx.user_id is not None:
+                user_id = ctx.user_id
+            if ctx.org_id is not None:
+                org_id = ctx.org_id
+            if ctx.feature:
+                feature = ctx.feature
+
         log_usage(
-            user_id=None,
-            org_id=None,
+            user_id=user_id,
+            org_id=org_id,
             provider="voyage",
             model=self._model,
-            feature="embedding",
+            feature=feature,
             tokens_input=token_count,
             tokens_output=0,
         )
@@ -142,11 +239,22 @@ class VoyageProvider(EmbeddingProvider):
         """Return the dimensionality of Voyage embeddings."""
         return self._dimensions
 
-    async def embed(self, texts: list[str]) -> list[list[float]]:
+    async def embed(
+        self,
+        texts: list[str],
+        *,
+        user_id: Any = None,
+        org_id: Any = None,
+        feature: str = "embedding",
+    ) -> list[list[float]]:
         """Embed a batch of texts using Voyage AI.
 
         Stub mode returns random vectors of the correct dimensionality
         seeded from the text content for reproducibility in tests.
+
+        ``user_id`` / ``org_id`` / ``feature`` flow to the ``llm_usage``
+        cost row (#854); see :meth:`_log_cost` for how an active
+        :func:`embedding_attribution` context interacts with them.
         """
         if not texts:
             return []
@@ -175,7 +283,7 @@ class VoyageProvider(EmbeddingProvider):
         # Log cost (Voyage charges per token)
         total_tokens = getattr(response, "total_tokens", 0)
         if total_tokens:
-            self._log_cost(total_tokens)
+            self._log_cost(total_tokens, user_id=user_id, org_id=org_id, feature=feature)
 
         return response.embeddings  # type: ignore[no-any-return]
 

--- a/app/rag/retriever.py
+++ b/app/rag/retriever.py
@@ -160,6 +160,7 @@ class Retriever:
         k: int = 10,
         source_type: str | None = None,
         org_id: str | None = None,
+        user_id: str | None = None,
         filters: dict[str, Any] | None = None,
         feature: str = "unknown",
     ) -> list[RetrievedChunk]:
@@ -183,6 +184,10 @@ class Retriever:
                 and only public chunks are returned. Callers must pass
                 the authenticated user's ``org_id`` — failing to do so is
                 a data-leak bug, not a convenience.
+            user_id: Optional authenticated user id, used purely for
+                cost attribution of the query-embedding call in
+                ``llm_usage`` (#854). Unlike ``org_id`` it has no effect
+                on which chunks are visible.
             filters: Optional metadata filter dict. Allowed keys are
                 ``source_type``, ``source_uri``, ``entity_type``. Values
                 may be a scalar (``=``), a list/tuple/set (``= ANY``),
@@ -194,6 +199,9 @@ class Retriever:
                 ``"drafter"``, ``"analyysikeskus_similarity"``). Defaults
                 to ``"unknown"`` so legacy callers still record metrics;
                 new callers should always pass an explicit label. (#323)
+                Also drives the cost-attribution label on the embedding
+                call: a known feature ``X`` logs the Voyage spend as
+                ``X_embedding`` (#854).
 
         Returns:
             List of :class:`RetrievedChunk` ordered by descending
@@ -222,7 +230,9 @@ class Retriever:
                 k=k,
                 source_type=source_type,
                 org_id=org_id,
+                user_id=user_id,
                 filters=filters,
+                feature=feature,
             )
         except Exception:
             status = "error"
@@ -242,7 +252,9 @@ class Retriever:
         k: int,
         source_type: str | None,
         org_id: str | None,
+        user_id: str | None,
         filters: dict[str, Any] | None,
+        feature: str,
     ) -> list[RetrievedChunk]:
         """Body of :meth:`retrieve`, kept separate so the metric wrapper
         is the only place that needs the try/except scaffolding."""
@@ -276,8 +288,19 @@ class Retriever:
         if any(clause == "FALSE" for clause in extra_clauses):
             return []
 
-        # 1. Embed the query
-        embeddings = await self.embedder.embed([query])
+        # 1. Embed the query. Thread the caller's identity + feature into
+        # the embedding cost row (#854) so Voyage spend lands in per-org
+        # budget enforcement instead of an unattributed "embedding"
+        # bucket. A known feature ``X`` becomes ``X_embedding`` to keep
+        # the provider="claude" feature labels distinct from the Voyage
+        # spend they trigger.
+        embed_feature = "embedding" if feature == "unknown" else f"{feature}_embedding"
+        embeddings = await self.embedder.embed(
+            [query],
+            user_id=user_id,
+            org_id=org_id,
+            feature=embed_feature,
+        )
         if not embeddings:
             return []
         query_embedding = embeddings[0]

--- a/tests/test_drafter_research_embedding_attribution.py
+++ b/tests/test_drafter_research_embedding_attribution.py
@@ -1,0 +1,167 @@
+"""Drafter research embedding spend is attributed to the session owner (#854).
+
+``drafter_research`` → ``_find_similar_provisions`` →
+``app.analyysikeskus.similarity.find_similar`` → ``Retriever`` →
+``VoyageProvider`` is a chain whose middle module we can't thread kwargs
+through, so the call site wraps the lookup in
+:func:`app.rag.embedding.embedding_attribution`. These tests prove the
+context is active for the duration of ``find_similar`` (including across
+the sync→async ``asyncio.run`` bridge that the similarity module uses)
+and stamps the Voyage ``llm_usage`` row with the drafter session's
+user/org and the ``drafter_research_embedding`` feature label — instead
+of the pre-#854 anonymous ``feature="embedding"`` rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.drafter.session_model import DraftingSession
+
+_SESSION_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_USER_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_ORG_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+
+
+def _make_session() -> DraftingSession:
+    now = datetime.now(UTC)
+    return DraftingSession(
+        id=_SESSION_ID,
+        user_id=_USER_ID,
+        org_id=_ORG_ID,
+        workflow_type="full_law",
+        current_step=3,
+        intent="Soovin luua tehisintellekti seaduse",
+        clarifications=[{"question": "Q1?", "answer": "A1"}],
+        research_data_encrypted=None,
+        proposed_structure=None,
+        draft_content_encrypted=None,
+        integrated_draft_id=None,
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestDrafterResearchEmbeddingAttribution:
+    @patch("app.analyysikeskus.similarity.find_similar")
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_find_similar_runs_inside_attribution_context(
+        self,
+        mock_fetch: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+        mock_find_similar: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A Voyage cost log fired anywhere inside ``find_similar`` —
+        even across the similarity module's ``asyncio.run`` bridge —
+        carries the session owner + drafter feature label."""
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+        mock_fetch.return_value = _make_session()
+        client = MagicMock()
+        client.query.return_value = [
+            {"provision": "uri:1", "label": "Provision 1", "actLabel": "Act 1"},
+        ]
+        mock_sparql_cls.return_value = client
+        mock_encrypt.return_value = b"encrypted-data"
+        mock_conn.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        logged_usage: list[dict[str, Any]] = []
+
+        def _fake_find_similar(**kwargs: Any) -> list[Any]:
+            """Stand-in for the analyysikeskus chain: trigger a real
+            ``VoyageProvider._log_cost`` via the same sync→async bridge
+            the similarity module uses."""
+            from app.rag.embedding import VoyageProvider
+
+            provider = VoyageProvider()  # stub mode; _log_cost is real
+
+            async def _run() -> None:
+                with patch(
+                    "app.llm.cost_tracker.log_usage",
+                    side_effect=lambda **kw: logged_usage.append(kw),
+                ):
+                    provider._log_cost(1234)
+
+            asyncio.run(_run())
+            return []
+
+        mock_find_similar.side_effect = _fake_find_similar
+
+        from app.drafter.handlers import drafter_research
+
+        result = drafter_research({"session_id": str(_SESSION_ID)})
+
+        assert result is not None
+        assert result["session_id"] == str(_SESSION_ID)
+        mock_find_similar.assert_called()
+        assert logged_usage, "expected the fake find_similar to log Voyage usage"
+        usage = logged_usage[0]
+        assert usage["user_id"] == _USER_ID
+        assert usage["org_id"] == _ORG_ID
+        assert usage["feature"] == "drafter_research_embedding"
+        assert usage["provider"] == "voyage"
+        assert usage["tokens_input"] == 1234
+
+    @patch("app.analyysikeskus.similarity.find_similar")
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_attribution_context_cleared_after_research(
+        self,
+        mock_fetch: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+        mock_find_similar: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The contextvar must not leak past the enrichment block — a
+        later unrelated embedding stays unattributed."""
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+
+        mock_fetch.return_value = _make_session()
+        client = MagicMock()
+        client.query.return_value = [
+            {"provision": "uri:1", "label": "Provision 1", "actLabel": "Act 1"},
+        ]
+        mock_sparql_cls.return_value = client
+        mock_encrypt.return_value = b"encrypted-data"
+        mock_conn.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+        mock_find_similar.return_value = []
+
+        from app.drafter.handlers import drafter_research
+        from app.rag.embedding import VoyageProvider
+
+        drafter_research({"session_id": str(_SESSION_ID)})
+
+        logged_usage: list[dict[str, Any]] = []
+        provider = VoyageProvider()
+        with patch(
+            "app.llm.cost_tracker.log_usage",
+            side_effect=lambda **kw: logged_usage.append(kw),
+        ):
+            provider._log_cost(10)
+
+        assert logged_usage[0]["user_id"] is None
+        assert logged_usage[0]["org_id"] is None
+        assert logged_usage[0]["feature"] == "embedding"

--- a/tests/test_llm_claude_stream_cost.py
+++ b/tests/test_llm_claude_stream_cost.py
@@ -1,0 +1,280 @@
+"""Mid-stream cost metering for ``ClaudeProvider.astream`` (#854).
+
+Before #854, ``_log_cost`` ran in a ``finally`` attached to the trailing
+``yield stop`` — so a mid-stream upstream error or a client-disconnect
+cancel (GeneratorExit via ``aclose()``) skipped it entirely and
+already-billed tokens never reached ``llm_usage``. These tests pin the
+new contract: once the stream has *opened*, exactly one usage row is
+recorded no matter how the stream ends; if the open itself fails, no
+row is recorded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.llm.claude import ClaudeProvider
+from app.llm.provider import StreamEvent
+
+
+def _make_provider(monkeypatch: pytest.MonkeyPatch) -> ClaudeProvider:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    return ClaudeProvider()
+
+
+def _message_start(input_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message_start",
+        message=SimpleNamespace(usage=SimpleNamespace(input_tokens=input_tokens)),
+    )
+
+
+def _text_delta(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(text=text),
+    )
+
+
+def _message_delta(output_tokens: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message_delta",
+        usage=SimpleNamespace(output_tokens=output_tokens),
+    )
+
+
+class _ScriptedStream:
+    """Async iterator that replays events; an Exception entry is raised."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = list(events)
+
+    def __aiter__(self) -> _ScriptedStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._events:
+            raise StopAsyncIteration
+        item = self._events.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _Ctx:
+    """Context manager wrapper mimicking ``client.messages.stream(...)``."""
+
+    def __init__(self, stream: _ScriptedStream) -> None:
+        self._stream = stream
+        self.exits = 0
+
+    async def __aenter__(self) -> _ScriptedStream:
+        return self._stream
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.exits += 1
+
+
+def _wire(provider: ClaudeProvider, ctx: _Ctx) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.messages.stream = MagicMock(return_value=ctx)
+    provider._async_client = mock_client
+    return mock_client
+
+
+class TestMidStreamUpstreamError:
+    def test_usage_row_recorded_on_mid_stream_error(self, monkeypatch: pytest.MonkeyPatch):
+        """Upstream dies after message_start — the billed input tokens
+        must still reach ``llm_usage``."""
+        provider = _make_provider(monkeypatch)
+        ctx = _Ctx(
+            _ScriptedStream(
+                [
+                    _message_start(120),
+                    _text_delta("Tere"),
+                    ConnectionError("upstream died mid-stream"),
+                ]
+            )
+        )
+        _wire(provider, ctx)
+
+        with patch.object(ClaudeProvider, "_log_cost") as mock_log_cost:
+
+            async def _drain() -> list[Any]:
+                got = []
+                async for evt in provider.astream("hi", feature="chat"):
+                    got.append(evt)
+                return got
+
+            with pytest.raises(ConnectionError):
+                asyncio.run(_drain())
+
+        mock_log_cost.assert_called_once_with(
+            feature="chat",
+            tokens_input=120,
+            tokens_output=0,
+            user_id=None,
+            org_id=None,
+        )
+        assert ctx.exits == 1  # httpx stream released exactly once
+
+    def test_no_usage_row_when_open_never_succeeds(self, monkeypatch: pytest.MonkeyPatch):
+        """A permanent 401 on the open call bills nothing — no row."""
+        provider = _make_provider(monkeypatch)
+
+        class _AuthError(Exception):
+            status_code = 401
+
+        class _BadCtx:
+            async def __aenter__(self) -> Any:
+                raise _AuthError("bad key")
+
+            async def __aexit__(self, *args: Any) -> None:
+                return None
+
+        mock_client = MagicMock()
+        mock_client.messages.stream = MagicMock(return_value=_BadCtx())
+        provider._async_client = mock_client
+
+        with patch.object(ClaudeProvider, "_log_cost") as mock_log_cost:
+
+            async def _drain() -> None:
+                async for _ in provider.astream("hi"):
+                    pass
+
+            with pytest.raises(_AuthError):
+                asyncio.run(_drain())
+
+        mock_log_cost.assert_not_called()
+
+
+class TestConsumerCancel:
+    def test_usage_row_recorded_on_generator_exit(self, monkeypatch: pytest.MonkeyPatch):
+        """Client disconnect → orchestrator ``aclose()`` → GeneratorExit.
+
+        The partial usage captured so far (here the message_start input
+        tokens) must still be metered.
+        """
+        provider = _make_provider(monkeypatch)
+        ctx = _Ctx(
+            _ScriptedStream(
+                [
+                    _message_start(250),
+                    _text_delta("Tere "),
+                    _text_delta("tulemast"),
+                    _message_delta(99),
+                ]
+            )
+        )
+        _wire(provider, ctx)
+
+        with patch.object(ClaudeProvider, "_log_cost") as mock_log_cost:
+
+            async def _cancel_mid_stream() -> None:
+                # ``astream`` is declared as AsyncIterator but is an async
+                # generator at runtime — cast so we can drive aclose().
+                agen = cast(
+                    AsyncGenerator[StreamEvent],
+                    provider.astream("hi", feature="chat", user_id="u-1", org_id="o-1"),
+                )
+                first = await agen.__anext__()
+                assert first.type == "content"
+                # Suspended at the first content yield — close like the
+                # WebSocket layer does when the client disconnects.
+                await agen.aclose()
+
+            asyncio.run(_cancel_mid_stream())
+
+        mock_log_cost.assert_called_once_with(
+            feature="chat",
+            tokens_input=250,
+            tokens_output=0,
+            user_id="u-1",
+            org_id="o-1",
+        )
+        assert ctx.exits == 1
+
+    def test_usage_row_recorded_on_cancel_after_stop_frame(self, monkeypatch: pytest.MonkeyPatch):
+        """The #662 scenario: consumer takes the stop frame then closes.
+        Still exactly one usage row, now with full token counts."""
+        provider = _make_provider(monkeypatch)
+        ctx = _Ctx(
+            _ScriptedStream(
+                [
+                    _message_start(80),
+                    _text_delta("Vastus"),
+                    _message_delta(7),
+                ]
+            )
+        )
+        _wire(provider, ctx)
+
+        with patch.object(ClaudeProvider, "_log_cost") as mock_log_cost:
+
+            async def _take_stop_then_close() -> None:
+                agen = cast(
+                    AsyncGenerator[StreamEvent],
+                    provider.astream("hi", feature="chat"),
+                )
+                stop_seen = False
+                while True:
+                    evt = await agen.__anext__()
+                    if evt.type == "stop":
+                        stop_seen = True
+                        break
+                assert stop_seen
+                # Generator is suspended at the stop yield — close it the
+                # way the orchestrator does after a client disconnect.
+                await agen.aclose()
+
+            asyncio.run(_take_stop_then_close())
+
+        mock_log_cost.assert_called_once_with(
+            feature="chat",
+            tokens_input=80,
+            tokens_output=7,
+            user_id=None,
+            org_id=None,
+        )
+
+
+class TestCleanCompletion:
+    def test_exactly_one_usage_row_on_clean_stop(self, monkeypatch: pytest.MonkeyPatch):
+        """The restructure must not double-log the happy path."""
+        provider = _make_provider(monkeypatch)
+        ctx = _Ctx(
+            _ScriptedStream(
+                [
+                    _message_start(60),
+                    _text_delta("Tere!"),
+                    _message_delta(11),
+                ]
+            )
+        )
+        _wire(provider, ctx)
+
+        with patch.object(ClaudeProvider, "_log_cost") as mock_log_cost:
+
+            async def _drain() -> list[Any]:
+                return [evt async for evt in provider.astream("hi", feature="chat")]
+
+            events = asyncio.run(_drain())
+
+        stop_events = [e for e in events if e.type == "stop"]
+        assert len(stop_events) == 1
+        assert stop_events[0].tokens_input == 60
+        assert stop_events[0].tokens_output == 11
+        mock_log_cost.assert_called_once_with(
+            feature="chat",
+            tokens_input=60,
+            tokens_output=11,
+            user_id=None,
+            org_id=None,
+        )
+        assert ctx.exits == 1

--- a/tests/test_llm_cost_tracker.py
+++ b/tests/test_llm_cost_tracker.py
@@ -27,9 +27,10 @@ class TestCalculateCost:
         assert opus > sonnet
 
     def test_calculate_cost_haiku(self):
-        """Haiku pricing: 0.80 input / 4.00 output per 1M tokens."""
+        """Haiku 4.5 pricing: 1.00 input / 5.00 output per 1M tokens (#854 —
+        the old 0.80/4.00 figures were Haiku 3.5 rates)."""
         cost = calculate_cost("claude", "claude-haiku-4-5", 1_000_000, 0)
-        assert abs(cost - 0.80) < 1e-9
+        assert abs(cost - 1.00) < 1e-9
 
     def test_calculate_cost_zero_tokens(self):
         """Zero tokens should produce zero cost."""

--- a/tests/test_llm_pricing.py
+++ b/tests/test_llm_pricing.py
@@ -1,0 +1,217 @@
+"""Tests for ``app.llm.pricing`` (#854, review E4).
+
+Covers:
+* Corrected per-model rates for every configured production model
+  (verified 2026-06-11 against platform.claude.com and docs.voyageai.com).
+* Voyage embedding entries exist and produce non-zero costs.
+* Unknown ``(provider, model)`` pairs warn loudly (once per model) and
+  return 0.0 instead of failing — the warn-and-record policy.
+* ``log_usage`` still records a row (cost 0) for unknown models so the
+  usage itself is never lost.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.llm.pricing import (
+    PRICING,
+    _reset_unknown_model_warnings,
+    calculate_cost,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warn_state():
+    """Each test starts with a clean warn-once registry."""
+    _reset_unknown_model_warnings()
+    yield
+    _reset_unknown_model_warnings()
+
+
+class TestClaudePricing:
+    """Rates from https://platform.claude.com/docs/en/docs/about-claude/pricing."""
+
+    @pytest.mark.parametrize(
+        ("model", "expected_input", "expected_output"),
+        [
+            ("claude-fable-5", 10.00, 50.00),
+            ("claude-opus-4-8", 5.00, 25.00),
+            ("claude-opus-4-7", 5.00, 25.00),
+            # The pre-#854 table had opus-4-6 at $15/$75 — Opus 4.0/4.1
+            # pricing — a 3x overcharge.
+            ("claude-opus-4-6", 5.00, 25.00),
+            ("claude-opus-4-5", 5.00, 25.00),
+            ("claude-sonnet-4-6", 3.00, 15.00),
+            ("claude-sonnet-4-5", 3.00, 15.00),
+            # The pre-#854 table had haiku-4-5 at $0.80/$4.00 — Haiku 3.5
+            # pricing — an undercharge.
+            ("claude-haiku-4-5", 1.00, 5.00),
+        ],
+    )
+    def test_rates_match_provider_docs(
+        self, model: str, expected_input: float, expected_output: float
+    ):
+        rates = PRICING[("claude", model)]
+        assert rates["input"] == expected_input
+        assert rates["output"] == expected_output
+
+    def test_default_model_cost_per_million_tokens(self):
+        """1M in + 1M out on the CLAUDE_MODEL default (sonnet-4-6) = $18."""
+        cost = calculate_cost("claude", "claude-sonnet-4-6", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(18.00)
+
+    def test_opus_4_6_no_longer_triple_charged(self):
+        """100k in + 10k out on opus-4-6 = $0.75, not $2.25."""
+        cost = calculate_cost("claude", "claude-opus-4-6", 100_000, 10_000)
+        assert cost == pytest.approx(0.75)
+
+    def test_haiku_4_5_cost(self):
+        """1M in + 200k out on haiku-4-5 = $1 + $1 = $2."""
+        cost = calculate_cost("claude", "claude-haiku-4-5", 1_000_000, 200_000)
+        assert cost == pytest.approx(2.00)
+
+    def test_zero_tokens_zero_cost(self):
+        assert calculate_cost("claude", "claude-sonnet-4-6", 0, 0) == 0.0
+
+
+class TestVoyagePricing:
+    """Rates from https://docs.voyageai.com/docs/pricing."""
+
+    def test_every_voyage_entry_has_zero_output_rate(self):
+        """Embeddings only bill input tokens."""
+        voyage_entries = {k: v for k, v in PRICING.items() if k[0] == "voyage"}
+        assert voyage_entries, "expected voyage entries in PRICING"
+        for rates in voyage_entries.values():
+            assert rates["output"] == 0.0
+
+    def test_default_embedding_model_present_and_priced(self):
+        """The VOYAGE_MODEL default (voyage-multilingual-2) is $0.12/MTok."""
+        rates = PRICING[("voyage", "voyage-multilingual-2")]
+        assert rates["input"] == 0.12
+
+    def test_embedding_cost_is_non_zero(self):
+        """Pre-#854 every embedding logged cost_usd=0 — must be real now."""
+        cost = calculate_cost("voyage", "voyage-multilingual-2", 1_000_000, 0)
+        assert cost == pytest.approx(0.12)
+        assert cost > 0.0
+
+    @pytest.mark.parametrize(
+        ("model", "expected_input"),
+        [
+            ("voyage-multilingual-2", 0.12),
+            ("voyage-law-2", 0.12),
+            ("voyage-3-large", 0.18),
+            ("voyage-3.5", 0.06),
+            ("voyage-3.5-lite", 0.02),
+        ],
+    )
+    def test_voyage_rates_match_provider_docs(self, model: str, expected_input: float):
+        assert PRICING[("voyage", model)]["input"] == expected_input
+
+
+class TestEveryConfiguredModelIsPriced:
+    """Every PRICING row must produce a non-zero, warning-free cost."""
+
+    @pytest.mark.parametrize(("provider", "model"), sorted(PRICING))
+    def test_table_entry_yields_positive_cost_without_warning(
+        self, provider: str, model: str, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.WARNING, logger="app.llm.pricing"):
+            cost = calculate_cost(provider, model, 1_000_000, 1_000_000)
+        assert cost > 0.0
+        assert not caplog.records
+
+
+class TestUnknownModelPolicy:
+    """Warn-and-record: loud warning, cost 0, billing paths never crash."""
+
+    def test_unknown_model_returns_zero(self):
+        assert calculate_cost("claude", "claude-nonexistent-9-9", 1000, 1000) == 0.0
+
+    def test_unknown_model_warns(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING, logger="app.llm.pricing"):
+            calculate_cost("claude", "claude-nonexistent-9-9", 1000, 1000)
+        assert len(caplog.records) == 1
+        message = caplog.records[0].getMessage()
+        assert "claude-nonexistent-9-9" in message
+        assert "cost_usd=0" in message
+
+    def test_unknown_provider_warns(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING, logger="app.llm.pricing"):
+            assert calculate_cost("openai", "gpt-x", 1000, 0) == 0.0
+        assert len(caplog.records) == 1
+
+    def test_warns_once_per_model_per_process(self, caplog: pytest.LogCaptureFixture):
+        """A busy ingest must not flood the logs with one line per call."""
+        with caplog.at_level(logging.WARNING, logger="app.llm.pricing"):
+            for _ in range(5):
+                calculate_cost("voyage", "voyage-unknown-99", 1000, 0)
+        assert len(caplog.records) == 1
+
+    def test_distinct_unknown_models_each_warn(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level(logging.WARNING, logger="app.llm.pricing"):
+            calculate_cost("claude", "claude-mystery-a", 1, 1)
+            calculate_cost("claude", "claude-mystery-b", 1, 1)
+        assert len(caplog.records) == 2
+
+    @patch("app.llm.cost_tracker.get_connection")
+    def test_log_usage_still_records_row_for_unknown_model(
+        self, mock_get_connection: MagicMock, caplog: pytest.LogCaptureFixture
+    ):
+        """The usage row must survive with cost 0 — never dropped or crashed."""
+        from app.llm.cost_tracker import log_usage
+
+        mock_conn = MagicMock()
+        mock_get_connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_get_connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        with caplog.at_level(logging.WARNING, logger="app.llm.pricing"):
+            log_usage(
+                user_id=None,
+                org_id=None,
+                provider="claude",
+                model="claude-brand-new-model",
+                feature="chat",
+                tokens_input=1234,
+                tokens_output=56,
+            )
+
+        # Warned loudly...
+        assert any("claude-brand-new-model" in r.getMessage() for r in caplog.records)
+        # ...and still inserted the row with cost 0.
+        mock_conn.execute.assert_called_once()
+        insert_params = mock_conn.execute.call_args[0][1]
+        assert insert_params[-1] == 0.0  # cost_usd
+        assert insert_params[5] == 1234  # tokens_input
+        mock_conn.commit.assert_called_once()
+
+    @patch("app.llm.cost_tracker.get_connection")
+    def test_log_usage_records_real_cost_for_known_voyage_model(
+        self, mock_get_connection: MagicMock
+    ):
+        """Voyage usage rows carry a non-zero cost_usd now (#854)."""
+        from app.llm.cost_tracker import log_usage
+
+        mock_conn = MagicMock()
+        mock_get_connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_get_connection.return_value.__exit__ = MagicMock(return_value=False)
+
+        log_usage(
+            user_id="22222222-2222-2222-2222-222222222222",
+            org_id="33333333-3333-3333-3333-333333333333",
+            provider="voyage",
+            model="voyage-multilingual-2",
+            feature="chat_embedding",
+            tokens_input=500_000,
+            tokens_output=0,
+        )
+
+        insert_params = mock_conn.execute.call_args[0][1]
+        assert insert_params[-1] == pytest.approx(0.06)  # 0.5M * $0.12/M
+        assert insert_params[0] == "22222222-2222-2222-2222-222222222222"
+        assert insert_params[1] == "33333333-3333-3333-3333-333333333333"
+        assert insert_params[4] == "chat_embedding"

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -48,13 +48,64 @@ class TestRetryClassification:
         exc = SimpleNamespace(status_code=status)
         assert _is_retryable(exc) is False  # type: ignore[arg-type]
 
-    @pytest.mark.parametrize("status", [404, 409, 422])
+    @pytest.mark.parametrize("status", [404, 410, 422])
     def test_other_4xx_is_not_retryable(self, status: int):
-        """Errors like 404/409/422 mean a bad request payload — not retryable."""
+        """Errors like 404/410/422 mean a bad request payload — not retryable."""
         from app.llm.retry import _is_retryable
 
         exc = SimpleNamespace(status_code=status)
         assert _is_retryable(exc) is False  # type: ignore[arg-type]
+
+    # -- #854: expanded transient set + voyageai ``http_status`` shape ------
+
+    def test_529_overloaded_is_retryable(self):
+        """529 is Anthropic's ``overloaded_error`` — its most common
+        transient failure; it must be retried."""
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(status_code=529)
+        assert _is_retryable(exc) is True  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("status", [408, 409])
+    def test_408_and_409_are_retryable(self, status: int):
+        """408 (request timeout) and 409 (conflict) are transient — both
+        SDKs treat them as retryable (#854)."""
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(status_code=status)
+        assert _is_retryable(exc) is True  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("status", [429, 500, 503, 529])
+    def test_voyage_http_status_transient_is_retryable(self, status: int):
+        """voyageai exceptions carry ``http_status`` (not ``status_code``).
+
+        Before #854 the extractor never read it, so a single Voyage 429
+        aborted a whole ingest with zero retries.
+        """
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(http_status=status)
+        assert _is_retryable(exc) is True  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("status", [400, 401, 403])
+    def test_voyage_http_status_permanent_is_not_retryable(self, status: int):
+        from app.llm.retry import _is_retryable
+
+        exc = SimpleNamespace(http_status=status)
+        assert _is_retryable(exc) is False  # type: ignore[arg-type]
+
+    def test_voyage_http_status_numeric_string_is_handled(self):
+        """voyageai stores the status verbatim; tolerate numeric strings."""
+        from app.llm.retry import _http_status
+
+        assert _http_status(SimpleNamespace(http_status="429")) == 429  # type: ignore[arg-type]
+
+    def test_status_code_takes_precedence_over_http_status(self):
+        """Anthropic-shaped ``status_code`` wins when both attrs exist."""
+        from app.llm.retry import _http_status
+
+        exc = SimpleNamespace(status_code=401, http_status=429)
+        assert _http_status(exc) == 401  # type: ignore[arg-type]
 
     def test_connection_error_is_retryable(self):
         from app.llm.retry import _is_retryable
@@ -697,3 +748,137 @@ class TestVoyageEmbeddingRetry:
 
         mock_client.embed.assert_called_once()
         sleep_mock.assert_not_called()
+
+    def test_embed_retries_on_voyage_http_status_429(self, monkeypatch: pytest.MonkeyPatch):
+        """#854: the real voyageai error shape carries ``http_status``
+        (not ``status_code``) — a 429 must now retry instead of aborting
+        the whole ingest on the first rate-limit hit."""
+        from app.rag.embedding import VoyageProvider
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+
+        provider = VoyageProvider()
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        class _FakeVoyageRateLimitError(Exception):
+            """Mimics voyageai.error.RateLimitError's attribute shape."""
+
+            http_status = 429
+
+        response = MagicMock(embeddings=[[0.1] * 1024], total_tokens=10)
+        mock_client.embed = AsyncMock(side_effect=[_FakeVoyageRateLimitError(), response])
+
+        with patch("app.rag.embedding.VoyageProvider._log_cost"):
+            result = asyncio.run(provider.embed(["hello"]))
+
+        assert result == [[0.1] * 1024]
+        assert mock_client.embed.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+    def test_embed_fails_fast_on_voyage_http_status_401(self, monkeypatch: pytest.MonkeyPatch):
+        from app.rag.embedding import VoyageProvider
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+
+        provider = VoyageProvider()
+        mock_client = MagicMock()
+        provider._client = mock_client
+
+        class _FakeVoyageAuthError(Exception):
+            http_status = 401
+
+        mock_client.embed = AsyncMock(side_effect=_FakeVoyageAuthError())
+
+        with pytest.raises(_FakeVoyageAuthError):
+            asyncio.run(provider.embed(["hello"]))
+
+        mock_client.embed.assert_called_once()
+        sleep_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #854: 529 (Anthropic overloaded) retries end-to-end through the helpers.
+# ---------------------------------------------------------------------------
+
+
+class TestOverloaded529Retry:
+    @patch("app.llm.retry.time.sleep")
+    def test_sync_529_then_success(self, mock_sleep: MagicMock):
+        from app.llm.retry import retry_sync
+
+        class _OverloadedError(Exception):
+            status_code = 529
+
+        fn = MagicMock(side_effect=[_OverloadedError(), "ok"])
+        assert retry_sync(fn, context="test") == "ok"
+        assert fn.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_async_529_then_success(self, monkeypatch: pytest.MonkeyPatch):
+        from app.llm.retry import retry_async
+
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("app.llm.retry.asyncio.sleep", sleep_mock)
+
+        class _OverloadedError(Exception):
+            status_code = 529
+
+        fn = AsyncMock(side_effect=[_OverloadedError(), "ok"])
+
+        result = asyncio.run(retry_async(fn, context="test"))
+
+        assert result == "ok"
+        assert fn.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+
+# ---------------------------------------------------------------------------
+# #854: SDK-internal retries are disabled — the outer wrapper is the single
+# retry authority. SDK default (anthropic max_retries=2) would stack under
+# the wrapper's 4 attempts → up to 12 HTTP calls.
+# ---------------------------------------------------------------------------
+
+
+class TestSdkRetryStackingDisabled:
+    def test_sync_anthropic_client_built_with_zero_retries(self, monkeypatch: pytest.MonkeyPatch):
+        from app.llm.claude import ClaudeProvider
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        provider = ClaudeProvider()
+
+        fake_anthropic = MagicMock()
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}):
+            provider._get_client()
+
+        fake_anthropic.Anthropic.assert_called_once_with(api_key="sk-ant-test", max_retries=0)
+
+    def test_async_anthropic_client_built_with_zero_retries(self, monkeypatch: pytest.MonkeyPatch):
+        from app.llm.claude import ClaudeProvider
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        provider = ClaudeProvider()
+
+        fake_anthropic = MagicMock()
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}):
+            provider._get_async_client()
+
+        fake_anthropic.AsyncAnthropic.assert_called_once_with(api_key="sk-ant-test", max_retries=0)
+
+    def test_voyage_client_built_with_zero_retries(self, monkeypatch: pytest.MonkeyPatch):
+        """voyageai's tenacity-based retries default to 0; pin it so an
+        SDK default bump can never reintroduce stacking."""
+        from app.rag.embedding import VoyageProvider
+
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+        provider = VoyageProvider()
+
+        fake_voyageai = MagicMock()
+        with patch.dict("sys.modules", {"voyageai": fake_voyageai}):
+            provider._get_client()
+
+        fake_voyageai.AsyncClient.assert_called_once_with(api_key="fake-key", max_retries=0)

--- a/tests/test_rag_embedding.py
+++ b/tests/test_rag_embedding.py
@@ -124,7 +124,7 @@ class TestVoyageRealMode:
             ["hello", "world"],
             model="voyage-multilingual-2",
         )
-        mock_log_cost.assert_called_once_with(100)
+        mock_log_cost.assert_called_once_with(100, user_id=None, org_id=None, feature="embedding")
 
     @patch("app.rag.embedding.VoyageProvider._log_cost")
     def test_embed_no_total_tokens_skips_cost_log(
@@ -169,3 +169,145 @@ class TestFactory:
 
         # Cleanup
         _reset_default_embedding_provider()
+
+
+# ---------------------------------------------------------------------------
+# #854: embedding cost attribution (kwargs + contextvar override)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingCostAttribution:
+    """Voyage spend must land in llm_usage with user/org/feature labels."""
+
+    def _make_real_mode_provider(self, monkeypatch: pytest.MonkeyPatch) -> VoyageProvider:
+        monkeypatch.setenv("VOYAGE_API_KEY", "fake-key")
+        provider = VoyageProvider()
+        mock_client = MagicMock()
+        mock_client.embed = AsyncMock(
+            return_value=SimpleNamespace(embeddings=[[0.1] * 1024], total_tokens=42)
+        )
+        provider._client = mock_client
+        return provider
+
+    @patch("app.llm.cost_tracker.log_usage")
+    def test_embed_kwargs_reach_log_usage(
+        self, mock_log_usage: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ):
+        provider = self._make_real_mode_provider(monkeypatch)
+
+        asyncio.run(
+            provider.embed(
+                ["tekst"],
+                user_id="user-1",
+                org_id="org-1",
+                feature="chat_embedding",
+            )
+        )
+
+        mock_log_usage.assert_called_once_with(
+            user_id="user-1",
+            org_id="org-1",
+            provider="voyage",
+            model="voyage-multilingual-2",
+            feature="chat_embedding",
+            tokens_input=42,
+            tokens_output=0,
+        )
+
+    @patch("app.llm.cost_tracker.log_usage")
+    def test_embed_defaults_remain_unattributed(
+        self, mock_log_usage: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Legacy callers without kwargs keep the old anonymous shape."""
+        provider = self._make_real_mode_provider(monkeypatch)
+
+        asyncio.run(provider.embed(["tekst"]))
+
+        mock_log_usage.assert_called_once_with(
+            user_id=None,
+            org_id=None,
+            provider="voyage",
+            model="voyage-multilingual-2",
+            feature="embedding",
+            tokens_input=42,
+            tokens_output=0,
+        )
+
+    @patch("app.llm.cost_tracker.log_usage")
+    def test_attribution_context_overrides_kwargs(
+        self, mock_log_usage: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The outermost business caller (drafter) wins over plumbing
+        defaults threaded through the retriever."""
+        from app.rag.embedding import embedding_attribution
+
+        provider = self._make_real_mode_provider(monkeypatch)
+
+        with embedding_attribution(
+            user_id="drafter-user",
+            org_id="drafter-org",
+            feature="drafter_research_embedding",
+        ):
+            asyncio.run(
+                provider.embed(
+                    ["tekst"],
+                    user_id=None,
+                    org_id=None,
+                    feature="analyysikeskus_similarity_embedding",
+                )
+            )
+
+        mock_log_usage.assert_called_once_with(
+            user_id="drafter-user",
+            org_id="drafter-org",
+            provider="voyage",
+            model="voyage-multilingual-2",
+            feature="drafter_research_embedding",
+            tokens_input=42,
+            tokens_output=0,
+        )
+
+    @patch("app.llm.cost_tracker.log_usage")
+    def test_attribution_context_survives_asyncio_run_bridge(
+        self, mock_log_usage: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``find_embedding_similar`` bridges sync→async via
+        ``asyncio.run``; the contextvar must survive that hop (it does —
+        ``asyncio.run`` copies the ambient context)."""
+        from app.rag.embedding import embedding_attribution
+
+        provider = self._make_real_mode_provider(monkeypatch)
+
+        def _sync_chain() -> None:
+            # Mimics similarity.find_embedding_similar's bridge shape.
+            async def _run() -> None:
+                await provider.embed(["tekst"])
+
+            asyncio.run(_run())
+
+        with embedding_attribution(
+            user_id="u-9", org_id="o-9", feature="drafter_research_embedding"
+        ):
+            _sync_chain()
+
+        kwargs = mock_log_usage.call_args.kwargs
+        assert kwargs["user_id"] == "u-9"
+        assert kwargs["org_id"] == "o-9"
+        assert kwargs["feature"] == "drafter_research_embedding"
+
+    @patch("app.llm.cost_tracker.log_usage")
+    def test_attribution_context_resets_after_block(
+        self, mock_log_usage: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.rag.embedding import embedding_attribution
+
+        provider = self._make_real_mode_provider(monkeypatch)
+
+        with embedding_attribution(user_id="u-1", feature="drafter_research_embedding"):
+            pass  # context opened and closed without embedding
+
+        asyncio.run(provider.embed(["tekst"]))
+
+        kwargs = mock_log_usage.call_args.kwargs
+        assert kwargs["user_id"] is None
+        assert kwargs["feature"] == "embedding"

--- a/tests/test_rag_retriever.py
+++ b/tests/test_rag_retriever.py
@@ -19,7 +19,7 @@ def _make_stub_embedder():
     """Create a mock embedding provider that returns deterministic vectors."""
     embedder = MagicMock()
 
-    async def fake_embed(texts):
+    async def fake_embed(texts, **kwargs):
         return [[0.1] * 1024 for _ in texts]
 
     embedder.embed = fake_embed
@@ -222,3 +222,67 @@ class TestRetrievedChunkDataclass:
         a = RetrievedChunk(content="test", metadata={"k": "v"}, score=0.9)
         b = RetrievedChunk(content="test", metadata={"k": "v"}, score=0.9)
         assert a == b
+
+
+# ---------------------------------------------------------------------------
+# #854: retriever threads cost attribution into the embedding call
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieverEmbeddingAttribution:
+    @staticmethod
+    def _mock_db(mock_get_conn: MagicMock) -> None:
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_conn.execute.return_value = mock_cursor
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+    @patch("app.rag.retriever.get_connection")
+    def test_user_org_feature_threaded_to_embed(self, mock_get_conn: MagicMock):
+        """retrieve(feature="chat", ...) logs the Voyage spend as
+        ``chat_embedding`` with the caller's user/org."""
+        from unittest.mock import AsyncMock
+
+        self._mock_db(mock_get_conn)
+        embedder = MagicMock()
+        embedder.embed = AsyncMock(return_value=[[0.1] * 1024])
+        retriever = Retriever(embedding_provider=embedder)
+
+        asyncio.run(
+            retriever.retrieve(
+                "test query",
+                org_id="org-1",
+                user_id="user-1",
+                feature="chat",
+            )
+        )
+
+        embedder.embed.assert_awaited_once_with(
+            ["test query"],
+            user_id="user-1",
+            org_id="org-1",
+            feature="chat_embedding",
+        )
+
+    @patch("app.rag.retriever.get_connection")
+    def test_unknown_feature_falls_back_to_plain_embedding_label(self, mock_get_conn: MagicMock):
+        """Legacy callers with the default feature don't get the awkward
+        ``unknown_embedding`` label."""
+        from unittest.mock import AsyncMock
+
+        self._mock_db(mock_get_conn)
+        embedder = MagicMock()
+        embedder.embed = AsyncMock(return_value=[[0.1] * 1024])
+        retriever = Retriever(embedding_provider=embedder)
+
+        asyncio.run(retriever.retrieve("test query"))
+
+        embedder.embed.assert_awaited_once_with(
+            ["test query"],
+            user_id=None,
+            org_id=None,
+            feature="embedding",
+        )

--- a/tests/test_rag_retriever_filters.py
+++ b/tests/test_rag_retriever_filters.py
@@ -23,7 +23,7 @@ def _make_stub_embedder():
     """Mock embedding provider returning deterministic 1024d vectors."""
     embedder = MagicMock()
 
-    async def fake_embed(texts):
+    async def fake_embed(texts, **kwargs):
         return [[0.1] * 1024 for _ in texts]
 
     embedder.embed = fake_embed
@@ -491,5 +491,7 @@ class TestEmptyListShortCircuit:
 
         asyncio.run(retriever.retrieve("test", filters={"source_type": "draft"}))
 
-        embedder.embed.assert_called_once_with(["test"])
+        embedder.embed.assert_called_once_with(
+            ["test"], user_id=None, org_id=None, feature="embedding"
+        )
         mock_conn.execute.assert_called_once()

--- a/tests/test_rag_tenant_scoping.py
+++ b/tests/test_rag_tenant_scoping.py
@@ -33,7 +33,7 @@ from app.rag.retriever import Retriever, delete_chunks_for_draft
 def _make_stub_embedder():
     embedder = MagicMock()
 
-    async def fake_embed(texts):
+    async def fake_embed(texts, **kwargs):
         return [[0.1] * 1024 for _ in texts]
 
     embedder.embed = fake_embed


### PR DESCRIPTION
## Summary

Implements all of #854 (review IDs E4 + E5) **plus the three comment items** (SDK retry stacking, mid-stream cost logging, embedding attribution).

## Verified prices (fetched 2026-06-11)

**Anthropic** — `https://docs.anthropic.com/en/docs/about-claude/pricing` (301 → `https://platform.claude.com/docs/en/docs/about-claude/pricing`):

| Model | Input $/MTok | Output $/MTok | Was in table |
|---|---|---|---|
| claude-fable-5 | 10.00 | 50.00 | — |
| claude-opus-4-8 / 4-7 / 4-6 / 4-5 | 5.00 | 25.00 | opus-4-6 at **15/75** (Opus 4.0/4.1 rates → 3x overcharge) |
| claude-sonnet-4-6 / 4-5 | 3.00 | 15.00 | 4-6 correct |
| claude-haiku-4-5 | 1.00 | 5.00 | **0.80/4.00** (Haiku 3.5 rates → undercharge) |

**Voyage AI** — `https://docs.voyageai.com/docs/pricing`:

| Model | $/MTok |
|---|---|
| voyage-multilingual-2 (app default), voyage-law-2 | 0.12 |
| voyage-3-large | 0.18 |
| voyage-3.5 | 0.06 |
| voyage-3.5-lite | 0.02 |

## Unknown-model policy (per ticket "warns clearly and/or fails per policy")

**Chosen: warn + record.** Unknown `(provider, model)` emits a loud `logger.warning` (once per model per process, thread-safe) and the usage row is still inserted with `cost_usd=0` — billing paths never crash, but the gap is visible in logs instead of silent.

## DoD status

- [x] Pricing table updated with current supported Claude model IDs + correct rates (sources above)
- [x] Voyage embedding pricing added — embeddings now produce non-zero `cost_usd`
- [x] Unknown provider/model warns clearly and still records (policy stated above)
- [x] Cost accounting tests cover every configured production model + embedding model (parametrized over the whole `PRICING` table, `tests/test_llm_pricing.py`)
- [x] Retry status extraction reads `status_code`, voyageai's `http_status` (incl. numeric-string tolerance), and `.response.status_code`
- [x] Retryable set now `{408, 409, 429, 500, 502, 503, 504, 529}` (529 = Anthropic `overloaded_error`)
- [x] Retries stay bounded: 400/401/403 + other 4xx fail fast; **SDK-internal retries disabled** — `anthropic.Anthropic`/`AsyncAnthropic` built with `max_retries=0`, `voyageai.AsyncClient` pinned to `max_retries=0` (its 0.3.7 default, confirmed from SDK source) so the outer wrapper is the single retry authority (no 4×3 stacking)

## Comment items

1. **SDK retry stacking** — both Anthropic clients constructed with `max_retries=0`; Voyage pinned. Constructor kwargs asserted in `TestSdkRetryStackingDisabled`.
2. **Mid-stream cost logging** — `astream` restructured: `_log_cost` runs in an **outer `finally`** once the stream has opened. Mid-stream upstream error, `GeneratorExit` (client-disconnect `aclose()`), and `asyncio.CancelledError` all record the event-derived partial usage (input tokens from `message_start`, running output from `message_delta`); open-failure records nothing; clean path records exactly once (no double-log). Latency metric now labels cancels as `status="cancelled"`.
3. **Embedding attribution** — `EmbeddingProvider.embed` + `Retriever.retrieve` thread `user_id`/`org_id`/`feature` to the Voyage cost row (feature `X` → `X_embedding`). The drafter → `analyysikeskus.similarity` → retriever chain can't be threaded (module off-limits in this PR), so a `contextvars`-based `embedding_attribution()` context manager in `app/rag/embedding.py` carries the session owner + `drafter_research_embedding` across it (survives the `asyncio.run` bridge; the drafter edit is confined to the `_find_similar_provisions` call site).
   - **Chat RAG**: org + `chat_embedding` now attributed automatically via the existing `org_id`/`feature="chat"` args the orchestrator already passes. `user_id` would need a one-line orchestrator change (file owned by another workstream) — reported, not fixed here.

## Verification

- [x] Corrected prices produce expected costs for every configured model (`tests/test_llm_pricing.py`)
- [x] Voyage calls produce non-zero tracked cost with org/user attribution (`test_llm_pricing.py`, `test_rag_embedding.py::TestEmbeddingCostAttribution`)
- [x] Unknown model warns (caplog-asserted, once-per-model) and records a cost-0 row
- [x] `http_status=429` retries; 529 retries (sync + async); 400/401/403 do not retry
- [x] SDK clients constructed with `max_retries=0` (constructor kwargs asserted)
- [x] Mid-stream cancel (`GeneratorExit` via `aclose`) and upstream error still write an `llm_usage` row (`tests/test_llm_claude_stream_cost.py`)
- [x] Drafter `find_similar` logs `drafter_research_embedding` with the session's user/org, and the context doesn't leak afterwards (`tests/test_drafter_research_embedding_attribution.py`)
- [x] Gate green: `uv run ruff check .` ✓ · `uv run pyright` 0 errors ✓ · `uv run pytest -q` **4348 passed, 45 skipped** ✓

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)