### PR TITLE
fix(analyysikeskus): current-law temporal scope for engines + ?oigus= wiring (#850)

### DIFF
--- a/app/analyysikeskus/burden.py
+++ b/app/analyysikeskus/burden.py
@@ -59,6 +59,11 @@ from app.ontology.relations import (
     norm_type_key,
 )
 from app.ontology.sparql_client import SparqlClient
+from app.ontology.temporal_scope import (
+    DEFAULT_SCOPE,
+    TemporalScope,
+    temporal_scope_clause,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +303,7 @@ def burden_key_order() -> tuple[BurdenKey, ...]:
 # so the count grid is honest).
 
 
-def _build_act_burden_query() -> str:
+def _build_act_burden_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
     """Return the act-level burden SPARQL.
 
     Joins via ``estleg:sourceAct`` only — the Wave 2 spike confirmed
@@ -308,6 +313,12 @@ def _build_act_burden_query() -> str:
     or a URI (canonical TTL fixture shape); the ``BIND`` clauses
     derive ``?act`` (URI form when applicable) and ``?actLabel``
     (label-or-literal) from whichever object the data carries.
+
+    The *temporal scope* (#850) is injected as a ``FILTER NOT EXISTS``
+    block via :func:`app.ontology.temporal_scope.temporal_scope_clause`.
+    The default :data:`~app.ontology.temporal_scope.DEFAULT_SCOPE`
+    (current law) drops provisions whose owning act is *positively*
+    marked repealed; pass :attr:`TemporalScope.ALL` for the full history.
     """
     return (
         PREFIXES
@@ -325,6 +336,7 @@ WHERE {{
        IF(isLiteral(?actLit), STR(?actLit), ""))
     AS ?actLabel
   )
+{temporal_scope_clause(scope, "provision")}
 }}
 ORDER BY ?provision
 LIMIT {_MAX_BURDEN_ROWS_PER_ACT}
@@ -332,13 +344,21 @@ LIMIT {_MAX_BURDEN_ROWS_PER_ACT}
     )
 
 
-def _build_provision_burden_query() -> str:
+def _build_provision_burden_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
     """Return the provision-level burden SPARQL (single-row OPTIONAL fan-out).
 
     Joins via ``estleg:sourceAct`` only — see :func:`_build_act_burden_query`
     for the rationale (Wave 2 spike, 2026-05-18). The whole
     ``sourceAct`` chain is wrapped in an OPTIONAL because a provision
     URI looked up in isolation may not carry the membership edge yet.
+
+    The temporal scope (#850) is injected as a ``FILTER NOT EXISTS``
+    block. Default = current law (positively-repealed provisions
+    dropped); :attr:`TemporalScope.ALL` keeps everything. Note the
+    ``?provision`` here is bound by the caller's URI VALUES clause, so
+    the filter operates on that single provision (it disappears from the
+    single-row result when the provision / its act is positively
+    repealed and the scope is current).
     """
     return (
         PREFIXES
@@ -358,6 +378,7 @@ WHERE {{
   }}
   OPTIONAL {{ ?provision <{PREDICATES.NORMATIVE_TYPE}> ?normType }}
   OPTIONAL {{ ?provision <{PREDICATES.DUTY_HOLDER}> ?dutyHolder }}
+{temporal_scope_clause(scope, "provision")}
 }}
 LIMIT 1
 """
@@ -412,6 +433,7 @@ def _looks_like_uri(value: str) -> bool:
 def list_burden_for_act(
     act: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> BurdenSummary:
     """Return the deontic-classified rows + counts for every provision of *act*.
@@ -432,6 +454,11 @@ def list_burden_for_act(
             detects the shape and emits the appropriate VALUES
             binding. Empty / whitespace input yields an empty
             :class:`BurdenSummary` (no SPARQL hit).
+        scope: Temporal scope (#850). Default
+            :data:`~app.ontology.temporal_scope.DEFAULT_SCOPE` (current
+            law) excludes provisions whose owning act is positively
+            marked repealed; :attr:`TemporalScope.ALL` includes the full
+            history.
         sparql_client: Optional :class:`SparqlClient` override (tests
             inject a mocked one).
 
@@ -446,7 +473,7 @@ def list_burden_for_act(
         return _empty_summary()
 
     client = sparql_client if sparql_client is not None else SparqlClient()
-    query = _build_act_burden_query()
+    query = _build_act_burden_query(scope)
     try:
         if _looks_like_uri(ident):
             rows = client.query(query, uri_bindings={"actLit": ident})
@@ -462,6 +489,7 @@ def list_burden_for_act(
 def list_burden_for_provision(
     provision_uri: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> BurdenSummary:
     """Return the deontic-classified single-row summary for a provision URI.
@@ -470,6 +498,17 @@ def list_burden_for_provision(
     Useful when the user's input resolves to a §-reference rather than an
     act / draft — the count grid then shows ``1`` in exactly one bucket
     and ``0`` in the rest.
+
+    Args:
+        provision_uri: The ``LegalProvision`` URI.
+        scope: Temporal scope (#850). Default current law — a
+            positively-repealed provision (or one whose owning act is
+            repealed) yields an empty summary under the current-law
+            scope. :attr:`TemporalScope.ALL` keeps it. The draft-delta
+            path (:func:`burden_delta_for_draft`) calls this without an
+            explicit scope and therefore inherits the current-law default
+            for its "before" baseline.
+        sparql_client: Optional :class:`SparqlClient` override.
     """
     uri = (provision_uri or "").strip()
     if not uri:
@@ -478,7 +517,7 @@ def list_burden_for_provision(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _build_provision_burden_query(),
+            _build_provision_burden_query(scope),
             uri_bindings={"provision": uri},
         )
     except Exception:

--- a/app/analyysikeskus/competency.py
+++ b/app/analyysikeskus/competency.py
@@ -63,6 +63,11 @@ from typing import Any
 
 from app.ontology.queries import PREFIXES
 from app.ontology.sparql_client import SparqlClient
+from app.ontology.temporal_scope import (
+    DEFAULT_SCOPE,
+    TemporalScope,
+    temporal_scope_clause,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -237,20 +242,33 @@ LIMIT """
 # membership edge in prod (the Wave 2 spike confirmed both
 # ``estleg:partOf`` and ``estleg:partOfAct`` carry zero triples in this
 # corpus). OPTIONAL so an orphan provision still surfaces.
-_INSTITUTION_COMPETENCES_QUERY = (
-    PREFIXES
-    + """
+#
+# Temporal scope (#850): the competence row IS a ``LegalProvision``, so
+# the current-law filter from :mod:`app.ontology.temporal_scope` drops
+# powers vested by provisions of a positively-repealed act — a ministry
+# lawyer asking "what powers does this body hold today" should not see
+# competences granted by acts that no longer exist. Default current law;
+# :attr:`TemporalScope.ALL` includes historical powers. Built as a
+# function so the scope clause can be spliced per call.
+
+
+def _build_institution_competences_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Competence provisions vested in an institution, scoped by *scope* (#850)."""
+    return (
+        PREFIXES
+        + f"""
 SELECT ?provision ?provisionLabel ?actLit
-WHERE {
+WHERE {{
   ?provision estleg:competentAuthority ?institution .
-  OPTIONAL { ?provision rdfs:label ?provisionLabel }
-  OPTIONAL { ?provision estleg:sourceAct ?actLit }
-}
+  OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+  OPTIONAL {{ ?provision estleg:sourceAct ?actLit }}
+{temporal_scope_clause(scope, "provision")}
+}}
 ORDER BY ?actLit ?provision
-LIMIT """
-    + str(_MAX_COMPETENCES_PER_INSTITUTION + 1)  # +1 sentinel so we can detect truncation
-    + "\n"
-)
+LIMIT {_MAX_COMPETENCES_PER_INSTITUTION + 1}
+"""
+    )
+
 
 # Overlap rows — every provision where the seed institution and at
 # least one *other* institution both appear on ``competentAuthority``.
@@ -260,24 +278,32 @@ LIMIT """
 #
 # ``FILTER(?other != ?institution)`` excludes self-pairs; the route
 # also runs a defence-in-depth Python filter.
-_INSTITUTION_OVERLAPS_QUERY = (
-    PREFIXES
-    + """
+#
+# Temporal scope (#850): same provision-level filter as the competences
+# query — an overlap on a repealed-act provision is not a live overlap.
+
+
+def _build_institution_overlaps_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Competence-overlap provisions for an institution, scoped by *scope* (#850)."""
+    return (
+        PREFIXES
+        + f"""
 SELECT DISTINCT ?provision ?provisionLabel ?actLit ?other ?otherLabel
-WHERE {
+WHERE {{
   ?provision estleg:competentAuthority ?institution .
   ?provision estleg:competentAuthority ?other .
   ?other a estleg:Institution .
-  OPTIONAL { ?provision rdfs:label ?provisionLabel }
-  OPTIONAL { ?provision estleg:sourceAct ?actLit }
-  OPTIONAL { ?other rdfs:label ?otherLabel }
+  OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+  OPTIONAL {{ ?provision estleg:sourceAct ?actLit }}
+  OPTIONAL {{ ?other rdfs:label ?otherLabel }}
   FILTER(?other != ?institution)
-}
+{temporal_scope_clause(scope, "provision")}
+}}
 ORDER BY ?actLit ?provision ?other
-LIMIT """
-    + str(_MAX_OVERLAP_ROWS)
-    + "\n"
-)
+LIMIT {_MAX_OVERLAP_ROWS}
+"""
+    )
+
 
 # Lookup a single Institution's rdfs:label by URI — used by
 # :func:`get_institution_label` when the route only has a URI in hand
@@ -422,6 +448,7 @@ def get_institution_label(
 def list_competences_for_institution(
     institution_uri: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[CompetenceRow]:
     """Return every competence provision vested in *institution_uri*.
@@ -433,6 +460,9 @@ def list_competences_for_institution(
     Args:
         institution_uri: The ``estleg:Institution`` URI. Empty input
             returns ``[]`` without hitting Jena.
+        scope: Temporal scope (#850). Default current law excludes
+            powers vested by provisions of a positively-repealed act;
+            :attr:`TemporalScope.ALL` includes historical powers.
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -449,7 +479,7 @@ def list_competences_for_institution(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _INSTITUTION_COMPETENCES_QUERY,
+            _build_institution_competences_query(scope),
             uri_bindings={"institution": uri},
         )
     except Exception:
@@ -466,6 +496,7 @@ def list_competences_for_institution(
 def list_competence_overlaps(
     institution_uri: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[OverlapRow]:
     """Return overlap rows — provisions where the institution shares competence.
@@ -478,6 +509,9 @@ def list_competence_overlaps(
     Args:
         institution_uri: The seed ``estleg:Institution`` URI. Empty
             input returns ``[]`` without hitting Jena.
+        scope: Temporal scope (#850). Default current law excludes
+            overlaps on provisions of a positively-repealed act;
+            :attr:`TemporalScope.ALL` includes historical overlaps.
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -491,7 +525,7 @@ def list_competence_overlaps(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _INSTITUTION_OVERLAPS_QUERY,
+            _build_institution_overlaps_query(scope),
             uri_bindings={"institution": uri},
         )
     except Exception:
@@ -530,6 +564,7 @@ def gather_institution_competences(
     institution_uri: str,
     *,
     institution_label: str | None = None,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> InstitutionCompetences:
     """Aggregate the full A3 v1 view for one institution.
@@ -547,6 +582,9 @@ def gather_institution_competences(
             the URI is non-empty, this function calls
             :func:`get_institution_label` so the result always carries a
             label (or the URI tail as a last resort).
+        scope: Temporal scope (#850), threaded to both the competences
+            and overlaps queries. Default current law; pass
+            :attr:`TemporalScope.ALL` for the full history.
         sparql_client: Optional :class:`SparqlClient` override — passed
             through to all three SPARQL calls so tests inject one mock.
 
@@ -568,7 +606,7 @@ def gather_institution_competences(
         tail = uri.rsplit("#", 1)[-1].rsplit("/", 1)[-1]
         label = tail or uri
 
-    rows = list_competences_for_institution(uri, sparql_client=sparql_client)
+    rows = list_competences_for_institution(uri, scope=scope, sparql_client=sparql_client)
     # Detect truncation: the SPARQL LIMIT is _MAX + 1 so we can see one
     # past the cap; we then trim back to _MAX for the actual view.
     truncated = len(rows) > _MAX_COMPETENCES_PER_INSTITUTION
@@ -584,7 +622,7 @@ def gather_institution_competences(
         # edge; the route labels it "Muud" rather than blank.
         by_act.setdefault(row.act_label, []).append(row)
 
-    overlaps = list_competence_overlaps(uri, sparql_client=sparql_client)
+    overlaps = list_competence_overlaps(uri, scope=scope, sparql_client=sparql_client)
 
     return InstitutionCompetences(
         institution_uri=uri,

--- a/app/analyysikeskus/court_practice.py
+++ b/app/analyysikeskus/court_practice.py
@@ -40,6 +40,11 @@ from typing import Any, Literal
 from app.ontology.queries import PREFIXES
 from app.ontology.relations import PREDICATES
 from app.ontology.sparql_client import SparqlClient
+from app.ontology.temporal_scope import (
+    DEFAULT_SCOPE,
+    TemporalScope,
+    temporal_scope_clause,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -288,9 +293,21 @@ class CourtPracticeGroup:
 # the URI constants are module-level :data:`~typing.Final` strings —
 # never user input.
 
-_PROVISION_DECISIONS_QUERY = (
-    PREFIXES
-    + f"""
+# Temporal scope (#850): both decision queries bind ``?provision`` (the
+# interpreted ``LegalProvision``), so the current-law filter from
+# :mod:`app.ontology.temporal_scope` drops court practice that
+# interprets provisions of a positively-repealed act — keeping the
+# provision/legal-basis join on the same temporal policy as the other
+# engines (the DoD's "uses the same temporal/version policy" item). The
+# templates are builder functions so the scope clause splices per call;
+# default-scope module constants are kept below for back-compat.
+
+
+def _build_provision_decisions_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Decisions interpreting a single provision, scoped by *scope* (#850)."""
+    return (
+        PREFIXES
+        + f"""
 SELECT DISTINCT ?decision ?decisionLabel ?caseNumber ?decisionDate
                 ?court ?courtLabel ?type
                 ?provision ?provisionLabel
@@ -308,11 +325,13 @@ WHERE {{
   OPTIONAL {{ ?decision a ?type .
              FILTER(STRSTARTS(STR(?type), "https://data.riik.ee/ontology/estleg#")) }}
   OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+{temporal_scope_clause(scope, "provision")}
 }}
 ORDER BY DESC(?decisionDate)
 LIMIT {_MAX_DECISIONS_PER_QUERY}
 """
-)
+    )
+
 
 # The act-level query joins provisions to the act via the literal
 # ``estleg:sourceAct`` title (the only join path that carries rows in
@@ -323,9 +342,13 @@ LIMIT {_MAX_DECISIONS_PER_QUERY}
 # The act-binding is therefore a string-literal — ``?actLit`` — not a
 # URI, and the caller injects it via :meth:`SparqlClient._inject_bindings`
 # (the string-literal variant of ``_inject_uri_bindings``).
-_ACT_DECISIONS_QUERY = (
-    PREFIXES
-    + f"""
+
+
+def _build_act_decisions_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Decisions interpreting any provision of an act, scoped by *scope* (#850)."""
+    return (
+        PREFIXES
+        + f"""
 SELECT DISTINCT ?decision ?decisionLabel ?caseNumber ?decisionDate
                 ?court ?courtLabel ?type
                 ?provision ?provisionLabel
@@ -344,11 +367,19 @@ WHERE {{
   OPTIONAL {{ ?decision a ?type .
              FILTER(STRSTARTS(STR(?type), "https://data.riik.ee/ontology/estleg#")) }}
   OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+{temporal_scope_clause(scope, "provision")}
 }}
 ORDER BY DESC(?decisionDate)
 LIMIT {_MAX_DECISIONS_PER_QUERY}
 """
-)
+    )
+
+
+# Default-scope (current-law) snapshots kept for backwards compatibility
+# with callers / tests that referenced the pre-#850 ``_*_QUERY`` strings;
+# new code should call the builder functions with an explicit scope.
+_PROVISION_DECISIONS_QUERY = _build_provision_decisions_query()
+_ACT_DECISIONS_QUERY = _build_act_decisions_query()
 
 
 # Lightweight URI → literal-title reverse lookup. The corpus has no
@@ -378,6 +409,7 @@ LIMIT 1
 def list_decisions_for_provision(
     provision_uri: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[CourtDecisionRow]:
     """Return every CourtDecision interpreting *provision_uri*.
@@ -387,6 +419,10 @@ def list_decisions_for_provision(
             ``estleg:interpretsLaw`` / subject of
             ``estleg:interpretedBy``). Empty / whitespace input yields
             ``[]`` without hitting Jena.
+        scope: Temporal scope (#850). Default current law drops court
+            practice interpreting a positively-repealed provision / act;
+            :attr:`TemporalScope.ALL` keeps the full history (e.g. for a
+            historical-research view).
         sparql_client: Optional :class:`SparqlClient` override (tests
             inject one whose ``.query`` is mocked).
 
@@ -403,7 +439,7 @@ def list_decisions_for_provision(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _PROVISION_DECISIONS_QUERY,
+            _build_provision_decisions_query(scope),
             uri_bindings={"provision": uri},
         )
     except Exception:
@@ -420,6 +456,7 @@ def list_decisions_for_provision(
 def list_decisions_for_act(
     act_identifier: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[CourtDecisionRow]:
     """Return every CourtDecision interpreting any provision of an act.
@@ -439,6 +476,13 @@ def list_decisions_for_act(
             does a one-shot ``rdfs:label`` reverse-lookup and uses
             that label as the literal. Empty / whitespace yields
             ``[]``.
+        scope: Temporal scope (#850). Default current law drops court
+            practice interpreting provisions of a positively-repealed
+            act; :attr:`TemporalScope.ALL` keeps the full history. Note:
+            if the act *itself* is repealed, every member provision is
+            excluded under current law and the result is empty — which is
+            the honest answer for "current court practice on a repealed
+            act".
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -457,7 +501,7 @@ def list_decisions_for_act(
 
     try:
         rows = client.query(
-            _ACT_DECISIONS_QUERY,
+            _build_act_decisions_query(scope),
             bindings={"actLit": act_literal},
         )
     except Exception:

--- a/app/analyysikeskus/routes.py
+++ b/app/analyysikeskus/routes.py
@@ -117,6 +117,7 @@ from app.docs.labels import TYPE_LABELS_ET as _TYPE_LABELS_ET
 from app.docs.reference_resolver import ReferenceResolver
 from app.docs.report_routes import explorer_focus_url
 from app.drafter.state_machine import STEP_LABELS_ET, Step
+from app.ontology.temporal_scope import TemporalScope, scope_from_param
 from app.ui.capabilities import CAPABILITIES, Capability
 from app.ui.data.data_table import Column, DataTable
 from app.ui.layout import PageShell
@@ -590,9 +591,13 @@ _CELEX_TOKEN_RE = re.compile(r"^\d{5}[A-Z]\d{1,4}$", re.IGNORECASE)
 class _Scope:
     """Parsed ``Ulatus`` scope from the GET query params.
 
-    ``oigus`` is informational only (temporal redactions aren't wired —
-    the second select option is disabled). The boolean flags are
-    workflow-specific:
+    ``oigus`` is the temporal-scope token: ``"current"`` (*kehtiv õigus*,
+    the default) vs ``"all"`` (*kogu ajalugu*). Since #850 it is **wired
+    end-to-end** — :attr:`temporal_scope` maps it to a
+    :class:`~app.ontology.temporal_scope.TemporalScope`, the Sanktsioonid
+    / Halduskoormus / Pädevused / Kohtupraktika handlers pass that scope
+    to their engine calls, and :func:`_scope_form` reflects the URL state
+    in the select. The boolean flags are workflow-specific:
 
     * **Normi mõjuahel** — ``include_eu`` / ``include_court`` actually
       filter the analysis output; ``org_wide_drafts`` only re-frames the
@@ -637,9 +642,26 @@ class _Scope:
                 self.include_eu = True
                 self.include_court = True
                 self.org_wide_drafts = False
-        self.oigus = params.get("oigus") or "current"
+        # Canonicalise the temporal-scope token through the helper so the
+        # form select + carried links always reflect a known value
+        # (``"current"`` / ``"all"``) even when the URL carried a legacy
+        # alias (``"kogu_ajalugu"`` / ``"current_plus_history"``). #850.
+        self.oigus = scope_from_param(params.get("oigus")).value
         self.ajavahemik_algus = params.get("ajavahemik_algus") or ""
         self.ajavahemik_lopp = params.get("ajavahemik_lopp") or ""
+
+    @property
+    def temporal_scope(self) -> TemporalScope:
+        """Map the ``?oigus=`` token to a :class:`TemporalScope` (#850).
+
+        ``"current"`` → :attr:`TemporalScope.CURRENT` (kehtiv õigus,
+        default); ``"all"`` / legacy history aliases →
+        :attr:`TemporalScope.ALL` (kogu ajalugu). The engines splice this
+        into their SPARQL so a positively-repealed provision is excluded
+        under the current-law default and kept under the all-history
+        scope.
+        """
+        return scope_from_param(self.oigus)
 
     def query_pairs(self, sisend: str) -> list[tuple[str, str]]:
         """Return the ``(key, value)`` pairs to carry the scope through links."""
@@ -735,6 +757,45 @@ _LAW_SCOPE_OPTIONS: list[tuple[str, str]] = [
     ("current", "Kehtiv õigus"),
     ("current_plus_history", "Kehtiv + varasemad redaktsioonid (tulekul)"),
 ]
+
+# #850: the *enabled* temporal-scope options for the four engines that
+# honour the scope end-to-end (Sanktsioonid / Halduskoormus / Pädevused /
+# Kohtupraktika). "Kehtiv õigus" excludes positively-repealed provisions;
+# "Kogu ajalugu" includes them. The option values are the canonical
+# ``TemporalScope`` tokens so the form round-trips through ``?oigus=``.
+_TEMPORAL_SCOPE_OPTIONS: list[tuple[str, str]] = [
+    (TemporalScope.CURRENT.value, "Kehtiv õigus"),
+    (TemporalScope.ALL.value, "Kogu ajalugu"),
+]
+
+
+def _temporal_scope_select(oigus: str) -> Any:
+    """Render the enabled ``Õigus`` (temporal-scope) field reflecting the URL.
+
+    Shared by the four scope-aware workflow forms (#850). The select's
+    value mirrors the request's ``?oigus=`` token (canonicalised by
+    :class:`_Scope` to ``"current"`` / ``"all"``) so a reload preserves
+    the user's choice, and the field name ``oigus`` round-trips the
+    selection straight back into the workflow URL. The default option,
+    *Kehtiv õigus*, excludes provisions whose owning act is positively
+    marked repealed; *Kogu ajalugu* includes the full history.
+    """
+    value = oigus if oigus in {opt[0] for opt in _TEMPORAL_SCOPE_OPTIONS} else "current"
+    return Div(  # noqa: F405
+        Label("Õigus", fr="analyysikeskus-scope-law"),  # noqa: F405
+        Select(
+            "oigus",
+            _TEMPORAL_SCOPE_OPTIONS,
+            value=value,
+            id="analyysikeskus-scope-law",
+        ),
+        Small(  # noqa: F405
+            "“Kehtiv õigus” jätab välja kehtetuks tunnistatud sätted; "
+            "“Kogu ajalugu” kaasab ka varasema õiguse.",
+            cls="muted-text",
+        ),
+        cls="form-field",
+    )
 
 
 def _scope_form(
@@ -2639,10 +2700,6 @@ def _sanctions_scope_block(sisend: str, scope: _Scope, *, include_comparison: bo
     also runs :func:`find_similar_sanctions` and renders the comparison
     section.
     """
-    # ``scope`` accepted for call-site symmetry with the sibling scope
-    # blocks even though Sanktsioonide indeks has just the one toggle
-    # — keeps the result-shell wiring identical across workflows.
-    _ = scope
     return Form(  # noqa: F405
         P(  # noqa: F405
             "Vaikimisi näitan ainult valitud sätte/akti sanktsioone. Märkige, "
@@ -2651,6 +2708,8 @@ def _sanctions_scope_block(sisend: str, scope: _Scope, *, include_comparison: bo
         ),
         Hidden(name="sisend", value=sisend),  # noqa: F405
         Hidden(name="ulatus_submitted", value="1"),  # noqa: F405
+        # #850: temporal scope — kehtiv õigus (default) vs kogu ajalugu.
+        _temporal_scope_select(scope.oigus),
         Checkbox(
             "vordle_sarnaste_aktidega",
             checked=include_comparison,
@@ -3056,28 +3115,29 @@ def _render_sanctions_result(
     label = _resolved_label(resolved, sisend)
     type_label = _resolved_type_label(resolved)
     partial_title = _partial_act_title(resolved)
+    ts = scope.temporal_scope  # #850 — kehtiv õigus / kogu ajalugu
 
     if entity_uri and _is_provision_resolved(resolved):
-        rows = list_sanctions_for_provision(entity_uri)
+        rows = list_sanctions_for_provision(entity_uri, scope=ts)
     elif partial_title is not None and not entity_uri:
         # Bare law input — Wave 2 Step 2 resolver returns
         # entity_uri=None, partial_match.act_title=<literal title>.
         # Route directly to the act-level helper with that title.
-        rows = list_sanctions_for_act(partial_title)
+        rows = list_sanctions_for_act(partial_title, scope=ts)
     else:
         # The act join is on the ``estleg:sourceAct`` literal title in
         # prod (no act URIs exist on provisions — see the Wave 2 spike
         # in ``docs/2026-05-18-bugfix-plan.md``). The best title we have
         # for a resolved law ref is the human label the resolver
         # surfaced; pass that to the SPARQL helper.
-        rows = list_sanctions_for_act(label)
+        rows = list_sanctions_for_act(label, scope=ts)
 
     similar_rows: list[Any] | None = None
     if include_comparison and rows:
         # Seed on the first row — keeps the comparison deterministic.
         # Future iterations may surface a "pick which sanction to
         # compare" affordance for multi-sanction provisions.
-        similar_rows = find_similar_sanctions(rows[0], limit=_MAX_RESULT_ROWS)
+        similar_rows = find_similar_sanctions(rows[0], limit=_MAX_RESULT_ROWS, scope=ts)
 
     input_summary = P(  # noqa: F405
         "Analüüsisin: ",
@@ -3322,7 +3382,6 @@ def _kohtupraktika_scope_block(sisend: str, scope: _Scope) -> Any:
     UX parity with the other workflows; the toggles ride through so URLs
     stay shareable.
     """
-    _ = scope  # call-site symmetry
     return Form(  # noqa: F405
         P(  # noqa: F405
             "Vaatan kõiki kohtuid, mis on seda sätet või akti tõlgendanud. "
@@ -3331,6 +3390,9 @@ def _kohtupraktika_scope_block(sisend: str, scope: _Scope) -> Any:
         ),
         Hidden(name="sisend", value=sisend),  # noqa: F405
         Hidden(name="ulatus_submitted", value="1"),  # noqa: F405
+        # #850: temporal scope — kehtiv õigus (default) excludes court
+        # practice that interprets provisions of a repealed act.
+        _temporal_scope_select(scope.oigus),
         Small(  # noqa: F405
             "Praeguses versioonis kuvan Riigikohtu, Euroopa Kohtu ja "
             "ringkonnakohtute lahendid eraldi sektsioonides; täpsemad "
@@ -3605,14 +3667,15 @@ def _render_court_practice_result(
     label = _resolved_label(resolved, sisend)
     type_label = _resolved_type_label(resolved)
     partial_title = _partial_act_title(resolved)
+    ts = scope.temporal_scope  # #850 — kehtiv õigus / kogu ajalugu
 
     if entity_uri and _is_court_practice_provision(resolved):
-        rows = list_decisions_for_provision(entity_uri)
+        rows = list_decisions_for_provision(entity_uri, scope=ts)
     elif partial_title is not None and not entity_uri:
         # Bare law input — the act-level helper accepts a literal title.
-        rows = list_decisions_for_act(partial_title)
+        rows = list_decisions_for_act(partial_title, scope=ts)
     else:
-        rows = list_decisions_for_act(entity_uri)
+        rows = list_decisions_for_act(entity_uri, scope=ts)
 
     groups = group_by_court(rows)
 
@@ -4057,8 +4120,8 @@ def _burden_actions(*, focus_uri: str | None) -> list[dict[str, str]]:
     return actions
 
 
-def _burden_scope_block(sisend: str) -> Any:
-    """A minimal ``Ulatus`` form — v1 has no toggles, just a "Uuenda" submit + intro."""
+def _burden_scope_block(sisend: str, scope: _Scope) -> Any:
+    """The ``Ulatus`` form for Halduskoormus — temporal scope + intro (#850)."""
     return Form(  # noqa: F405
         P(  # noqa: F405
             "Vaikimisi loendatakse kõik sätte või akti deontilised liigitused. "
@@ -4068,6 +4131,9 @@ def _burden_scope_block(sisend: str) -> Any:
         ),
         Hidden(name="sisend", value=sisend),  # noqa: F405
         Hidden(name="ulatus_submitted", value="1"),  # noqa: F405
+        # #850: temporal scope — kehtiv õigus (default) excludes the
+        # deontic rows of provisions belonging to a repealed act.
+        _temporal_scope_select(scope.oigus),
         Button("Uuenda ulatust", type="submit", variant="secondary", size="sm"),
         method="get",
         action="/analyysikeskus/halduskoormus",
@@ -4142,6 +4208,7 @@ def _render_burden_result(
     theme: str,
     resolved: Any,
     sisend: str,
+    scope: _Scope,
 ) -> Any:
     """Render the result page for a single resolved entity.
 
@@ -4154,15 +4221,20 @@ def _render_burden_result(
     * No URI but ``partial_match["act_title"]`` set (bare law input
       like ``TLS``) → :func:`list_burden_for_act` against the literal
       title. Wave 2 Step 5 (#801 follow-up).
+
+    The act/provision branches honour the ``?oigus=`` temporal scope
+    (#850); the draft-delta branch is owned by the draft engine and is
+    left on its existing behaviour.
     """
     entity_uri_raw = getattr(resolved, "entity_uri", None)
     entity_uri = str(entity_uri_raw) if entity_uri_raw else ""
     label = _resolved_label(resolved, sisend)
     type_label = _resolved_type_label(resolved)
     partial_title = _partial_act_title(resolved)
+    ts = scope.temporal_scope
 
     if entity_uri and _is_provision_resolved(resolved):
-        summary = list_burden_for_provision(entity_uri)
+        summary = list_burden_for_provision(entity_uri, scope=ts)
         results_block: Any = _burden_results_block(summary)
         evidence_summary = summary
     elif entity_uri and _is_draft_resolved(resolved):
@@ -4171,11 +4243,11 @@ def _render_burden_result(
         evidence_summary = delta.before
     elif partial_title is not None and not entity_uri:
         # Bare law input — pass the literal title to the act helper.
-        summary = list_burden_for_act(partial_title)
+        summary = list_burden_for_act(partial_title, scope=ts)
         results_block = _burden_results_block(summary)
         evidence_summary = summary
     else:
-        summary = list_burden_for_act(entity_uri)
+        summary = list_burden_for_act(entity_uri, scope=ts)
         results_block = _burden_results_block(summary)
         evidence_summary = summary
 
@@ -4196,7 +4268,7 @@ def _render_burden_result(
         actions=actions,
         user=auth,
         theme=theme,
-        scope_block=_burden_scope_block(sisend),
+        scope_block=_burden_scope_block(sisend, scope),
     )
 
 
@@ -4206,6 +4278,7 @@ def _render_burden_disambiguation(
     theme: str,
     resolved: list[Any],
     sisend: str,
+    scope: _Scope,
 ) -> Any:
     """Render a disambiguation page listing plausible resolutions as links."""
     candidates: list[dict[str, str]] = []
@@ -4239,7 +4312,7 @@ def _render_burden_disambiguation(
         ],
         user=auth,
         theme=theme,
-        scope_block=_burden_scope_block(sisend),
+        scope_block=_burden_scope_block(sisend, scope),
     )
 
 
@@ -4249,6 +4322,7 @@ def _render_burden_unresolved(
     theme: str,
     sisend: str,
     org_id: str | None,
+    scope: _Scope,
 ) -> Any:
     """Render the "no structured reference recognised" page (+ optional RAG candidates)."""
     warning = Alert(
@@ -4282,7 +4356,7 @@ def _render_burden_unresolved(
         ],
         user=auth,
         theme=theme,
-        scope_block=_burden_scope_block(sisend),
+        scope_block=_burden_scope_block(sisend, scope),
     )
 
 
@@ -4311,6 +4385,9 @@ def halduskoormus_page(req: Request):
     org_id = auth.get("org_id") if auth else None
 
     sisend = (req.query_params.get("sisend") or "").strip()
+    # #850: parse the ``?oigus=`` temporal scope so the engine calls + the
+    # scope form honour kehtiv õigus (default) vs kogu ajalugu.
+    scope = _Scope(req.query_params, workflow=_WORKFLOW_NORMI)
 
     if not sisend:
         return _render_burden_landing(auth=auth, theme=theme)
@@ -4328,6 +4405,7 @@ def halduskoormus_page(req: Request):
             theme=theme,
             resolved=unique_resolved[0],
             sisend=sisend,
+            scope=scope,
         )
 
     if len(unique_resolved) > 1:
@@ -4336,6 +4414,7 @@ def halduskoormus_page(req: Request):
             theme=theme,
             resolved=unique_resolved,
             sisend=sisend,
+            scope=scope,
         )
 
     return _render_burden_unresolved(
@@ -4343,6 +4422,7 @@ def halduskoormus_page(req: Request):
         theme=theme,
         sisend=sisend,
         org_id=org_id,
+        scope=scope,
     )
 
 
@@ -4401,11 +4481,11 @@ def _padevused_scope_block(sisend: str, scope: _Scope) -> Any:
     """The ``Ulatus`` scope form for the Pädevuste kaardistus workflow.
 
     Legal-language only — the controls explain what the page covers (and
-    what it does **not** yet cover in v1). No active toggles in v1 since
-    the grouping vocabulary (competence area) is missing from the
-    ontology; the form is kept for UX parity and shareability.
+    what it does **not** yet cover in v1). Since #850 the temporal-scope
+    select (kehtiv õigus / kogu ajalugu) is active and the submit is
+    enabled; pädevusala-grouping + gap analysis remain deferred (they
+    need ontology CompetenceShape + competenceArea).
     """
-    _ = scope  # call-site symmetry
     return Form(  # noqa: F405
         P(  # noqa: F405
             "Vaatan kõiki sätteid, mille puhul valitud asutus on määratud "
@@ -4415,6 +4495,9 @@ def _padevused_scope_block(sisend: str, scope: _Scope) -> Any:
         ),
         Hidden(name="sisend", value=sisend),  # noqa: F405
         Hidden(name="ulatus_submitted", value="1"),  # noqa: F405
+        # #850: temporal scope — kehtiv õigus (default) excludes powers
+        # vested by provisions of a repealed act.
+        _temporal_scope_select(scope.oigus),
         Small(  # noqa: F405
             "Pädevusalade kaupa rühmitamine ja lünkade analüüs on tulekul — "
             "ootame ontoloogia täiendust (CompetenceShape + competenceArea).",
@@ -4425,8 +4508,6 @@ def _padevused_scope_block(sisend: str, scope: _Scope) -> Any:
             type="submit",
             variant="secondary",
             size="sm",
-            disabled=True,
-            title="Tulekul",
         ),
         method="get",
         action="/analyysikeskus/padevused",
@@ -4764,6 +4845,7 @@ def _render_padevused_result(
     view = gather_institution_competences(
         institution_uri,
         institution_label=institution_label,
+        scope=scope.temporal_scope,  # #850 — kehtiv õigus / kogu ajalugu
     )
     label = view.institution_label or institution_label or sisend
 

--- a/app/analyysikeskus/sanctions.py
+++ b/app/analyysikeskus/sanctions.py
@@ -43,6 +43,11 @@ from typing import Any
 
 from app.ontology.queries import PREFIXES
 from app.ontology.sparql_client import SparqlClient
+from app.ontology.temporal_scope import (
+    DEFAULT_SCOPE,
+    TemporalScope,
+    temporal_scope_clause,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -193,10 +198,21 @@ def sanction_unit_label(unit: str, currency: str | None = None) -> str:
 # every field except ``provision`` and ``sanction`` because the
 # corpus' completeness varies — e.g. some sanctions have only a max
 # bound, some lack currency entirely.
+#
+# Temporal scope (#850): every template binds ``?provision`` (a
+# ``LegalProvision``) so the current-law filter from
+# :mod:`app.ontology.temporal_scope` drops sanctions attached to
+# provisions of positively-repealed acts. The default is current law;
+# :attr:`TemporalScope.ALL` keeps repealed-act sanctions. The templates
+# are now builder *functions* (rather than module constants) so the
+# scope clause can be spliced at call time.
 
-_PROVISION_SANCTIONS_QUERY = (
-    PREFIXES
-    + """
+
+def _build_provision_sanctions_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Sanctions attached to a single provision, scoped by *scope* (#850)."""
+    return (
+        PREFIXES
+        + f"""
 SELECT ?sanction ?provision ?provisionLabel
        ?actLit
        ?sanctionType
@@ -205,29 +221,32 @@ SELECT ?sanction ?provision ?provisionLabel
        ?minCurrency ?maxCurrency
        ?enforcedAtLevel
        ?isStatutoryDefault
-WHERE {
+WHERE {{
   ?provision estleg:hasSanction ?sanction .
-  OPTIONAL { ?provision rdfs:label ?provisionLabel }
-  OPTIONAL { ?provision estleg:sourceAct ?actLit }
-  OPTIONAL { ?sanction estleg:sanctionType ?sanctionType }
-  OPTIONAL { ?sanction estleg:minPenaltyAmount ?minAmount }
-  OPTIONAL { ?sanction estleg:maxPenaltyAmount ?maxAmount }
-  OPTIONAL { ?sanction estleg:minPenaltyUnit ?minUnit }
-  OPTIONAL { ?sanction estleg:maxPenaltyUnit ?maxUnit }
-  OPTIONAL { ?sanction estleg:minPenaltyCurrency ?minCurrency }
-  OPTIONAL { ?sanction estleg:maxPenaltyCurrency ?maxCurrency }
-  OPTIONAL { ?sanction estleg:enforcedAtLevel ?enforcedAtLevel }
-  OPTIONAL { ?sanction estleg:isStatutoryDefault ?isStatutoryDefault }
-}
+  OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+  OPTIONAL {{ ?provision estleg:sourceAct ?actLit }}
+  OPTIONAL {{ ?sanction estleg:sanctionType ?sanctionType }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyAmount ?minAmount }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyAmount ?maxAmount }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyUnit ?minUnit }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyUnit ?maxUnit }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyCurrency ?minCurrency }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyCurrency ?maxCurrency }}
+  OPTIONAL {{ ?sanction estleg:enforcedAtLevel ?enforcedAtLevel }}
+  OPTIONAL {{ ?sanction estleg:isStatutoryDefault ?isStatutoryDefault }}
+{temporal_scope_clause(scope, "provision")}
+}}
 ORDER BY ?provision
-LIMIT """
-    + str(_MAX_SANCTIONS_PER_ACT)
-    + "\n"
-)
+LIMIT {_MAX_SANCTIONS_PER_ACT}
+"""
+    )
 
-_ACT_SANCTIONS_QUERY = (
-    PREFIXES
-    + """
+
+def _build_act_sanctions_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Sanctions across every provision of an act, scoped by *scope* (#850)."""
+    return (
+        PREFIXES
+        + f"""
 SELECT ?sanction ?provision ?provisionLabel
        ?actLit
        ?sanctionType
@@ -236,46 +255,54 @@ SELECT ?sanction ?provision ?provisionLabel
        ?minCurrency ?maxCurrency
        ?enforcedAtLevel
        ?isStatutoryDefault
-WHERE {
+WHERE {{
   ?provision estleg:sourceAct ?actLit .
   ?provision estleg:hasSanction ?sanction .
-  OPTIONAL { ?provision rdfs:label ?provisionLabel }
-  OPTIONAL { ?sanction estleg:sanctionType ?sanctionType }
-  OPTIONAL { ?sanction estleg:minPenaltyAmount ?minAmount }
-  OPTIONAL { ?sanction estleg:maxPenaltyAmount ?maxAmount }
-  OPTIONAL { ?sanction estleg:minPenaltyUnit ?minUnit }
-  OPTIONAL { ?sanction estleg:maxPenaltyUnit ?maxUnit }
-  OPTIONAL { ?sanction estleg:minPenaltyCurrency ?minCurrency }
-  OPTIONAL { ?sanction estleg:maxPenaltyCurrency ?maxCurrency }
-  OPTIONAL { ?sanction estleg:enforcedAtLevel ?enforcedAtLevel }
-  OPTIONAL { ?sanction estleg:isStatutoryDefault ?isStatutoryDefault }
-}
+  OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+  OPTIONAL {{ ?sanction estleg:sanctionType ?sanctionType }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyAmount ?minAmount }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyAmount ?maxAmount }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyUnit ?minUnit }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyUnit ?maxUnit }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyCurrency ?minCurrency }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyCurrency ?maxCurrency }}
+  OPTIONAL {{ ?sanction estleg:enforcedAtLevel ?enforcedAtLevel }}
+  OPTIONAL {{ ?sanction estleg:isStatutoryDefault ?isStatutoryDefault }}
+{temporal_scope_clause(scope, "provision")}
+}}
 ORDER BY ?provision
-LIMIT """
-    + str(_MAX_SANCTIONS_PER_ACT)
-    + "\n"
-)
+LIMIT {_MAX_SANCTIONS_PER_ACT}
+"""
+    )
 
-# Similar sanctions — same sanctionType, other acts only, with a
-# range-overlap filter on the amount bounds. We bind ``?type`` /
-# ``?seedMin`` / ``?seedMax`` / ``?seedActLit`` via
-# :meth:`SparqlClient._inject_bindings`. The injector emits VALUES
-# with **string literals** (it has to — the same injector is used for
-# URI strings, language tags, etc.), so the numeric comparisons in the
-# FILTER cast explicitly through ``xsd:decimal(?seedMin)`` and
-# ``xsd:decimal(?seedMax)``. Without the cast SPARQL compares lex order
-# string-to-decimal, which silently returns no overlapping rows (F2,
-# 2026-05-15 review repro: rdflib confirmed 0 rows for string vs 1 row
-# for typed decimal).
-#
-# The range-overlap maths: two ranges [a, b] and [c, d] overlap iff
-# a <= d AND c <= b, i.e. ``?seedMin <= ?maxAmount`` AND
-# ``?minAmount <= ?seedMax``. Either bound missing on the candidate
-# row passes the filter (treated as open-ended), so we don't lose
-# rows that have only one numeric bound.
-_SIMILAR_SANCTIONS_QUERY = (
-    PREFIXES
-    + """
+
+def _build_similar_sanctions_query(scope: TemporalScope = DEFAULT_SCOPE) -> str:
+    """Comparable sanctions in *other* acts, scoped by *scope* (#850).
+
+    Same sanctionType, other acts only, with a range-overlap filter on
+    the amount bounds. We bind ``?type`` / ``?seedMin`` / ``?seedMax`` /
+    ``?seedActLit`` via :meth:`SparqlClient._inject_bindings`. The
+    injector emits VALUES with **string literals** (it has to — the same
+    injector is used for URI strings, language tags, etc.), so the
+    numeric comparisons in the FILTER cast explicitly through
+    ``xsd:decimal(?seedMin)`` and ``xsd:decimal(?seedMax)``. Without the
+    cast SPARQL compares lex order string-to-decimal, which silently
+    returns no overlapping rows (F2, 2026-05-15 review repro: rdflib
+    confirmed 0 rows for string vs 1 row for typed decimal).
+
+    The range-overlap maths: two ranges [a, b] and [c, d] overlap iff
+    a <= d AND c <= b, i.e. ``?seedMin <= ?maxAmount`` AND
+    ``?minAmount <= ?seedMax``. Either bound missing on the candidate
+    row passes the filter (treated as open-ended), so we don't lose
+    rows that have only one numeric bound.
+
+    Temporal scope (#850): the comparison list should not surface
+    sanctions from repealed acts as live alternatives, so the default
+    current-law filter is applied here too.
+    """
+    return (
+        PREFIXES
+        + f"""
 SELECT ?sanction ?provision ?provisionLabel
        ?actLit
        ?sanctionType
@@ -284,29 +311,38 @@ SELECT ?sanction ?provision ?provisionLabel
        ?minCurrency ?maxCurrency
        ?enforcedAtLevel
        ?isStatutoryDefault
-WHERE {
+WHERE {{
   ?provision estleg:hasSanction ?sanction .
   ?sanction estleg:sanctionType ?sanctionType .
-  OPTIONAL { ?provision rdfs:label ?provisionLabel }
-  OPTIONAL { ?provision estleg:sourceAct ?actLit }
-  OPTIONAL { ?sanction estleg:minPenaltyAmount ?minAmount }
-  OPTIONAL { ?sanction estleg:maxPenaltyAmount ?maxAmount }
-  OPTIONAL { ?sanction estleg:minPenaltyUnit ?minUnit }
-  OPTIONAL { ?sanction estleg:maxPenaltyUnit ?maxUnit }
-  OPTIONAL { ?sanction estleg:minPenaltyCurrency ?minCurrency }
-  OPTIONAL { ?sanction estleg:maxPenaltyCurrency ?maxCurrency }
-  OPTIONAL { ?sanction estleg:enforcedAtLevel ?enforcedAtLevel }
-  OPTIONAL { ?sanction estleg:isStatutoryDefault ?isStatutoryDefault }
+  OPTIONAL {{ ?provision rdfs:label ?provisionLabel }}
+  OPTIONAL {{ ?provision estleg:sourceAct ?actLit }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyAmount ?minAmount }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyAmount ?maxAmount }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyUnit ?minUnit }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyUnit ?maxUnit }}
+  OPTIONAL {{ ?sanction estleg:minPenaltyCurrency ?minCurrency }}
+  OPTIONAL {{ ?sanction estleg:maxPenaltyCurrency ?maxCurrency }}
+  OPTIONAL {{ ?sanction estleg:enforcedAtLevel ?enforcedAtLevel }}
+  OPTIONAL {{ ?sanction estleg:isStatutoryDefault ?isStatutoryDefault }}
   FILTER(STR(?sanctionType) = ?type)
   FILTER(!BOUND(?actLit) || STR(?actLit) != ?seedActLit)
   FILTER(!BOUND(?maxAmount) || xsd:decimal(?seedMin) <= ?maxAmount)
   FILTER(!BOUND(?minAmount) || ?minAmount <= xsd:decimal(?seedMax))
-}
+{temporal_scope_clause(scope, "provision")}
+}}
 ORDER BY ?actLit ?provision
-LIMIT """
-    + str(_MAX_SIMILAR_SANCTIONS)
-    + "\n"
-)
+LIMIT {_MAX_SIMILAR_SANCTIONS}
+"""
+    )
+
+
+# Default-scope (current-law) snapshots of the templates. Kept as
+# module constants for backwards compatibility with callers / tests that
+# referenced the pre-#850 ``_*_QUERY`` strings directly; new code should
+# call the builder functions with an explicit scope.
+_PROVISION_SANCTIONS_QUERY = _build_provision_sanctions_query()
+_ACT_SANCTIONS_QUERY = _build_act_sanctions_query()
+_SIMILAR_SANCTIONS_QUERY = _build_similar_sanctions_query()
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +353,7 @@ LIMIT """
 def list_sanctions_for_provision(
     provision_uri: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[SanctionRow]:
     """Return every Sanction attached to *provision_uri*.
@@ -325,6 +362,9 @@ def list_sanctions_for_provision(
         provision_uri: A ``LegalProvision`` URI (the
             ``estleg:hasSanction`` subject). Empty / whitespace
             input yields ``[]`` without hitting Jena.
+        scope: Temporal scope (#850). Default current law — a sanction
+            on a positively-repealed provision / act is dropped;
+            :attr:`TemporalScope.ALL` keeps it.
         sparql_client: Optional :class:`SparqlClient` override (tests
             inject one whose ``.query`` is mocked).
 
@@ -341,7 +381,7 @@ def list_sanctions_for_provision(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _PROVISION_SANCTIONS_QUERY,
+            _build_provision_sanctions_query(scope),
             uri_bindings={"provision": uri},
         )
     except Exception:
@@ -358,6 +398,7 @@ def list_sanctions_for_provision(
 def list_sanctions_for_act(
     act_title: str,
     *,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[SanctionRow]:
     """Return every Sanction attached to any provision of *act_title*.
@@ -381,6 +422,9 @@ def list_sanctions_for_act(
             caller passes a URI here by mistake the query simply returns
             no rows (no triples have a URI on the right-hand side of
             ``sourceAct``) — degrades gracefully rather than 500-ing.
+        scope: Temporal scope (#850). Default current law excludes
+            sanctions on provisions of a positively-repealed act;
+            :attr:`TemporalScope.ALL` includes them.
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -395,7 +439,7 @@ def list_sanctions_for_act(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _ACT_SANCTIONS_QUERY,
+            _build_act_sanctions_query(scope),
             bindings={"actLit": title},
         )
     except Exception:
@@ -413,6 +457,7 @@ def find_similar_sanctions(
     sanction_row: SanctionRow,
     *,
     limit: int = 10,
+    scope: TemporalScope = DEFAULT_SCOPE,
     sparql_client: SparqlClient | None = None,
 ) -> list[SanctionRow]:
     """Find sanctions in *other* acts with matching type and overlapping range.
@@ -432,6 +477,9 @@ def find_similar_sanctions(
         limit: Cap the result list (default 10). Hard-capped to
             :data:`_MAX_SIMILAR_SANCTIONS` so the SPARQL query stays
             quick on a 1M-triple corpus.
+        scope: Temporal scope (#850). Default current law — comparable
+            sanctions are not drawn from positively-repealed acts;
+            :attr:`TemporalScope.ALL` widens to the full corpus.
         sparql_client: Optional :class:`SparqlClient` override.
 
     Returns:
@@ -472,7 +520,7 @@ def find_similar_sanctions(
     client = sparql_client if sparql_client is not None else SparqlClient()
     try:
         rows = client.query(
-            _SIMILAR_SANCTIONS_QUERY,
+            _build_similar_sanctions_query(scope),
             bindings={
                 "type": sanction_type,
                 "seedMin": _xsd_decimal_literal(seed_min),

--- a/app/ontology/temporal_scope.py
+++ b/app/ontology/temporal_scope.py
@@ -253,8 +253,19 @@ def current_law_filter(provision_var: str = "provision") -> str:
     # Internal helper variables are name-spaced with the provision var so
     # splicing two of these blocks (different provision vars) into one
     # query never collides.
-    title = f"_tsTitle_{p}"
     act = f"_tsAct_{p}"
+    # The literal-title hop (arms b) joins the provision's ``sourceAct``
+    # literal to an ``Act`` node's ``rdfs:label``. We deliberately bind
+    # the two sides to *distinct* variables and compare them with
+    # ``STR()`` on both sides rather than re-using one variable: a shared
+    # variable forces RDF-term equality, which includes the language tag,
+    # so the moment labels become ``"…"@et`` (while ``sourceAct`` stays a
+    # plain literal — today's JSON-LD shape) the join would silently stop
+    # matching and the literal-title hop would degrade to a no-op. The
+    # ``STR()`` coercion compares lexical forms only, so it survives a
+    # later move to language-tagged labels. (Review follow-up, #850.)
+    sa = f"_tsSourceAct_{p}"
+    lbl = f"_tsLabel_{p}"
     return f"""  FILTER NOT EXISTS {{
     {{
       # (a) repeal marker directly on the provision itself
@@ -263,14 +274,17 @@ def current_law_filter(provision_var: str = "provision") -> str:
       ?{p} <{repeal_uri}> ?_tsProvRepeal_{p} .
     }} UNION {{
       # (b) repeal marker on the owning act — prod shape: sourceAct is a
-      #     literal title; match the Act node whose rdfs:label equals it.
-      ?{p} estleg:sourceAct ?{title} .
-      ?{act} rdfs:label ?{title} .
+      #     literal title; match the Act node whose rdfs:label equals it
+      #     (STR()-coerced so a future "@et" label tag can't break it).
+      ?{p} estleg:sourceAct ?{sa} .
+      ?{act} rdfs:label ?{lbl} .
       ?{act} <{status_uri}> "{repealed}" .
+      FILTER(STR(?{lbl}) = STR(?{sa}))
     }} UNION {{
-      ?{p} estleg:sourceAct ?{title}b .
-      ?{act}b rdfs:label ?{title}b .
+      ?{p} estleg:sourceAct ?{sa}b .
+      ?{act}b rdfs:label ?{lbl}b .
       ?{act}b <{repeal_uri}> ?_tsActRepeal_{p} .
+      FILTER(STR(?{lbl}b) = STR(?{sa}b))
     }} UNION {{
       # (c) repeal marker on the owning act — fixture shape: sourceAct is
       #     an Act URI; check that URI node directly.

--- a/app/ontology/temporal_scope.py
+++ b/app/ontology/temporal_scope.py
@@ -1,0 +1,324 @@
+"""Temporal-scope policy for Analüüsikeskus SPARQL aggregates (C5, #850).
+
+The single place that codifies *which redactions of the law an
+Analüüsikeskus engine counts*. Before this module the burden /
+sanctions / competency / court-practice aggregates walked every
+provision regardless of whether the owning act had been repealed — so a
+"how many obligations does this act impose" count happily mixed live law
+with provisions of acts that ceased to exist years ago. In a
+legal-advisory tool that silently overstates the answer.
+
+Why a *positive-knowledge exclusion* and not a version-chain filter
+--------------------------------------------------------------------
+
+The obvious design — "keep only the current ``ProvisionVersion``" — is a
+trap in this corpus. The 2026-05-15 ontology audit (recorded in
+:mod:`app.ontology.relations`, lines 140-160) confirmed:
+
+* ``ProvisionVersion`` / ``versionValidFrom`` / ``versionValidTo`` /
+  ``supersededByVersion`` / ``versionText`` exist in the SHACL shapes but
+  the *populated* data is **sample-only** — deferred to ontology issue
+  ``henrikaavik/estonian-legal-ontology#208`` (V2). A version-chain
+  filter would match almost nothing in production.
+* ``temporalStatus`` (values ``"in_force"`` / ``"in_force_partial"`` /
+  ``"repealed"`` / ``"pending"``), ``repealDate``, ``entryIntoForce`` and
+  ``lastAmendmentDate`` **are** populated corpus-wide on ``Act`` nodes —
+  this is the data ``app.analyysikeskus.history`` already reads.
+
+A naive ``FILTER NOT EXISTS { … repealed … }`` over the *version-chain*
+predicates would therefore be a silent no-op: it passes everything in
+production (the predicates aren't populated) while looking green on
+synthetic fixtures that do carry them. To stay honest when the data is
+sparse, the default filter is built **only on the positively-populated
+predicates** (:data:`POSITIVE_REPEAL_PREDICATES`) and uses
+*positive-knowledge exclusion*:
+
+    Exclude a provision **only when it is positively marked repealed /
+    superseded**. Absent data ⇒ included.
+
+That is the correct default for an advisory tool over an incomplete
+graph: we never *hide* a provision we merely lack temporal data for, and
+the filter automatically gets stricter as the ontology back-fills repeal
+markers — no code change required. The same property makes the filter
+testable: :func:`current_law_filter` references *only* the audited
+predicates, so a regression test can assert the emitted clause never
+drifts onto an unpopulated predicate (which would re-introduce the
+no-op).
+
+Where the temporal markers live
+-------------------------------
+
+In production a provision links to its act via ``estleg:sourceAct``,
+whose object is a **literal act title** (24,221 triples, all
+``xsd:string``; ``estleg:partOf`` / ``estleg:partOfAct`` carry zero rows
+— see ``docs/2026-05-18-bugfix-plan.md`` Wave 2). The repeal markers
+(``temporalStatus`` / ``repealDate``) hang off a separate ``Act`` *node*
+whose ``rdfs:label`` equals that title. The canonical TTL fixture instead
+points ``sourceAct`` straight at an ``Act`` URI. :func:`current_law_filter`
+handles **both** shapes, and additionally checks the provision *itself*
+for a direct marker, so the same clause is correct on prod and on
+fixtures.
+
+Neighbour policy (the rest of the Analüüsikeskus)
+-------------------------------------------------
+
+* :mod:`app.analyysikeskus.history` is **intentionally historical** — its
+  whole job is to surface repealed acts and amendment timelines, so it
+  deliberately does **not** apply the current-law default. It owns its
+  own temporal reads.
+* :mod:`app.analyysikeskus.similarity` and
+  :mod:`app.analyysikeskus.eu_transposition` do not apply a temporal
+  scope today; when they adopt this helper they must declare their scope
+  explicitly (pass :data:`TemporalScope.ALL` if they want history, or
+  :data:`TemporalScope.CURRENT` to inherit the exclusion). They are out
+  of scope for #850.
+
+Usage
+-----
+
+The engine query-builder layers splice the clause into a
+provision-bound SELECT::
+
+    from app.ontology.temporal_scope import TemporalScope, temporal_scope_clause
+
+    sparql = (
+        PREFIXES
+        + f'''
+    SELECT ?provision ...
+    WHERE {{
+      ?provision estleg:sourceAct ?actLit .
+      ...
+    {temporal_scope_clause(scope, "provision")}
+    }}
+    '''
+    )
+
+The clause is pure SPARQL 1.1 (``FILTER NOT EXISTS`` + ``rdfs:label``
+joins + equality), so it behaves identically on Apache Jena/ARQ and on
+the rdflib engine the regression tests run against.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Final
+
+from app.ontology.relations import PREDICATES
+
+# ---------------------------------------------------------------------------
+# Scope model
+# ---------------------------------------------------------------------------
+
+
+class TemporalScope(StrEnum):
+    """Which redactions of the law an aggregate counts.
+
+    The value strings are the canonical request-parameter tokens carried
+    by the ``?oigus=`` query parameter (see
+    :class:`app.analyysikeskus.routes._Scope`), so a route can round-trip
+    a scope through a URL with :func:`scope_from_param` and ``scope.value``.
+
+    Members:
+        CURRENT: *Kehtiv õigus* — the default. Exclude provisions that
+            are **positively** marked repealed / superseded (their owning
+            act, or the provision itself, carries a populated repeal
+            marker). Provisions with no temporal data are **included** —
+            see the module docstring on positive-knowledge exclusion.
+        ALL: *Kogu ajalugu* — no temporal filtering; repealed and current
+            provisions both count. The explicit historical/all scope the
+            DoD requires.
+    """
+
+    CURRENT = "current"
+    ALL = "all"
+
+
+#: The default scope when a request carries no (or an unrecognised)
+#: ``?oigus=`` token. Current law is the honest default for an advisory
+#: tool — a lawyer asking "how many obligations does this act impose"
+#: means *today's* law unless they opt into history.
+DEFAULT_SCOPE: Final[TemporalScope] = TemporalScope.CURRENT
+
+
+def scope_from_param(value: str | None) -> TemporalScope:
+    """Fold a raw ``?oigus=`` token into a :class:`TemporalScope`.
+
+    Accepts the canonical member values (``"current"`` / ``"all"``) plus a
+    couple of legacy / UI aliases the scope form has historically emitted
+    (``"current_plus_history"`` and ``"kogu_ajalugu"`` both mean "include
+    history"). Anything unrecognised — including ``None`` and the empty
+    string — folds to :data:`DEFAULT_SCOPE` so a malformed URL degrades to
+    the safe current-law default rather than erroring.
+    """
+    token = (value or "").strip().lower()
+    if not token:
+        return DEFAULT_SCOPE
+    if token == TemporalScope.ALL.value:
+        return TemporalScope.ALL
+    # Legacy / UI aliases meaning "include history".
+    if token in {"kogu_ajalugu", "ajalugu", "current_plus_history", "all_history"}:
+        return TemporalScope.ALL
+    if token == TemporalScope.CURRENT.value:
+        return TemporalScope.CURRENT
+    return DEFAULT_SCOPE
+
+
+# ---------------------------------------------------------------------------
+# Positively-populated repeal predicates (the audit result)
+# ---------------------------------------------------------------------------
+#
+# These are the ONLY predicates the current-law filter is allowed to
+# reference. They were confirmed populated corpus-wide by the 2026-05-15
+# ontology audit and are already read by app.analyysikeskus.history:
+#
+#   * estleg:temporalStatus — literal; the value "repealed" positively
+#     marks a repealed act/provision. ("in_force" / "in_force_partial" /
+#     "pending" are NOT treated as repeal markers — only the explicit
+#     "repealed" string excludes.)
+#   * estleg:repealDate     — a populated repeal-date literal is itself a
+#     positive repeal marker (an act with a repealDate has been repealed).
+#
+# Deliberately EXCLUDED (sample-only / would no-op — see module docstring):
+#   versionValidFrom / versionValidTo / supersededByVersion / versionText
+#
+# A regression test asserts the emitted FILTER references only these two
+# predicate URIs, guarding against silent drift back onto an unpopulated
+# predicate.
+
+#: The literal value of ``estleg:temporalStatus`` that positively marks a
+#: repealed act / provision. Mirrors the ``"repealed"`` key in
+#: :data:`app.analyysikeskus.history.TEMPORAL_STATUS_LABELS_ET`.
+REPEALED_STATUS_VALUE: Final[str] = "repealed"
+
+#: The closed set of predicate URIs the current-law exclusion is built
+#: on. Exposed so a regression test can assert no other predicate sneaks
+#: into the emitted clause (the silent-no-op guard).
+POSITIVE_REPEAL_PREDICATES: Final[frozenset[str]] = frozenset(
+    {
+        PREDICATES.TEMPORAL_STATUS,
+        PREDICATES.REPEAL_DATE,
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Clause builders
+# ---------------------------------------------------------------------------
+
+
+def _clean_var(var: str, fallback: str) -> str:
+    """Strip a SPARQL variable name to ``[A-Za-z0-9_]`` (defensive)."""
+    return re.sub(r"[^A-Za-z0-9_]", "", var or "") or fallback
+
+
+def current_law_filter(provision_var: str = "provision") -> str:
+    """Return the *current-law* ``FILTER NOT EXISTS`` block for a provision.
+
+    The block excludes ``?<provision_var>`` **only when it is positively
+    marked repealed** — either directly on the provision, or on its owning
+    act. "Positively marked" means one of the audited
+    :data:`POSITIVE_REPEAL_PREDICATES` is populated with a repeal value:
+
+    * ``estleg:temporalStatus "repealed"`` — explicit repealed status, or
+    * ``estleg:repealDate <any>`` — a populated repeal date.
+
+    Crucially this is *exclusion by positive knowledge*: a provision with
+    no temporal data at all passes the filter (``FILTER NOT EXISTS`` over
+    an unmatched pattern is true), so the incomplete production corpus is
+    never silently hollowed out. See the module docstring.
+
+    Both ``sourceAct`` shapes are handled in one clause:
+
+    * **Prod** — ``?provision estleg:sourceAct "<title>"`` (a literal); we
+      match an ``Act`` node whose ``rdfs:label`` equals that title and
+      check its markers.
+    * **Fixture** — ``?provision estleg:sourceAct estleg:Act_x`` (a URI);
+      a second arm checks that URI node directly for a marker.
+
+    The returned string is a complete ``FILTER NOT EXISTS { … }`` block
+    (indented two spaces, no trailing newline) ready to splice straight
+    into a ``WHERE`` clause after the patterns that bind
+    ``?<provision_var>``.
+
+    Args:
+        provision_var: The SPARQL variable (without ``?``) carrying the
+            ``LegalProvision`` IRI to test. Non-word characters are
+            stripped defensively.
+    """
+    p = _clean_var(provision_var, "provision")
+    status_uri = PREDICATES.TEMPORAL_STATUS
+    repeal_uri = PREDICATES.REPEAL_DATE
+    repealed = REPEALED_STATUS_VALUE
+    # Internal helper variables are name-spaced with the provision var so
+    # splicing two of these blocks (different provision vars) into one
+    # query never collides.
+    title = f"_tsTitle_{p}"
+    act = f"_tsAct_{p}"
+    return f"""  FILTER NOT EXISTS {{
+    {{
+      # (a) repeal marker directly on the provision itself
+      ?{p} <{status_uri}> "{repealed}" .
+    }} UNION {{
+      ?{p} <{repeal_uri}> ?_tsProvRepeal_{p} .
+    }} UNION {{
+      # (b) repeal marker on the owning act — prod shape: sourceAct is a
+      #     literal title; match the Act node whose rdfs:label equals it.
+      ?{p} estleg:sourceAct ?{title} .
+      ?{act} rdfs:label ?{title} .
+      ?{act} <{status_uri}> "{repealed}" .
+    }} UNION {{
+      ?{p} estleg:sourceAct ?{title}b .
+      ?{act}b rdfs:label ?{title}b .
+      ?{act}b <{repeal_uri}> ?_tsActRepeal_{p} .
+    }} UNION {{
+      # (c) repeal marker on the owning act — fixture shape: sourceAct is
+      #     an Act URI; check that URI node directly.
+      ?{p} estleg:sourceAct ?{act}u .
+      ?{act}u <{status_uri}> "{repealed}" .
+    }} UNION {{
+      ?{p} estleg:sourceAct ?{act}u2 .
+      ?{act}u2 <{repeal_uri}> ?_tsActRepealU_{p} .
+    }}
+  }}"""
+
+
+def temporal_scope_clause(
+    scope: TemporalScope,
+    provision_var: str = "provision",
+) -> str:
+    """Return the SPARQL scope clause for *scope* (the engine entry point).
+
+    This is what the engine query-builders call. It is the *only* place
+    engines need to reason about temporal scope — pass the resolved
+    :class:`TemporalScope` and the provision variable, splice the result
+    into the ``WHERE`` clause, and the default-current policy is inherited
+    automatically:
+
+    * :attr:`TemporalScope.CURRENT` → :func:`current_law_filter` (the
+      positive-knowledge exclusion).
+    * :attr:`TemporalScope.ALL` → an empty string (no filtering; repealed
+      provisions are kept).
+
+    Args:
+        scope: The resolved temporal scope. A non-:class:`TemporalScope`
+            value (e.g. a raw string that slipped through) is folded via
+            :func:`scope_from_param` so callers can't accidentally disable
+            the filter by passing ``"current"`` as a bare string.
+        provision_var: The provision SPARQL variable (without ``?``).
+    """
+    resolved = scope if isinstance(scope, TemporalScope) else scope_from_param(str(scope))
+    if resolved is TemporalScope.ALL:
+        return ""
+    return current_law_filter(provision_var)
+
+
+__all__ = [
+    "TemporalScope",
+    "DEFAULT_SCOPE",
+    "REPEALED_STATUS_VALUE",
+    "POSITIVE_REPEAL_PREDICATES",
+    "scope_from_param",
+    "current_law_filter",
+    "temporal_scope_clause",
+]

--- a/tests/test_analyysikeskus_burden.py
+++ b/tests/test_analyysikeskus_burden.py
@@ -31,6 +31,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from app.ontology.temporal_scope import TemporalScope
+
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "ontology_canonical.ttl"
 
 
@@ -533,7 +535,7 @@ def test_burden_resolved_provision_renders_full_result(
     # Suggested actions include the "Tagasi" link.
     assert "Tagasi analüüsikeskusesse" in body
 
-    mock_list.assert_called_once_with(_TLS_P12_URI)
+    mock_list.assert_called_once_with(_TLS_P12_URI, scope=TemporalScope.CURRENT)
 
 
 @patch("app.analyysikeskus.routes.list_burden_for_act")
@@ -562,7 +564,7 @@ def test_burden_resolved_law_uses_act_query(
     assert resp.status_code == 200
     # The route now passes the literal act title (from partial_match)
     # rather than a fake URI — matches the real resolver shape.
-    mock_list_act.assert_called_once_with("Töölepingu seadus")
+    mock_list_act.assert_called_once_with("Töölepingu seadus", scope=TemporalScope.CURRENT)
 
 
 @patch("app.analyysikeskus.routes.list_burden_for_act")
@@ -595,7 +597,7 @@ def test_burden_bare_law_input_routes_to_for_act(
     body = resp.text
 
     # The act-level helper was called with the literal title.
-    mock_list_act.assert_called_once_with("Töölepingu seadus")
+    mock_list_act.assert_called_once_with("Töölepingu seadus", scope=TemporalScope.CURRENT)
     # The RAG fallback was NOT consulted.
     mock_rag.assert_not_called()
     # The "Ei tuvastanud" warning is absent — we resolved (partially).

--- a/tests/test_analyysikeskus_court_practice.py
+++ b/tests/test_analyysikeskus_court_practice.py
@@ -26,6 +26,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from app.ontology.temporal_scope import TemporalScope
+
 # ---------------------------------------------------------------------------
 # Test fixtures — shared CourtDecisionRow instances and SPARQL row stubs
 # ---------------------------------------------------------------------------
@@ -749,7 +751,7 @@ def test_kohtupraktika_resolved_provision_multi_court_grouping(
     assert "Aastate kaupa" in body
 
     # The provision branch was called (not the act branch).
-    mock_list.assert_called_once_with(_AVTS_P35_URI)
+    mock_list.assert_called_once_with(_AVTS_P35_URI, scope=TemporalScope.CURRENT)
 
 
 @patch("app.analyysikeskus.routes.list_decisions_for_act")
@@ -774,7 +776,7 @@ def test_kohtupraktika_resolved_law_uses_act_query(
     assert resp.status_code == 200
     # The act-level helper accepts a literal title; the route passes
     # the title from ``partial_match["act_title"]``.
-    mock_list_act.assert_called_once_with("Avaliku teabe seadus")
+    mock_list_act.assert_called_once_with("Avaliku teabe seadus", scope=TemporalScope.CURRENT)
 
 
 @patch("app.analyysikeskus.routes.list_decisions_for_act")
@@ -803,7 +805,7 @@ def test_kohtupraktika_bare_law_input_routes_to_for_act(
     assert resp.status_code == 200
     body = resp.text
 
-    mock_list_act.assert_called_once_with("Avaliku teabe seadus")
+    mock_list_act.assert_called_once_with("Avaliku teabe seadus", scope=TemporalScope.CURRENT)
     mock_rag.assert_not_called()
     assert "Ei tuvastanud õiguslikku viidet" not in body
 

--- a/tests/test_analyysikeskus_sanctions.py
+++ b/tests/test_analyysikeskus_sanctions.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from app.ontology.temporal_scope import TemporalScope
+
 # ---------------------------------------------------------------------------
 # Test fixtures — shared SanctionRow instances and SPARQL row stubs
 # ---------------------------------------------------------------------------
@@ -747,7 +749,7 @@ def test_sanctions_resolved_provision_renders_full_result(
 
     # The provision branch was called, similar query was NOT called
     # (no vordle_sarnaste_aktidega param on this request).
-    mock_list.assert_called_once_with(_KARS_P211_URI)
+    mock_list.assert_called_once_with(_KARS_P211_URI, scope=TemporalScope.CURRENT)
     mock_similar.assert_not_called()
 
 
@@ -806,7 +808,7 @@ def test_sanctions_resolved_law_uses_act_query(
     resp = client.get("/analyysikeskus/sanktsioonid?sisend=KarS+%C2%A7+211")
     assert resp.status_code == 200
     # The route passes the literal act title via partial_match.
-    mock_list_act.assert_called_once_with("Karistusseadustik")
+    mock_list_act.assert_called_once_with("Karistusseadustik", scope=TemporalScope.CURRENT)
 
 
 @patch("app.analyysikeskus.routes.find_similar_sanctions", return_value=[])
@@ -842,7 +844,7 @@ def test_sanctions_bare_law_input_routes_to_for_act(
     body = resp.text
 
     # The act-level helper was called with the literal title.
-    mock_list_act.assert_called_once_with("Karistusseadustik")
+    mock_list_act.assert_called_once_with("Karistusseadustik", scope=TemporalScope.CURRENT)
     # The RAG fallback was NOT consulted.
     mock_rag.assert_not_called()
     # The "Ei tuvastanud" warning is absent — we resolved (partially).

--- a/tests/test_analyysikeskus_temporal_scope.py
+++ b/tests/test_analyysikeskus_temporal_scope.py
@@ -330,6 +330,22 @@ class TestClauseReferencesOnlyAuditedPredicates:
         clause = current_law_filter("prov")
         assert "?prov " in clause or "?prov\n" in clause
 
+    def test_literal_title_join_is_str_coerced(self):
+        """The label↔sourceAct literal join must compare lexical forms.
+
+        Review follow-up (#850): the literal-title hop binds the
+        ``rdfs:label`` and ``estleg:sourceAct`` literals to *distinct*
+        variables and joins them with ``STR(...) = STR(...)`` rather than
+        re-using one variable. A shared variable forces RDF-term equality
+        (including the language tag), which would silently no-op the hop
+        the moment labels become ``"…"@et`` while ``sourceAct`` stays a
+        plain literal. This guards against a refactor reverting to that.
+        """
+        clause = current_law_filter("provision")
+        # Both label and sourceAct are STR()-coerced in the join filter.
+        assert "STR(?_tsLabel_provision) = STR(?_tsSourceAct_provision)" in clause
+        assert "STR(?_tsLabel_provisionb) = STR(?_tsSourceAct_provisionb)" in clause
+
 
 # ===========================================================================
 # 3. The filter bites real rdflib data
@@ -365,6 +381,60 @@ class TestFilterBitesRealData:
         kept = _select_provisions(g, TemporalScope.CURRENT)
         for repealed in _REPEALED_PROVISIONS:
             assert repealed not in kept, f"{repealed} should be excluded under current"
+
+    def test_language_tagged_act_label_still_excludes(self):
+        """Review follow-up (#850): a future ``"…"@et`` act label must not no-op.
+
+        The literal-title hop joins the act's ``rdfs:label`` to the
+        provision's plain ``estleg:sourceAct`` literal. If the join used a
+        shared variable (RDF-term equality), an ``@et`` tag on the label
+        would stop matching and a repealed act's provisions would silently
+        leak back into the current-law scope. The ``STR()``-coerced join
+        keeps comparing lexical forms, so the repealed act's provision is
+        still excluded — and the live act's provision is still kept.
+        """
+        ttl = f"""
+        @prefix estleg: <{_NS}> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        # Repealed act with an @et-tagged label; provision sourceAct is PLAIN.
+        estleg:ActDeadEt a estleg:Act ; rdfs:label "Kehtetu seadus"@et ;
+            estleg:temporalStatus "repealed" .
+        estleg:P_taggedRep a estleg:LegalProvision ; rdfs:label "prov rep" ;
+            estleg:sourceAct "Kehtetu seadus" .
+
+        # Repealed-by-date act, @et label, plain sourceAct.
+        estleg:ActDeadDateEt a estleg:Act ; rdfs:label "Aegunud seadus"@et ;
+            estleg:repealDate "2018-06-30"^^xsd:date .
+        estleg:P_taggedDateRep a estleg:LegalProvision ; rdfs:label "prov date rep" ;
+            estleg:sourceAct "Aegunud seadus" .
+
+        # Live act with @et label, plain sourceAct (must stay included).
+        estleg:ActLiveEt a estleg:Act ; rdfs:label "Elav seadus"@et ;
+            estleg:temporalStatus "in_force" .
+        estleg:P_taggedLive a estleg:LegalProvision ; rdfs:label "prov live" ;
+            estleg:sourceAct "Elav seadus" .
+        """
+        g = Graph()
+        g.parse(data=ttl, format="turtle")
+
+        kept = _select_provisions(g, TemporalScope.CURRENT)
+        assert f"{_NS}P_taggedRep" not in kept, (
+            "repealed act with @et label must still be excluded under current scope"
+        )
+        assert f"{_NS}P_taggedDateRep" not in kept, (
+            "date-repealed act with @et label must still be excluded under current scope"
+        )
+        assert f"{_NS}P_taggedLive" in kept, "live act with @et label must be kept"
+
+        # Under all-history scope every provision survives.
+        kept_all = _select_provisions(g, TemporalScope.ALL)
+        assert kept_all == {
+            f"{_NS}P_taggedRep",
+            f"{_NS}P_taggedDateRep",
+            f"{_NS}P_taggedLive",
+        }
 
 
 # ===========================================================================

--- a/tests/test_analyysikeskus_temporal_scope.py
+++ b/tests/test_analyysikeskus_temporal_scope.py
@@ -1,0 +1,706 @@
+"""Tests for the current-law temporal scope across Analüüsikeskus engines (C5, #850).
+
+Covers:
+
+1. :mod:`app.ontology.temporal_scope` — the scope model
+   (:class:`TemporalScope`, :func:`scope_from_param`), the clause
+   builders, and the **silent-no-op guard**: the emitted ``FILTER NOT
+   EXISTS`` references *only* the positively-populated predicates from the
+   audit (``temporalStatus`` / ``repealDate``), never the deferred
+   sample-only version-chain predicates.
+
+2. The filter **bites real rdflib data** — a hand-built graph with a
+   current provision, a provision whose owning act is positively repealed
+   (both the literal-title prod shape and the URI fixture shape), a
+   provision marked repealed on itself, and a provision with **no**
+   temporal data. Default (current) scope drops only the positively-marked
+   ones; the no-data provision survives (positive-knowledge exclusion);
+   ``TemporalScope.ALL`` keeps everything.
+
+3. Per-engine regression — burden / sanctions / competency / court-practice
+   each honour the scope end-to-end against the same fixture graph through
+   the real :meth:`SparqlClient.query` VALUES-injection path.
+
+4. Scope-form round-trip — ``?oigus=`` is reflected in the rendered select
+   and rides through the workflow links.
+
+The rdflib ``SparqlClient`` fake mirrors the production
+:meth:`SparqlClient.query` (VALUES / URI-VALUES injection then execute
+against an in-memory :class:`rdflib.Graph`), the same shape used by
+``test_analyysikeskus_competency.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from rdflib import Graph
+
+from app.ontology.queries import PREFIXES
+from app.ontology.sparql_client import SparqlClient
+from app.ontology.temporal_scope import (
+    DEFAULT_SCOPE,
+    POSITIVE_REPEAL_PREDICATES,
+    REPEALED_STATUS_VALUE,
+    TemporalScope,
+    current_law_filter,
+    scope_from_param,
+    temporal_scope_clause,
+)
+
+_NS = "https://data.riik.ee/ontology/estleg#"
+
+
+# ---------------------------------------------------------------------------
+# A graph that exercises every repeal-marker shape the filter must catch.
+# ---------------------------------------------------------------------------
+#
+# Acts:
+#   ActLive   — temporalStatus "in_force"            → NOT repealed
+#   ActDead   — temporalStatus "repealed"            → repealed (literal-title hop)
+#   ActDateRepealed — repealDate present              → repealed (literal-title hop)
+#   ActUriDead — temporalStatus "repealed", reached via a URI sourceAct
+#
+# Provisions (all carry the engine predicates so one graph drives all four):
+#   P_live      — in ActLive                          → kept under CURRENT
+#   P_statusRep — in ActDead (literal title)          → dropped under CURRENT
+#   P_dateRep   — in ActDateRepealed (literal title)  → dropped under CURRENT
+#   P_uriRep    — sourceAct → ActUriDead (URI)        → dropped under CURRENT
+#   P_selfRep   — temporalStatus "repealed" on itself → dropped under CURRENT
+#   P_nodata    — sourceAct "Unknown act", no markers → kept under CURRENT
+_GRAPH_TTL = f"""
+@prefix estleg: <{_NS}> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# --- Acts (carry the temporal markers) ---
+estleg:ActLive a estleg:Act ; rdfs:label "Live act" ;
+    estleg:temporalStatus "in_force" .
+estleg:ActDead a estleg:Act ; rdfs:label "Dead act" ;
+    estleg:temporalStatus "repealed" .
+estleg:ActDateRepealed a estleg:Act ; rdfs:label "Date-repealed act" ;
+    estleg:repealDate "2019-12-31"^^xsd:date .
+estleg:ActUriDead a estleg:Act ; rdfs:label "Uri-dead act" ;
+    estleg:temporalStatus "repealed" .
+
+# --- Provisions ---
+# Current provision (live act, literal-title shape)
+estleg:P_live a estleg:LegalProvision ; rdfs:label "Live provision" ;
+    estleg:sourceAct "Live act" ;
+    estleg:normativeType estleg:NormType_Obligation ;
+    estleg:dutyHolder "Tööandja" ;
+    estleg:competentAuthority estleg:Inst_A ;
+    estleg:hasSanction estleg:San_live ;
+    estleg:interpretedBy estleg:Dec_live .
+
+# Provision whose act is positively repealed via temporalStatus (literal title)
+estleg:P_statusRep a estleg:LegalProvision ; rdfs:label "Status-repealed provision" ;
+    estleg:sourceAct "Dead act" ;
+    estleg:normativeType estleg:NormType_Prohibition ;
+    estleg:competentAuthority estleg:Inst_A ;
+    estleg:hasSanction estleg:San_statusRep ;
+    estleg:interpretedBy estleg:Dec_statusRep .
+
+# Provision whose act is positively repealed via repealDate (literal title)
+estleg:P_dateRep a estleg:LegalProvision ; rdfs:label "Date-repealed provision" ;
+    estleg:sourceAct "Date-repealed act" ;
+    estleg:normativeType estleg:NormType_Obligation ;
+    estleg:competentAuthority estleg:Inst_A ;
+    estleg:hasSanction estleg:San_dateRep ;
+    estleg:interpretedBy estleg:Dec_dateRep .
+
+# Provision whose act is repealed, reached through a URI sourceAct (fixture shape)
+estleg:P_uriRep a estleg:LegalProvision ; rdfs:label "Uri-repealed provision" ;
+    estleg:sourceAct estleg:ActUriDead ;
+    estleg:normativeType estleg:NormType_Right ;
+    estleg:competentAuthority estleg:Inst_A ;
+    estleg:hasSanction estleg:San_uriRep ;
+    estleg:interpretedBy estleg:Dec_uriRep .
+
+# Provision marked repealed directly on itself
+estleg:P_selfRep a estleg:LegalProvision ; rdfs:label "Self-repealed provision" ;
+    estleg:sourceAct "Live act" ;
+    estleg:temporalStatus "repealed" ;
+    estleg:normativeType estleg:NormType_Obligation ;
+    estleg:competentAuthority estleg:Inst_A ;
+    estleg:hasSanction estleg:San_selfRep ;
+    estleg:interpretedBy estleg:Dec_selfRep .
+
+# Provision with NO temporal data at all (positive-knowledge ⇒ kept)
+estleg:P_nodata a estleg:LegalProvision ; rdfs:label "No-data provision" ;
+    estleg:sourceAct "Unknown act" ;
+    estleg:normativeType estleg:NormType_Permission ;
+    estleg:competentAuthority estleg:Inst_A ;
+    estleg:hasSanction estleg:San_nodata ;
+    estleg:interpretedBy estleg:Dec_nodata .
+
+# --- NormativeType individuals ---
+estleg:NormType_Obligation a estleg:NormativeType ; rdfs:label "Kohustus" .
+estleg:NormType_Right a estleg:NormativeType ; rdfs:label "Õigus" .
+estleg:NormType_Permission a estleg:NormativeType ; rdfs:label "Luba" .
+estleg:NormType_Prohibition a estleg:NormativeType ; rdfs:label "Keeld" .
+
+# --- Sanctions (one per provision; all type "fine" with an overlapping range) ---
+estleg:San_live a estleg:Sanction ; estleg:sanctionType "fine" ;
+    estleg:minPenaltyAmount "100"^^xsd:decimal ; estleg:maxPenaltyAmount "500"^^xsd:decimal .
+estleg:San_statusRep a estleg:Sanction ; estleg:sanctionType "fine" ;
+    estleg:minPenaltyAmount "100"^^xsd:decimal ; estleg:maxPenaltyAmount "500"^^xsd:decimal .
+estleg:San_dateRep a estleg:Sanction ; estleg:sanctionType "fine" ;
+    estleg:minPenaltyAmount "100"^^xsd:decimal ; estleg:maxPenaltyAmount "500"^^xsd:decimal .
+estleg:San_uriRep a estleg:Sanction ; estleg:sanctionType "fine" ;
+    estleg:minPenaltyAmount "100"^^xsd:decimal ; estleg:maxPenaltyAmount "500"^^xsd:decimal .
+estleg:San_selfRep a estleg:Sanction ; estleg:sanctionType "fine" ;
+    estleg:minPenaltyAmount "100"^^xsd:decimal ; estleg:maxPenaltyAmount "500"^^xsd:decimal .
+estleg:San_nodata a estleg:Sanction ; estleg:sanctionType "fine" ;
+    estleg:minPenaltyAmount "100"^^xsd:decimal ; estleg:maxPenaltyAmount "500"^^xsd:decimal .
+
+# --- Institutions (competency) ---
+estleg:Inst_A a estleg:Institution ; rdfs:label "Asutus A" .
+
+# --- Court decisions (one per provision via interpretedBy above) ---
+estleg:Dec_live a estleg:CourtDecision ; rdfs:label "Dec live" ;
+    estleg:caseNumber "3-1-1-1-20" ; estleg:decisionDate "2020-01-01" .
+estleg:Dec_statusRep a estleg:CourtDecision ; rdfs:label "Dec status-rep" ;
+    estleg:caseNumber "3-1-1-2-20" ; estleg:decisionDate "2020-02-01" .
+estleg:Dec_dateRep a estleg:CourtDecision ; rdfs:label "Dec date-rep" ;
+    estleg:caseNumber "3-1-1-3-20" ; estleg:decisionDate "2020-03-01" .
+estleg:Dec_uriRep a estleg:CourtDecision ; rdfs:label "Dec uri-rep" ;
+    estleg:caseNumber "3-1-1-4-20" ; estleg:decisionDate "2020-04-01" .
+estleg:Dec_selfRep a estleg:CourtDecision ; rdfs:label "Dec self-rep" ;
+    estleg:caseNumber "3-1-1-5-20" ; estleg:decisionDate "2020-05-01" .
+estleg:Dec_nodata a estleg:CourtDecision ; rdfs:label "Dec nodata" ;
+    estleg:caseNumber "3-1-1-6-20" ; estleg:decisionDate "2020-06-01" .
+"""
+
+# The provisions that must be EXCLUDED under the default current-law scope.
+_REPEALED_PROVISIONS = {
+    f"{_NS}P_statusRep",
+    f"{_NS}P_dateRep",
+    f"{_NS}P_uriRep",
+    f"{_NS}P_selfRep",
+}
+# The provisions that must SURVIVE under the default current-law scope.
+_CURRENT_PROVISIONS = {
+    f"{_NS}P_live",
+    f"{_NS}P_nodata",
+}
+_ALL_PROVISIONS = _CURRENT_PROVISIONS | _REPEALED_PROVISIONS
+
+
+def _make_sparql_against(ttl: str) -> SparqlClient:
+    """Return a SparqlClient whose ``query`` runs SPARQL against *ttl* via rdflib.
+
+    Mirrors :meth:`SparqlClient.query` — applies the VALUES / URI-VALUES
+    injectors then executes against an in-memory graph — so the test
+    exercises the real injection path (the nested-brace ``FILTER NOT
+    EXISTS`` interaction with the VALUES splice).
+    """
+    graph = Graph()
+    graph.parse(data=ttl, format="turtle")
+
+    client = SparqlClient.__new__(SparqlClient)
+    client.jena_url = "http://localhost:3030"  # type: ignore[attr-defined]
+    client.dataset = "ontology"  # type: ignore[attr-defined]
+    client.timeout = 5.0  # type: ignore[attr-defined]
+
+    def _query(
+        sparql: str,
+        bindings: dict[str, str] | None = None,
+        uri_bindings: dict[str, str] | None = None,
+        **_kw: Any,
+    ) -> list[dict[str, str]]:
+        text = sparql
+        if bindings:
+            text = client._inject_bindings(text, bindings)
+        if uri_bindings:
+            text = client._inject_uri_bindings(text, uri_bindings)
+        rows: list[dict[str, str]] = []
+        for row in graph.query(text):
+            d: dict[str, str] = {}
+            for var in row.labels:  # type: ignore[attr-defined,union-attr]
+                value = row[var]  # type: ignore[index]
+                d[str(var)] = str(value) if value is not None else ""
+            rows.append(d)
+        return rows
+
+    client.query = MagicMock(side_effect=_query)  # type: ignore[assignment]
+    return client
+
+
+def _select_provisions(graph: Graph, scope: TemporalScope) -> set[str]:
+    """Run a bare provision SELECT with the scope clause; return the URIs kept."""
+    q = (
+        PREFIXES
+        + "SELECT ?provision WHERE {\n  ?provision a estleg:LegalProvision .\n"
+        + temporal_scope_clause(scope, "provision")
+        + "\n}"
+    )
+    return {str(r[0]) for r in graph.query(q)}  # type: ignore[index]
+
+
+# ===========================================================================
+# 1. Scope model — TemporalScope + scope_from_param
+# ===========================================================================
+
+
+class TestScopeModel:
+    def test_default_scope_is_current(self):
+        assert DEFAULT_SCOPE is TemporalScope.CURRENT
+
+    def test_scope_from_param_canonical(self):
+        assert scope_from_param("current") is TemporalScope.CURRENT
+        assert scope_from_param("all") is TemporalScope.ALL
+
+    def test_scope_from_param_blank_and_unknown_default_to_current(self):
+        assert scope_from_param(None) is TemporalScope.CURRENT
+        assert scope_from_param("") is TemporalScope.CURRENT
+        assert scope_from_param("   ") is TemporalScope.CURRENT
+        assert scope_from_param("garbage") is TemporalScope.CURRENT
+
+    def test_scope_from_param_history_aliases(self):
+        for alias in ("kogu_ajalugu", "ajalugu", "current_plus_history", "all_history"):
+            assert scope_from_param(alias) is TemporalScope.ALL, alias
+
+    def test_scope_from_param_is_case_insensitive(self):
+        assert scope_from_param("ALL") is TemporalScope.ALL
+        assert scope_from_param("Current") is TemporalScope.CURRENT
+
+
+# ===========================================================================
+# 2. The silent-no-op guard — clause references ONLY audited predicates
+# ===========================================================================
+
+
+class TestClauseReferencesOnlyAuditedPredicates:
+    """The core anti-pitfall test: prove the filter cannot silently no-op.
+
+    The whole design hinges on building the exclusion over the
+    *positively-populated* predicates (``temporalStatus`` / ``repealDate``)
+    and NOT the deferred sample-only version-chain predicates. If a future
+    edit swaps in ``versionValidFrom`` / ``supersededByVersion`` etc. the
+    filter would pass everything in production while staying green on
+    synthetic fixtures — exactly the trap #850's comment warns about.
+    """
+
+    def test_clause_contains_every_audited_predicate(self):
+        clause = current_law_filter("provision")
+        for pred in POSITIVE_REPEAL_PREDICATES:
+            assert pred in clause, f"audited predicate {pred} missing from clause"
+
+    def test_clause_references_no_deferred_version_chain_predicate(self):
+        clause = current_law_filter("provision")
+        for deferred in (
+            "versionValidFrom",
+            "versionValidTo",
+            "supersededByVersion",
+            "versionText",
+            "previousVersion",
+            "ProvisionVersion",
+        ):
+            assert deferred not in clause, f"deferred predicate {deferred} leaked into clause"
+
+    def test_clause_only_estleg_predicates_are_the_audited_two(self):
+        """No estleg predicate other than the audited two + structural joins.
+
+        The clause is allowed to use ``estleg:sourceAct`` (the act
+        membership hop) and ``rdfs:label`` (the literal-title → Act-node
+        bridge), but the only ``estleg:`` *repeal-marker* predicates must
+        be the two audited ones. We assert the full estleg URIs of the
+        audited predicates are present and that the deferred ones are not
+        (covered above) — together these pin the clause to the audit.
+        """
+        clause = current_law_filter("provision")
+        assert f"{_NS}temporalStatus" in clause
+        assert f"{_NS}repealDate" in clause
+        # The repeal value is the explicit "repealed" status, never a
+        # false-positive on "in_force" / "pending".
+        assert f'"{REPEALED_STATUS_VALUE}"' in clause
+        assert '"in_force"' not in clause
+        assert '"pending"' not in clause
+
+    def test_all_scope_emits_empty_clause(self):
+        assert temporal_scope_clause(TemporalScope.ALL, "provision") == ""
+
+    def test_current_scope_emits_filter_not_exists(self):
+        clause = temporal_scope_clause(TemporalScope.CURRENT, "provision")
+        assert "FILTER NOT EXISTS" in clause
+
+    def test_clause_respects_custom_provision_var(self):
+        clause = current_law_filter("prov")
+        assert "?prov " in clause or "?prov\n" in clause
+
+
+# ===========================================================================
+# 3. The filter bites real rdflib data
+# ===========================================================================
+
+
+class TestFilterBitesRealData:
+    def test_current_scope_excludes_only_positively_repealed(self):
+        g = Graph()
+        g.parse(data=_GRAPH_TTL, format="turtle")
+        kept = _select_provisions(g, TemporalScope.CURRENT)
+        assert kept == _CURRENT_PROVISIONS, (
+            f"current scope must keep exactly the live + no-data provisions; got {sorted(kept)}"
+        )
+
+    def test_no_data_provision_is_included_under_current(self):
+        """Positive-knowledge exclusion: absent temporal data ⇒ kept."""
+        g = Graph()
+        g.parse(data=_GRAPH_TTL, format="turtle")
+        kept = _select_provisions(g, TemporalScope.CURRENT)
+        assert f"{_NS}P_nodata" in kept
+
+    def test_all_scope_includes_everything(self):
+        g = Graph()
+        g.parse(data=_GRAPH_TTL, format="turtle")
+        kept = _select_provisions(g, TemporalScope.ALL)
+        assert kept == _ALL_PROVISIONS
+
+    def test_each_repeal_shape_is_excluded(self):
+        """Every repeal-marker shape (status/date, literal/URI, self) bites."""
+        g = Graph()
+        g.parse(data=_GRAPH_TTL, format="turtle")
+        kept = _select_provisions(g, TemporalScope.CURRENT)
+        for repealed in _REPEALED_PROVISIONS:
+            assert repealed not in kept, f"{repealed} should be excluded under current"
+
+
+# ===========================================================================
+# 4. Per-engine regression — all four engines honour the scope
+# ===========================================================================
+
+
+class TestBurdenEngineScope:
+    def test_act_default_excludes_repealed_act_provisions(self):
+        from app.analyysikeskus.burden import list_burden_for_act
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        # "Dead act" is positively repealed → current scope yields nothing.
+        cur = list_burden_for_act("Dead act", scope=TemporalScope.CURRENT, sparql_client=client)
+        allh = list_burden_for_act("Dead act", scope=TemporalScope.ALL, sparql_client=client)
+        assert cur.total == 0
+        assert allh.total == 1
+
+    def test_act_live_act_counted_under_both_scopes(self):
+        from app.analyysikeskus.burden import list_burden_for_act
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        # "Live act" hosts P_live (current) + P_selfRep (self-repealed).
+        cur = list_burden_for_act("Live act", scope=TemporalScope.CURRENT, sparql_client=client)
+        allh = list_burden_for_act("Live act", scope=TemporalScope.ALL, sparql_client=client)
+        assert cur.total == 1  # only P_live; P_selfRep excluded
+        assert allh.total == 2  # P_live + P_selfRep
+
+    def test_provision_self_repealed_dropped_under_current(self):
+        from app.analyysikeskus.burden import list_burden_for_provision
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        cur = list_burden_for_provision(
+            f"{_NS}P_selfRep", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = list_burden_for_provision(
+            f"{_NS}P_selfRep", scope=TemporalScope.ALL, sparql_client=client
+        )
+        assert cur.total == 0
+        assert allh.total == 1
+
+
+class TestSanctionsEngineScope:
+    def test_act_default_excludes_repealed_act_sanctions(self):
+        from app.analyysikeskus.sanctions import list_sanctions_for_act
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        cur = list_sanctions_for_act(
+            "Date-repealed act", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = list_sanctions_for_act(
+            "Date-repealed act", scope=TemporalScope.ALL, sparql_client=client
+        )
+        assert len(cur) == 0
+        assert len(allh) == 1
+
+    def test_provision_uri_repealed_act_dropped_under_current(self):
+        from app.analyysikeskus.sanctions import list_sanctions_for_provision
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        # P_uriRep's act (URI shape) is repealed.
+        cur = list_sanctions_for_provision(
+            f"{_NS}P_uriRep", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = list_sanctions_for_provision(
+            f"{_NS}P_uriRep", scope=TemporalScope.ALL, sparql_client=client
+        )
+        assert len(cur) == 0
+        assert len(allh) == 1
+
+    def test_similar_sanctions_excludes_repealed_acts_under_current(self):
+        from app.analyysikeskus.sanctions import SanctionRow, find_similar_sanctions
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        seed = SanctionRow(
+            sanction_type="fine", act_label="Seed act", min_amount=100.0, max_amount=500.0
+        )
+        cur = find_similar_sanctions(
+            seed, scope=TemporalScope.CURRENT, sparql_client=client, limit=50
+        )
+        allh = find_similar_sanctions(
+            seed, scope=TemporalScope.ALL, sparql_client=client, limit=50
+        )
+        # Under current, only live + no-data sanctions are comparable (2);
+        # under all, every "fine" sanction is comparable (6).
+        assert len(cur) == 2
+        assert len(allh) == 6
+
+
+class TestCompetencyEngineScope:
+    def test_competences_default_excludes_repealed_act_powers(self):
+        from app.analyysikeskus.competency import list_competences_for_institution
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        cur = list_competences_for_institution(
+            f"{_NS}Inst_A", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = list_competences_for_institution(
+            f"{_NS}Inst_A", scope=TemporalScope.ALL, sparql_client=client
+        )
+        cur_uris = {r.provision_uri for r in cur}
+        all_uris = {r.provision_uri for r in allh}
+        assert cur_uris == _CURRENT_PROVISIONS
+        assert all_uris == _ALL_PROVISIONS
+
+    def test_gather_threads_scope(self):
+        from app.analyysikeskus.competency import gather_institution_competences
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        cur = gather_institution_competences(
+            f"{_NS}Inst_A", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = gather_institution_competences(
+            f"{_NS}Inst_A", scope=TemporalScope.ALL, sparql_client=client
+        )
+        assert cur.total_count == len(_CURRENT_PROVISIONS)
+        assert allh.total_count == len(_ALL_PROVISIONS)
+
+
+class TestCourtPracticeEngineScope:
+    def test_provision_default_excludes_repealed_act_practice(self):
+        from app.analyysikeskus.court_practice import list_decisions_for_provision
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        # P_dateRep's act is repealed → no current court practice.
+        cur = list_decisions_for_provision(
+            f"{_NS}P_dateRep", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = list_decisions_for_provision(
+            f"{_NS}P_dateRep", scope=TemporalScope.ALL, sparql_client=client
+        )
+        assert len(cur) == 0
+        assert len(allh) == 1
+
+    def test_provision_live_act_practice_kept_under_both(self):
+        from app.analyysikeskus.court_practice import list_decisions_for_provision
+
+        client = _make_sparql_against(_GRAPH_TTL)
+        cur = list_decisions_for_provision(
+            f"{_NS}P_live", scope=TemporalScope.CURRENT, sparql_client=client
+        )
+        allh = list_decisions_for_provision(
+            f"{_NS}P_live", scope=TemporalScope.ALL, sparql_client=client
+        )
+        assert len(cur) == 1
+        assert len(allh) == 1
+
+
+# ===========================================================================
+# 5. _Scope.temporal_scope mapping
+# ===========================================================================
+
+
+class TestRouteScopeMapping:
+    def _scope(self, params: dict[str, str]):
+        from app.analyysikeskus.routes import _Scope
+
+        return _Scope(params)
+
+    def test_default_scope_is_current(self):
+        s = self._scope({})
+        assert s.oigus == "current"
+        assert s.temporal_scope is TemporalScope.CURRENT
+
+    def test_oigus_all_maps_to_all(self):
+        s = self._scope({"oigus": "all"})
+        assert s.oigus == "all"
+        assert s.temporal_scope is TemporalScope.ALL
+
+    def test_legacy_alias_canonicalised(self):
+        s = self._scope({"oigus": "kogu_ajalugu"})
+        # Canonicalised to the "all" token for clean round-tripping.
+        assert s.oigus == "all"
+        assert s.temporal_scope is TemporalScope.ALL
+
+    def test_all_scope_carried_in_query_pairs(self):
+        s = self._scope({"oigus": "all"})
+        pairs = dict(s.query_pairs("Karistusseadustik"))
+        assert pairs.get("oigus") == "all"
+
+    def test_current_scope_not_carried_in_query_pairs(self):
+        """Default current is the implicit state — keep links clean."""
+        s = self._scope({})
+        pairs = dict(s.query_pairs("Karistusseadustik"))
+        assert "oigus" not in pairs
+
+
+# ===========================================================================
+# 6. Scope-form round-trip through a live endpoint
+# ===========================================================================
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": "33333333-3333-3333-3333-333333333333",
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": "11111111-1111-1111-1111-111111111111",
+    }
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+        raise_server_exceptions=True,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+def _resolved_kars_law_ref():
+    from app.docs.entity_extractor import ExtractedRef
+    from app.docs.reference_resolver import ResolvedRef
+
+    return ResolvedRef(
+        extracted=ExtractedRef(
+            ref_text="KarS",
+            ref_type="law",
+            confidence=1.0,
+            location={"source": "analyysikeskus_input"},
+        ),
+        entity_uri=None,
+        matched_label="Karistusseadustik",
+        match_score=1.0,
+        partial_match={"act_token": "KARS", "act_title": "Karistusseadustik", "section": None},
+    )
+
+
+class TestScopeFormRoundTrip:
+    @patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+    @patch("app.auth.middleware._get_provider")
+    def test_sanctions_result_form_offers_both_scopes_default_current(
+        self,
+        mock_provider: MagicMock,
+        mock_resolve: MagicMock,
+    ):
+        """The result-page scope form offers both options; default = current."""
+        mock_provider.return_value = _stub_provider()
+        mock_resolve.return_value = [_resolved_kars_law_ref()]
+        with patch("app.analyysikeskus.routes.list_sanctions_for_act", return_value=[]):
+            client = _authed_client()
+            resp = client.get("/analyysikeskus/sanktsioonid?sisend=KarS")
+        assert resp.status_code == 200
+        body = resp.text
+        # Both scope options are offered in legal language.
+        assert "Kehtiv õigus" in body
+        assert "Kogu ajalugu" in body
+        # Default reflects current (the select option for current is chosen).
+        assert 'value="current" selected' in body or 'value="current"  selected' in body
+
+    @patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+    @patch("app.auth.middleware._get_provider")
+    def test_sanctions_result_form_reflects_oigus_all(
+        self,
+        mock_provider: MagicMock,
+        mock_resolve: MagicMock,
+    ):
+        """A ``?oigus=all`` request renders the select with the all option chosen."""
+        from app.docs.entity_extractor import ExtractedRef
+        from app.docs.reference_resolver import ResolvedRef
+
+        mock_provider.return_value = _stub_provider()
+        mock_resolve.return_value = [
+            ResolvedRef(
+                extracted=ExtractedRef(
+                    ref_text="KarS",
+                    ref_type="law",
+                    confidence=1.0,
+                    location={"source": "analyysikeskus_input"},
+                ),
+                entity_uri=None,
+                matched_label="Karistusseadustik",
+                match_score=1.0,
+                partial_match={
+                    "act_token": "KARS",
+                    "act_title": "Karistusseadustik",
+                    "section": None,
+                },
+            )
+        ]
+        with patch("app.analyysikeskus.routes.list_sanctions_for_act", return_value=[]):
+            client = _authed_client()
+            resp = client.get(
+                "/analyysikeskus/sanktsioonid?sisend=KarS&oigus=all&ulatus_submitted=1"
+            )
+        assert resp.status_code == 200
+        body = resp.text
+        # The select reflects the URL state: the "all" option is marked selected.
+        assert 'value="all" selected' in body or 'value="all"  selected' in body
+
+    @patch("app.docs.reference_resolver.ReferenceResolver.resolve")
+    @patch("app.auth.middleware._get_provider")
+    def test_sanctions_result_passes_all_scope_to_engine(
+        self,
+        mock_provider: MagicMock,
+        mock_resolve: MagicMock,
+    ):
+        """``?oigus=all`` reaches the engine as TemporalScope.ALL."""
+        from app.docs.entity_extractor import ExtractedRef
+        from app.docs.reference_resolver import ResolvedRef
+
+        mock_provider.return_value = _stub_provider()
+        mock_resolve.return_value = [
+            ResolvedRef(
+                extracted=ExtractedRef(
+                    ref_text="KarS",
+                    ref_type="law",
+                    confidence=1.0,
+                    location={"source": "analyysikeskus_input"},
+                ),
+                entity_uri=None,
+                matched_label="Karistusseadustik",
+                match_score=1.0,
+                partial_match={
+                    "act_token": "KARS",
+                    "act_title": "Karistusseadustik",
+                    "section": None,
+                },
+            )
+        ]
+        with patch(
+            "app.analyysikeskus.routes.list_sanctions_for_act", return_value=[]
+        ) as mock_act:
+            client = _authed_client()
+            resp = client.get(
+                "/analyysikeskus/sanktsioonid?sisend=KarS&oigus=all&ulatus_submitted=1"
+            )
+            assert resp.status_code == 200
+        mock_act.assert_called_once_with("Karistusseadustik", scope=TemporalScope.ALL)


### PR DESCRIPTION
Closes #850

## Problem

The four Analüüsikeskus engines — `burden.py` (Halduskoormus), `sanctions.py` (Sanktsioonid), `competency.py` (Pädevused), `court_practice.py` (Kohtupraktika) — aggregated over provisions with **no** validity/version filter. Counts mixed provisions of repealed acts with current law, overstating results in a legal-advisory workflow. The parsed `?oigus=` request param was dead (`_scope_form` hardcoded `value="current"`).

## The pitfall that decided the design

The "keep only the current `ProvisionVersion`" approach is a trap in this corpus. Per the in-repo ontology audit (`app/ontology/relations.py:140-160`):

- **Deferred / sample-only** (ontology issue `henrikaavik/estonian-legal-ontology#208`): `versionValidFrom`, `versionValidTo`, `supersededByVersion`, `versionText`, the `ProvisionVersion` chain. A version-chain filter matches ~nothing in prod.
- A naïve `FILTER NOT EXISTS { …repealed… }` over those unpopulated predicates **silently passes everything** — green on synthetic fixtures, useless in production.

So the default filter is built as **positive-knowledge exclusion** over only the **populated** predicates: exclude a provision **only when it is positively marked repealed**; absent data ⇒ included. This is honest when data is sparse and strengthens automatically as repeal markers backfill.

## Audit verdict (which predicates are real)

Static audit (no local Fuseki reachable in this environment — `docker compose` not running; prod probe queries below). Grounded in the `relations.py` audit comments + the predicates `app/analyysikeskus/history.py` already reads corpus-wide:

| Predicate | Status | Used by filter? |
|---|---|---|
| `estleg:temporalStatus` (`"in_force"` / `"in_force_partial"` / `"repealed"` / `"pending"`) | **Populated corpus-wide on `Act`** (history.py reads it) | **Yes** — value `"repealed"` excludes |
| `estleg:repealDate` | **Populated corpus-wide on `Act`** (history.py reads it) | **Yes** — presence excludes |
| `estleg:entryIntoForce`, `estleg:lastAmendmentDate` | Populated, but not repeal markers | No |
| `estleg:versionValidFrom` / `versionValidTo` / `supersededByVersion` / `versionText` | **Deferred sample-only** (#208) | **No** (would no-op) |

Where the markers live: in prod a provision links to its act via `estleg:sourceAct` whose object is a **literal act title** (24,221 triples, all `xsd:string`; `partOf`/`partOfAct` carry zero rows — Wave 2 spike). The repeal markers hang off a separate `Act` node whose `rdfs:label` equals that title. The canonical TTL fixture instead points `sourceAct` at an `Act` URI. `current_law_filter()` handles **both** shapes plus a direct marker on the provision itself.

### Prod spot-check probe queries

Run against `http://seadusloome-jena:3030/legal/sparql` to confirm the markers are populated (and the filter will bite real data):

```sparql
# 1. How many Acts carry temporalStatus, and what values?
PREFIX estleg: <https://data.riik.ee/ontology/estleg#>
SELECT ?status (COUNT(?act) AS ?n) WHERE {
  ?act estleg:temporalStatus ?status .
} GROUP BY ?status ORDER BY DESC(?n)
```

```sparql
# 2. How many Acts carry a repealDate?
PREFIX estleg: <https://data.riik.ee/ontology/estleg#>
SELECT (COUNT(DISTINCT ?act) AS ?actsWithRepealDate) WHERE {
  ?act estleg:repealDate ?d .
}
```

```sparql
# 3. Are the version-chain predicates really empty? (expect ~0 / sample-only)
PREFIX estleg: <https://data.riik.ee/ontology/estleg#>
SELECT
  (COUNT(?a) AS ?versionValidFrom)
  (COUNT(?b) AS ?supersededByVersion) WHERE {
  { ?x estleg:versionValidFrom ?a } UNION { ?y estleg:supersededByVersion ?b }
}
```

```sparql
# 4. Before/after on a KNOWN repealed act — count its provisions with vs without the filter.
#    Replace "<Repealed act title>" with a genuinely-repealed Estonian act.
PREFIX estleg: <https://data.riik.ee/ontology/estleg#>
SELECT (COUNT(?p) AS ?allProvisions) WHERE {
  ?p estleg:sourceAct "<Repealed act title>" .
}
# then re-run wrapped in the current_law_filter FILTER NOT EXISTS block;
# the second count should drop to 0 if the act is positively marked repealed.
```

## What changed

- **`app/ontology/temporal_scope.py` (new)** — the single shared policy module (mirrors `app/ontology/scoping.py`'s clause-builder pattern):
  - `TemporalScope` (`current` / `all`), `scope_from_param` (folds legacy aliases + unknown → safe current default).
  - `current_law_filter(provision_var)` → a `FILTER NOT EXISTS` over **only** `temporalStatus "repealed"` / `repealDate`, checking the provision itself + its owning act (literal-title hop **and** URI hop).
  - `temporal_scope_clause(scope, provision_var)` — the engine entry point (empty string for `all`).
  - Docstring states the **neighbour policy**: `history.py` is intentionally historical (excluded from default-current); `similarity.py` / `eu_transposition.py` adopt explicitly later.
- **Four engines** — query builders take a `scope` and splice the clause; public fns gain a `scope` kwarg (default current law). Burden: **act-level queries only** — `_build_draft_affected_provisions_query` / `burden_delta_for_draft` left untouched (owned by another agent); the shared `list_burden_for_provision` gained the kwarg with a documented default.
- **`routes.py`** — `_Scope.temporal_scope` maps `?oigus=`; the four scope-aware forms render an enabled `Õigus` select (`Kehtiv õigus` / `Kogu ajalugu`) that reflects URL state; handlers thread the scope into the engine calls. (Normi/EL keep their existing "tulekul" placeholder — they don't filter by scope.)

## Tests

`tests/test_analyysikeskus_temporal_scope.py` (new):
- **Silent-no-op guard** — asserts the emitted clause references the audited predicates and **none** of the deferred version-chain predicates (the anti-pitfall guard against future drift).
- **Filter bites real rdflib data** — a graph with current + status-repealed + date-repealed + URI-repealed + self-repealed + no-data provisions; current scope excludes only the positively-marked ones (no-data survives), `all` keeps everything.
- **Per-engine regression** — burden / sanctions / competency / court-practice each honour the scope through the real `SparqlClient.query` VALUES-injection path.
- **Scope-form round-trip** — `?oigus=all` reflected in the select + reaches the engine as `TemporalScope.ALL`.

Existing route tests updated to assert the new `scope=` kwarg.

## DoD status

- [x] One shared temporal scope model (current default + explicit historical/all)
- [x] Burden excludes repealed/superseded from default aggregates (act-level)
- [x] Sanctions excludes repealed/superseded from default aggregates
- [x] Competency excludes repealed/superseded from default aggregates
- [x] Court-practice uses the same temporal policy for provision/legal-basis joins
- [x] `?oigus=` wired to a visible scope choice (`kehtiv õigus` vs `kogu ajalugu`)
- [x] Behaviour documented next to the shared helper (future SPARQL inherits the default)
- [x] Tests: fixture current/repealed/superseded → default = current only
- [x] Tests: explicit all scope includes historical rows
- [x] Tests: per-engine regression for all four
- [x] Tests: silent-no-op guard (filter references only audited predicates)
- [x] `uv run ruff check .` · `uv run pyright` · `uv run pytest -q` all green (4308 passed, 45 skipped)

## Deviations

- **Static audit** — no local Fuseki was reachable, so the audit is grounded in the in-repo audit notes + history.py usage; prod probe queries above are provided for a spot-check.
- **Positive-knowledge default over version chains** — by design (see pitfall). If/when #208 backfills the version chain, an opt-in stricter scope can layer on top without touching callers.
- **Neighbours** — `history.py` deliberately keeps its own historical reads; `similarity.py` / `eu_transposition.py` are out of scope and will adopt the helper explicitly later (documented in the helper docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
