### PR TITLE
fix(auth): login throttling, origin-check CSRF, WS origin allowlist, trusted proxy, auth audit (#851)

### DIFF
--- a/app/auth/jwt_provider.py
+++ b/app/auth/jwt_provider.py
@@ -37,6 +37,16 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 JWT_ALGORITHM = "HS256"
 
+# #851 (timing enumeration): a static bcrypt hash (cost 12 — the same
+# default cost ``hash_password`` uses) that ``authenticate`` verifies a
+# candidate password against when the email is UNKNOWN. Without this,
+# an unknown email returned in ~1 ms (no bcrypt work) versus ~100 ms of
+# bcrypt for a known email — a remotely measurable account-existence
+# oracle. The hash value is irrelevant (it is the hash of a throwaway
+# pad, and the comparison result is discarded); only the equal-cost
+# bcrypt work matters.
+_DUMMY_PASSWORD_HASH = "$2b$12$0geTT8MNXJAq7cFcnXIJLeKPJf1v7qmcEKSW.LYuxOBxAMbCcomd6"
+
 
 def _hash_token(token: str) -> str:
     """Return a SHA-256 hex digest of *token* for safe storage."""
@@ -72,6 +82,10 @@ class JWTAuthProvider(AuthProvider):
         """Verify *email* / *password* against the users table.
 
         Returns a ``UserDict`` on success, ``None`` otherwise.
+
+        #851: the unknown-email path performs a dummy bcrypt check
+        against :data:`_DUMMY_PASSWORD_HASH` so the response time does
+        not reveal whether the email exists.
         """
         with self._connect() as conn:
             row = conn.execute(
@@ -82,6 +96,9 @@ class JWTAuthProvider(AuthProvider):
             ).fetchone()
 
         if row is None:
+            # Equalize timing with the known-email path (see #851 note
+            # on _DUMMY_PASSWORD_HASH). Result intentionally discarded.
+            bcrypt.checkpw(password.encode(), _DUMMY_PASSWORD_HASH.encode())
             return None
 
         user_id, user_email, pw_hash, full_name, role, org_id, must_change = row

--- a/app/auth/middleware.py
+++ b/app/auth/middleware.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qsl
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, Response
 
+from app.auth.audit import log_action
 from app.auth.cookies import set_auth_cookie
 from app.auth.jwt_provider import JWTAuthProvider
 
@@ -251,6 +252,17 @@ def auth_before(req: Request) -> Response | None:
         rotated = try_refresh_access_token(refresh_token, provider=provider)
         if rotated is not None:
             new_access, new_refresh, _user = rotated
+
+            # #851: audit the token rotation with the validated source IP.
+            # The IP is read inline (not via perimeter.client_ip) because
+            # app.auth.perimeter imports _TOKEN_BEARER_PATHS from this
+            # module — importing back would be circular. log_action is
+            # fire-and-forget, so this cannot break the refresh path.
+            ip = "unknown"
+            client = getattr(req, "client", None)
+            if client is not None and getattr(client, "host", None):
+                ip = str(client.host)
+            log_action(_user.get("id"), "auth.token_refresh", {"ip": ip})
 
             # We cannot simply set cookies on the current response because the
             # Beforeware runs *before* the handler and the response object does

--- a/app/auth/perimeter.py
+++ b/app/auth/perimeter.py
@@ -14,8 +14,10 @@ headers on every unsafe-method HTTP request (POST/PUT/PATCH/DELETE):
    so a forged cross-site request always carries the attacker's origin
    and is rejected here with 403.
 2. No ``Origin`` → fall back to ``Referer``'s origin, same comparison.
-3. Neither → fall back to ``Sec-Fetch-Site``; ``cross-site`` is
-   rejected, ``same-origin`` / ``same-site`` / ``none`` pass.
+3. Neither → fall back to ``Sec-Fetch-Site``; only ``same-origin`` and
+   ``none`` (direct navigation) pass — ``same-site`` (sibling
+   subdomains) and ``cross-site`` are rejected. The app is strictly
+   single-origin, so a bare same-site signal is insufficient.
 4. None of the three headers → the request cannot have been initiated
    by a (modern) browser from a foreign site; it is allowed. This keeps
    server-to-server callers, curl, and test clients working. CSRF is
@@ -84,19 +86,36 @@ DEFAULT_TRUSTED_PROXY_HOSTS = (
 def get_trusted_proxy_hosts() -> list[str]:
     """Return the proxy hosts/CIDRs whose X-Forwarded-* headers are trusted.
 
-    Reads ``TRUSTED_PROXY_HOSTS`` (comma-separated IPs / CIDR networks,
-    or ``*`` to trust everything — discouraged, this restores the D3
-    vulnerability). Defaults to :data:`DEFAULT_TRUSTED_PROXY_HOSTS`.
+    Reads ``TRUSTED_PROXY_HOSTS`` (comma-separated IPs / CIDR networks).
+    Defaults to :data:`DEFAULT_TRUSTED_PROXY_HOSTS`.
+
+    Wildcards are REFUSED, not honoured (#851 review round 1): a value
+    containing ``*`` anywhere (``*``, ``10.*``, ``*.example.com``) is a
+    misconfiguration that would reopen the exact D3 hole this module
+    closes — ``trusted_hosts=["*"]`` flips uvicorn's
+    ``_TrustedHosts.always_trust`` and makes ``X-Forwarded-For`` fully
+    spoofable again. We log at ERROR and fall back to the private-range
+    defaults instead of crashing at startup: the defaults are the
+    correct production posture behind Traefik/Coolify, so degrading
+    keeps the service available while the error log (and Sentry) makes
+    the bad value visible. Globs are not supported by uvicorn anyway —
+    any non-``*`` wildcard entry would silently never match.
     """
     raw = os.environ.get("TRUSTED_PROXY_HOSTS", "").strip()
     if not raw:
         return list(DEFAULT_TRUSTED_PROXY_HOSTS)
     hosts = [item.strip() for item in raw.split(",") if item.strip()]
-    if "*" in hosts:
-        logger.warning(
-            "TRUSTED_PROXY_HOSTS contains '*' — X-Forwarded-For is trusted from "
-            "ANY peer, client IPs are spoofable (issue #851 D3)."
+    if any("*" in host for host in hosts):
+        logger.error(
+            "TRUSTED_PROXY_HOSTS=%r contains a wildcard entry — REFUSING it. "
+            "Trusting '*' would let any direct client spoof X-Forwarded-For "
+            "(issue #851 D3: throttle bypass + audit-IP forging). Falling "
+            "back to the private-range defaults %s; set explicit IPs/CIDRs "
+            "to override.",
+            raw,
+            list(DEFAULT_TRUSTED_PROXY_HOSTS),
         )
+        return list(DEFAULT_TRUSTED_PROXY_HOSTS)
     return hosts or list(DEFAULT_TRUSTED_PROXY_HOSTS)
 
 
@@ -137,7 +156,15 @@ CSRF_EXEMPT_PATHS: list[str] = [
     *_TOKEN_BEARER_PATHS,
 ]
 
-_ALLOWED_SEC_FETCH_SITE = frozenset({"same-origin", "same-site", "none"})
+# Sec-Fetch-Site values accepted when it is the DECIDING signal (i.e.
+# Origin and Referer are both absent). ``same-origin`` covers in-app
+# requests; ``none`` covers direct user navigations (address bar,
+# bookmark). ``same-site`` is deliberately ABSENT (#851 review round 1):
+# accepting it would extend write trust to every sibling subdomain of
+# the registrable domain (anything under sixtyfour.ee), and this app is
+# strictly single-origin. If a legitimate sibling-subdomain flow ever
+# appears, the revert is one word: add "same-site" back to this set.
+_ALLOWED_SEC_FETCH_SITE = frozenset({"same-origin", "none"})
 
 # Estonian rejection body. Plain page on purpose: this is shown to
 # browsers only in attack/misconfiguration scenarios.

--- a/app/auth/perimeter.py
+++ b/app/auth/perimeter.py
@@ -1,0 +1,322 @@
+"""Auth perimeter hardening: CSRF origin check, WS origin allowlist, proxy trust.
+
+Issue #851 (review findings D2 + D3 and the WS-hijack comment) in one
+enforcement point:
+
+**CSRF via origin verification (D2).** Instead of per-form token
+plumbing, :class:`OriginCheckMiddleware` verifies browser *provenance*
+headers on every unsafe-method HTTP request (POST/PUT/PATCH/DELETE):
+
+1. ``Origin`` present → must equal one of the allowed origins
+   (the request's own ``scheme://host`` and the origin of
+   ``APP_BASE_URL``). Browsers attach ``Origin`` to **every**
+   cross-origin POST — fetch, XHR, and auto-submitted ``<form>`` alike —
+   so a forged cross-site request always carries the attacker's origin
+   and is rejected here with 403.
+2. No ``Origin`` → fall back to ``Referer``'s origin, same comparison.
+3. Neither → fall back to ``Sec-Fetch-Site``; ``cross-site`` is
+   rejected, ``same-origin`` / ``same-site`` / ``none`` pass.
+4. None of the three headers → the request cannot have been initiated
+   by a (modern) browser from a foreign site; it is allowed. This keeps
+   server-to-server callers, curl, and test clients working. CSRF is
+   strictly a browser-credential attack, and browser-issued cross-site
+   requests are guaranteed to carry positive evidence (header 1 or 3).
+
+This is HTMX-compatible with zero per-form changes: HTMX requests are
+same-origin fetches and carry a matching ``Origin``/``Sec-Fetch-Site``.
+
+**WebSocket origin allowlist (cross-site WS hijacking).** Browsers do
+not apply SOP to WebSocket handshakes, but they DO send ``Origin``. All
+``/ws/*`` channels authenticate via cookies, so a foreign page could
+otherwise open an authenticated socket. The same middleware validates
+``Origin`` on ``websocket`` scopes and rejects the handshake (close
+code 1008) before the app ever accepts it — one enforcement point
+instead of edits to the five hand-rolled WS modules.
+
+**Trusted proxy ranges (D3).** :func:`get_trusted_proxy_hosts` feeds
+uvicorn's ``ProxyHeadersMiddleware`` so ``X-Forwarded-For`` /
+``X-Forwarded-Proto`` are only honoured when the direct peer is the
+Traefik/Coolify proxy (private/Docker ranges by default, overridable
+via ``TRUSTED_PROXY_HOSTS``). Everything downstream — login throttling,
+audit logging, rejection logs — then reads a *validated* client IP via
+:func:`client_ip`.
+
+Escape hatch: ``CSRF_ORIGIN_CHECK=off`` disables the HTTP and WS origin
+checks for emergencies (default: enforced).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+from starlette.datastructures import Headers
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+
+from app.auth.middleware import _TOKEN_BEARER_PATHS
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Trusted proxy configuration (D3)
+# ---------------------------------------------------------------------------
+
+# Default trust: loopback + RFC1918 ranges. Coolify runs the app and
+# Traefik on a Docker bridge network, so the direct peer of the app
+# container is the proxy's container address (typically 10.x / 172.x).
+# A real client connecting directly (i.e. not through Traefik) gets a
+# public source address, falls outside these ranges, and its
+# X-Forwarded-* headers are ignored — so it cannot spoof its IP for the
+# login throttle or the audit log.
+DEFAULT_TRUSTED_PROXY_HOSTS = (
+    "127.0.0.1",
+    "::1",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+)
+
+
+def get_trusted_proxy_hosts() -> list[str]:
+    """Return the proxy hosts/CIDRs whose X-Forwarded-* headers are trusted.
+
+    Reads ``TRUSTED_PROXY_HOSTS`` (comma-separated IPs / CIDR networks,
+    or ``*`` to trust everything — discouraged, this restores the D3
+    vulnerability). Defaults to :data:`DEFAULT_TRUSTED_PROXY_HOSTS`.
+    """
+    raw = os.environ.get("TRUSTED_PROXY_HOSTS", "").strip()
+    if not raw:
+        return list(DEFAULT_TRUSTED_PROXY_HOSTS)
+    hosts = [item.strip() for item in raw.split(",") if item.strip()]
+    if "*" in hosts:
+        logger.warning(
+            "TRUSTED_PROXY_HOSTS contains '*' — X-Forwarded-For is trusted from "
+            "ANY peer, client IPs are spoofable (issue #851 D3)."
+        )
+    return hosts or list(DEFAULT_TRUSTED_PROXY_HOSTS)
+
+
+def client_ip(req: Request) -> str:
+    """Return the validated client IP for throttling/audit purposes.
+
+    After ProxyHeaders hardening (D3) ``req.client.host`` reflects the
+    real client when the request came through a trusted proxy, and the
+    direct peer otherwise — it can no longer be forged via
+    ``X-Forwarded-For`` from untrusted sources.
+    """
+    if req.client is not None and req.client.host:
+        return str(req.client.host)
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# CSRF origin verification (D2) + WS origin allowlist
+# ---------------------------------------------------------------------------
+
+_UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Paths exempt from the HTTP origin check (matched with ``re.fullmatch``,
+# same semantics as SKIP_PATHS). Each exemption is justified in place:
+CSRF_EXEMPT_PATHS: list[str] = [
+    # GitHub push webhook — server-to-server, authenticated by an HMAC
+    # signature over the body (app/sync/webhook.py::verify_signature),
+    # never carries browser cookies, never sends an Origin header.
+    r"/webhooks/github",
+    # Health endpoints — GET-only in practice, but kept here so a probe
+    # implementation change can never lock out the Coolify healthcheck.
+    r"/api/health",
+    r"/api/ping",
+    # Signed-URL downloads (#307) — bearer credential in the ``?token=``
+    # query param, validated by the handler. GET-only today (so already
+    # outside _UNSAFE_METHODS); listed for belt-and-braces parity with
+    # the auth middleware's bypass list.
+    *_TOKEN_BEARER_PATHS,
+]
+
+_ALLOWED_SEC_FETCH_SITE = frozenset({"same-origin", "same-site", "none"})
+
+# Estonian rejection body. Plain page on purpose: this is shown to
+# browsers only in attack/misconfiguration scenarios.
+_REJECT_BODY_ET = (
+    "<!doctype html><html lang='et'><head><meta charset='utf-8'>"
+    "<title>403 — Keelatud</title></head><body>"
+    "<h1>403 — Keelatud</h1>"
+    "<p>Päringu päritolu ei vasta lubatud aadressile (CSRF-kaitse). "
+    "Palun avage leht uuesti rakenduse aadressilt ja proovige uuesti.</p>"
+    "</body></html>"
+)
+
+
+def is_origin_check_enabled() -> bool:
+    """Return True unless ``CSRF_ORIGIN_CHECK`` disables the check.
+
+    Enforced by default; ``off``/``0``/``false``/``no``/``disabled``
+    (case-insensitive) switch it off — an emergency escape hatch only.
+    Read per-request so a container restart is not required to flip it
+    in tests; the cost is one env lookup.
+    """
+    raw = os.environ.get("CSRF_ORIGIN_CHECK", "").strip().lower()
+    return raw not in {"off", "0", "false", "no", "disabled"}
+
+
+def _origin_of_url(url: str) -> str | None:
+    """Return the lowercased ``scheme://host[:port]`` origin of *url*."""
+    try:
+        parts = urlsplit(url.strip())
+    except ValueError:
+        return None
+    if not parts.scheme or not parts.netloc:
+        return None
+    return f"{parts.scheme.lower()}://{parts.netloc.lower()}"
+
+
+def _request_own_origin(scope: dict[str, Any]) -> str | None:
+    """Origin of the request target itself: ``scheme://Host-header``.
+
+    The scheme comes from the ASGI scope, which ProxyHeadersMiddleware
+    has already corrected from ``X-Forwarded-Proto`` when (and only
+    when) the peer is a trusted proxy. WS schemes map onto their HTTP
+    equivalents because the browser's ``Origin`` header is always
+    ``http(s)://``.
+    """
+    host = Headers(scope=scope).get("host")
+    if not host:
+        return None
+    scheme = str(scope.get("scheme") or "http").lower()
+    scheme = {"ws": "http", "wss": "https"}.get(scheme, scheme)
+    return f"{scheme}://{host.strip().lower()}"
+
+
+def allowed_origins(scope: dict[str, Any]) -> set[str]:
+    """The set of origins allowed to issue mutating/WS requests.
+
+    The request's own origin (Host header + validated scheme) plus the
+    origin of ``APP_BASE_URL``. The latter keeps production working even
+    if scheme detection degrades (e.g. proxy trust misconfigured →
+    scope scheme stays ``http`` while browsers send the canonical
+    ``https://…`` Origin).
+    """
+    allowed: set[str] = set()
+    own = _request_own_origin(scope)
+    if own:
+        allowed.add(own)
+    base = os.environ.get("APP_BASE_URL", "").strip()
+    if base:
+        base_origin = _origin_of_url(base)
+        if base_origin:
+            allowed.add(base_origin)
+    return allowed
+
+
+def is_csrf_exempt(path: str) -> bool:
+    """True when *path* is exempt from the HTTP origin check."""
+    return any(re.fullmatch(pattern, path) for pattern in CSRF_EXEMPT_PATHS)
+
+
+def evaluate_http_request(scope: dict[str, Any]) -> str | None:
+    """Return a rejection reason for an unsafe HTTP request, or None.
+
+    Decision ladder (first available signal wins — see module docstring
+    for why absent-everything is allowed):
+    Origin → Referer → Sec-Fetch-Site → allow.
+    """
+    headers = Headers(scope=scope)
+    allowed = allowed_origins(scope)
+
+    origin = headers.get("origin")
+    if origin:
+        # ``Origin: null`` (sandboxed iframes, some privacy modes) is
+        # deliberately rejected: it cannot be proven same-origin.
+        if origin.strip().lower() in allowed:
+            return None
+        return f"Origin {origin!r} not in allowed origins {sorted(allowed)}"
+
+    referer = headers.get("referer")
+    if referer:
+        ref_origin = _origin_of_url(referer)
+        if ref_origin and ref_origin in allowed:
+            return None
+        return f"Referer {referer!r} not same-origin (allowed {sorted(allowed)})"
+
+    fetch_site = headers.get("sec-fetch-site")
+    if fetch_site:
+        if fetch_site.strip().lower() in _ALLOWED_SEC_FETCH_SITE:
+            return None
+        return f"Sec-Fetch-Site {fetch_site!r}"
+
+    # No browser provenance headers → not a cross-site browser request.
+    return None
+
+
+def evaluate_ws_handshake(scope: dict[str, Any]) -> str | None:
+    """Return a rejection reason for a WS handshake, or None.
+
+    Browsers always send ``Origin`` on WebSocket handshakes; a present
+    but foreign Origin is the cross-site WS hijack signature. Absent
+    Origin means a non-browser client, which holds its own credentials
+    legitimately (no ambient-cookie confusion to exploit).
+    """
+    origin = Headers(scope=scope).get("origin")
+    if not origin:
+        return None
+    if origin.strip().lower() in allowed_origins(scope):
+        return None
+    return f"Origin {origin!r} not in allowed origins"
+
+
+class OriginCheckMiddleware:
+    """Pure ASGI middleware enforcing the origin checks described above.
+
+    Added in ``app/main.py`` *inside* ProxyHeadersMiddleware (so the
+    scheme/client have already been validated) and outside the FastHTML
+    beforeware (so rejections fire before any auth/handler code,
+    including the ``app.ws()`` handshakes that beforeware never sees).
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        scope_type = scope.get("type") if isinstance(scope, dict) else None
+
+        if scope_type == "http" and is_origin_check_enabled():
+            method = str(scope.get("method", "GET")).upper()
+            path = str(scope.get("path", ""))
+            if method in _UNSAFE_METHODS and not is_csrf_exempt(path):
+                reason = evaluate_http_request(scope)
+                if reason is not None:
+                    client = scope.get("client")
+                    logger.warning(
+                        "CSRF origin check rejected %s %s from %s: %s",
+                        method,
+                        path,
+                        client[0] if client else "unknown",
+                        reason,
+                    )
+                    response = HTMLResponse(_REJECT_BODY_ET, status_code=403)
+                    await response(scope, receive, send)
+                    return
+
+        elif scope_type == "websocket" and is_origin_check_enabled():
+            reason = evaluate_ws_handshake(scope)
+            if reason is not None:
+                client = scope.get("client")
+                logger.warning(
+                    "WS origin check rejected handshake %s from %s: %s",
+                    scope.get("path"),
+                    client[0] if client else "unknown",
+                    reason,
+                )
+                # Per the ASGI spec the server sends ``websocket.connect``
+                # first; consume it, then close without accepting. Servers
+                # surface this as a 403 handshake rejection (close code
+                # 1008 = policy violation).
+                await receive()
+                await send({"type": "websocket.close", "code": 1008})
+                return
+
+        await self.app(scope, receive, send)

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -9,6 +9,7 @@ from fasthtml.common import *
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
+from app.auth import throttle
 from app.auth.audit import log_action
 from app.auth.cookies import clear_auth_cookie, set_auth_cookie
 from app.auth.jwt_provider import JWTAuthProvider
@@ -20,6 +21,7 @@ from app.auth.password import (
     issue_reset_token,
     validate_password,
 )
+from app.auth.perimeter import client_ip
 from app.db import get_connection
 from app.email.service import get_email_provider
 from app.email.templates import password_reset
@@ -49,7 +51,7 @@ def _login_form(email: str = "", error: str | None = None):
     return Card(
         CardHeader(H2("Sisselogimine", cls="card-title")),
         CardBody(
-            Alert("Vale e-post või parool.", variant="danger") if error else None,
+            Alert(error, variant="danger") if error else None,
             AppForm(
                 FormField(
                     name="email",
@@ -99,9 +101,47 @@ def login_page(req: Request):
 
 
 def login_post(req: Request, email: str, password: str):
-    """POST /auth/login — authenticate and set cookies."""
+    """POST /auth/login — authenticate and set cookies.
+
+    #851 (D1): per-email AND per-IP failure throttling backed by the
+    ``login_attempts`` table (migration 040), mirroring the
+    forgot-password pattern. The throttle is keyed on the *normalized*
+    email hash before any user lookup, so unknown emails are throttled
+    identically to known ones — neither the response body nor the
+    throttle behaviour leaks account existence (the underlying bcrypt
+    timing leak is closed in ``JWTAuthProvider.authenticate``). All
+    auth lifecycle events are audit-logged with the validated client IP
+    (validated because ProxyHeaders only trusts ``TRUSTED_PROXY_HOSTS``).
+    """
+    ip = client_ip(req)
+    email_h = hash_email(email or "")
+
+    if throttle.is_login_throttled(email_h, ip):
+        logger.info("login throttled email_hash=%s ip=%s", email_h, ip)
+        log_action(None, "auth.login_throttled", {"ip": ip, "email_hash": email_h})
+        return FtResponse(
+            PageShell(
+                _login_form(
+                    email=email,
+                    error=(
+                        "Liiga palju sisselogimiskatseid. "
+                        "Palun oodake 15 minutit ja proovige uuesti."
+                    ),
+                ),
+                title="Sisselogimine",
+                user=None,
+                theme=get_theme_from_request(req),
+                container_size="sm",
+            ),
+            status_code=429,
+        )
+
     user = _provider.authenticate(email, password)
     if user is None:
+        throttle.record_login_failure(email_h, ip)
+        # email_hash, not the raw submitted address: failed attempts may
+        # carry arbitrary non-user strings we should not persist as PII.
+        log_action(None, "auth.login_failed", {"ip": ip, "email_hash": email_h})
         theme = get_theme_from_request(req)
         return PageShell(
             _login_form(email=email, error="Vale e-post või parool."),
@@ -110,6 +150,9 @@ def login_post(req: Request, email: str, password: str):
             theme=theme,
             container_size="sm",
         )
+
+    throttle.clear_login_failures(email_h)
+    log_action(user["id"], "auth.login", {"ip": ip, "email": user["email"]})
 
     access_token, refresh_token = _provider.create_tokens(user)
     response = RedirectResponse(url="/", status_code=303)
@@ -123,6 +166,9 @@ def logout_post(req: Request):
     refresh_token = req.cookies.get("refresh_token")
     if refresh_token:
         _provider.delete_refresh_token(refresh_token)
+
+    auth = req.scope.get("auth") or {}
+    log_action(auth.get("id"), "auth.logout", {"ip": client_ip(req)})
 
     response = RedirectResponse(url="/auth/login", status_code=303)
     clear_auth_cookie(response, "access_token")
@@ -206,7 +252,9 @@ def forgot_post(req: Request, email: str):
         return forgot_page(req)
 
     email_h = hash_email(email)
-    ip = (req.client.host if req.client else "unknown") or "unknown"
+    # #851 D3: validated client IP (X-Forwarded-For honoured only from
+    # trusted proxies) so this rate limit can no longer be spoofed away.
+    ip = client_ip(req)
 
     with get_connection() as conn:
         conn.execute(

--- a/app/auth/throttle.py
+++ b/app/auth/throttle.py
@@ -1,0 +1,105 @@
+"""Login brute-force throttling backed by the ``login_attempts`` table.
+
+Issue #851 (review finding D1): ``POST /auth/login`` had no rate
+limiting while the forgot-password flow was already throttled via
+``password_reset_attempts``. This module mirrors that pattern for the
+login flow:
+
+- failures are counted per normalized email (``hash_email`` — SHA-256
+  of the lowercased address, so unknown emails throttle identically to
+  known ones and the limiter cannot be used for account enumeration);
+- failures are also counted per validated client IP (validated because
+  ``ProxyHeadersMiddleware`` only honours ``X-Forwarded-For`` from the
+  ``TRUSTED_PROXY_HOSTS`` ranges after #851 D3);
+- a successful login clears the email-keyed failures so a legitimate
+  user who finally remembers their password is not locked out for the
+  rest of the window. IP-keyed failures age out with the window.
+
+Failure posture: every function here is **fail-open** — DB errors are
+logged loudly and treated as "not throttled" / no-op. This cannot be
+abused to brute-force during a DB outage because
+``JWTAuthProvider.authenticate`` needs the very same database to check
+the password: when Postgres is down, logins fail anyway. The fail-open
+branch only matters when the ``login_attempts`` table is missing
+(migration 040 not applied), which the error log makes obvious. This
+matches the fire-and-forget posture of :mod:`app.auth.audit`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.db import get_connection
+
+logger = logging.getLogger(__name__)
+
+# Limits chosen against the password-reset precedent (3/hour per email,
+# 10/hour per IP) but tuned for login UX: typos are common, so the email
+# budget is a little larger over a much shorter window.
+LOGIN_EMAIL_FAIL_LIMIT = 5
+LOGIN_IP_FAIL_LIMIT = 20
+LOGIN_THROTTLE_WINDOW_MINUTES = 15
+
+
+def is_login_throttled(email_hash: str, ip: str) -> bool:
+    """Return True when *email_hash* or *ip* has exhausted its failure budget.
+
+    Checked BEFORE ``authenticate`` so a locked identifier is refused
+    even with the correct password (standard lockout semantics), and so
+    the check costs the same whether or not the email exists.
+    """
+    try:
+        with get_connection() as conn:
+            # NB: ``%s::interval`` / ``make_interval`` — never ``interval %s``
+            # (psycopg substitution rule, see Sprint-2 postmortem).
+            row = conn.execute(
+                "SELECT "
+                "  (SELECT COUNT(*) FROM login_attempts "
+                "    WHERE email_hash = %s "
+                "    AND attempted_at > now() - make_interval(mins => %s)), "
+                "  (SELECT COUNT(*) FROM login_attempts "
+                "    WHERE ip = %s "
+                "    AND attempted_at > now() - make_interval(mins => %s))",
+                (
+                    email_hash,
+                    LOGIN_THROTTLE_WINDOW_MINUTES,
+                    ip,
+                    LOGIN_THROTTLE_WINDOW_MINUTES,
+                ),
+            ).fetchone()
+    except Exception:
+        logger.exception(
+            "login throttle check failed (fail-open) email_hash=%s ip=%s", email_hash, ip
+        )
+        return False
+
+    if row is None:
+        return False
+    n_email, n_ip = int(row[0]), int(row[1])
+    return n_email >= LOGIN_EMAIL_FAIL_LIMIT or n_ip >= LOGIN_IP_FAIL_LIMIT
+
+
+def record_login_failure(email_hash: str, ip: str) -> None:
+    """Persist one failed login attempt for *email_hash* / *ip*."""
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                "INSERT INTO login_attempts (email_hash, ip) VALUES (%s, %s)",
+                (email_hash, ip),
+            )
+            conn.commit()
+    except Exception:
+        logger.exception("failed to record login failure email_hash=%s ip=%s", email_hash, ip)
+
+
+def clear_login_failures(email_hash: str) -> None:
+    """Delete failure rows for *email_hash* after a successful login."""
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                "DELETE FROM login_attempts WHERE email_hash = %s",
+                (email_hash,),
+            )
+            conn.commit()
+    except Exception:
+        logger.exception("failed to clear login failures email_hash=%s", email_hash)

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from app.analyysikeskus import register_analyysikeskus_routes
 from app.annotations.routes import register_annotation_routes
 from app.auth.middleware import SKIP_PATHS, auth_before
 from app.auth.organizations import register_org_routes
+from app.auth.perimeter import OriginCheckMiddleware, get_trusted_proxy_hosts
 from app.auth.profile import register_profile_routes
 from app.auth.routes import register_auth_routes
 from app.auth.users import register_user_routes
@@ -300,10 +301,24 @@ if os.environ.get("APP_ENV", "development") != "development":
         ],
     )
 
+# #851 (D2 + WS comment): CSRF origin verification for unsafe-method HTTP
+# requests and an Origin allowlist for every /ws/* handshake. Added BEFORE
+# ProxyHeadersMiddleware so it executes AFTER it (add_middleware prepends):
+# by the time the check runs, scope['scheme'] and scope['client'] have been
+# rewritten from X-Forwarded-* iff the peer is a trusted proxy — rejection
+# logs therefore carry the validated client IP, and the request's own
+# origin is computed from the real external scheme.
+app.add_middleware(OriginCheckMiddleware)
+
 # Trust X-Forwarded-* headers from the reverse proxy (Traefik/Coolify) so
 # that request.url.scheme, request.client.host, etc. reflect the original
 # client request rather than the proxy hop.
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+#
+# #851 (D3): trust is restricted to TRUSTED_PROXY_HOSTS (default: loopback
+# + RFC1918/Docker ranges, which cover the Coolify/Traefik bridge network).
+# Previously trusted_hosts="*" let ANY direct client spoof X-Forwarded-For,
+# bypassing IP rate limits and forging audit-log IPs.
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=get_trusted_proxy_hosts())
 
 # Record per-request latency into the metrics table for the admin
 # performance dashboard.  Added after ProxyHeadersMiddleware so that

--- a/migrations/040_login_attempts.sql
+++ b/migrations/040_login_attempts.sql
@@ -1,0 +1,25 @@
+-- migrations/040_login_attempts.sql
+--
+-- Issue #851 (D1): login brute-force throttling. `POST /auth/login` had
+-- no rate limiting while the forgot-password flow already throttled via
+-- `password_reset_attempts` (migration 025). This table mirrors that
+-- pattern 1:1 so the login flow can count recent FAILED attempts per
+-- normalized email (SHA-256 of lowercased address — works for unknown
+-- emails too, so throttling cannot leak account existence) and per
+-- validated client IP (post-#851 ProxyHeaders hardening).
+--
+-- Only failures are recorded; a successful login deletes the rows for
+-- that email_hash so a legitimate user is not locked out after they
+-- recover their password. Rows are tiny and both lookups are bounded by
+-- the composite time indexes, matching the 025 retention posture
+-- (no scheduled pruning).
+
+CREATE TABLE IF NOT EXISTS login_attempts (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email_hash    TEXT NOT NULL,
+    ip            TEXT NOT NULL,
+    attempted_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_login_attempts_email_hash_time ON login_attempts(email_hash, attempted_at);
+CREATE INDEX IF NOT EXISTS idx_login_attempts_ip_time ON login_attempts(ip, attempted_at);

--- a/tests/test_auth_perimeter.py
+++ b/tests/test_auth_perimeter.py
@@ -1,0 +1,454 @@
+"""CSRF origin-check, WS origin allowlist, and trusted-proxy tests (#851).
+
+Covers review findings D2 + D3 and the ticket-comment WS item:
+
+- unsafe-method HTTP requests with cross-site provenance (Origin /
+  Referer / Sec-Fetch-Site) are rejected with 403 + Estonian message,
+  on representative mutating routes (login, draft delete, chat delete,
+  admin purge, annotations);
+- same-origin browser requests and HTMX requests pass with zero
+  per-form changes; requests without browser provenance headers
+  (server-to-server, curl, test clients) pass;
+- exempt paths: the HMAC-authenticated GitHub webhook works unchanged
+  (verified with a VALID signature + a foreign Origin), signed-URL
+  token-bearer downloads and health endpoints are exempt;
+- every ``/ws/*`` handshake with a foreign Origin is rejected (close
+  1008) before the app accepts; same-origin and origin-less handshakes
+  connect;
+- ``CSRF_ORIGIN_CHECK=off`` escape hatch disables enforcement;
+- ``get_trusted_proxy_hosts`` parses ``TRUSTED_PROXY_HOSTS`` and
+  defaults to loopback + RFC1918 (the Coolify/Traefik Docker ranges).
+
+The spoofed X-Forwarded-For ↔ throttle/audit integration lives in
+``tests/test_auth_throttle.py`` (it needs the login route fixtures).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import re
+from typing import Any
+
+import pytest
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.auth.middleware import _TOKEN_BEARER_PATHS
+from app.auth.perimeter import (
+    DEFAULT_TRUSTED_PROXY_HOSTS,
+    OriginCheckMiddleware,
+    evaluate_http_request,
+    evaluate_ws_handshake,
+    get_trusted_proxy_hosts,
+    is_csrf_exempt,
+    is_origin_check_enabled,
+)
+from app.main import app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scope(
+    headers: dict[str, str] | None = None,
+    *,
+    scheme: str = "http",
+    host: str | None = "testserver",
+    type_: str = "http",
+    method: str = "POST",
+    path: str = "/x",
+) -> dict[str, Any]:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    if host is not None:
+        raw.append((b"host", host.encode()))
+    return {
+        "type": type_,
+        "scheme": scheme,
+        "method": method,
+        "path": path,
+        "headers": raw,
+        "client": ("203.0.113.9", 1234),
+    }
+
+
+async def _tiny_app(scope: Any, receive: Any, send: Any) -> None:
+    """Minimal ASGI app: 200 'ok' for HTTP, accept-then-idle for WS."""
+    if scope["type"] == "http":
+        await PlainTextResponse("ok")(scope, receive, send)
+        return
+    if scope["type"] == "websocket":
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        while True:
+            msg = await receive()
+            if msg["type"] == "websocket.disconnect":
+                return
+
+
+@pytest.fixture
+def tiny_client() -> TestClient:
+    return TestClient(OriginCheckMiddleware(_tiny_app))
+
+
+# ---------------------------------------------------------------------------
+# Unit: decision ladder for HTTP requests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateHttpRequest:
+    def test_matching_origin_allowed(self):
+        assert evaluate_http_request(_scope({"Origin": "http://testserver"})) is None
+
+    def test_origin_match_is_case_insensitive(self):
+        assert evaluate_http_request(_scope({"Origin": "HTTP://TestServer"})) is None
+
+    def test_foreign_origin_rejected(self):
+        reason = evaluate_http_request(_scope({"Origin": "https://evil.example"}))
+        assert reason is not None and "evil.example" in reason
+
+    def test_null_origin_rejected(self):
+        assert evaluate_http_request(_scope({"Origin": "null"})) is not None
+
+    def test_app_base_url_origin_allowed_even_if_scheme_degraded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """If proxy trust were misconfigured the scope scheme stays http
+        while browsers send the canonical https Origin — APP_BASE_URL
+        keeps production logins working."""
+        monkeypatch.setenv("APP_BASE_URL", "https://seadusloome.sixtyfour.ee")
+        scope = _scope(
+            {"Origin": "https://seadusloome.sixtyfour.ee"},
+            scheme="http",
+            host="seadusloome.sixtyfour.ee",
+        )
+        assert evaluate_http_request(scope) is None
+
+    def test_referer_fallback_same_origin_allowed(self):
+        scope = _scope({"Referer": "http://testserver/auth/login"})
+        assert evaluate_http_request(scope) is None
+
+    def test_referer_fallback_foreign_rejected(self):
+        scope = _scope({"Referer": "https://evil.example/page"})
+        assert evaluate_http_request(scope) is not None
+
+    def test_referer_fallback_malformed_rejected(self):
+        assert evaluate_http_request(_scope({"Referer": "garbage"})) is not None
+
+    @pytest.mark.parametrize("value", ["same-origin", "same-site", "none"])
+    def test_sec_fetch_site_allowed_values(self, value: str):
+        assert evaluate_http_request(_scope({"Sec-Fetch-Site": value})) is None
+
+    def test_sec_fetch_site_cross_site_rejected(self):
+        assert evaluate_http_request(_scope({"Sec-Fetch-Site": "cross-site"})) is not None
+
+    def test_no_provenance_headers_allowed(self):
+        """No Origin/Referer/Sec-Fetch-Site → cannot be a cross-site
+        browser request (browsers always attach Origin to cross-origin
+        POSTs) → allowed, keeping curl/tests/server-to-server working."""
+        assert evaluate_http_request(_scope({})) is None
+
+    def test_origin_checked_before_sec_fetch_site(self):
+        """A foreign Origin loses even if Sec-Fetch-Site claims same-site
+        (strict exact-origin policy — no sibling-subdomain writes)."""
+        scope = _scope({"Origin": "https://other.sixtyfour.ee", "Sec-Fetch-Site": "same-site"})
+        assert evaluate_http_request(scope) is not None
+
+
+class TestEvaluateWsHandshake:
+    def test_no_origin_allowed(self):
+        assert evaluate_ws_handshake(_scope({}, type_="websocket", scheme="ws")) is None
+
+    def test_matching_origin_allowed_ws_scheme_mapping(self):
+        scope = _scope({"Origin": "http://testserver"}, type_="websocket", scheme="ws")
+        assert evaluate_ws_handshake(scope) is None
+
+    def test_matching_origin_allowed_wss_scheme_mapping(self):
+        scope = _scope(
+            {"Origin": "https://seadusloome.sixtyfour.ee"},
+            type_="websocket",
+            scheme="wss",
+            host="seadusloome.sixtyfour.ee",
+        )
+        assert evaluate_ws_handshake(scope) is None
+
+    def test_foreign_origin_rejected(self):
+        scope = _scope({"Origin": "https://evil.example"}, type_="websocket", scheme="ws")
+        assert evaluate_ws_handshake(scope) is not None
+
+
+# ---------------------------------------------------------------------------
+# Unit: exemptions + escape hatch + proxy trust parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExemptionsAndConfig:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/webhooks/github",
+            "/api/health",
+            "/api/ping",
+            "/drafts/00000000-0000-0000-0000-000000000001/report/full.docx",
+            "/drafts/00000000-0000-0000-0000-000000000001/report/full.pdf",
+        ],
+    )
+    def test_exempt_paths(self, path: str):
+        assert is_csrf_exempt(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/auth/login",
+            "/auth/logout",
+            "/drafts/x/delete",
+            "/admin/jobs/purge",
+            "/chat/x/delete",
+            "/api/annotations",
+            "/webhooks/github/extra",  # fullmatch — no prefix bleed
+        ],
+    )
+    def test_non_exempt_paths(self, path: str):
+        assert not is_csrf_exempt(path)
+
+    def test_token_bearer_paths_stay_in_sync_with_auth_middleware(self):
+        """#307 signed-URL paths must remain exempt if they ever grow
+        unsafe methods; the list is imported, not copied — verify each
+        pattern is honoured by is_csrf_exempt."""
+        for pattern in _TOKEN_BEARER_PATHS:
+            sample = pattern.replace("[^/]+", "abc123").replace("\\", "")
+            assert re.fullmatch(pattern, sample), f"bad sample for {pattern!r}"
+            assert is_csrf_exempt(sample)
+
+    def test_origin_check_enabled_by_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("CSRF_ORIGIN_CHECK", raising=False)
+        assert is_origin_check_enabled() is True
+
+    @pytest.mark.parametrize("value", ["off", "0", "false", "NO", "Disabled"])
+    def test_origin_check_disable_values(self, value: str, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CSRF_ORIGIN_CHECK", value)
+        assert is_origin_check_enabled() is False
+
+    def test_trusted_proxy_default_is_private_ranges(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("TRUSTED_PROXY_HOSTS", raising=False)
+        hosts = get_trusted_proxy_hosts()
+        assert hosts == list(DEFAULT_TRUSTED_PROXY_HOSTS)
+        assert "*" not in hosts
+
+    def test_trusted_proxy_env_override(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TRUSTED_PROXY_HOSTS", " 172.18.0.0/16 , 127.0.0.1 ")
+        assert get_trusted_proxy_hosts() == ["172.18.0.0/16", "127.0.0.1"]
+
+    def test_trusted_proxy_blank_env_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("TRUSTED_PROXY_HOSTS", "   ")
+        assert get_trusted_proxy_hosts() == list(DEFAULT_TRUSTED_PROXY_HOSTS)
+
+    def test_main_app_no_longer_trusts_all_proxies(self):
+        """D3 regression pin: the wired ProxyHeadersMiddleware must not
+        be in always-trust mode (trusted_hosts='*')."""
+        from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+        proxy_layers = [m for m in app.user_middleware if m.cls is ProxyHeadersMiddleware]
+        assert proxy_layers, "ProxyHeadersMiddleware missing from app"
+        for layer in proxy_layers:
+            trusted = layer.kwargs.get("trusted_hosts")
+            assert trusted != "*" and trusted != ["*"]
+
+
+# ---------------------------------------------------------------------------
+# Middleware behaviour against a tiny ASGI app (all unsafe methods)
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareTinyApp:
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+    def test_unsafe_methods_rejected_cross_origin(self, method: str, tiny_client: TestClient):
+        resp = tiny_client.request(method, "/anything", headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 403
+        assert "CSRF-kaitse" in resp.text
+
+    @pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS"])
+    def test_safe_methods_never_checked(self, method: str, tiny_client: TestClient):
+        resp = tiny_client.request(method, "/anything", headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 200
+
+    def test_exempt_path_passes_cross_origin(self, tiny_client: TestClient):
+        resp = tiny_client.post("/webhooks/github", headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 200
+
+    def test_token_bearer_download_unaffected_by_foreign_origin(self, tiny_client: TestClient):
+        path = "/drafts/00000000-0000-0000-0000-000000000001/report/full.docx"
+        with_origin = tiny_client.get(
+            path, params={"token": "x"}, headers={"Origin": "https://evil.example"}
+        )
+        without_origin = tiny_client.get(path, params={"token": "x"})
+        assert with_origin.status_code == without_origin.status_code == 200
+
+    def test_escape_hatch_disables_http_check(
+        self, tiny_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CSRF_ORIGIN_CHECK", "off")
+        resp = tiny_client.post("/anything", headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 200
+
+    def test_escape_hatch_disables_ws_check(
+        self, tiny_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("CSRF_ORIGIN_CHECK", "off")
+        with tiny_client.websocket_connect(
+            "/ws/anything", headers={"Origin": "https://evil.example"}
+        ):
+            pass  # accepted
+
+    def test_ws_foreign_origin_rejected_with_1008(self, tiny_client: TestClient):
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with tiny_client.websocket_connect(
+                "/ws/anything", headers={"Origin": "https://evil.example"}
+            ):
+                pass
+        assert excinfo.value.code == 1008
+
+
+# ---------------------------------------------------------------------------
+# Integration on the real app: representative mutating routes
+# ---------------------------------------------------------------------------
+
+_MUTATING_PATHS = [
+    "/auth/login",  # session-changing (login CSRF)
+    "/drafts/00000000-0000-0000-0000-000000000001/delete",  # draft delete
+    "/chat/00000000-0000-0000-0000-000000000001/delete",  # chat mutation
+    "/admin/jobs/purge",  # admin purge
+    "/api/annotations",  # annotation mutation
+]
+
+
+class TestRealAppCsrf:
+    @pytest.mark.parametrize("path", _MUTATING_PATHS)
+    def test_cross_origin_post_rejected_403(self, path: str, caplog: Any):
+        client = TestClient(app, follow_redirects=False)
+        with caplog.at_level(logging.WARNING, logger="app.auth.perimeter"):
+            resp = client.post(path, headers={"Origin": "https://evil.example"})
+        assert resp.status_code == 403
+        assert "CSRF-kaitse" in resp.text
+        # Rejection is log-visible (DoD: audit/log visible).
+        assert any("CSRF origin check rejected" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.parametrize("path", _MUTATING_PATHS[1:])  # login handled below
+    def test_same_origin_post_passes_check(self, path: str):
+        """Same-origin POSTs clear the CSRF layer; unauthenticated they
+        then get the beforeware's 303 to /auth/login — NOT a 403."""
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(path, headers={"Origin": "http://testserver"})
+        assert resp.status_code != 403
+
+    def test_same_origin_htmx_login_passes(self, monkeypatch: pytest.MonkeyPatch):
+        """HTMX-shaped request (Origin + HX-Request + Sec-Fetch-Site) on
+        the login route reaches the handler with zero form changes."""
+        from unittest.mock import patch
+
+        from app.auth import throttle
+
+        monkeypatch.setattr(throttle, "is_login_throttled", lambda *_a: False)
+        monkeypatch.setattr(throttle, "record_login_failure", lambda *_a: None)
+        with (
+            patch("app.auth.routes._provider") as provider,
+            patch("app.auth.routes.log_action"),
+        ):
+            provider.authenticate.return_value = None
+            client = TestClient(app, follow_redirects=False)
+            resp = client.post(
+                "/auth/login",
+                data={"email": "a@b.ee", "password": "x"},
+                headers={
+                    "Origin": "http://testserver",
+                    "HX-Request": "true",
+                    "Sec-Fetch-Site": "same-origin",
+                },
+            )
+        assert resp.status_code == 200
+        assert "Vale e-post või parool." in resp.text
+
+    def test_headerless_post_passes_check(self):
+        """Non-browser clients (no provenance headers) are not blocked."""
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(_MUTATING_PATHS[1])
+        assert resp.status_code != 403
+
+    def test_escape_hatch_on_real_app(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CSRF_ORIGIN_CHECK", "off")
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(_MUTATING_PATHS[1], headers={"Origin": "https://evil.example"})
+        # Falls through to the auth redirect instead of the CSRF 403.
+        assert resp.status_code == 303
+
+    def test_webhook_with_valid_hmac_unaffected(self, monkeypatch: pytest.MonkeyPatch):
+        """The HMAC-authenticated webhook must work even with a foreign
+        Origin header — proves the exemption end-to-end with a VALID
+        signature (ping event: no DB involved)."""
+        secret = "test-webhook-secret"
+        monkeypatch.setattr("app.sync.webhook.WEBHOOK_SECRET", secret)
+        body = b'{"zen": "test ping"}'
+        signature = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(
+            "/webhooks/github",
+            content=body,
+            headers={
+                "Origin": "https://evil.example",
+                "X-GitHub-Event": "ping",
+                "X-GitHub-Delivery": "00000000-0000-0000-0000-00000000d851",
+                "X-Hub-Signature-256": signature,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "pong"}
+
+    def test_webhook_invalid_hmac_still_rejected_by_handler(self, monkeypatch: pytest.MonkeyPatch):
+        """Exemption does not weaken the webhook: its own HMAC check
+        still rejects bad signatures (401), it just isn't OUR 403."""
+        monkeypatch.setattr("app.sync.webhook.WEBHOOK_SECRET", "test-webhook-secret")
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(
+            "/webhooks/github",
+            content=b"{}",
+            headers={
+                "Origin": "https://evil.example",
+                "X-GitHub-Event": "push",
+                "X-Hub-Signature-256": "sha256=deadbeef",
+            },
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Integration on the real app: WS handshakes
+# ---------------------------------------------------------------------------
+
+
+class TestRealAppWsOrigin:
+    def test_ws_foreign_origin_rejected(self, caplog: Any):
+        client = TestClient(app)
+        with caplog.at_level(logging.WARNING, logger="app.auth.perimeter"):
+            with pytest.raises(WebSocketDisconnect) as excinfo:
+                with client.websocket_connect(
+                    "/ws/explorer", headers={"Origin": "https://evil.example"}
+                ):
+                    pass
+        assert excinfo.value.code == 1008
+        assert any("WS origin check rejected" in r.getMessage() for r in caplog.records)
+
+    def test_ws_same_origin_accepted(self):
+        client = TestClient(app)
+        with client.websocket_connect("/ws/explorer", headers={"Origin": "http://testserver"}):
+            pass  # handshake accepted
+
+    def test_ws_no_origin_accepted(self):
+        """Non-browser WS clients carry no Origin — must keep working."""
+        client = TestClient(app)
+        with client.websocket_connect("/ws/explorer"):
+            pass

--- a/tests/test_auth_perimeter.py
+++ b/tests/test_auth_perimeter.py
@@ -138,12 +138,18 @@ class TestEvaluateHttpRequest:
     def test_referer_fallback_malformed_rejected(self):
         assert evaluate_http_request(_scope({"Referer": "garbage"})) is not None
 
-    @pytest.mark.parametrize("value", ["same-origin", "same-site", "none"])
+    @pytest.mark.parametrize("value", ["same-origin", "none"])
     def test_sec_fetch_site_allowed_values(self, value: str):
         assert evaluate_http_request(_scope({"Sec-Fetch-Site": value})) is None
 
     def test_sec_fetch_site_cross_site_rejected(self):
         assert evaluate_http_request(_scope({"Sec-Fetch-Site": "cross-site"})) is not None
+
+    def test_sec_fetch_site_bare_same_site_rejected(self):
+        """#851 review round 1: the app is single-origin, so when SFS is
+        the deciding signal (no Origin/Referer), ``same-site`` — i.e. a
+        sibling subdomain of sixtyfour.ee — is NOT sufficient."""
+        assert evaluate_http_request(_scope({"Sec-Fetch-Site": "same-site"})) is not None
 
     def test_no_provenance_headers_allowed(self):
         """No Origin/Referer/Sec-Fetch-Site → cannot be a cross-site
@@ -246,16 +252,47 @@ class TestExemptionsAndConfig:
         monkeypatch.setenv("TRUSTED_PROXY_HOSTS", "   ")
         assert get_trusted_proxy_hosts() == list(DEFAULT_TRUSTED_PROXY_HOSTS)
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "*",
+            " * ",
+            "10.0.0.0/8,*",
+            "*,127.0.0.1",
+            "*.sixtyfour.ee",
+            "172.16.0.0/12, 10.*",
+        ],
+    )
+    def test_trusted_proxy_wildcard_refused_with_safe_fallback(
+        self, value: str, monkeypatch: pytest.MonkeyPatch, caplog: Any
+    ):
+        """#851 review round 1 (P2): a wildcard anywhere in
+        TRUSTED_PROXY_HOSTS is REFUSED — error-logged and replaced by the
+        private-range defaults — never returned. Previously the function
+        warned but still returned ['*'], which flips uvicorn's
+        always-trust mode and reopens X-Forwarded-For spoofing (D3)."""
+        monkeypatch.setenv("TRUSTED_PROXY_HOSTS", value)
+        with caplog.at_level(logging.ERROR, logger="app.auth.perimeter"):
+            hosts = get_trusted_proxy_hosts()
+        assert hosts == list(DEFAULT_TRUSTED_PROXY_HOSTS)
+        assert all("*" not in h for h in hosts)
+        assert any(
+            "TRUSTED_PROXY_HOSTS" in r.getMessage() and r.levelno == logging.ERROR
+            for r in caplog.records
+        )
+
     def test_main_app_no_longer_trusts_all_proxies(self):
         """D3 regression pin: the wired ProxyHeadersMiddleware must not
-        be in always-trust mode (trusted_hosts='*')."""
+        be in always-trust mode, nor carry any wildcard entry."""
         from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
         proxy_layers = [m for m in app.user_middleware if m.cls is ProxyHeadersMiddleware]
         assert proxy_layers, "ProxyHeadersMiddleware missing from app"
         for layer in proxy_layers:
             trusted = layer.kwargs.get("trusted_hosts")
-            assert trusted != "*" and trusted != ["*"]
+            assert trusted not in ("*", ["*"])
+            assert isinstance(trusted, list)
+            assert all("*" not in h for h in trusted)
 
 
 # ---------------------------------------------------------------------------
@@ -274,6 +311,26 @@ class TestMiddlewareTinyApp:
     def test_safe_methods_never_checked(self, method: str, tiny_client: TestClient):
         resp = tiny_client.request(method, "/anything", headers={"Origin": "https://evil.example"})
         assert resp.status_code == 200
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("same-origin", 200),
+            ("none", 200),
+            ("same-site", 403),  # sibling subdomain — insufficient (#851 r1)
+            ("cross-site", 403),
+        ],
+    )
+    def test_sec_fetch_site_policy_as_deciding_signal(
+        self, value: str, expected: int, tiny_client: TestClient
+    ):
+        """No Origin/Referer present → Sec-Fetch-Site decides: only
+        same-origin and none pass; bare same-site is rejected because
+        the app is single-origin."""
+        resp = tiny_client.post("/anything", headers={"Sec-Fetch-Site": value})
+        assert resp.status_code == expected
+        if expected == 403:
+            assert "CSRF-kaitse" in resp.text
 
     def test_exempt_path_passes_cross_origin(self, tiny_client: TestClient):
         resp = tiny_client.post("/webhooks/github", headers={"Origin": "https://evil.example"})

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -9,9 +9,28 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from starlette.testclient import TestClient
 
+from app.auth import throttle
 from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _stub_throttle_and_audit(monkeypatch: pytest.MonkeyPatch):
+    """#851: keep these cookie/redirect contract tests DB-free.
+
+    login/logout now consult the login throttle and write audit rows
+    (both Postgres-backed, both fail-safe). Stub them so the contract
+    tests stay deterministic regardless of whether a local DB — with or
+    without migration 040 — happens to be running. Throttle/audit
+    behaviour has dedicated coverage in tests/test_auth_throttle.py.
+    """
+    monkeypatch.setattr(throttle, "is_login_throttled", lambda *_a: False)
+    monkeypatch.setattr(throttle, "record_login_failure", lambda *_a: None)
+    monkeypatch.setattr(throttle, "clear_login_failures", lambda *_a: None)
+    monkeypatch.setattr("app.auth.routes.log_action", lambda *_a, **_k: None)
+    monkeypatch.setattr("app.auth.middleware.log_action", lambda *_a, **_k: None)
 
 
 def _user_dict() -> dict:

--- a/tests/test_auth_throttle.py
+++ b/tests/test_auth_throttle.py
@@ -1,0 +1,582 @@
+"""Login throttling, timing-equalization, and auth audit tests (#851).
+
+Covers review finding D1 plus the ticket-comment additions:
+
+- per-email AND per-IP failure throttling on ``POST /auth/login``
+  (mirrors the ``password_reset_attempts`` pattern, migration 040);
+- no account-existence leak: the throttle keys on the normalized email
+  hash before any user lookup, and ``JWTAuthProvider.authenticate``
+  runs a dummy bcrypt check on the unknown-email path so timing is
+  equal for known and unknown emails;
+- audit events for the full auth lifecycle (login success/failure/
+  throttled, logout, token refresh) carrying the validated client IP;
+- spoofed ``X-Forwarded-For`` from an untrusted peer does NOT change
+  the IP used for throttling/audit (D3 integration).
+
+DB-backed counting SQL is unit-tested with a mocked connection; the
+route-level limit semantics use a stateful in-memory fake of the
+throttle module. A live-DB integration test (skipped without
+``DATABASE_URL``) exercises the real SQL end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from app.auth import throttle
+from app.auth.password import hash_email
+from app.auth.throttle import (
+    LOGIN_EMAIL_FAIL_LIMIT,
+    LOGIN_IP_FAIL_LIMIT,
+    clear_login_failures,
+    is_login_throttled,
+    record_login_failure,
+)
+from app.main import app
+
+
+def _user_dict() -> dict[str, Any]:
+    return {
+        "id": "uid-1",
+        "email": "user@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": None,
+    }
+
+
+def _mock_conn_ctx(conn: MagicMock) -> MagicMock:
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: throttle SQL + thresholds (mocked connection)
+# ---------------------------------------------------------------------------
+
+
+class TestThrottleUnit:
+    @patch("app.auth.throttle.get_connection")
+    def test_below_limits_not_throttled(self, mock_get_conn: MagicMock):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (
+            LOGIN_EMAIL_FAIL_LIMIT - 1,
+            LOGIN_IP_FAIL_LIMIT - 1,
+        )
+        mock_get_conn.return_value = _mock_conn_ctx(conn)
+
+        assert is_login_throttled("ehash", "1.2.3.4") is False
+        sql = conn.execute.call_args[0][0]
+        assert "login_attempts" in sql
+        # psycopg interval substitution rule: make_interval, never `interval %s`.
+        assert "make_interval" in sql
+        assert "interval %s" not in sql
+
+    @patch("app.auth.throttle.get_connection")
+    def test_email_limit_throttles(self, mock_get_conn: MagicMock):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (LOGIN_EMAIL_FAIL_LIMIT, 0)
+        mock_get_conn.return_value = _mock_conn_ctx(conn)
+
+        assert is_login_throttled("ehash", "1.2.3.4") is True
+
+    @patch("app.auth.throttle.get_connection")
+    def test_ip_limit_throttles(self, mock_get_conn: MagicMock):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0, LOGIN_IP_FAIL_LIMIT)
+        mock_get_conn.return_value = _mock_conn_ctx(conn)
+
+        assert is_login_throttled("other-hash", "1.2.3.4") is True
+
+    @patch("app.auth.throttle.get_connection")
+    def test_db_error_fails_open(self, mock_get_conn: MagicMock):
+        """A DB outage must not raise — authenticate() needs the same DB
+        anyway, so fail-open cannot enable brute force during an outage."""
+        mock_get_conn.side_effect = Exception("connection refused")
+
+        assert is_login_throttled("ehash", "1.2.3.4") is False
+        record_login_failure("ehash", "1.2.3.4")  # must not raise
+        clear_login_failures("ehash")  # must not raise
+
+    @patch("app.auth.throttle.get_connection")
+    def test_record_failure_inserts_and_commits(self, mock_get_conn: MagicMock):
+        conn = MagicMock()
+        mock_get_conn.return_value = _mock_conn_ctx(conn)
+
+        record_login_failure("ehash", "1.2.3.4")
+
+        sql = conn.execute.call_args[0][0]
+        assert "INSERT INTO login_attempts" in sql
+        assert conn.execute.call_args[0][1] == ("ehash", "1.2.3.4")
+        conn.commit.assert_called_once()
+
+    @patch("app.auth.throttle.get_connection")
+    def test_clear_failures_deletes_email_rows(self, mock_get_conn: MagicMock):
+        conn = MagicMock()
+        mock_get_conn.return_value = _mock_conn_ctx(conn)
+
+        clear_login_failures("ehash")
+
+        sql = conn.execute.call_args[0][0]
+        assert "DELETE FROM login_attempts" in sql
+        assert conn.execute.call_args[0][1] == ("ehash",)
+        conn.commit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Route-level throttle semantics with a stateful in-memory fake
+# ---------------------------------------------------------------------------
+
+
+class _FakeThrottle:
+    """In-memory reimplementation of the throttle contract (no window)."""
+
+    def __init__(self) -> None:
+        self.email_failures: dict[str, int] = {}
+        self.ip_failures: dict[str, int] = {}
+
+    def is_login_throttled(self, email_hash: str, ip: str) -> bool:
+        return (
+            self.email_failures.get(email_hash, 0) >= LOGIN_EMAIL_FAIL_LIMIT
+            or self.ip_failures.get(ip, 0) >= LOGIN_IP_FAIL_LIMIT
+        )
+
+    def record_login_failure(self, email_hash: str, ip: str) -> None:
+        self.email_failures[email_hash] = self.email_failures.get(email_hash, 0) + 1
+        self.ip_failures[ip] = self.ip_failures.get(ip, 0) + 1
+
+    def clear_login_failures(self, email_hash: str) -> None:
+        self.email_failures.pop(email_hash, None)
+
+
+@pytest.fixture
+def fake_throttle(monkeypatch: pytest.MonkeyPatch) -> _FakeThrottle:
+    fake = _FakeThrottle()
+    monkeypatch.setattr(throttle, "is_login_throttled", fake.is_login_throttled)
+    monkeypatch.setattr(throttle, "record_login_failure", fake.record_login_failure)
+    monkeypatch.setattr(throttle, "clear_login_failures", fake.clear_login_failures)
+    return fake
+
+
+class TestLoginThrottleRoute:
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_repeated_failures_throttle_by_email(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        mock_provider.authenticate.return_value = None
+        client = TestClient(app, follow_redirects=False)
+
+        for _ in range(LOGIN_EMAIL_FAIL_LIMIT):
+            resp = client.post(
+                "/auth/login",
+                data={"email": "victim@seadusloome.ee", "password": "wrong"},
+            )
+            assert resp.status_code == 200
+            assert "Vale e-post või parool." in resp.text
+
+        resp = client.post(
+            "/auth/login",
+            data={"email": "victim@seadusloome.ee", "password": "wrong"},
+        )
+        assert resp.status_code == 429
+        assert "Liiga palju sisselogimiskatseid" in resp.text
+        # Lockout holds even with the CORRECT password (and authenticate
+        # is never consulted while throttled).
+        mock_provider.authenticate.reset_mock()
+        mock_provider.authenticate.return_value = _user_dict()
+        resp = client.post(
+            "/auth/login",
+            data={"email": "victim@seadusloome.ee", "password": "correct"},
+        )
+        assert resp.status_code == 429
+        mock_provider.authenticate.assert_not_called()
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_email_normalization_shares_throttle_key(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        """`Victim@…` and `victim@…` must hit the same throttle bucket."""
+        mock_provider.authenticate.return_value = None
+        client = TestClient(app, follow_redirects=False)
+
+        for _ in range(LOGIN_EMAIL_FAIL_LIMIT):
+            client.post(
+                "/auth/login",
+                data={"email": "Victim@Seadusloome.EE ", "password": "wrong"},
+            )
+        resp = client.post(
+            "/auth/login",
+            data={"email": "victim@seadusloome.ee", "password": "wrong"},
+        )
+        assert resp.status_code == 429
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_repeated_failures_throttle_by_ip(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        """Spreading failures over many emails still trips the IP limit."""
+        mock_provider.authenticate.return_value = None
+        client = TestClient(app, follow_redirects=False)
+
+        for i in range(LOGIN_IP_FAIL_LIMIT):
+            resp = client.post(
+                "/auth/login",
+                data={"email": f"spray-{i}@example.com", "password": "wrong"},
+            )
+            assert resp.status_code == 200
+
+        resp = client.post(
+            "/auth/login",
+            data={"email": "fresh-email@example.com", "password": "wrong"},
+        )
+        assert resp.status_code == 429
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_unknown_and_known_email_throttle_identically(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        """Same status code and same body for known vs unknown emails —
+        neither the failure response nor the throttled response may leak
+        account existence."""
+        mock_provider.authenticate.return_value = None
+        client = TestClient(app, follow_redirects=False)
+
+        def drain(email: str) -> tuple[list[int], int]:
+            codes = []
+            for _ in range(LOGIN_EMAIL_FAIL_LIMIT):
+                codes.append(
+                    client.post("/auth/login", data={"email": email, "password": "x"}).status_code
+                )
+            throttled = client.post("/auth/login", data={"email": email, "password": "x"})
+            return codes, throttled.status_code
+
+        known_codes, known_throttled = drain("user@seadusloome.ee")
+        unknown_codes, unknown_throttled = drain("ghost@example.com")
+        assert known_codes == unknown_codes
+        assert known_throttled == unknown_throttled == 429
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_successful_login_clears_email_failures(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        mock_provider.authenticate.return_value = None
+        client = TestClient(app, follow_redirects=False)
+        for _ in range(LOGIN_EMAIL_FAIL_LIMIT - 1):
+            client.post(
+                "/auth/login",
+                data={"email": "user@seadusloome.ee", "password": "wrong"},
+            )
+
+        mock_provider.authenticate.return_value = _user_dict()
+        mock_provider.create_tokens.return_value = ("at", "rt")
+        resp = client.post(
+            "/auth/login",
+            data={"email": "user@seadusloome.ee", "password": "correct"},
+        )
+        assert resp.status_code == 303
+        assert fake_throttle.email_failures.get(hash_email("user@seadusloome.ee"), 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# D3 integration: spoofed X-Forwarded-For must not bypass the IP throttle
+# ---------------------------------------------------------------------------
+
+
+class TestSpoofedForwardedFor:
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_untrusted_peer_xff_is_ignored(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """The default TestClient peer ('testclient') is not a trusted
+        proxy, so a spoofed X-Forwarded-For must NOT change the IP the
+        throttle records — rotating XFF cannot reset the budget."""
+        mock_provider.authenticate.return_value = None
+        seen_ips: list[str] = []
+        monkeypatch.setattr(throttle, "is_login_throttled", lambda *_a: False)
+        monkeypatch.setattr(throttle, "record_login_failure", lambda _eh, ip: seen_ips.append(ip))
+
+        client = TestClient(app, follow_redirects=False)
+        for spoofed in ("6.6.6.1", "6.6.6.2", "6.6.6.3"):
+            client.post(
+                "/auth/login",
+                data={"email": "a@b.ee", "password": "wrong"},
+                headers={"X-Forwarded-For": spoofed},
+            )
+
+        assert seen_ips == ["testclient", "testclient", "testclient"]
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_trusted_proxy_xff_is_honoured(
+        self,
+        mock_provider: MagicMock,
+        _mock_log: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """When the direct peer IS in the trusted ranges (Docker bridge),
+        the forwarded client address is used — that is the whole point of
+        ProxyHeadersMiddleware behind Traefik."""
+        mock_provider.authenticate.return_value = None
+        seen_ips: list[str] = []
+        monkeypatch.setattr(throttle, "is_login_throttled", lambda *_a: False)
+        monkeypatch.setattr(throttle, "record_login_failure", lambda _eh, ip: seen_ips.append(ip))
+
+        client = TestClient(app, follow_redirects=False, client=("10.0.0.5", 7777))
+        client.post(
+            "/auth/login",
+            data={"email": "a@b.ee", "password": "wrong"},
+            headers={"X-Forwarded-For": "203.0.113.7"},
+        )
+
+        assert seen_ips == ["203.0.113.7"]
+
+
+# ---------------------------------------------------------------------------
+# Timing equalization (#851 comment): dummy bcrypt on unknown email
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticateTiming:
+    def _provider(self):  # noqa: ANN202
+        from app.auth.jwt_provider import JWTAuthProvider
+
+        return JWTAuthProvider(database_url="postgresql://fake:fake@localhost/fake")
+
+    def test_unknown_email_runs_dummy_bcrypt(self):
+        from app.auth.jwt_provider import _DUMMY_PASSWORD_HASH
+
+        provider = self._provider()
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+
+        with (
+            patch(
+                "app.auth.jwt_provider.JWTAuthProvider._connect",
+                return_value=_mock_conn_ctx(conn),
+            ),
+            patch("app.auth.jwt_provider.bcrypt.checkpw", return_value=False) as mock_checkpw,
+        ):
+            result = provider.authenticate("ghost@example.com", "any-password")
+
+        assert result is None
+        mock_checkpw.assert_called_once_with(b"any-password", _DUMMY_PASSWORD_HASH.encode())
+
+    def test_known_email_runs_bcrypt_against_stored_hash(self):
+        provider = self._provider()
+        stored_hash = "$2b$12$abcdefghijklmnopqrstuvCDEF0123456789012345678901234"
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (
+            "uid-1",
+            "user@seadusloome.ee",
+            stored_hash,
+            "Test Kasutaja",
+            "drafter",
+            None,
+            False,
+        )
+
+        with (
+            patch(
+                "app.auth.jwt_provider.JWTAuthProvider._connect",
+                return_value=_mock_conn_ctx(conn),
+            ),
+            patch("app.auth.jwt_provider.bcrypt.checkpw", return_value=False) as mock_checkpw,
+        ):
+            result = provider.authenticate("user@seadusloome.ee", "wrong")
+
+        assert result is None
+        # Both paths perform exactly one bcrypt verification — equal cost.
+        mock_checkpw.assert_called_once_with(b"wrong", stored_hash.encode())
+
+    def test_dummy_hash_has_default_cost_factor(self):
+        """The pad must cost the same as real hashes (gensalt default 12)."""
+        from app.auth.jwt_provider import _DUMMY_PASSWORD_HASH
+
+        assert _DUMMY_PASSWORD_HASH.startswith("$2b$12$")
+
+
+# ---------------------------------------------------------------------------
+# Audit events for the auth lifecycle (#851 comment) with validated IP
+# ---------------------------------------------------------------------------
+
+
+class TestAuthAuditEvents:
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_login_success_audited_with_ip(
+        self,
+        mock_provider: MagicMock,
+        mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        mock_provider.authenticate.return_value = _user_dict()
+        mock_provider.create_tokens.return_value = ("at", "rt")
+        client = TestClient(app, follow_redirects=False)
+
+        resp = client.post(
+            "/auth/login",
+            data={"email": "user@seadusloome.ee", "password": "correct"},
+            # Spoof attempt — must not reach the audit row (untrusted peer).
+            headers={"X-Forwarded-For": "6.6.6.6"},
+        )
+
+        assert resp.status_code == 303
+        mock_log.assert_called_once_with(
+            "uid-1",
+            "auth.login",
+            {"ip": "testclient", "email": "user@seadusloome.ee"},
+        )
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_login_failure_audited_with_email_hash(
+        self,
+        mock_provider: MagicMock,
+        mock_log: MagicMock,
+        fake_throttle: _FakeThrottle,
+    ):
+        mock_provider.authenticate.return_value = None
+        client = TestClient(app, follow_redirects=False)
+
+        client.post(
+            "/auth/login",
+            data={"email": "Ghost@Example.com", "password": "wrong"},
+            headers={"X-Forwarded-For": "6.6.6.6"},
+        )
+
+        mock_log.assert_called_once_with(
+            None,
+            "auth.login_failed",
+            {"ip": "testclient", "email_hash": hash_email("ghost@example.com")},
+        )
+
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_login_throttled_audited(
+        self,
+        mock_provider: MagicMock,
+        mock_log: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(throttle, "is_login_throttled", lambda *_a: True)
+        client = TestClient(app, follow_redirects=False)
+
+        resp = client.post("/auth/login", data={"email": "a@b.ee", "password": "x"})
+
+        assert resp.status_code == 429
+        mock_log.assert_called_once_with(
+            None,
+            "auth.login_throttled",
+            {"ip": "testclient", "email_hash": hash_email("a@b.ee")},
+        )
+        mock_provider.authenticate.assert_not_called()
+
+    @patch("app.auth.middleware._get_provider")
+    @patch("app.auth.routes.log_action")
+    @patch("app.auth.routes._provider")
+    def test_logout_audited_with_ip(
+        self,
+        mock_route_provider: MagicMock,
+        mock_log: MagicMock,
+        mock_get_mw_provider: MagicMock,
+    ):
+        mw_provider = MagicMock()
+        mw_provider.get_current_user.return_value = _user_dict()
+        mock_get_mw_provider.return_value = mw_provider
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(
+            "/auth/logout",
+            cookies={"access_token": "at-123", "refresh_token": "rt-123"},
+        )
+
+        assert resp.status_code == 303
+        mock_log.assert_called_once_with("uid-1", "auth.logout", {"ip": "testclient"})
+
+    @patch("app.auth.middleware.log_action")
+    @patch("app.auth.middleware._get_provider")
+    def test_token_refresh_audited_with_ip(
+        self,
+        mock_get_mw_provider: MagicMock,
+        mock_log: MagicMock,
+    ):
+        mw_provider = MagicMock()
+        mw_provider.get_current_user.return_value = None
+        mw_provider.verify_refresh_token.return_value = _user_dict()
+        mw_provider.create_tokens.return_value = ("new-at", "new-rt")
+        mock_get_mw_provider.return_value = mw_provider
+
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get(
+            "/dashboard",
+            cookies={"access_token": "expired", "refresh_token": "ok"},
+        )
+
+        assert resp.status_code == 307
+        mock_log.assert_called_once_with("uid-1", "auth.token_refresh", {"ip": "testclient"})
+
+
+# ---------------------------------------------------------------------------
+# Live-DB integration (skipped without DATABASE_URL) — real SQL end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestThrottleIntegration:
+    def test_real_counting_and_clearing(self):
+        if not os.getenv("DATABASE_URL"):
+            pytest.skip("integration test — DATABASE_URL not set")
+        import psycopg
+
+        with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+            if conn.execute("SELECT to_regclass('login_attempts')").fetchone() == (None,):
+                pytest.skip("migration 040 (login_attempts) not applied")
+
+        email_hash = hash_email(f"throttle-{uuid.uuid4()}@example.com")
+        ip = f"203.0.113.{uuid.uuid4().int % 250 + 1}"
+        try:
+            assert is_login_throttled(email_hash, ip) is False
+            for _ in range(LOGIN_EMAIL_FAIL_LIMIT):
+                record_login_failure(email_hash, ip)
+            assert is_login_throttled(email_hash, ip) is True
+            clear_login_failures(email_hash)
+            assert is_login_throttled(email_hash, ip) is False
+        finally:
+            with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+                conn.execute(
+                    "DELETE FROM login_attempts WHERE email_hash = %s OR ip = %s",
+                    (email_hash, ip),
+                )
+                conn.commit()

--- a/tests/test_migration_040.py
+++ b/tests/test_migration_040.py
@@ -1,0 +1,31 @@
+"""Migration 040 creates the login_attempts throttling table (#851 D1)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.db import get_connection
+
+
+def test_login_attempts_table_exists():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("integration test — DATABASE_URL not set")
+    with get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'login_attempts' ORDER BY column_name"
+        )
+        cols = {r[0] for r in cur.fetchall()}
+    assert {"id", "email_hash", "ip", "attempted_at"} <= cols
+
+
+def test_login_attempts_indexes_exist():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("integration test — DATABASE_URL not set")
+    with get_connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT indexname FROM pg_indexes WHERE tablename = 'login_attempts'")
+        indexes = {r[0] for r in cur.fetchall()}
+    assert "idx_login_attempts_email_hash_time" in indexes
+    assert "idx_login_attempts_ip_time" in indexes


### PR DESCRIPTION
Implements all of #851 — body DoD (D1/D2/D3) **and** the three ticket-comment additions (auth lifecycle audit events, WebSocket Origin allowlist, bcrypt timing-enumeration sibling).

## Definition of Done — status

| DoD item | Status | Where |
|---|---|---|
| Login POST per-IP + per-account/email throttling, reusing the password-reset pattern | ✅ | `app/auth/throttle.py` + migration `040_login_attempts.sql` (mirror of 025's `password_reset_attempts`); 5 failures / email and 20 / IP per 15-min window; 429 + Estonian message; lockout checked before `authenticate` |
| Normalized identifiers, no email-existence leak | ✅ | Throttle keys on `hash_email()` (strip+lower → SHA-256) *before* any user lookup; identical status/body for known vs unknown emails (test-pinned); the underlying ~1 ms vs ~100 ms bcrypt timing oracle in `jwt_provider.authenticate` closed with a dummy `bcrypt.checkpw` against a static cost-12 hash |
| CSRF layer over mutating routes (auth/session, draft delete/upload, admin purge/retry, chat, annotations) | ✅ | `OriginCheckMiddleware` (`app/auth/perimeter.py`) covers **every** unsafe-method (POST/PUT/PATCH/DELETE) route app-wide — strictly broader than the listed minimum; integration tests pin login, draft delete, chat delete, admin purge, annotations |
| CSRF failures → clear 4xx, audit/log visible | ✅ | 403 + Estonian body (`CSRF-kaitse`); every rejection emits a `logger.warning` with method/path/validated client IP/reason (no per-rejection DB write — an anonymous attacker must not get audit-table write amplification) |
| `ProxyHeadersMiddleware` trusts only expected proxy hosts/ranges | ✅ | `TRUSTED_PROXY_HOSTS` env (CIDR-capable, uvicorn 0.44), default `127.0.0.1, ::1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`; regression test pins that the app is never in `trusted_hosts="*"` mode |
| Rate limiting + audit use the validated client IP | ✅ | `perimeter.client_ip()` everywhere (login throttle, forgot-password throttle, all audit events); spoofed `X-Forwarded-For` from an untrusted peer is test-proven inert, honoured only from a trusted-range peer |
| Frontend/HTMX token propagation | ✅ N/A by design | Origin verification needs **zero** form/HTMX changes — that is the point (rationale below) |
| **Comment 1:** auth lifecycle audit events | ✅ | `auth.login`, `auth.login_failed` (email_hash, not raw PII), `auth.login_throttled`, `auth.logout`, `auth.token_refresh` — all with source IP |
| **Comment 2:** WS Origin allowlist | ✅ | Same middleware validates `Origin` on **all** `websocket` scopes (all five `/ws/*` channels) and rejects before accept with close 1008 — one enforcement point, no edits to the WS modules |
| **Comment 3:** timing-enumeration sibling | ✅ | Dummy `bcrypt.checkpw` on unknown-email path; test asserts the call and the cost factor parity (`$2b$12$`) |

## Verification

- ✅ Repeated login failures throttle by email and by IP (route-level tests with a stateful fake; SQL-level unit tests; live-DB integration test, skipped without `DATABASE_URL`)
- ✅ Spoofed `X-Forwarded-For` from untrusted source does NOT bypass (records `testclient`); trusted-peer XFF honoured (`client=("10.0.0.5", …)` → forwarded IP)
- ✅ Unknown-vs-known email both run exactly one bcrypt verification (dummy-call asserted)
- ✅ Cross-origin POST → 403 on login, draft delete, chat delete, admin purge, annotations; same-origin + HTMX-shaped requests pass; headerless (non-browser) requests pass; `PUT/PATCH/DELETE` covered
- ✅ Exempt paths: webhook with **valid HMAC** + foreign Origin → `200 pong` (and bad HMAC still 401 from the handler's own check); token-bearer download paths + health endpoints exempt
- ✅ WS handshake with foreign Origin → close 1008 (log-visible); same-origin and origin-less handshakes accepted
- ✅ Audit rows asserted for all lifecycle events with the validated IP
- ✅ Gate: `ruff check` clean, `ruff format --check` clean, `pyright` 0 errors, `pytest` **4366 passed, 48 skipped** (baseline was 4275/45; +91 new tests, +3 DB-gated skips)

## Design rationale: origin verification instead of CSRF tokens

- **Coverage without plumbing.** A token scheme needs a hidden field in every form, a header on every HTMX/fetch call, and server-side issuance/validation state. This codebase has dozens of mutating routes across 7 modules; token plumbing is exactly the kind of cross-cutting change that rots. The origin check covers all of them (and all future ones) from one middleware.
- **Equivalent security for this threat model.** CSRF is strictly a *browser ambient-credential* attack. Browsers attach `Origin` to every cross-origin POST (forms, fetch, XHR) and to all WebSocket handshakes — the attacker cannot strip or forge it from a victim's browser. Requests with **no** provenance headers (curl, server-to-server, tests) cannot be cross-site browser requests, so they pass — that's why the GitHub webhook keeps working with zero changes and the existing 4k-test suite needed no header retrofits.
- **Decision ladder:** `Origin` → `Referer` fallback → `Sec-Fetch-Site` (`cross-site` rejected) → allow. Exact-origin equality only (allowed set = request's own `scheme://host` + `APP_BASE_URL` origin); sibling `*.sixtyfour.ee` subdomains are NOT allowed to write.
- **Resilience pairing with D3:** if proxy trust were ever misconfigured the scope scheme would degrade to `http`, but the `APP_BASE_URL` (`https://…`) entry keeps legitimate production browsers passing — misconfiguration fails *loud on attackers, safe on users*.
- **WS analog:** cookie-authed `/ws/*` channels get the same Origin allowlist at the same enforcement point (the only layer that sees the upgrade request before FastHTML's `app.ws()` handlers — beforeware never runs for WS).

## Deploy notes (Coolify)

1. **`TRUSTED_PROXY_HOSTS` — no action needed for the standard setup.** The default (`127.0.0.1, ::1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`) covers Coolify's Docker bridge networks, where Traefik is the app container's direct peer. To pin tighter, set it to the actual proxy network, e.g. `TRUSTED_PROXY_HOSTS=10.0.0.0/8` (check with `docker network inspect` on the Coolify network / `docker inspect` the Traefik container on 89.116.22.4). Do **not** set `*`.
2. **`APP_BASE_URL` must be `https://seadusloome.sixtyfour.ee`** (it already is — the forgot-password flow uses it). It doubles as a CSRF-allowed origin.
3. **Migration 040** is applied automatically by `docker/entrypoint.sh` → `scripts/migrate.py` on deploy.
4. **Emergency switch:** `CSRF_ORIGIN_CHECK=off` disables the HTTP+WS origin checks (default: enforced). Use only to triage a production lockout, then re-enable.
5. **Post-deploy smoke:** log in normally (should work), check `audit_log` for `auth.login` rows with the real client IP (not a 10.x proxy IP), and confirm the Õiguskaart/chat/notification WebSockets still connect from the site.

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 1 (bc04d0d)

Ratified as-is: DB-fail-open throttle, log-only CSRF rejections, headerless-allowed. Two changes:

**P2 — "never `*`" proxy trust is now enforced, not advisory.** `get_trusted_proxy_hosts()` previously warned on `TRUSTED_PROXY_HOSTS=*` but still returned `["*"]`, which flips uvicorn's `_TrustedHosts.always_trust` and reopens X-Forwarded-For spoofing (D3). Any entry containing `*` (`*`, `10.*`, `*.example.com`) now **refuses the whole value**: ERROR-level log + fallback to the private-range defaults.

*Why ignore-with-defaults instead of fail-at-startup:* the fallback default (loopback + RFC1918) is exactly the correct production posture behind Traefik/Coolify, so degrading keeps the service available through an env typo while refusing the foot-gun; failing startup would turn that typo into a full outage with no security gain. The misconfiguration stays visible via the ERROR log (and Sentry). Tests pin the actual fallback for 6 adversarial env values and that the wired middleware never carries a wildcard. (Deploy note 1 above stands; `*` is now refused rather than merely discouraged.)

**Tightening — `Sec-Fetch-Site: same-site` no longer sufficient.** When SFS is the deciding signal (no Origin/Referer), only `same-origin` and `none` (direct navigation) pass; bare `same-site` would extend write trust to sibling subdomains of `sixtyfour.ee` and the app is strictly single-origin. HTMX/browser flows are unaffected (they carry Origin, which decides first). If a legitimate sibling-subdomain flow ever appears, the revert is one word — add `"same-site"` back to `_ALLOWED_SEC_FETCH_SITE` (documented in code). Tests: `same-origin` → pass, `none` → pass, bare `same-site` → 403, `cross-site` → 403, at both evaluator and middleware level.

Gate after round 1: ruff + format clean, pyright 0 errors, **pytest 4376 passed, 48 skipped** (+10 tests vs round 0).
