### PR TITLE
fix(jobs+drafter): reaper for orphaned jobs, retry-gating contracts, idempotent review submit (#852)

### DIFF
--- a/app/admin/job_monitor.py
+++ b/app/admin/job_monitor.py
@@ -330,7 +330,18 @@ def _get_job_detail(job_id: int) -> dict | None:  # type: ignore[type-arg]
 
 
 def _retry_job(job_id: int) -> bool:
-    """Reset a job to 'pending' status for retry. Returns True on success."""
+    """Reset a failed job to 'pending' for ONE more attempt. True on success.
+
+    #852: ``attempts`` is deliberately PRESERVED (it used to be reset to
+    0, which made a poison job retryable forever and defeated
+    ``max_attempts``). A failed job already has ``attempts >=
+    max_attempts``, so each admin click grants exactly one extra
+    attempt: the worker runs it, and on failure ``mark_failed`` sees
+    ``attempts + 1 > max_attempts`` and flips it straight back to
+    ``failed`` (handlers likewise see ``attempt >= max_attempts`` and
+    apply their final-attempt domain consequences). The climbing
+    counter (e.g. ``4/3``) doubles as the audit trail of admin retries.
+    """
     try:
         with _connect() as conn:
             result = conn.execute(
@@ -341,7 +352,6 @@ def _retry_job(job_id: int) -> bool:
                 "    claimed_by = NULL, "
                 "    claimed_at = NULL, "
                 "    started_at = NULL, "
-                "    attempts = 0, "
                 "    scheduled_for = %s "
                 "WHERE id = %s AND status = 'failed'",
                 (datetime.now(UTC), job_id),
@@ -638,6 +648,13 @@ def _jobs_table(
                 hx_post=f"/admin/jobs/{job['id']}/retry",
                 hx_target="#job-monitor-content",
                 hx_swap="innerHTML",
+                # #852: state-mutating action — confirm like the adjacent
+                # purge button. One click grants exactly one extra
+                # attempt (the attempt counter is preserved).
+                hx_confirm=(
+                    "Kas olete kindel? Töö käivitatakse uuesti "
+                    "ühe lisakatsega; katsete ajalugu säilib."
+                ),
                 variant="secondary",
                 size="sm",
             )

--- a/app/docs/analyze_handler.py
+++ b/app/docs/analyze_handler.py
@@ -92,95 +92,101 @@ def analyze_impact(
 
     logger.info("analyze_impact: starting pipeline for draft %s", draft_id)
 
-    # ------------------------------------------------------------------
-    # 1. Load draft + resolved references
-    # ------------------------------------------------------------------
-    #
-    # Step 5 of docs/2026-05-18-bugfix-plan.md: widen the SELECT to
-    # include ``partial_match`` (jsonb column from migration 034).
-    # Previously the WHERE clause filtered ``entity_uri is not null``
-    # which silently dropped every act-level partial match the resolver
-    # wrote. Those rows now surface so the graph builder can emit an
-    # act-level annotation triple and the impact engine can include the
-    # partial-match reference in the report (as an act-level finding,
-    # not as a synthetic provision URI).
-    with get_connection() as conn:
-        draft = get_draft(conn, draft_id)
-        if draft is None:
-            raise ValueError(f"Draft {draft_id} not found")
-        # #815: fetch fully-unresolved EU references BEFORE the resolved
-        # SELECT below filters them out. The downstream analyzer never
-        # sees these rows (entity_uri IS NULL AND partial_match IS NULL),
-        # but the impact-report renderer + .docx export use them to
-        # surface a "we detected EU refs but couldn't map them" warning
-        # so the user knows the analysis is missing coverage rather
-        # than silently treating "no EU findings" as "no EU impact".
-        unresolved_eu_rows = conn.execute(
-            """
-            select ref_text, confidence
-            from draft_entities
-            where draft_id = %s
-              and ref_type = 'eu_act'
-              and entity_uri is null
-              and partial_match is null
-            order by confidence desc
-            """,
-            (str(draft_id),),
-        ).fetchall()
-        entity_rows = conn.execute(
-            """
-            select ref_text, entity_uri, confidence, ref_type, location,
-                   partial_match
-            from draft_entities
-            where draft_id = %s
-              and (entity_uri is not null or partial_match is not null)
-            """,
-            (str(draft_id),),
-        ).fetchall()
-        # #844 A3b: resolve the org's owned draft UUIDs on the *same*
-        # connection so the conflict pass can mask cross-org draft rows
-        # (foreign draft URIs / titles are never persisted into the
-        # report). Best-effort — a lookup failure yields an empty set,
-        # which masks every cross-draft row (the safe default). Done here,
-        # inside the already-open connection, so we add no extra
-        # ``get_connection()`` round-trip.
-        owned_draft_ids = _owned_draft_ids_on_conn(conn, draft.org_id)
-
-    # Normalise the unresolved rows into the JSON-friendly shape that
-    # gets persisted in ``report_data["unresolved_eu_refs"]``.
-    # Tolerates both tuple-style rows (psycopg default) and dict-style
-    # rows (rare; some test fixtures use DictRow).
-    unresolved_eu_refs: list[dict[str, Any]] = []
-    for row in unresolved_eu_rows or []:
-        if isinstance(row, dict):
-            ref_text = row.get("ref_text")
-            confidence = row.get("confidence")
-        else:
-            ref_text = row[0] if len(row) > 0 else None
-            confidence = row[1] if len(row) > 1 else None
-        ref_text_str = str(ref_text or "").strip()
-        if not ref_text_str:
-            continue
-        try:
-            conf = float(confidence) if confidence is not None else 0.0
-        except (TypeError, ValueError):
-            conf = 0.0
-        unresolved_eu_refs.append({"ref_text": ref_text_str, "confidence": conf})
-
-    resolved_refs = [_row_to_resolved_ref(row) for row in entity_rows]
-    logger.info(
-        "analyze_impact: draft %s has %d resolved references "
-        "(%d full URI, %d act-level partial match)",
-        draft_id,
-        len(resolved_refs),
-        sum(1 for r in resolved_refs if r.entity_uri),
-        sum(1 for r in resolved_refs if r.partial_match is not None),
-    )
-
-    # ------------------------------------------------------------------
-    # 2-7. Build graph, load to Jena, analyse, persist, flip status
-    # ------------------------------------------------------------------
+    # #852 E6: the whole pipeline — INCLUDING the draft/entity load below —
+    # runs inside the retry-gated try. The load used to sit before the
+    # gated region, so a DB hiccup (or missing draft) there never flipped
+    # the draft to ``failed`` even on the final attempt and the pipeline
+    # appeared stuck in ``analyzing``. (When the draft row itself is gone,
+    # ``_mark_draft_failed`` simply updates zero rows — harmless.)
     try:
+        # ------------------------------------------------------------------
+        # 1. Load draft + resolved references
+        # ------------------------------------------------------------------
+        #
+        # Step 5 of docs/2026-05-18-bugfix-plan.md: widen the SELECT to
+        # include ``partial_match`` (jsonb column from migration 034).
+        # Previously the WHERE clause filtered ``entity_uri is not null``
+        # which silently dropped every act-level partial match the resolver
+        # wrote. Those rows now surface so the graph builder can emit an
+        # act-level annotation triple and the impact engine can include the
+        # partial-match reference in the report (as an act-level finding,
+        # not as a synthetic provision URI).
+        with get_connection() as conn:
+            draft = get_draft(conn, draft_id)
+            if draft is None:
+                raise ValueError(f"Draft {draft_id} not found")
+            # #815: fetch fully-unresolved EU references BEFORE the resolved
+            # SELECT below filters them out. The downstream analyzer never
+            # sees these rows (entity_uri IS NULL AND partial_match IS NULL),
+            # but the impact-report renderer + .docx export use them to
+            # surface a "we detected EU refs but couldn't map them" warning
+            # so the user knows the analysis is missing coverage rather
+            # than silently treating "no EU findings" as "no EU impact".
+            unresolved_eu_rows = conn.execute(
+                """
+                select ref_text, confidence
+                from draft_entities
+                where draft_id = %s
+                  and ref_type = 'eu_act'
+                  and entity_uri is null
+                  and partial_match is null
+                order by confidence desc
+                """,
+                (str(draft_id),),
+            ).fetchall()
+            entity_rows = conn.execute(
+                """
+                select ref_text, entity_uri, confidence, ref_type, location,
+                       partial_match
+                from draft_entities
+                where draft_id = %s
+                  and (entity_uri is not null or partial_match is not null)
+                """,
+                (str(draft_id),),
+            ).fetchall()
+            # #844 A3b: resolve the org's owned draft UUIDs on the *same*
+            # connection so the conflict pass can mask cross-org draft rows
+            # (foreign draft URIs / titles are never persisted into the
+            # report). Best-effort — a lookup failure yields an empty set,
+            # which masks every cross-draft row (the safe default). Done here,
+            # inside the already-open connection, so we add no extra
+            # ``get_connection()`` round-trip.
+            owned_draft_ids = _owned_draft_ids_on_conn(conn, draft.org_id)
+
+        # Normalise the unresolved rows into the JSON-friendly shape that
+        # gets persisted in ``report_data["unresolved_eu_refs"]``.
+        # Tolerates both tuple-style rows (psycopg default) and dict-style
+        # rows (rare; some test fixtures use DictRow).
+        unresolved_eu_refs: list[dict[str, Any]] = []
+        for row in unresolved_eu_rows or []:
+            if isinstance(row, dict):
+                ref_text = row.get("ref_text")
+                confidence = row.get("confidence")
+            else:
+                ref_text = row[0] if len(row) > 0 else None
+                confidence = row[1] if len(row) > 1 else None
+            ref_text_str = str(ref_text or "").strip()
+            if not ref_text_str:
+                continue
+            try:
+                conf = float(confidence) if confidence is not None else 0.0
+            except (TypeError, ValueError):
+                conf = 0.0
+            unresolved_eu_refs.append({"ref_text": ref_text_str, "confidence": conf})
+
+        resolved_refs = [_row_to_resolved_ref(row) for row in entity_rows]
+        logger.info(
+            "analyze_impact: draft %s has %d resolved references "
+            "(%d full URI, %d act-level partial match)",
+            draft_id,
+            len(resolved_refs),
+            sum(1 for r in resolved_refs if r.entity_uri),
+            sum(1 for r in resolved_refs if r.partial_match is not None),
+        )
+
+        # ------------------------------------------------------------------
+        # 2-7. Build graph, load to Jena, analyse, persist, flip status
+        # ------------------------------------------------------------------
         turtle = build_draft_graph(draft, resolved_refs)
         loaded = put_named_graph(draft.graph_uri, turtle)
         if not loaded:

--- a/app/docs/extract_handler.py
+++ b/app/docs/extract_handler.py
@@ -12,9 +12,13 @@ Flow:
     6. Update ``drafts.status = 'analyzing'`` and enqueue the next
        pipeline step (``analyze_impact``).
 
-Any exception along the way flips the draft to ``failed`` with a
-truncated error message and re-raises so the job queue retry loop
-picks it up.
+Any exception along the way — including the load/decrypt/empty-text
+preconditions (#852 E6) — re-raises so the job queue retry loop picks
+it up, and flips the draft to ``failed`` with a truncated error
+message once the retry budget is exhausted. Keeping the preconditions
+inside the gated region matters: a ``DecryptionError`` on the final
+attempt must surface as a failed draft with a retry button, not a
+draft stuck in ``extracting`` forever.
 
 The handler registers itself via ``@register_handler`` when this
 module is imported; ``app/docs/__init__.py`` pulls it in so the
@@ -73,23 +77,33 @@ def extract_entities(
         raise ValueError("extract_entities payload missing draft_id")
     draft_id = UUID(str(draft_id_raw))
 
-    # -- 1. Load draft + preconditions ---------------------------------
-    with get_connection() as conn:
-        draft = get_draft(conn, draft_id)
-    if draft is None:
-        raise ValueError(f"Draft {draft_id} not found")
-    if draft.parsed_text_encrypted is None:
-        raise ValueError(f"Draft {draft_id} has no parsed text — was parse_draft skipped?")
-    parsed_text = decrypt_text(draft.parsed_text_encrypted)
-    if not parsed_text.strip():
-        raise ValueError(f"Draft {draft_id} has no parsed text — was parse_draft skipped?")
-
-    # -- 2. Mark 'extracting' ------------------------------------------
-    with get_connection() as conn:
-        update_draft_status(conn, draft_id, "extracting")
-        conn.commit()
-
     try:
+        # -- 1. Load draft + preconditions -----------------------------
+        #
+        # #852 E6: these run INSIDE the retry-gated try. A decrypt
+        # failure (or missing parsed text) used to raise before the
+        # gated region, so the draft never flipped to ``failed`` even
+        # on the final attempt — it sat in ``extracting`` with no retry
+        # button. Now every precondition failure consumes the retry
+        # budget like any other handler error and marks the draft
+        # failed on the last attempt. (If the draft row itself is gone,
+        # the failure UPDATE in the except branch simply matches zero
+        # rows — harmless.)
+        with get_connection() as conn:
+            draft = get_draft(conn, draft_id)
+        if draft is None:
+            raise ValueError(f"Draft {draft_id} not found")
+        if draft.parsed_text_encrypted is None:
+            raise ValueError(f"Draft {draft_id} has no parsed text — was parse_draft skipped?")
+        parsed_text = decrypt_text(draft.parsed_text_encrypted)
+        if not parsed_text.strip():
+            raise ValueError(f"Draft {draft_id} has no parsed text — was parse_draft skipped?")
+
+        # -- 2. Mark 'extracting' --------------------------------------
+        with get_connection() as conn:
+            update_draft_status(conn, draft_id, "extracting")
+            conn.commit()
+
         # -- 3. Extract refs via LLM -----------------------------------
         extracted = extract_refs_from_text(parsed_text)
         logger.info(

--- a/app/drafter/handlers.py
+++ b/app/drafter/handlers.py
@@ -1119,7 +1119,21 @@ def drafter_regenerate_clause(
         result = _require_llm_json(
             result, context=f"drafter_regenerate_clause clause {clause_index}"
         )
-        clause["text"] = result.get("text", clause.get("text", ""))
+        # #852 review F2: same nonblank contract as ``drafter_draft`` —
+        # ``{"text": ""}`` (or whitespace-only) passes the parse check
+        # above but used to OVERWRITE a good clause with blank text. A
+        # blank regeneration now raises (retry-gating engages) and the
+        # existing clause is left untouched; only a non-blank result may
+        # replace the text. Stub payloads carry no ``text`` and keep the
+        # existing clause so keyless local dev still completes.
+        new_text = str(result.get("text") or "").strip()
+        if not new_text and not result.get("stub"):
+            raise LLMOutputError(
+                "drafter_regenerate_clause: LLM returned no clause text for "
+                f"clause {clause_index} ({clause.get('paragraph', '?')!r})"
+            )
+        if new_text:
+            clause["text"] = result["text"]
         # #842: resolve citations through the ontology (see drafter_draft).
         clause["citations"] = resolve_citations(
             result.get("citations", clause.get("citations", []))

--- a/app/drafter/handlers.py
+++ b/app/drafter/handlers.py
@@ -47,6 +47,38 @@ from app.storage import decrypt_text, encrypt_text
 logger = logging.getLogger(__name__)
 
 
+class LLMOutputError(RuntimeError):
+    """LLM returned unusable output (parse failure or missing required fields).
+
+    #852 E2: the provider's ``extract_json`` returns ``{"error": ...}``
+    instead of raising when the model's reply is not parseable JSON.
+    Treating that dict as data let ``drafter_draft`` persist blank
+    clauses while the job "succeeded" — retry-gating never engaged and
+    the state machine waved empty clauses into review. Raising this
+    (a ``RuntimeError`` subclass, so existing except/re-wrap paths and
+    tests keep working) routes bad output through the normal retry
+    budget + abandon gating instead.
+    """
+
+
+def _require_llm_json(result: Any, *, context: str) -> dict[str, Any]:
+    """Validate a raw ``extract_json`` payload before it is used (#852 E2).
+
+    Raises :class:`LLMOutputError` when the payload is not a dict or
+    carries the provider's ``{"error": ...}`` parse-failure marker, so
+    the job fails (and retries) instead of silently persisting garbage.
+
+    Stub-mode payloads (``{"stub": True, ...}``) pass through: local
+    development without API keys must still complete the pipeline, and
+    each call site decides how strict to be about stub content.
+    """
+    if not isinstance(result, dict):
+        raise LLMOutputError(f"{context}: LLM returned a non-dict payload")
+    if result.get("error"):
+        raise LLMOutputError(f"{context}: LLM output could not be parsed: {result['error']}")
+    return result
+
+
 # ---------------------------------------------------------------------------
 # SPARQL helpers
 # ---------------------------------------------------------------------------
@@ -579,44 +611,60 @@ def drafter_clarify(
     provider = get_default_provider()
     prompt = CLARIFY_PROMPT.format(intent=session.intent or "", laws=laws_text)
 
+    # #852 E2: post-LLM parsing + persistence used to live OUTSIDE this
+    # gated region, so a malformed payload or a DB write failure skipped
+    # the abandon-on-final-attempt gating entirely. Everything from the
+    # LLM call to the session write is now inside one gate.
     try:
-        result = provider.extract_json(
-            prompt,
-            feature="drafter_clarify",
-            user_id=session.user_id,
-            org_id=session.org_id,
-        )
-    except Exception as exc:
+        try:
+            result = provider.extract_json(
+                prompt,
+                feature="drafter_clarify",
+                user_id=session.user_id,
+                org_id=session.org_id,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"LLM call failed: {exc}") from exc
+
+        result = _require_llm_json(result, context="drafter_clarify")
+
+        questions = result.get("questions", [])
+        if not questions:
+            # Fallback: generate minimal questions. Deliberately NOT an
+            # error — an empty-but-valid payload (or stub mode) still has
+            # a safe deterministic interview to fall back on, unlike the
+            # parse-failure case handled by ``_require_llm_json`` above.
+            questions = [
+                {"question": "Milliseid asutusi see seadus mõjutab?", "rationale": "scope"},
+                {
+                    "question": "Kas see täiendab või asendab olemasolevat seadust?",
+                    "rationale": "relationship",
+                },
+                {
+                    "question": "Kas on EL-i nõudeid, mida tuleb arvestada?",
+                    "rationale": "EU compliance",
+                },
+            ]
+
+        clarifications = [
+            {
+                "question": q.get("question", ""),
+                "answer": None,
+                "rationale": q.get("rationale", ""),
+            }
+            for q in questions
+        ]
+
+        with get_connection() as conn:
+            update_session(conn, session_id, clarifications=clarifications)
+            conn.commit()
+    except Exception:
         if attempt >= max_attempts:
             logger.exception("drafter_clarify permanently failed for session %s", session_id)
             with get_connection() as conn:
                 abandon_session(conn, session_id)
                 conn.commit()
-        raise RuntimeError(f"LLM call failed: {exc}") from exc
-
-    questions = result.get("questions", [])
-    if not questions:
-        # Fallback: generate minimal questions
-        questions = [
-            {"question": "Milliseid asutusi see seadus mõjutab?", "rationale": "scope"},
-            {
-                "question": "Kas see täiendab või asendab olemasolevat seadust?",
-                "rationale": "relationship",
-            },
-            {
-                "question": "Kas on EL-i nõudeid, mida tuleb arvestada?",
-                "rationale": "EU compliance",
-            },
-        ]
-
-    clarifications = [
-        {"question": q.get("question", ""), "answer": None, "rationale": q.get("rationale", "")}
-        for q in questions
-    ]
-
-    with get_connection() as conn:
-        update_session(conn, session_id, clarifications=clarifications)
-        conn.commit()
+        raise
 
     logger.info(
         "drafter_clarify: generated %d questions for session %s",
@@ -776,48 +824,57 @@ def drafter_structure(
         similar_laws=similar_laws_text,
     )
 
+    # #852 E2: same gating fix as ``drafter_clarify`` — post-LLM parsing
+    # and the session write now live inside the retry-gated region so a
+    # malformed payload or DB failure also engages abandon-on-final-attempt.
     try:
-        result = provider.extract_json(
-            prompt,
-            feature="drafter_structure",
-            user_id=session.user_id,
-            org_id=session.org_id,
-        )
-    except Exception as exc:
+        try:
+            result = provider.extract_json(
+                prompt,
+                feature="drafter_structure",
+                user_id=session.user_id,
+                org_id=session.org_id,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"LLM call failed: {exc}") from exc
+
+        structure = _require_llm_json(result, context="drafter_structure")
+
+        # Validate structure has minimum fields. An empty-but-valid
+        # payload (or stub mode) falls back to a deterministic skeleton —
+        # only the parse-failure marker above is treated as a hard error.
+        if "chapters" not in structure or not structure["chapters"]:
+            structure = {
+                "title": session.intent or "Uus seadus",
+                "chapters": [
+                    {
+                        "number": "1. peatukk",
+                        "title": "Uldsatted",
+                        "sections": [
+                            {"paragraph": "par 1", "title": "Seaduse reguleerimisala"},
+                            {"paragraph": "par 2", "title": "Moistete selgitused"},
+                        ],
+                    },
+                    {
+                        "number": "2. peatukk",
+                        "title": "Rakendussatted",
+                        "sections": [
+                            {"paragraph": "par 3", "title": "Seaduse joustumise aeg"},
+                        ],
+                    },
+                ],
+            }
+
+        with get_connection() as conn:
+            update_session(conn, session_id, proposed_structure=structure)
+            conn.commit()
+    except Exception:
         if attempt >= max_attempts:
             logger.exception("drafter_structure permanently failed for session %s", session_id)
             with get_connection() as conn:
                 abandon_session(conn, session_id)
                 conn.commit()
-        raise RuntimeError(f"LLM call failed: {exc}") from exc
-
-    structure = result
-    # Validate structure has minimum fields
-    if "chapters" not in structure or not structure["chapters"]:
-        structure = {
-            "title": session.intent or "Uus seadus",
-            "chapters": [
-                {
-                    "number": "1. peatukk",
-                    "title": "Uldsatted",
-                    "sections": [
-                        {"paragraph": "par 1", "title": "Seaduse reguleerimisala"},
-                        {"paragraph": "par 2", "title": "Moistete selgitused"},
-                    ],
-                },
-                {
-                    "number": "2. peatukk",
-                    "title": "Rakendussatted",
-                    "sections": [
-                        {"paragraph": "par 3", "title": "Seaduse joustumise aeg"},
-                    ],
-                },
-            ],
-        }
-
-    with get_connection() as conn:
-        update_session(conn, session_id, proposed_structure=structure)
-        conn.commit()
+        raise
 
     logger.info(
         "drafter_structure: generated %d chapters for session %s",
@@ -904,6 +961,21 @@ def drafter_draft(
                     org_id=session.org_id,
                 )
 
+                # #852 E2: a parse-failure payload ({"error": ...}) or a
+                # clause without text must FAIL the job (and consume the
+                # retry budget) instead of being persisted as a blank
+                # clause that the state machine happily waves into review.
+                result = _require_llm_json(
+                    result,
+                    context=f"drafter_draft section {section.get('paragraph', '?')!r}",
+                )
+                clause_text = str(result.get("text") or "").strip()
+                if not clause_text and not result.get("stub"):
+                    raise LLMOutputError(
+                        "drafter_draft: LLM returned no clause text for section "
+                        f"{section.get('paragraph', '?')!r} ({section_title!r})"
+                    )
+
                 clauses.append(
                     {
                         "chapter": chapter.get("number", ""),
@@ -919,6 +991,23 @@ def drafter_draft(
                     }
                 )
 
+        # #852 E2: an empty clause list means the structure had no
+        # sections (or every section was skipped) — persisting it would
+        # let the step-5→6 guard pass on encrypted-but-empty content.
+        if not clauses:
+            raise LLMOutputError(
+                f"drafter_draft produced no clauses for session {session_id} "
+                "(structure has no sections?)"
+            )
+
+        # The persist step sits inside the gated region too, so a DB
+        # failure here also engages abandon-on-final-attempt.
+        encrypted = encrypt_text(json.dumps({"clauses": clauses}, ensure_ascii=False))
+
+        with get_connection() as conn:
+            update_session(conn, session_id, draft_content_encrypted=encrypted)
+            conn.commit()
+
     except Exception as exc:
         if attempt >= max_attempts:
             logger.exception(
@@ -930,12 +1019,6 @@ def drafter_draft(
                 abandon_session(conn, session_id)
                 conn.commit()
         raise RuntimeError(f"Clause drafting failed: {exc}") from exc
-
-    encrypted = encrypt_text(json.dumps({"clauses": clauses}, ensure_ascii=False))
-
-    with get_connection() as conn:
-        update_session(conn, session_id, draft_content_encrypted=encrypted)
-        conn.commit()
 
     logger.info(
         "drafter_draft: drafted %d clauses for session %s",
@@ -1029,6 +1112,12 @@ def drafter_regenerate_clause(
             feature="drafter_regenerate",
             user_id=session.user_id,
             org_id=session.org_id,
+        )
+        # #852 E2: a parse-failure payload must fail the job (visibly,
+        # with retries) — silently keeping the old clause would look
+        # like a successful regeneration that changed nothing.
+        result = _require_llm_json(
+            result, context=f"drafter_regenerate_clause clause {clause_index}"
         )
         clause["text"] = result.get("text", clause.get("text", ""))
         # #842: resolve citations through the ontology (see drafter_draft).

--- a/app/drafter/routes.py
+++ b/app/drafter/routes.py
@@ -1267,6 +1267,8 @@ def _trigger_integrated_review(session: DraftingSession, auth: UserDict) -> uuid
 
     graph_uri_prefix = "https://data.riik.ee/ontology/estleg/drafts/"
 
+    from app.docs.version_model import create_draft_version
+
     with _connect() as conn:
         draft = create_draft(
             conn,
@@ -1284,7 +1286,38 @@ def _trigger_integrated_review(session: DraftingSession, auth: UserDict) -> uuid
             "UPDATE drafts SET graph_uri = %s WHERE id = %s",
             (final_graph_uri, str(draft.id)),
         )
+        # #852 review F1: mirror the upload path (#618 PR-B,
+        # ``app/docs/upload.py::_create_new_draft``) — every new drafts
+        # row needs its explicit v1 ``draft_versions`` row in the SAME
+        # transaction. Without it ``analyze_impact`` resolves
+        # ``latest_version=None`` → ``impact_reports.draft_version_id``
+        # NULL, the stale-annotation reconciliation is skipped, and the
+        # §4.2 status mirror has no version row to write to. (The gap
+        # predates #852: Phase 3A never retrofitted the #618 PR-B
+        # version bookkeeping into this path.)
+        create_draft_version(
+            conn,
+            draft_id=draft.id,
+            version_number=1,
+            reading_stage="vtk",
+            storage_path=stored.storage_path,
+            graph_uri=final_graph_uri,
+            status="uploaded",
+            created_by=session.user_id,
+        )
         conn.commit()
+
+    # Audit parity with the upload path's v1 creation (fire-and-forget;
+    # log_action never raises).
+    log_action(
+        str(session.user_id),
+        "draft.version.create",
+        {
+            "draft_id": str(draft.id),
+            "version_number": 1,
+            "reading_stage": "vtk",
+        },
+    )
 
     # Enqueue parse_draft job
     try:

--- a/app/drafter/routes.py
+++ b/app/drafter/routes.py
@@ -1121,15 +1121,63 @@ async def submit_review(req: Request, session_id: str):
             status_code=303,
         )
 
-    # Trigger integrated review: assemble draft, call Phase 2 upload
+    # Trigger integrated review: assemble draft, call Phase 2 upload.
+    #
+    # #852 E3: the old read-then-act check (``if session.integrated_draft_id
+    # is not None`` on a snapshot fetched above) let two concurrent POSTs
+    # both see NULL and both run ``_trigger_integrated_review`` — duplicate
+    # draft rows, named graphs, and parse jobs. The claim is now atomic:
+    # a per-session advisory transaction lock serialises submitters, the
+    # winner re-checks ``integrated_draft_id`` under the lock and claims it
+    # with a conditional UPDATE (``... WHERE integrated_draft_id IS NULL``);
+    # losers block on the lock, then see the winner's value and idempotently
+    # render the existing state.
     if session.integrated_draft_id is not None:
-        # Already done — show the page
+        # Already done — show the page (idempotent fast path).
         return _step_6_page(session, auth)
 
     try:
-        draft_id = _trigger_integrated_review(session, auth)
         with _connect() as conn:
-            update_session(conn, session.id, integrated_draft_id=str(draft_id))
+            # Transaction-scoped advisory lock keyed on the session id;
+            # released automatically at COMMIT/ROLLBACK (including the
+            # implicit rollback when this block raises).
+            conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended('drafter-review:' || %s, 0))",
+                (str(session.id),),
+            )
+            row = conn.execute(
+                "SELECT integrated_draft_id FROM drafting_sessions WHERE id = %s",
+                (str(session.id),),
+            ).fetchone()
+            if row is None:
+                return _not_found_page(req)
+            if row[0] is not None:
+                # A concurrent POST won the claim while we waited on the
+                # lock — return the existing state instead of duplicating.
+                conn.commit()
+                session = fetch_session(parsed) or session
+                return _step_6_page(session, auth)
+
+            draft_id = _trigger_integrated_review(session, auth)
+            claimed = conn.execute(
+                """
+                UPDATE drafting_sessions
+                SET integrated_draft_id = %s, updated_at = now()
+                WHERE id = %s AND integrated_draft_id IS NULL
+                """,
+                (str(draft_id), str(session.id)),
+            )
+            if getattr(claimed, "rowcount", 1) == 0:
+                # Defence in depth: unreachable while every writer goes
+                # through this route (the advisory lock serialises them).
+                # An out-of-band writer would orphan the draft we just
+                # created — log loudly so the operator can clean it up.
+                logger.error(
+                    "submit_review: lost integrated-review claim race for "
+                    "session %s despite advisory lock; orphaned draft %s",
+                    session.id,
+                    draft_id,
+                )
             conn.commit()
     except Exception:
         logger.exception("Failed to trigger integrated review for session %s", session_id)
@@ -1172,21 +1220,45 @@ def _trigger_integrated_review(session: DraftingSession, auth: UserDict) -> uuid
     structure = session.proposed_structure or {}
     title = structure.get("title", session.intent or "Eelnõu")
 
-    # Build .docx
-    docx_path = build_drafter_docx(
-        session_id=str(session.id),
-        title=title,
-        workflow_type=session.workflow_type,
-        structure=structure,
-        clauses=clauses,
+    # Build .docx into a request-scoped 0600 temp file (#852, residual of
+    # #845/#867): the default ``build_drafter_docx`` output path is
+    # ``EXPORT_DIR/drafter-<session_id>.docx``, which left the politically
+    # sensitive plaintext draft on disk forever with no deletion path.
+    # Only the Fernet-encrypted copy written by ``store_file`` below may
+    # persist; the plaintext temp file is removed in the ``finally``.
+    import tempfile
+    from pathlib import Path as _Path
+
+    tmp_handle = tempfile.NamedTemporaryFile(
+        prefix=f"seadusloome-integreeritud-{session.id}-",
+        suffix=".docx",
+        delete=False,
     )
+    tmp_handle.close()
+    tmp_path = _Path(tmp_handle.name)
 
     # Create a draft row and enqueue parse_draft via Phase 2 infrastructure
     from app.docs.draft_model import create_draft
     from app.storage import store_file
 
-    # Read the docx and store it encrypted
-    docx_bytes = docx_path.read_bytes()
+    try:
+        docx_path = build_drafter_docx(
+            session_id=str(session.id),
+            title=title,
+            workflow_type=session.workflow_type,
+            structure=structure,
+            clauses=clauses,
+            out_path=tmp_path,
+        )
+        # Read the docx and store it encrypted
+        docx_bytes = docx_path.read_bytes()
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning(
+                "Failed to remove temp integrated-review docx %s", tmp_path, exc_info=True
+            )
     stored = store_file(
         docx_bytes,
         filename=f"drafter-{session.id}.docx",

--- a/app/jobs/queue.py
+++ b/app/jobs/queue.py
@@ -25,6 +25,18 @@ the worker no longer parks failed jobs there. Re-queued jobs go
 straight back to ``pending`` with a future ``scheduled_for``, so the
 ``claim_next`` SELECT (which only looks at ``status='pending'``)
 picks them up automatically once the backoff window passes (#441).
+
+Orphan recovery (#852 E1): ``claim_next`` only ever looks at
+``status='pending'``, so a worker that dies (crash, OOM, deploy
+SIGKILL) between claim and completion used to strand its row in
+``claimed``/``running`` forever. :meth:`JobQueue.reap_stale_jobs`
+implements a visibility timeout: rows stuck in ``claimed`` or
+``running`` past a threshold are treated as one lost attempt and fed
+through the SAME retry policy as :meth:`JobQueue.mark_failed` —
+re-pended while budget remains, flipped to ``failed`` once the budget
+is exhausted (including the domain-row consequence for draft-pipeline
+jobs). The worker loop runs a pass at startup and periodically; see
+``app/jobs/worker.py``.
 """
 
 from __future__ import annotations
@@ -40,6 +52,63 @@ from psycopg.types.json import Jsonb
 from app.db import get_connection
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Reaper policy (#852 E1)
+# ---------------------------------------------------------------------------
+#
+# Threshold rationale:
+#   * ``claimed`` → ``running`` is a single UPDATE issued immediately after
+#     the claim (see ``JobWorker._tick``), so a row sitting in ``claimed``
+#     for 10 minutes can only mean the worker died in between. 10 min is
+#     pure safety margin over the realistic worst case of milliseconds.
+#   * ``running`` jobs hold no DB lock while the handler executes, so age
+#     is the only stall signal. The threshold must exceed the LONGEST
+#     legitimate handler runtime or a slow-but-alive job gets double-run.
+#     Worst case today is ``drafter_draft`` (one LLM call per section;
+#     a VTK/full-law structure can mean tens of sequential calls), which
+#     can legitimately run for many minutes — 30 min clears it with room
+#     while still bounding the stuck-pipeline window to one reaper pass.
+# Both are overridable via env (``JOB_REAPER_CLAIMED_TIMEOUT_S`` /
+# ``JOB_REAPER_RUNNING_TIMEOUT_S``, read in ``app/jobs/worker.py``) so an
+# operator can tighten or relax them without a release.
+DEFAULT_REAPER_CLAIMED_TIMEOUT_S = 600
+DEFAULT_REAPER_RUNNING_TIMEOUT_S = 1800
+
+# Upper bound per reaper pass — keeps a pathological backlog from turning
+# one pass into a long transaction. The next pass picks up the remainder.
+_REAP_BATCH_LIMIT = 100
+
+# Draft statuses the reaper may flip to ``failed`` when a draft-pipeline
+# job loses its retry budget. Terminal states (``ready``/``failed``) are
+# never touched — e.g. an orphaned ``export_report`` job must not fail a
+# draft that already finished analysis.
+_REAPABLE_DRAFT_STATUSES = frozenset({"uploaded", "parsing", "extracting", "analyzing"})
+
+# ``background_jobs.error_message`` surfaces in the admin job monitor and
+# in the drafter step-status alert, so the strings are Estonian.
+_REAPED_RETRY_MSG_ET = (
+    "Töötlus katkes ootamatult (tööprotsess seiskus); "
+    "töö pandi automaatselt uuesti järjekorda (katse {attempts}/{max_attempts})."
+)
+_REAPED_EXHAUSTED_MSG_ET = (
+    "Töötlus katkes ootamatult ja katsete limiit on ammendatud ({attempts}/{max_attempts})."
+)
+_REAPED_DRAFT_MSG_ET = (
+    "Töötlemine katkes ootamatult (näiteks süsteemi taaskäivituse tõttu). Palun proovige uuesti."
+)
+
+
+@dataclass
+class ReapStats:
+    """Outcome counts of one :meth:`JobQueue.reap_stale_jobs` pass."""
+
+    recovered: int = 0
+    """Orphaned jobs re-pended for another attempt."""
+
+    exhausted: int = 0
+    """Orphaned jobs whose retry budget ran out — flipped to ``failed``."""
 
 
 @dataclass
@@ -333,6 +402,147 @@ class JobQueue:
                 )
             conn.commit()
 
+    # -- orphan recovery (#852 E1) -------------------------------------------
+
+    def reap_stale_jobs(
+        self,
+        *,
+        claimed_timeout_s: int = DEFAULT_REAPER_CLAIMED_TIMEOUT_S,
+        running_timeout_s: int = DEFAULT_REAPER_RUNNING_TIMEOUT_S,
+    ) -> ReapStats:
+        """Recover ``claimed``/``running`` rows orphaned by a dead worker.
+
+        A worker killed mid-job (crash, OOM, deploy SIGKILL) leaves its row
+        in ``claimed`` or ``running``; ``claim_next`` only selects
+        ``pending`` so the row would otherwise be stuck forever. Each stale
+        row counts as ONE lost attempt and follows the same retry policy as
+        :meth:`mark_failed`:
+
+        * budget remaining → back to ``pending`` with ``scheduled_for=now``
+          (no backoff — the failure was not the job's fault, so the retry
+          runs as soon as a worker is free),
+        * budget exhausted → ``failed``, plus the domain-row consequence
+          for draft-pipeline jobs (the draft is flipped to ``failed`` so
+          the user sees the error and the retry button instead of a
+          pipeline stuck in ``extracting``/``analyzing``).
+
+        Bounded (``LIMIT {batch}``) and concurrency-safe: the candidate
+        SELECT uses ``FOR UPDATE SKIP LOCKED`` so multiple reapers (web
+        replicas + standalone worker) never double-process a row.
+
+        Returns:
+            :class:`ReapStats` with recovered/exhausted counts so callers
+            can log and meter the pass.
+        """
+        now = datetime.now(UTC)
+        claimed_cutoff = now - timedelta(seconds=claimed_timeout_s)
+        running_cutoff = now - timedelta(seconds=running_timeout_s)
+        stats = ReapStats()
+        # (job_id, job_type, payload) of permanently-failed jobs; domain
+        # finalisation runs AFTER the queue transaction commits so a
+        # domain-side error cannot roll back the queue bookkeeping.
+        exhausted_jobs: list[tuple[int, str, dict[str, Any]]] = []
+
+        with get_connection() as conn:
+            # COALESCE keeps the predicate total even if an operator
+            # hand-edited a row and nulled the timestamps — such rows age
+            # out via created_at instead of being stranded forever.
+            rows = conn.execute(
+                """
+                SELECT id, job_type, payload, status, attempts, max_attempts, claimed_by
+                FROM background_jobs
+                WHERE (status = 'claimed' AND COALESCE(claimed_at, created_at) < %s)
+                   OR (status = 'running'
+                       AND COALESCE(started_at, claimed_at, created_at) < %s)
+                ORDER BY id
+                LIMIT %s
+                FOR UPDATE SKIP LOCKED
+                """,
+                (claimed_cutoff, running_cutoff, _REAP_BATCH_LIMIT),
+            ).fetchall()
+
+            for row in rows:
+                job_id, job_type, payload, status, attempts, max_attempts, claimed_by = row
+                next_attempts = int(attempts or 0) + 1
+                budget = int(max_attempts or 1)
+
+                if next_attempts < budget:
+                    conn.execute(
+                        """
+                        UPDATE background_jobs
+                        SET status = 'pending',
+                            attempts = %s,
+                            error_message = %s,
+                            scheduled_for = %s,
+                            claimed_by = NULL,
+                            claimed_at = NULL,
+                            started_at = NULL
+                        WHERE id = %s
+                        """,
+                        (
+                            next_attempts,
+                            _REAPED_RETRY_MSG_ET.format(
+                                attempts=next_attempts, max_attempts=budget
+                            ),
+                            now,
+                            job_id,
+                        ),
+                    )
+                    stats.recovered += 1
+                    logger.warning(
+                        "Reaper: recovered orphaned job id=%s type=%s status=%s "
+                        "worker=%s — re-pended (attempt %d/%d)",
+                        job_id,
+                        job_type,
+                        status,
+                        claimed_by,
+                        next_attempts,
+                        budget,
+                    )
+                else:
+                    conn.execute(
+                        """
+                        UPDATE background_jobs
+                        SET status = 'failed',
+                            attempts = %s,
+                            error_message = %s,
+                            finished_at = %s
+                        WHERE id = %s
+                        """,
+                        (
+                            next_attempts,
+                            _REAPED_EXHAUSTED_MSG_ET.format(
+                                attempts=next_attempts, max_attempts=budget
+                            ),
+                            now,
+                            job_id,
+                        ),
+                    )
+                    stats.exhausted += 1
+                    logger.error(
+                        "Reaper: orphaned job id=%s type=%s status=%s worker=%s "
+                        "exhausted its retry budget (%d/%d) — marked failed",
+                        job_id,
+                        job_type,
+                        status,
+                        claimed_by,
+                        next_attempts,
+                        budget,
+                    )
+                    exhausted_jobs.append((int(job_id), str(job_type), _parse_json(payload) or {}))
+            conn.commit()
+
+        for job_id, job_type, payload in exhausted_jobs:
+            _finalize_draft_for_lost_job(job_id, job_type, payload)
+
+        if stats.recovered or stats.exhausted:
+            logger.info(
+                "Reaper pass complete: recovered=%d exhausted=%d",
+                stats.recovered,
+                stats.exhausted,
+            )
+        return stats
+
     # -- query helpers ------------------------------------------------------
 
     def get(self, job_id: int) -> Job | None:
@@ -361,3 +571,90 @@ class JobQueue:
                 (status, limit),
             ).fetchall()
         return [_row_to_job(row) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Reaper domain finalisation (#852 E1)
+# ---------------------------------------------------------------------------
+
+
+def _finalize_draft_for_lost_job(job_id: int, job_type: str, payload: dict[str, Any]) -> None:
+    """Apply the domain-row consequence when the reaper permanently fails a job.
+
+    Handlers normally flip their domain row to ``failed`` on the final
+    attempt (#448), but a reaped job never got to run its final attempt —
+    without this hook the draft would sit in ``parsing``/``extracting``/
+    ``analyzing`` forever with no retry button.
+
+    Only draft-pipeline jobs (payloads carrying ``draft_id``) need this:
+    the drafter wizard reads the JOB row's status/error directly (see
+    ``step_status_fragment``), so ``session_id`` payloads already surface
+    the failure without touching the session row (abandoning a session for
+    an infrastructure failure would destroy user work).
+
+    Best-effort by design — every error is logged and swallowed so a
+    domain-side hiccup never breaks the reaper pass. The imports are local
+    to avoid an ``app.jobs`` → ``app.docs`` import cycle at module load
+    (``app.docs`` handlers import ``app.jobs.worker`` for registration).
+    """
+    draft_id = (payload or {}).get("draft_id")
+    if not draft_id:
+        return
+
+    try:
+        from app.docs.status import update_draft_status
+
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT status FROM drafts WHERE id = %s",
+                (str(draft_id),),
+            ).fetchone()
+            if row is None:
+                return
+            current = str(row[0])
+            if current not in _REAPABLE_DRAFT_STATUSES:
+                return
+            # ``expected_status`` guards against a concurrent transition
+            # between our SELECT and the UPDATE.
+            update_draft_status(
+                conn,
+                draft_id,
+                "failed",
+                _REAPED_DRAFT_MSG_ET,
+                error_debug=(
+                    f"Reaper: background job id={job_id} type={job_type} was orphaned "
+                    f"(worker lost) and its retry budget is exhausted"
+                ),
+                expected_status=current,
+            )
+            conn.commit()
+        logger.warning(
+            "Reaper: marked draft %s failed after orphaned job id=%s type=%s "
+            "exhausted its retry budget",
+            draft_id,
+            job_id,
+            job_type,
+        )
+    except Exception:  # noqa: BLE001 — domain flip must never break the reaper
+        logger.exception(
+            "Reaper: failed to mark draft %s failed for lost job id=%s",
+            draft_id,
+            job_id,
+        )
+        return
+
+    # Push the failure to WS subscribers so an open draft page updates
+    # without a manual refresh (#608 pattern). Best-effort.
+    try:
+        from uuid import UUID
+
+        from app.docs.status_events import emit_threadsafe
+
+        emit_threadsafe(
+            UUID(str(draft_id)),
+            type="status",
+            status="failed",
+            error_message=_REAPED_DRAFT_MSG_ET,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("Reaper: WS status emit failed for draft %s", draft_id, exc_info=True)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -40,6 +40,7 @@ There are no stubs left in this module.
 from __future__ import annotations
 
 import logging
+import os
 import socket
 import threading
 import time
@@ -48,10 +49,35 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
-from app.jobs.queue import JobQueue
+from app.jobs.queue import (
+    DEFAULT_REAPER_CLAIMED_TIMEOUT_S,
+    DEFAULT_REAPER_RUNNING_TIMEOUT_S,
+    JobQueue,
+)
 from app.metrics import record_metric
 
 logger = logging.getLogger(__name__)
+
+# How often the worker loop runs an orphan-recovery pass (#852 E1).
+# Cheap (one indexed SELECT when nothing is stale), so once a minute keeps
+# the stuck-job window small without measurable load.
+DEFAULT_REAP_INTERVAL_S = 60.0
+
+
+def _env_seconds(name: str, default: float) -> float:
+    """Read a positive seconds value from the environment, else *default*."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s=%r; using %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Ignoring non-positive %s=%r; using %s", name, raw, default)
+        return default
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -108,11 +134,35 @@ class JobWorker:
             same box do not collide.
         poll_interval: Seconds to sleep when the queue is empty. Kept low
             (2s) because ``stop_event.wait`` wakes immediately on shutdown.
+        reap_interval: Seconds between orphan-recovery passes (#852 E1).
+            The FIRST pass runs immediately on startup so jobs orphaned by
+            the previous process (deploy kill, crash) are recovered before
+            any new work is claimed. ``None`` reads
+            ``JOB_REAPER_INTERVAL_S`` from the environment (default 60s).
     """
 
-    def __init__(self, worker_id: str | None = None, poll_interval: float = 2.0) -> None:
+    def __init__(
+        self,
+        worker_id: str | None = None,
+        poll_interval: float = 2.0,
+        reap_interval: float | None = None,
+    ) -> None:
         self.worker_id = worker_id or _default_worker_id()
         self.poll_interval = poll_interval
+        self.reap_interval = (
+            reap_interval
+            if reap_interval is not None
+            else _env_seconds("JOB_REAPER_INTERVAL_S", DEFAULT_REAP_INTERVAL_S)
+        )
+        self.claimed_timeout_s = int(
+            _env_seconds("JOB_REAPER_CLAIMED_TIMEOUT_S", DEFAULT_REAPER_CLAIMED_TIMEOUT_S)
+        )
+        self.running_timeout_s = int(
+            _env_seconds("JOB_REAPER_RUNNING_TIMEOUT_S", DEFAULT_REAPER_RUNNING_TIMEOUT_S)
+        )
+        # Monotonic deadline of the next reaper pass. 0.0 means "reap on
+        # the first loop iteration" — that IS the startup recovery pass.
+        self._next_reap_at = 0.0
 
     def run_forever(self, stop_event: threading.Event) -> None:
         """Main loop. Runs until *stop_event* is set.
@@ -124,10 +174,14 @@ class JobWorker:
         propagate out of the loop.
         """
         logger.info(
-            "JobWorker %s starting (poll_interval=%ss)", self.worker_id, self.poll_interval
+            "JobWorker %s starting (poll_interval=%ss reap_interval=%ss)",
+            self.worker_id,
+            self.poll_interval,
+            self.reap_interval,
         )
         while not stop_event.is_set():
             try:
+                self._maybe_reap()
                 self._tick(stop_event)
             except Exception:  # noqa: BLE001 — top-level guard, must never die
                 logger.exception(
@@ -139,6 +193,38 @@ class JobWorker:
         logger.info("JobWorker %s stopped", self.worker_id)
 
     # -- internal -----------------------------------------------------------
+
+    def _maybe_reap(self) -> None:
+        """Run an orphan-recovery pass when the reap interval has elapsed.
+
+        The deadline advances BEFORE the pass so a failing reaper (DB
+        down, etc.) backs off to the next interval instead of hot-looping;
+        normal job dispatch continues regardless. Counts are logged inside
+        :meth:`JobQueue.reap_stale_jobs`; here they are also metered so the
+        admin dashboard can chart recovery volume.
+        """
+        now = time.monotonic()
+        if now < self._next_reap_at:
+            return
+        self._next_reap_at = now + self.reap_interval
+
+        try:
+            stats = JobQueue().reap_stale_jobs(
+                claimed_timeout_s=self.claimed_timeout_s,
+                running_timeout_s=self.running_timeout_s,
+            )
+        except Exception:  # noqa: BLE001 — reaper failures must not stop dispatch
+            logger.exception("JobWorker %s: reaper pass failed", self.worker_id)
+            return
+
+        recovered = getattr(stats, "recovered", 0)
+        exhausted = getattr(stats, "exhausted", 0)
+        # isinstance guards keep the metric write type-safe even when a
+        # test substitutes JobQueue with a mock.
+        if isinstance(recovered, int) and recovered > 0:
+            record_metric("jobs_reaped", float(recovered), {"outcome": "recovered"})
+        if isinstance(exhausted, int) and exhausted > 0:
+            record_metric("jobs_reaped", float(exhausted), {"outcome": "exhausted"})
 
     def _tick(self, stop_event: threading.Event) -> None:
         """Claim at most one job and dispatch it. May sleep if idle."""

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,6 +55,15 @@ services:
         condition: service_healthy
       tika:
         condition: service_healthy
+    # #852: the lifespan shutdown joins worker + scheduler threads against a
+    # shared 30s deadline (app/main.py); Docker's default SIGTERM grace is
+    # 10s, which SIGKILLed mid-job workers on every deploy and orphaned
+    # claimed/running rows. 35s = 30s join budget + margin. Production
+    # (Coolify) does not read this file — set the equivalent stop-grace
+    # there too (Coolify UI: application "Advanced" → custom docker options
+    # `--stop-timeout 35`, or the docker-compose `stop_grace_period` field
+    # for compose-based apps).
+    stop_grace_period: 35s
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------

--- a/tests/test_admin_job_retry_budget.py
+++ b/tests/test_admin_job_retry_budget.py
@@ -1,0 +1,78 @@
+"""#852 — admin job retry must respect the retry budget + confirm.
+
+``_retry_job`` used to reset ``attempts = 0``, which made a poison job
+retryable forever (each admin click restored the FULL ``max_attempts``
+budget). The attempt counter is now preserved: a failed job already has
+``attempts >= max_attempts``, so one click grants exactly one extra
+attempt and the climbing counter doubles as the audit trail. The retry
+button also gets an ``hx-confirm`` like the adjacent purge button.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestRetryPreservesBudget:
+    @patch("app.admin.job_monitor._connect")
+    def test_retry_does_not_reset_attempts(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _retry_job
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.rowcount = 1
+
+        assert _retry_job(42) is True
+
+        sql = mock_conn.execute.call_args[0][0]
+        # The poison-job hole: resetting attempts restored the whole
+        # budget on every click. The counter must be left alone.
+        assert "attempts" not in sql, f"retry must not touch attempts: {sql}"
+        # The rest of the reset contract is unchanged.
+        assert "SET status = 'pending'" in sql
+        assert "error_message = NULL" in sql
+        assert "claimed_by = NULL" in sql
+        assert "WHERE id = %s AND status = 'failed'" in sql
+
+    @patch("app.admin.job_monitor._connect")
+    def test_retry_only_targets_failed_jobs(self, mock_connect: MagicMock):
+        from app.admin.job_monitor import _retry_job
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.rowcount = 0
+
+        assert _retry_job(999) is False
+
+
+class TestRetryButtonConfirm:
+    def _render_jobs_table(self) -> str:
+        from fasthtml.common import to_xml
+
+        from app.admin.job_monitor import _jobs_table
+
+        job = {
+            "id": 42,
+            "job_type": "drafter_draft",
+            "status": "failed",
+            "error_message": "boom",
+            "attempts": 3,
+            "max_attempts": 3,
+            "finished_at": None,
+        }
+        return to_xml(_jobs_table([job], "failed"))
+
+    def test_retry_button_has_confirm_dialog(self):
+        html = self._render_jobs_table()
+        assert "/admin/jobs/42/retry" in html
+        # The retry button must carry a confirm like the purge button —
+        # it is a state-mutating action on a permanently-failed job.
+        assert "hx-confirm" in html
+        assert "Kas olete kindel?" in html
+
+    def test_attempt_counter_is_displayed(self):
+        """The preserved counter is the admin-facing audit trail."""
+        html = self._render_jobs_table()
+        assert "3/3" in html

--- a/tests/test_docs_precondition_gating.py
+++ b/tests/test_docs_precondition_gating.py
@@ -1,0 +1,222 @@
+"""#852 E6 — pipeline preconditions are inside the retry-gated region.
+
+``extract_entities`` and ``analyze_impact`` used to run their
+draft-load/decrypt/empty-text preconditions BEFORE the retry-gated
+``try``, so a ``DecryptionError`` (or a DB hiccup during the load)
+never flipped the draft to ``failed`` even on the final attempt — the
+draft sat in ``extracting``/``analyzing`` forever with no retry button.
+
+These tests prove precondition failures now consume the retry budget
+like any other handler error and mark the draft ``failed`` on the last
+attempt (which is exactly the state the ``POST /drafts/{id}/retry``
+button requires — see ``app.docs.retry_handler``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.docs.draft_model import Draft
+from app.storage import DecryptionError
+
+_DRAFT_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_FAKE_CIPHERTEXT = b"gAAAA_fake_ciphertext_bytes_for_tests"
+
+
+def _make_draft(
+    *,
+    parsed_text_encrypted: bytes | None = _FAKE_CIPHERTEXT,
+    status: str = "uploaded",
+) -> Draft:
+    now = datetime.now(UTC)
+    return Draft(
+        id=_DRAFT_ID,
+        user_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        org_id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        title="Test eelnõu",
+        filename="eelnou.docx",
+        content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        file_size=1024,
+        storage_path="/tmp/ciphertext.enc",
+        graph_uri="https://data.riik.ee/ontology/estleg/drafts/test",
+        status=status,
+        parsed_text_encrypted=parsed_text_encrypted,
+        entity_count=None,
+        error_message=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class _ConnectCM:
+    def __init__(self, conn: MagicMock):
+        self.conn = conn
+
+    def __enter__(self) -> MagicMock:
+        return self.conn
+
+    def __exit__(self, *_: Any) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# extract_entities
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPreconditionGating:
+    def _run(self, *, attempt: int, max_attempts: int = 3):
+        from app.docs.extract_handler import extract_entities
+
+        return extract_entities(
+            {"draft_id": str(_DRAFT_ID)}, attempt=attempt, max_attempts=max_attempts
+        )
+
+    def test_decrypt_failure_final_attempt_marks_draft_failed(self):
+        """The headline E6 case: DecryptionError → draft failed, retryable."""
+        draft = _make_draft()
+        with (
+            patch("app.docs.extract_handler.get_connection") as mock_get_conn,
+            patch("app.docs.extract_handler.get_draft", return_value=draft),
+            patch(
+                "app.docs.extract_handler.decrypt_text",
+                side_effect=DecryptionError("bad key"),
+            ),
+            patch("app.docs.extract_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.return_value = _ConnectCM(MagicMock())
+
+            with pytest.raises(DecryptionError):
+                self._run(attempt=3, max_attempts=3)
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args
+        assert args.args[2] == "failed"
+        # The user-facing message column is populated (retry button needs
+        # a failed status; the message tells the user what to do).
+        assert args.args[3]
+
+    def test_decrypt_failure_earlier_attempt_does_not_flip(self):
+        """#448 gating still holds: budget remaining → no failed flip."""
+        draft = _make_draft()
+        with (
+            patch("app.docs.extract_handler.get_connection") as mock_get_conn,
+            patch("app.docs.extract_handler.get_draft", return_value=draft),
+            patch(
+                "app.docs.extract_handler.decrypt_text",
+                side_effect=DecryptionError("bad key"),
+            ),
+            patch("app.docs.extract_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.return_value = _ConnectCM(MagicMock())
+
+            with pytest.raises(DecryptionError):
+                self._run(attempt=1, max_attempts=3)
+
+        mock_update.assert_not_called()
+
+    def test_missing_parsed_text_final_attempt_marks_draft_failed(self):
+        draft = _make_draft(parsed_text_encrypted=None)
+        with (
+            patch("app.docs.extract_handler.get_connection") as mock_get_conn,
+            patch("app.docs.extract_handler.get_draft", return_value=draft),
+            patch("app.docs.extract_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.return_value = _ConnectCM(MagicMock())
+
+            with pytest.raises(ValueError, match="no parsed text"):
+                self._run(attempt=3, max_attempts=3)
+
+        mock_update.assert_called_once()
+        assert mock_update.call_args.args[2] == "failed"
+
+    def test_missing_draft_final_attempt_raises_without_exploding(self):
+        """No draft row → the failure UPDATE matches zero rows; the
+        handler still raises so the JOB is marked failed."""
+        with (
+            patch("app.docs.extract_handler.get_connection") as mock_get_conn,
+            patch("app.docs.extract_handler.get_draft", return_value=None),
+            patch("app.docs.extract_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.return_value = _ConnectCM(MagicMock())
+
+            with pytest.raises(ValueError, match="not found"):
+                self._run(attempt=3, max_attempts=3)
+
+        # Best-effort flip attempted (harmless zero-row UPDATE).
+        mock_update.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# analyze_impact
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzePreconditionGating:
+    def _run(self, *, attempt: int, max_attempts: int = 3):
+        from app.docs.analyze_handler import analyze_impact
+
+        return analyze_impact(
+            {"draft_id": str(_DRAFT_ID)}, attempt=attempt, max_attempts=max_attempts
+        )
+
+    def test_load_failure_final_attempt_marks_draft_failed(self):
+        """A DB error during the draft/entity load (pre-#852 it ran
+        before the gated try) must flip the draft on the final attempt."""
+        draft = _make_draft(status="analyzing")
+        load_conn = MagicMock()
+        load_conn.execute.side_effect = RuntimeError("db hiccup during load")
+        fail_conn = MagicMock()
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.side_effect = [
+                _ConnectCM(load_conn),
+                _ConnectCM(fail_conn),  # opened by _mark_draft_failed
+            ]
+
+            with pytest.raises(RuntimeError, match="db hiccup"):
+                self._run(attempt=3, max_attempts=3)
+
+        mock_update.assert_called_once()
+        assert mock_update.call_args.args[2] == "failed"
+
+    def test_load_failure_earlier_attempt_does_not_flip(self):
+        draft = _make_draft(status="analyzing")
+        load_conn = MagicMock()
+        load_conn.execute.side_effect = RuntimeError("db hiccup during load")
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.side_effect = [_ConnectCM(load_conn)]
+
+            with pytest.raises(RuntimeError, match="db hiccup"):
+                self._run(attempt=1, max_attempts=3)
+
+        mock_update.assert_not_called()
+
+    def test_missing_draft_final_attempt_marks_failed_best_effort(self):
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=None),
+            patch("app.docs.analyze_handler.update_draft_status") as mock_update,
+        ):
+            mock_get_conn.return_value = _ConnectCM(MagicMock())
+
+            with pytest.raises(ValueError, match="not found"):
+                self._run(attempt=3, max_attempts=3)
+
+        # Zero-row UPDATE — harmless, but the attempt is made so a
+        # still-existing row can never be left stuck.
+        mock_update.assert_called_once()

--- a/tests/test_drafter_llm_output_validation.py
+++ b/tests/test_drafter_llm_output_validation.py
@@ -494,3 +494,174 @@ class TestRegenerateParseFailure:
             drafter_regenerate_clause({"session_id": str(_SESSION_ID), "clause_index": 0})
 
         mock_update.assert_not_called()
+
+
+class TestRegenerateNonblankContract:
+    """#852 review F2 — a blank regeneration must never overwrite a good
+    clause. ``{"text": ""}`` passes the parse check (no ``error`` key)
+    but used to land via ``result.get("text", ...)`` — the key IS
+    present, so the blank value replaced the existing text and the job
+    "succeeded"."""
+
+    _OLD_TEXT = "Vana kehtiv tekst."
+
+    def _drive(
+        self,
+        payload: dict[str, Any],
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_conn: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure=_STRUCTURE,
+            draft_content_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps(
+            {
+                "clauses": [
+                    {
+                        "chapter": "1",
+                        "paragraph": "§ 1",
+                        "title": "Reguleerimisala",
+                        "text": self._OLD_TEXT,
+                        "citations": [],
+                        "notes": "",
+                    }
+                ]
+            }
+        )
+        mock_get_provider.return_value = _provider(payload)
+        _wire_conn(mock_conn)
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_blank_text_fails_and_leaves_clause_untouched(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        self._drive(
+            {"text": "", "citations": [], "notes": ""},
+            mock_fetch,
+            mock_decrypt,
+            mock_get_provider,
+            mock_conn,
+        )
+
+        from app.drafter.handlers import drafter_regenerate_clause
+
+        with pytest.raises(RuntimeError, match="no clause text"):
+            drafter_regenerate_clause({"session_id": str(_SESSION_ID), "clause_index": 0})
+
+        # Nothing re-encrypted, nothing persisted — the good clause
+        # survives for the retry.
+        mock_encrypt.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_whitespace_only_text_fails_too(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        self._drive(
+            {"text": " \n\t ", "citations": [], "notes": ""},
+            mock_fetch,
+            mock_decrypt,
+            mock_get_provider,
+            mock_conn,
+        )
+
+        from app.drafter.handlers import drafter_regenerate_clause
+
+        with pytest.raises(RuntimeError, match="no clause text"):
+            drafter_regenerate_clause({"session_id": str(_SESSION_ID), "clause_index": 0})
+
+        mock_encrypt.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_valid_regeneration_still_applies(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        self._drive(
+            {"text": "Uus parem tekst.", "citations": [], "notes": ""},
+            mock_fetch,
+            mock_decrypt,
+            mock_get_provider,
+            mock_conn,
+        )
+        mock_encrypt.return_value = b"encrypted-clauses"
+
+        from app.drafter.handlers import drafter_regenerate_clause
+
+        result = drafter_regenerate_clause({"session_id": str(_SESSION_ID), "clause_index": 0})
+
+        assert result["clause_index"] == 0
+        # The persisted clause list carries the NEW text.
+        persisted = json.loads(mock_encrypt.call_args.args[0])
+        assert persisted["clauses"][0]["text"] == "Uus parem tekst."
+        mock_update.assert_called_once()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_stub_payload_keeps_existing_text(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        """Keyless local dev: stub regen succeeds without clobbering."""
+        self._drive(
+            {"stub": True, "prompt": "..."},
+            mock_fetch,
+            mock_decrypt,
+            mock_get_provider,
+            mock_conn,
+        )
+        mock_encrypt.return_value = b"encrypted-clauses"
+
+        from app.drafter.handlers import drafter_regenerate_clause
+
+        result = drafter_regenerate_clause({"session_id": str(_SESSION_ID), "clause_index": 0})
+
+        assert result["clause_index"] == 0
+        persisted = json.loads(mock_encrypt.call_args.args[0])
+        assert persisted["clauses"][0]["text"] == self._OLD_TEXT

--- a/tests/test_drafter_llm_output_validation.py
+++ b/tests/test_drafter_llm_output_validation.py
@@ -1,0 +1,496 @@
+# pyright: reportOptionalSubscript=false
+"""#852 E2 — drafter handlers must FAIL on unusable LLM output.
+
+The provider's ``extract_json`` returns ``{"error": ...}`` instead of
+raising when the model's reply is not parseable JSON. These tests prove
+the handlers treat that marker — and missing required fields such as
+clause text — as a job failure that engages the retry budget and the
+abandon-on-final-attempt gating, instead of persisting blank output that
+the state machine would wave into review.
+
+Mocking mirrors ``tests/test_drafter_handlers.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.drafter.handlers import LLMOutputError, _require_llm_json
+from app.drafter.session_model import DraftingSession
+
+_SESSION_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_USER_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_ORG_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+
+_STRUCTURE = {
+    "title": "Test seadus",
+    "chapters": [
+        {
+            "number": "1",
+            "title": "Üldsätted",
+            "sections": [{"paragraph": "§ 1", "title": "Reguleerimisala"}],
+        }
+    ],
+}
+
+
+def _make_session(**overrides: Any) -> DraftingSession:
+    now = datetime.now(UTC)
+    fields: dict[str, Any] = dict(
+        id=_SESSION_ID,
+        user_id=_USER_ID,
+        org_id=_ORG_ID,
+        workflow_type="full_law",
+        current_step=2,
+        intent="Soovin luua tehisintellekti seaduse",
+        clarifications=[],
+        research_data_encrypted=None,
+        proposed_structure=None,
+        draft_content_encrypted=None,
+        integrated_draft_id=None,
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+    fields.update(overrides)
+    return DraftingSession(**fields)
+
+
+def _provider(payload: dict[str, Any]) -> MagicMock:
+    provider = MagicMock()
+    provider.extract_json.return_value = payload
+    return provider
+
+
+def _wire_conn(mock_conn: MagicMock) -> None:
+    ctx = MagicMock()
+    mock_conn.return_value.__enter__ = MagicMock(return_value=ctx)
+    mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+
+# ---------------------------------------------------------------------------
+# _require_llm_json contract
+# ---------------------------------------------------------------------------
+
+
+class TestRequireLlmJson:
+    def test_error_marker_raises(self):
+        with pytest.raises(LLMOutputError, match="could not be parsed"):
+            _require_llm_json({"error": "failed to parse"}, context="x")
+
+    def test_non_dict_raises(self):
+        with pytest.raises(LLMOutputError, match="non-dict"):
+            _require_llm_json(["not", "a", "dict"], context="x")
+
+    def test_stub_payload_passes(self):
+        payload = {"stub": True, "prompt": "..."}
+        assert _require_llm_json(payload, context="x") is payload
+
+    def test_valid_payload_passes(self):
+        payload = {"text": "Sisu."}
+        assert _require_llm_json(payload, context="x") is payload
+
+    def test_is_runtime_error_subclass(self):
+        """Existing except/re-wrap paths catch RuntimeError."""
+        assert issubclass(LLMOutputError, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# drafter_clarify
+# ---------------------------------------------------------------------------
+
+
+class TestClarifyParseFailure:
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.abandon_session")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_error_payload_raises_and_never_persists(
+        self,
+        mock_fetch: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_abandon: MagicMock,
+        mock_conn: MagicMock,
+    ):
+        mock_fetch.return_value = _make_session()
+        mock_sparql_cls.return_value = MagicMock(query=MagicMock(return_value=[]))
+        mock_get_provider.return_value = _provider({"error": "failed to parse"})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_clarify
+
+        with pytest.raises(LLMOutputError):
+            drafter_clarify({"session_id": str(_SESSION_ID)}, attempt=1, max_attempts=3)
+
+        mock_update.assert_not_called()
+        # Attempt 1 of 3: retry budget remains, no abandon yet.
+        mock_abandon.assert_not_called()
+
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.abandon_session")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_error_payload_final_attempt_abandons(
+        self,
+        mock_fetch: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_abandon: MagicMock,
+        mock_conn: MagicMock,
+    ):
+        mock_fetch.return_value = _make_session()
+        mock_sparql_cls.return_value = MagicMock(query=MagicMock(return_value=[]))
+        mock_get_provider.return_value = _provider({"error": "failed to parse"})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_clarify
+
+        with pytest.raises(LLMOutputError):
+            drafter_clarify({"session_id": str(_SESSION_ID)}, attempt=3, max_attempts=3)
+
+        mock_update.assert_not_called()
+        mock_abandon.assert_called_once()
+
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.abandon_session")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_persist_failure_is_gated_too(
+        self,
+        mock_fetch: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_abandon: MagicMock,
+        mock_conn: MagicMock,
+    ):
+        """Post-LLM persistence now sits inside the gated region: a DB
+        write failure on the final attempt abandons the session instead
+        of bypassing the gate (the pre-#852 behaviour)."""
+        mock_fetch.return_value = _make_session()
+        mock_sparql_cls.return_value = MagicMock(query=MagicMock(return_value=[]))
+        mock_get_provider.return_value = _provider(
+            {"questions": [{"question": "K?", "rationale": "r"}]}
+        )
+        _wire_conn(mock_conn)
+        mock_update.side_effect = RuntimeError("db write failed")
+
+        from app.drafter.handlers import drafter_clarify
+
+        with pytest.raises(RuntimeError, match="db write failed"):
+            drafter_clarify({"session_id": str(_SESSION_ID)}, attempt=3, max_attempts=3)
+
+        mock_abandon.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# drafter_structure
+# ---------------------------------------------------------------------------
+
+
+class TestStructureParseFailure:
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.abandon_session")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_error_payload_raises_instead_of_fallback_structure(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_abandon: MagicMock,
+        mock_conn: MagicMock,
+    ):
+        """A parse failure must NOT be laundered into the fallback
+        skeleton structure — it raises and consumes a retry."""
+        mock_fetch.return_value = _make_session(
+            current_step=4, research_data_encrypted=b"encrypted"
+        )
+        mock_decrypt.return_value = json.dumps({"provisions": []})
+        mock_sparql_cls.return_value = MagicMock(query=MagicMock(return_value=[]))
+        mock_get_provider.return_value = _provider({"error": "failed to parse"})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_structure
+
+        with pytest.raises(LLMOutputError):
+            drafter_structure({"session_id": str(_SESSION_ID)}, attempt=3, max_attempts=3)
+
+        mock_update.assert_not_called()
+        mock_abandon.assert_called_once()
+
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.SparqlClient")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_stub_payload_still_uses_fallback(
+        self,
+        mock_fetch: MagicMock,
+        mock_sparql_cls: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+    ):
+        """Stub mode (no API key) keeps working via the fallback skeleton."""
+        mock_fetch.return_value = _make_session(current_step=4)
+        mock_sparql_cls.return_value = MagicMock(query=MagicMock(return_value=[]))
+        mock_get_provider.return_value = _provider({"stub": True, "prompt": "..."})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_structure
+
+        result = drafter_structure({"session_id": str(_SESSION_ID)})
+
+        assert result["chapters"] == 2  # fallback skeleton
+        mock_update.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# drafter_draft
+# ---------------------------------------------------------------------------
+
+
+class TestDraftOutputValidation:
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.abandon_session")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_error_payload_fails_job_and_persists_nothing(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_abandon: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        """The exact E2 bug: ``{"error": ...}`` used to become a clause
+        with ``text=""`` and the job "succeeded"."""
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure=_STRUCTURE,
+            research_data_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps({"provisions": []})
+        mock_get_provider.return_value = _provider({"error": "failed to parse"})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_draft
+
+        with pytest.raises(RuntimeError, match="Clause drafting failed"):
+            drafter_draft({"session_id": str(_SESSION_ID)}, attempt=1, max_attempts=3)
+
+        # Nothing persisted, nothing encrypted — no blank clauses on disk.
+        mock_encrypt.assert_not_called()
+        mock_update.assert_not_called()
+        # Retry budget remains → not abandoned yet.
+        mock_abandon.assert_not_called()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.abandon_session")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_error_payload_final_attempt_abandons(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_abandon: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure=_STRUCTURE,
+            research_data_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps({"provisions": []})
+        mock_get_provider.return_value = _provider({"error": "failed to parse"})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_draft
+
+        with pytest.raises(RuntimeError, match="Clause drafting failed"):
+            drafter_draft({"session_id": str(_SESSION_ID)}, attempt=3, max_attempts=3)
+
+        mock_encrypt.assert_not_called()
+        mock_update.assert_not_called()
+        mock_abandon.assert_called_once()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_blank_clause_text_fails_job(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        """Valid JSON but no clause text — required-field validation."""
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure=_STRUCTURE,
+            research_data_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps({"provisions": []})
+        mock_get_provider.return_value = _provider({"text": "   ", "citations": [], "notes": ""})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_draft
+
+        with pytest.raises(RuntimeError, match="no clause text"):
+            drafter_draft({"session_id": str(_SESSION_ID)})
+
+        mock_encrypt.assert_not_called()
+        mock_update.assert_not_called()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_stub_payload_is_allowed_through(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        """Stub mode has no ``text`` field; the pipeline must still finish."""
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure=_STRUCTURE,
+            research_data_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps({"provisions": []})
+        mock_get_provider.return_value = _provider({"stub": True, "prompt": "..."})
+        mock_encrypt.return_value = b"encrypted-clauses"
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_draft
+
+        result = drafter_draft({"session_id": str(_SESSION_ID)})
+
+        assert result["clause_count"] == 1
+        mock_update.assert_called_once()
+
+    @patch("app.drafter.handlers.encrypt_text")
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_sectionless_structure_fails_instead_of_empty_review(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+        mock_encrypt: MagicMock,
+    ):
+        """Zero clauses must never be persisted — the step-5→6 guard
+        treats any encrypted content as proof of >= 1 clause."""
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure={"title": "T", "chapters": [{"number": "1", "sections": []}]},
+            research_data_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps({"provisions": []})
+        mock_get_provider.return_value = _provider({"text": "Sisu."})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_draft
+
+        with pytest.raises(RuntimeError, match="no clauses"):
+            drafter_draft({"session_id": str(_SESSION_ID)})
+
+        mock_encrypt.assert_not_called()
+        mock_update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# drafter_regenerate_clause
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateParseFailure:
+    @patch("app.drafter.handlers.get_connection")
+    @patch("app.drafter.handlers.update_session")
+    @patch("app.drafter.handlers.get_default_provider")
+    @patch("app.drafter.handlers.decrypt_text")
+    @patch("app.drafter.handlers.fetch_session")
+    def test_error_payload_fails_instead_of_silent_keep(
+        self,
+        mock_fetch: MagicMock,
+        mock_decrypt: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_update: MagicMock,
+        mock_conn: MagicMock,
+    ):
+        mock_fetch.return_value = _make_session(
+            current_step=5,
+            proposed_structure=_STRUCTURE,
+            draft_content_encrypted=b"encrypted",
+        )
+        mock_decrypt.return_value = json.dumps(
+            {
+                "clauses": [
+                    {
+                        "chapter": "1",
+                        "paragraph": "§ 1",
+                        "title": "Reguleerimisala",
+                        "text": "Vana tekst.",
+                        "citations": [],
+                        "notes": "",
+                    }
+                ]
+            }
+        )
+        mock_get_provider.return_value = _provider({"error": "failed to parse"})
+        _wire_conn(mock_conn)
+
+        from app.drafter.handlers import drafter_regenerate_clause
+
+        with pytest.raises(RuntimeError, match="Clause regeneration failed"):
+            drafter_regenerate_clause({"session_id": str(_SESSION_ID), "clause_index": 0})
+
+        mock_update.assert_not_called()

--- a/tests/test_drafter_review_submit_idempotent.py
+++ b/tests/test_drafter_review_submit_idempotent.py
@@ -1,0 +1,314 @@
+"""#852 E3 — ``submit_review`` claims the integrated review atomically.
+
+Two concurrent POSTs to ``/drafter/{id}/step/6`` used to both observe
+``integrated_draft_id IS NULL`` on a stale session snapshot and both run
+``_trigger_integrated_review`` — duplicate draft rows, named graphs and
+parse jobs. The route now serialises submitters with a per-session
+advisory transaction lock, re-checks under the lock, and claims with a
+conditional ``UPDATE ... WHERE integrated_draft_id IS NULL``; repeats
+idempotently render the existing state.
+
+Also covers the residual from #867: ``_trigger_integrated_review`` must
+route its plaintext .docx through a request-scoped temp file (deleted in
+``finally``) instead of leaving ``EXPORT_DIR/drafter-<session_id>.docx``
+behind forever.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.drafter.session_model import DraftingSession
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+_USER_ID = "33333333-3333-3333-3333-333333333333"
+_SESSION_ID = uuid.UUID("44444444-4444-4444-4444-444444444444")
+_DRAFT_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
+
+
+def _authed_user() -> dict[str, Any]:
+    return {
+        "id": _USER_ID,
+        "email": "koostaja@seadusloome.ee",
+        "full_name": "Test Koostaja",
+        "role": "drafter",
+        "org_id": _ORG_ID,
+    }
+
+
+def _make_session(*, integrated_draft_id: uuid.UUID | None = None) -> DraftingSession:
+    now = datetime.now(UTC)
+    return DraftingSession(
+        id=_SESSION_ID,
+        user_id=uuid.UUID(_USER_ID),
+        org_id=uuid.UUID(_ORG_ID),
+        workflow_type="full_law",
+        current_step=6,
+        intent="Testi ülevaadet",
+        clarifications=[],
+        research_data_encrypted=None,
+        proposed_structure={"title": "Test", "chapters": []},
+        draft_content_encrypted=None,
+        integrated_draft_id=integrated_draft_id,
+        status="active",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _stub_provider() -> MagicMock:
+    provider = MagicMock()
+    provider.get_current_user.return_value = _authed_user()
+    return provider
+
+
+def _authed_client():
+    from starlette.testclient import TestClient
+
+    client = TestClient(
+        __import__("app.main", fromlist=["app"]).app,
+        follow_redirects=False,
+    )
+    client.cookies.set("access_token", "stub-token")
+    return client
+
+
+class _StatefulClaimConn:
+    """Fake connection that models the ``integrated_draft_id`` column.
+
+    The advisory lock is a no-op (the TestClient is sequential), but the
+    SELECT/UPDATE pair behaves like Postgres: the conditional UPDATE only
+    "writes" while the column is NULL, and the under-lock SELECT returns
+    whatever the previous request claimed.
+    """
+
+    def __init__(self, state: dict):
+        self.state = state
+        self.executed: list[str] = []
+
+    def execute(self, sql: str, params: tuple | None = None):
+        sql_norm = " ".join(str(sql).split())
+        self.executed.append(sql_norm)
+        cursor = MagicMock()
+        if "SELECT integrated_draft_id FROM drafting_sessions" in sql_norm:
+            cursor.fetchone.return_value = (self.state.get("claimed"),)
+            return cursor
+        if "SET integrated_draft_id" in sql_norm and "IS NULL" in sql_norm:
+            if self.state.get("claimed") is None:
+                self.state["claimed"] = params[0]  # type: ignore[index]
+                cursor.rowcount = 1
+            else:
+                cursor.rowcount = 0
+            return cursor
+        cursor.fetchone.return_value = None
+        return cursor
+
+    def commit(self) -> None:
+        pass
+
+
+class _ConnCM:
+    def __init__(self, conn: Any):
+        self.conn = conn
+
+    def __enter__(self):
+        return self.conn
+
+    def __exit__(self, *_: Any) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Idempotent / atomic claim
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitReviewIdempotent:
+    @patch("app.drafter.routes._trigger_integrated_review")
+    @patch("app.drafter.routes._connect")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_double_post_triggers_exactly_once(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_trigger: MagicMock,
+    ):
+        """Worst case: BOTH requests read a stale snapshot with
+        ``integrated_draft_id=None``. The under-lock recheck must stop
+        the second from creating a duplicate draft/graph/job."""
+        mock_get_provider.return_value = _stub_provider()
+        # Stale snapshot on every fetch — the pre-#852 race condition.
+        mock_fetch.return_value = _make_session(integrated_draft_id=None)
+        mock_trigger.return_value = _DRAFT_ID
+
+        state: dict = {"claimed": None}
+        mock_connect.side_effect = lambda: _ConnCM(_StatefulClaimConn(state))
+
+        client = _authed_client()
+        resp1 = client.post(f"/drafter/{_SESSION_ID}/step/6", data={})
+        resp2 = client.post(f"/drafter/{_SESSION_ID}/step/6", data={})
+
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        # Exactly ONE integrated draft (and hence one graph + one job —
+        # both are created inside _trigger_integrated_review).
+        mock_trigger.assert_called_once()
+        assert state["claimed"] == str(_DRAFT_ID)
+
+    @patch("app.drafter.routes._trigger_integrated_review")
+    @patch("app.drafter.routes._connect")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_claim_is_serialised_by_advisory_lock(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_trigger: MagicMock,
+    ):
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_session(integrated_draft_id=None)
+        mock_trigger.return_value = _DRAFT_ID
+
+        state: dict = {"claimed": None}
+        conn = _StatefulClaimConn(state)
+        mock_connect.side_effect = lambda: _ConnCM(conn)
+
+        client = _authed_client()
+        resp = client.post(f"/drafter/{_SESSION_ID}/step/6", data={})
+
+        assert resp.status_code == 200
+        joined = " ".join(conn.executed)
+        # Lock taken BEFORE the recheck, claim is conditional.
+        assert "pg_advisory_xact_lock" in conn.executed[0]
+        assert "SELECT integrated_draft_id FROM drafting_sessions" in joined
+        assert "integrated_draft_id IS NULL" in joined
+
+    @patch("app.drafter.routes._trigger_integrated_review")
+    @patch("app.drafter.routes._connect")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_fast_path_skips_lock_when_already_linked(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_trigger: MagicMock,
+    ):
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_session(integrated_draft_id=_DRAFT_ID)
+
+        client = _authed_client()
+        resp = client.post(f"/drafter/{_SESSION_ID}/step/6", data={})
+
+        assert resp.status_code == 200
+        mock_trigger.assert_not_called()
+        mock_connect.assert_not_called()
+
+    @patch("app.drafter.routes._trigger_integrated_review")
+    @patch("app.drafter.routes._connect")
+    @patch("app.drafter.routes.fetch_session")
+    @patch("app.auth.middleware._get_provider")
+    def test_loser_renders_existing_state_without_triggering(
+        self,
+        mock_get_provider: MagicMock,
+        mock_fetch: MagicMock,
+        mock_connect: MagicMock,
+        mock_trigger: MagicMock,
+    ):
+        """Stale snapshot + already-claimed column (the blocked-on-lock
+        loser's view) → idempotent render, no second pipeline."""
+        mock_get_provider.return_value = _stub_provider()
+        mock_fetch.return_value = _make_session(integrated_draft_id=None)
+
+        state: dict = {"claimed": str(_DRAFT_ID)}
+        mock_connect.side_effect = lambda: _ConnCM(_StatefulClaimConn(state))
+
+        client = _authed_client()
+        resp = client.post(f"/drafter/{_SESSION_ID}/step/6", data={})
+
+        assert resp.status_code == 200
+        mock_trigger.assert_not_called()
+        assert state["claimed"] == str(_DRAFT_ID)  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Residual #867 — integrated-review docx must not persist in EXPORT_DIR
+# ---------------------------------------------------------------------------
+
+
+class TestIntegratedReviewTempfile:
+    def _run_trigger(self, builder_side_effect=None) -> tuple[uuid.UUID | None, dict]:
+        """Drive ``_trigger_integrated_review`` with everything mocked
+        except the temp-file lifecycle. Returns (draft_id, captured)."""
+        from app.drafter.routes import _trigger_integrated_review
+
+        captured: dict = {}
+
+        def fake_builder(**kwargs):
+            out_path = kwargs.get("out_path")
+            captured["out_path"] = out_path
+            if builder_side_effect is not None:
+                raise builder_side_effect
+            assert out_path is not None
+            Path(out_path).write_bytes(b"PK-fake-docx")
+            return Path(out_path)
+
+        stored = MagicMock()
+        stored.storage_path = "stored/path.enc"
+        draft = MagicMock()
+        draft.id = _DRAFT_ID
+
+        conn = MagicMock()
+
+        with (
+            patch("app.drafter.docx_builder.build_drafter_docx", side_effect=fake_builder),
+            patch("app.storage.store_file", return_value=stored) as mock_store,
+            patch("app.docs.draft_model.create_draft", return_value=draft),
+            patch("app.drafter.routes._connect") as mock_connect,
+            patch("app.drafter.routes.JobQueue") as mock_queue_cls,
+        ):
+            mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+            mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+            session = _make_session()
+            result = _trigger_integrated_review(session, _authed_user())  # type: ignore[arg-type]
+            captured["store_calls"] = mock_store.call_args_list
+            captured["enqueue_calls"] = mock_queue_cls.return_value.enqueue.call_args_list
+        return result, captured
+
+    def test_docx_goes_through_temp_file_and_is_removed(self):
+        result, captured = self._run_trigger()
+
+        assert result == _DRAFT_ID
+        out_path = captured["out_path"]
+        assert out_path is not None, "builder must receive an explicit out_path"
+        # Request-scoped temp file, not the EXPORT_DIR default name.
+        assert Path(out_path).name.startswith("seadusloome-integreeritud-")
+        assert not Path(out_path).exists(), "plaintext temp docx must be removed"
+        # The encrypted copy got the bytes the builder wrote.
+        assert captured["store_calls"][0].args[0] == b"PK-fake-docx"
+        # The pipeline job was still enqueued.
+        assert captured["enqueue_calls"][0].args[0] == "parse_draft"
+
+    def test_temp_file_removed_when_builder_raises(self):
+        with pytest.raises(RuntimeError, match="render boom"):
+            self._run_trigger(builder_side_effect=RuntimeError("render boom"))
+
+        # The captured path was created by NamedTemporaryFile before the
+        # builder ran; the finally must have removed it.
+        # (captured dict is not returned on raise, so re-check via scan:
+        # nothing matching the prefix may remain in the temp dir.)
+        import tempfile
+
+        leftovers = list(
+            Path(tempfile.gettempdir()).glob(f"seadusloome-integreeritud-{_SESSION_ID}-*")
+        )
+        assert leftovers == []

--- a/tests/test_drafter_review_submit_idempotent.py
+++ b/tests/test_drafter_review_submit_idempotent.py
@@ -273,6 +273,7 @@ class TestIntegratedReviewTempfile:
             patch("app.drafter.docx_builder.build_drafter_docx", side_effect=fake_builder),
             patch("app.storage.store_file", return_value=stored) as mock_store,
             patch("app.docs.draft_model.create_draft", return_value=draft),
+            patch("app.docs.version_model.create_draft_version"),
             patch("app.drafter.routes._connect") as mock_connect,
             patch("app.drafter.routes.JobQueue") as mock_queue_cls,
         ):
@@ -312,3 +313,246 @@ class TestIntegratedReviewTempfile:
             Path(tempfile.gettempdir()).glob(f"seadusloome-integreeritud-{_SESSION_ID}-*")
         )
         assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# #852 review F1 — integrated-review drafts get a v1 draft_versions row
+# ---------------------------------------------------------------------------
+#
+# ``_trigger_integrated_review`` used to create the drafts row + patch
+# graph_uri but never insert the required v1 ``draft_versions`` row that
+# normal uploads create (``app/docs/upload.py::_create_new_draft``, #618
+# PR-B). Consequence chain: ``analyze_impact`` resolved
+# ``latest_version=None`` → ``impact_reports.draft_version_id`` NULL →
+# stale-annotation reconciliation skipped and the §4.2 status mirror had
+# no version row, for EVERY drafter-generated draft. (Gap pre-dates #852
+# — present on merged main — but fixed here as part of this PR's blast
+# radius.)
+
+
+class TestIntegratedReviewVersionRow:
+    def _run_trigger_with_version_capture(self) -> dict:
+        from app.drafter.routes import _trigger_integrated_review
+
+        captured: dict = {}
+        conn = MagicMock()
+
+        def fake_create_draft(c, **kwargs):
+            captured["draft_conn"] = c
+            draft = MagicMock()
+            draft.id = _DRAFT_ID
+            return draft
+
+        def fake_create_version(c, **kwargs):
+            captured["version_conn"] = c
+            captured["version_kwargs"] = kwargs
+            # Same-transaction proof: the connection must NOT have been
+            # committed between the draft insert and the version insert.
+            captured["commits_before_version"] = conn.commit.call_count
+            return MagicMock()
+
+        def fake_builder(**kwargs):
+            out_path = kwargs["out_path"]
+            Path(out_path).write_bytes(b"PK-fake-docx")
+            return Path(out_path)
+
+        stored = MagicMock()
+        stored.storage_path = "stored/path.enc"
+
+        with (
+            patch("app.drafter.docx_builder.build_drafter_docx", side_effect=fake_builder),
+            patch("app.storage.store_file", return_value=stored),
+            patch("app.docs.draft_model.create_draft", side_effect=fake_create_draft),
+            patch(
+                "app.docs.version_model.create_draft_version",
+                side_effect=fake_create_version,
+            ),
+            patch("app.drafter.routes.log_action") as mock_log,
+            patch("app.drafter.routes._connect") as mock_connect,
+            patch("app.drafter.routes.JobQueue"),
+        ):
+            mock_connect.return_value.__enter__ = MagicMock(return_value=conn)
+            mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+            session = _make_session()
+            result = _trigger_integrated_review(session, _authed_user())  # type: ignore[arg-type]
+
+        captured["result"] = result
+        captured["total_commits"] = conn.commit.call_count
+        captured["log_calls"] = mock_log.call_args_list
+        return captured
+
+    def test_v1_version_row_created_in_same_transaction(self):
+        captured = self._run_trigger_with_version_capture()
+
+        assert captured["result"] == _DRAFT_ID
+        # The version insert happened — and on the SAME connection as
+        # the draft insert, BEFORE the single commit (one transaction:
+        # a partial commit can never leave a draft without its v1 row).
+        assert captured["version_conn"] is captured["draft_conn"]
+        assert captured["commits_before_version"] == 0
+        assert captured["total_commits"] == 1
+
+    def test_v1_version_row_mirrors_upload_path_fields(self):
+        captured = self._run_trigger_with_version_capture()
+        kwargs = captured["version_kwargs"]
+
+        # Mirrors app/docs/upload.py::_create_new_draft exactly.
+        assert kwargs["draft_id"] == _DRAFT_ID
+        assert kwargs["version_number"] == 1
+        assert kwargs["reading_stage"] == "vtk"
+        assert kwargs["status"] == "uploaded"
+        # created_by = the drafting-session OWNER (not e.g. org).
+        assert kwargs["created_by"] == uuid.UUID(_USER_ID)
+        assert kwargs["storage_path"] == "stored/path.enc"
+        # The version points at the FINAL graph URI (with the draft id),
+        # not the pending- placeholder.
+        assert kwargs["graph_uri"].endswith(str(_DRAFT_ID))
+        assert "pending-" not in kwargs["graph_uri"]
+
+    def test_v1_creation_is_audited_like_uploads(self):
+        captured = self._run_trigger_with_version_capture()
+
+        version_logs = [c for c in captured["log_calls"] if c.args[1] == "draft.version.create"]
+        assert len(version_logs) == 1
+        assert version_logs[0].args[0] == _USER_ID
+        assert version_logs[0].args[2]["draft_id"] == str(_DRAFT_ID)
+        assert version_logs[0].args[2]["version_number"] == 1
+
+
+class TestIntegratedDraftAnalyzeLinksVersion:
+    """End of the F1 chain: once the v1 row exists, ``analyze_impact``
+    must bind ``impact_reports.draft_version_id`` to it (NOT NULL).
+
+    Uses the REAL ``get_latest_version`` reading the v1 row off the
+    insert connection — no patching of the version lookup — so this
+    proves the wiring an integrated-review draft now satisfies.
+    """
+
+    def test_analyze_binds_report_to_v1_version(self):
+        from datetime import datetime as _dt
+
+        from app.docs.analyze_handler import analyze_impact
+        from app.docs.draft_model import Draft
+        from app.docs.impact.analyzer import ImpactFindings
+
+        now = datetime.now(UTC)
+        version_id = uuid.UUID("66666666-6666-6666-6666-666666666666")
+        graph_uri = f"https://data.riik.ee/ontology/estleg/drafts/{_DRAFT_ID}"
+        draft = Draft(
+            id=_DRAFT_ID,
+            user_id=uuid.UUID(_USER_ID),
+            org_id=uuid.UUID(_ORG_ID),
+            title="Integreeritud eelnõu",
+            filename=f"drafter-{_SESSION_ID}.docx",
+            content_type=(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+            file_size=1024,
+            storage_path="stored/path.enc",
+            graph_uri=graph_uri,
+            status="analyzing",
+            parsed_text_encrypted=None,
+            entity_count=0,
+            error_message=None,
+            created_at=now,
+            updated_at=now,
+        )
+        findings = ImpactFindings(
+            affected_entities=[],
+            conflicts=[],
+            gaps=[],
+            eu_compliance=[],
+            affected_count=0,
+            conflict_count=0,
+            gap_count=0,
+        )
+
+        # Row served to the REAL get_latest_version — _VERSION_COLUMNS
+        # order: id, draft_id, version_number, reading_stage,
+        # parsed_text_encrypted, storage_path, graph_uri, status,
+        # created_at, created_by.
+        version_row = (
+            str(version_id),
+            str(_DRAFT_ID),
+            1,
+            "vtk",
+            None,
+            "stored/path.enc",
+            graph_uri,
+            "analyzing",
+            now,
+            _USER_ID,
+        )
+
+        load_conn = MagicMock()
+        eu_cursor = MagicMock()
+        eu_cursor.fetchall.return_value = []
+        entity_cursor = MagicMock()
+        entity_cursor.fetchall.return_value = []
+        load_conn.execute.side_effect = [eu_cursor, entity_cursor]
+
+        sync_conn = MagicMock()
+        sync_conn.execute.return_value.fetchone.return_value = (
+            _dt(2026, 6, 1, 12, 0, tzinfo=UTC),
+            90000,
+        )
+
+        insert_conn = MagicMock()
+        insert_sqls: list[tuple] = []
+
+        def insert_execute(sql: str, params: tuple | None = None):
+            insert_sqls.append((sql, params))
+            cursor = MagicMock()
+            cursor.rowcount = 1
+            if "from draft_versions" in " ".join(str(sql).lower().split()):
+                cursor.fetchone.return_value = version_row
+            else:
+                cursor.fetchone.return_value = None
+            return cursor
+
+        insert_conn.execute.side_effect = insert_execute
+
+        class _CM:
+            def __init__(self, c):
+                self.c = c
+
+            def __enter__(self):
+                return self.c
+
+            def __exit__(self, *_):
+                return False
+
+        mock_analyzer = MagicMock()
+        mock_analyzer.analyze.return_value = findings
+
+        with (
+            patch("app.docs.analyze_handler.get_connection") as mock_get_conn,
+            patch("app.docs.analyze_handler.get_draft", return_value=draft),
+            patch("app.docs.analyze_handler.build_draft_graph", return_value="# t"),
+            patch("app.docs.analyze_handler.put_named_graph", return_value=True),
+            patch("app.docs.analyze_handler.write_doc_lineage", return_value=None),
+            patch("app.docs.analyze_handler.fetch_draft", return_value=None),
+            patch("app.docs.analyze_handler.ImpactAnalyzer", return_value=mock_analyzer),
+            patch("app.docs.analyze_handler.calculate_impact_score", return_value=7),
+        ):
+            mock_get_conn.side_effect = [
+                _CM(load_conn),
+                _CM(sync_conn),
+                _CM(insert_conn),
+            ]
+            analyze_impact({"draft_id": str(_DRAFT_ID)})
+
+        report_inserts = [
+            (sql, params)
+            for sql, params in insert_sqls
+            if "insert into impact_reports" in " ".join(str(sql).lower().split())
+        ]
+        assert len(report_inserts) == 1
+        _sql, params = report_inserts[0]
+        # Param order: report_id, draft_id, draft_version_id, ...
+        assert params is not None
+        assert params[2] == str(version_id), (
+            "impact_reports.draft_version_id must bind to the v1 row that "
+            "_trigger_integrated_review now creates — NULL means the F1 "
+            "regression is back"
+        )

--- a/tests/test_drafter_routes.py
+++ b/tests/test_drafter_routes.py
@@ -1380,18 +1380,28 @@ class TestPostStep6Review:
         mock_trigger.return_value = draft_id
 
         mock_conn = MagicMock()
+        # #852 E3: the route re-checks ``integrated_draft_id`` under a
+        # per-session advisory lock before triggering — (None,) means
+        # "not yet claimed", so the trigger must run.
+        mock_conn.execute.return_value.fetchone.return_value = (None,)
+        mock_conn.execute.return_value.rowcount = 1
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        with patch("app.drafter.routes.update_session"):
-            client = _authed_client()
-            resp = client.post(
-                f"/drafter/{_SESSION_ID}/step/6",
-                data={},
-            )
+        client = _authed_client()
+        resp = client.post(
+            f"/drafter/{_SESSION_ID}/step/6",
+            data={},
+        )
 
         assert resp.status_code == 200
         mock_trigger.assert_called_once()
+        # The claim must be the atomic conditional UPDATE (#852 E3).
+        executed_sql = " ".join(
+            " ".join(str(c.args[0]).split()) for c in mock_conn.execute.call_args_list
+        )
+        assert "pg_advisory_xact_lock" in executed_sql
+        assert "integrated_draft_id IS NULL" in executed_sql
 
 
 class TestGetExport:

--- a/tests/test_jobs_reaper.py
+++ b/tests/test_jobs_reaper.py
@@ -1,0 +1,571 @@
+"""Tests for the orphaned-job reaper (#852 E1).
+
+Covers :meth:`app.jobs.queue.JobQueue.reap_stale_jobs` (retry-policy
+accounting, batch/locking SQL shape, domain-row consequence for draft
+jobs), the crash-simulation round-trip (claimed row + dead worker →
+recovered and re-claimable), and the worker-loop wiring (startup pass,
+interval gating, metric emission, failure isolation).
+
+Mocking mirrors ``tests/test_jobs_queue.py`` / ``tests/test_jobs_worker.py``
+— no real Postgres, no real threads beyond a driven ``run_forever``.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from app.jobs.queue import (
+    JobQueue,
+    ReapStats,
+    _finalize_draft_for_lost_job,
+)
+from app.jobs.worker import JobWorker
+
+
+def _mock_conn(mock_get_connection: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    mock_get_connection.return_value.__enter__ = MagicMock(return_value=conn)
+    mock_get_connection.return_value.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+def _stale_row(
+    *,
+    job_id: int = 7,
+    job_type: str = "extract_entities",
+    payload: dict | None = None,
+    status: str = "running",
+    attempts: int = 0,
+    max_attempts: int = 3,
+    claimed_by: str = "dead-worker",
+) -> tuple:
+    """Row shape of the reaper's candidate SELECT."""
+    return (
+        job_id,
+        job_type,
+        payload if payload is not None else {"draft_id": "abc"},
+        status,
+        attempts,
+        max_attempts,
+        claimed_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# reap_stale_jobs — retry policy
+# ---------------------------------------------------------------------------
+
+
+class TestReapStaleJobs:
+    @patch("app.jobs.queue._finalize_draft_for_lost_job")
+    @patch("app.jobs.queue.get_connection")
+    def test_stale_claimed_job_is_repended(
+        self, mock_get_connection: MagicMock, mock_finalize: MagicMock
+    ):
+        """claimed + budget remaining → back to pending, attempt consumed."""
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchall.return_value = [
+            _stale_row(status="claimed", attempts=0, max_attempts=3)
+        ]
+
+        stats = JobQueue().reap_stale_jobs()
+
+        assert stats.recovered == 1
+        assert stats.exhausted == 0
+        # SELECT + one UPDATE.
+        update_sql = conn.execute.call_args_list[1].args[0]
+        update_params = conn.execute.call_args_list[1].args[1]
+        assert "status = 'pending'" in update_sql
+        assert "claimed_by = NULL" in update_sql
+        assert "claimed_at = NULL" in update_sql
+        assert "started_at = NULL" in update_sql
+        # One lost attempt is consumed: attempts 0 → 1.
+        assert update_params[0] == 1
+        # Re-pend is immediate (scheduled_for = now, no backoff).
+        assert isinstance(update_params[2], datetime)
+        assert update_params[2] <= datetime.now(UTC)
+        conn.commit.assert_called_once()
+        # Budget not exhausted → no domain finalisation.
+        mock_finalize.assert_not_called()
+
+    @patch("app.jobs.queue._finalize_draft_for_lost_job")
+    @patch("app.jobs.queue.get_connection")
+    def test_stale_running_job_is_repended(
+        self, mock_get_connection: MagicMock, mock_finalize: MagicMock
+    ):
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchall.return_value = [
+            _stale_row(status="running", attempts=1, max_attempts=3)
+        ]
+
+        stats = JobQueue().reap_stale_jobs()
+
+        assert stats.recovered == 1
+        assert stats.exhausted == 0
+        update_sql = conn.execute.call_args_list[1].args[0]
+        update_params = conn.execute.call_args_list[1].args[1]
+        assert "status = 'pending'" in update_sql
+        assert update_params[0] == 2  # attempts 1 → 2
+        mock_finalize.assert_not_called()
+
+    @patch("app.jobs.queue._finalize_draft_for_lost_job")
+    @patch("app.jobs.queue.get_connection")
+    def test_exhausted_job_is_failed_and_finalized(
+        self, mock_get_connection: MagicMock, mock_finalize: MagicMock
+    ):
+        """No budget left → failed + draft-pipeline domain consequence."""
+        conn = _mock_conn(mock_get_connection)
+        payload = {"draft_id": "11111111-1111-1111-1111-111111111111"}
+        conn.execute.return_value.fetchall.return_value = [
+            _stale_row(
+                job_id=42,
+                job_type="analyze_impact",
+                payload=payload,
+                status="running",
+                attempts=2,
+                max_attempts=3,
+            )
+        ]
+
+        stats = JobQueue().reap_stale_jobs()
+
+        assert stats.recovered == 0
+        assert stats.exhausted == 1
+        update_sql = conn.execute.call_args_list[1].args[0]
+        update_params = conn.execute.call_args_list[1].args[1]
+        assert "status = 'failed'" in update_sql
+        assert "finished_at" in update_sql
+        assert update_params[0] == 3  # attempts 2 → 3 == max
+        # Domain finalisation ran AFTER commit, with the job's payload.
+        mock_finalize.assert_called_once_with(42, "analyze_impact", payload)
+
+    @patch("app.jobs.queue._finalize_draft_for_lost_job")
+    @patch("app.jobs.queue.get_connection")
+    def test_empty_pass_is_noop(self, mock_get_connection: MagicMock, mock_finalize: MagicMock):
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchall.return_value = []
+
+        stats = JobQueue().reap_stale_jobs()
+
+        assert stats == ReapStats(recovered=0, exhausted=0)
+        assert conn.execute.call_count == 1  # only the candidate SELECT
+        mock_finalize.assert_not_called()
+
+    @patch("app.jobs.queue._finalize_draft_for_lost_job")
+    @patch("app.jobs.queue.get_connection")
+    def test_candidate_select_is_bounded_and_lock_safe(
+        self, mock_get_connection: MagicMock, _mock_finalize: MagicMock
+    ):
+        """SELECT must use SKIP LOCKED + LIMIT and both status cutoffs."""
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchall.return_value = []
+
+        JobQueue().reap_stale_jobs(claimed_timeout_s=600, running_timeout_s=1800)
+
+        select_sql = conn.execute.call_args_list[0].args[0]
+        params = conn.execute.call_args_list[0].args[1]
+        assert "FOR UPDATE SKIP LOCKED" in select_sql
+        assert "LIMIT" in select_sql
+        assert "status = 'claimed'" in select_sql
+        assert "status = 'running'" in select_sql
+        # Two cutoffs ~now-600s and ~now-1800s, claimed first.
+        claimed_cutoff, running_cutoff = params[0], params[1]
+        assert claimed_cutoff > running_cutoff
+        delta = claimed_cutoff - running_cutoff
+        assert abs(delta.total_seconds() - 1200) < 5
+
+
+# ---------------------------------------------------------------------------
+# Crash simulation: claimed row, worker gone → recovered and re-claimable
+# ---------------------------------------------------------------------------
+
+
+class TestCrashRecoveryRoundTrip:
+    """A deploy-killed worker leaves a ``claimed`` row behind; the reaper
+    must re-pend it so a fresh ``claim_next`` picks it up — i.e. the job
+    is never permanently stuck. Stateful fake-row pattern mirrors
+    ``tests/test_jobs_queue.py::TestRetryRoundTrip``."""
+
+    def test_orphaned_claimed_row_is_recovered_and_reclaimed(self):
+        stale_claimed_at = datetime.now(UTC) - timedelta(hours=2)
+        row_state: dict = {
+            "id": 55,
+            "job_type": "parse_draft",
+            "payload": {"draft_id": "abc"},
+            "status": "claimed",  # crash happened between claim and run
+            "priority": 0,
+            "attempts": 0,
+            "max_attempts": 3,
+            "claimed_by": "worker-died",
+            "claimed_at": stale_claimed_at,
+            "started_at": None,
+            "finished_at": None,
+            "error_message": None,
+            "result": None,
+            "scheduled_for": stale_claimed_at,
+            "created_at": stale_claimed_at,
+        }
+
+        def _full_row() -> tuple:
+            return (
+                row_state["id"],
+                row_state["job_type"],
+                row_state["payload"],
+                row_state["status"],
+                row_state["priority"],
+                row_state["attempts"],
+                row_state["max_attempts"],
+                row_state["claimed_by"],
+                row_state["claimed_at"],
+                row_state["started_at"],
+                row_state["finished_at"],
+                row_state["error_message"],
+                row_state["result"],
+                row_state["scheduled_for"],
+                row_state["created_at"],
+            )
+
+        def _execute(sql: str, params: tuple | None = None):
+            sql_norm = " ".join(sql.split())
+            cursor = MagicMock()
+
+            if "WHERE (status = 'claimed'" in sql_norm:
+                # Reaper candidate SELECT — apply the age predicate.
+                claimed_cutoff = params[0]  # type: ignore[index]
+                stale = (
+                    row_state["status"] == "claimed" and row_state["claimed_at"] < claimed_cutoff
+                )
+                cursor.fetchall.return_value = (
+                    [
+                        (
+                            row_state["id"],
+                            row_state["job_type"],
+                            row_state["payload"],
+                            row_state["status"],
+                            row_state["attempts"],
+                            row_state["max_attempts"],
+                            row_state["claimed_by"],
+                        )
+                    ]
+                    if stale
+                    else []
+                )
+                return cursor
+
+            if "SET status = 'pending'" in sql_norm and "scheduled_for = %s" in sql_norm:
+                # Reaper re-pend UPDATE.
+                next_attempts, error_message, scheduled_for, _job_id = params  # type: ignore[misc]
+                row_state.update(
+                    status="pending",
+                    attempts=next_attempts,
+                    error_message=error_message,
+                    scheduled_for=scheduled_for,
+                    claimed_by=None,
+                    claimed_at=None,
+                    started_at=None,
+                )
+                cursor.rowcount = 1
+                return cursor
+
+            if "FROM background_jobs WHERE status = 'pending'" in sql_norm:
+                # claim_next SELECT.
+                if (
+                    row_state["status"] == "pending" and row_state["scheduled_for"] <= params[0]  # type: ignore[index]
+                ):
+                    cursor.fetchone.return_value = _full_row()
+                else:
+                    cursor.fetchone.return_value = None
+                return cursor
+
+            if "SET status = 'claimed'" in sql_norm:
+                row_state["status"] = "claimed"
+                row_state["claimed_by"] = params[0]  # type: ignore[index]
+                row_state["claimed_at"] = params[1]  # type: ignore[index]
+                cursor.rowcount = 1
+                return cursor
+
+            cursor.fetchone.return_value = None
+            cursor.fetchall.return_value = []
+            return cursor
+
+        conn = MagicMock()
+        conn.execute.side_effect = _execute
+
+        with patch("app.jobs.queue.get_connection") as mock_get_connection:
+            mock_get_connection.return_value.__enter__ = MagicMock(return_value=conn)
+            mock_get_connection.return_value.__exit__ = MagicMock(return_value=False)
+
+            queue = JobQueue()
+
+            # Sanity: before the reaper runs, the orphan is unclaimable.
+            assert queue.claim_next(worker_id="worker-new") is None
+
+            stats = queue.reap_stale_jobs()
+            assert stats.recovered == 1
+            assert stats.exhausted == 0
+            assert row_state["status"] == "pending"
+            assert row_state["attempts"] == 1  # the lost attempt was consumed
+            assert row_state["claimed_by"] is None
+
+            # The recovered job must be immediately claimable.
+            job = queue.claim_next(worker_id="worker-new")
+            assert job is not None, "orphaned job was not re-claimable after reap"
+            assert job.id == 55
+            assert job.claimed_by == "worker-new"
+
+    def test_fresh_claimed_row_is_left_alone(self):
+        """A row claimed seconds ago must NOT be reaped (no double-run)."""
+        fresh_claimed_at = datetime.now(UTC) - timedelta(seconds=5)
+        select_calls: list[tuple] = []
+
+        def _execute(sql: str, params: tuple | None = None):
+            sql_norm = " ".join(sql.split())
+            cursor = MagicMock()
+            if "WHERE (status = 'claimed'" in sql_norm:
+                select_calls.append(params or ())
+                claimed_cutoff = params[0]  # type: ignore[index]
+                stale = fresh_claimed_at < claimed_cutoff
+                cursor.fetchall.return_value = [] if not stale else [("should-not-happen",)]
+                return cursor
+            cursor.fetchall.return_value = []
+            cursor.fetchone.return_value = None
+            return cursor
+
+        conn = MagicMock()
+        conn.execute.side_effect = _execute
+
+        with patch("app.jobs.queue.get_connection") as mock_get_connection:
+            mock_get_connection.return_value.__enter__ = MagicMock(return_value=conn)
+            mock_get_connection.return_value.__exit__ = MagicMock(return_value=False)
+
+            stats = JobQueue().reap_stale_jobs(claimed_timeout_s=600)
+
+        assert select_calls, "candidate SELECT did not run"
+        assert stats.recovered == 0
+        assert stats.exhausted == 0
+
+
+# ---------------------------------------------------------------------------
+# Domain finalisation for draft-pipeline jobs
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeDraftForLostJob:
+    @patch("app.docs.status.update_draft_status")
+    @patch("app.jobs.queue.get_connection")
+    def test_processing_draft_is_marked_failed(
+        self, mock_get_connection: MagicMock, mock_update: MagicMock
+    ):
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchone.return_value = ("extracting",)
+
+        _finalize_draft_for_lost_job(
+            9, "extract_entities", {"draft_id": "11111111-1111-1111-1111-111111111111"}
+        )
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args
+        assert args.args[2] == "failed"
+        # The user-facing message is Estonian and actionable.
+        assert "Palun proovige uuesti" in args.args[3]
+        # Optimistic-concurrency guard against a parallel transition.
+        assert args.kwargs.get("expected_status") == "extracting"
+        conn.commit.assert_called_once()
+
+    @patch("app.docs.status.update_draft_status")
+    @patch("app.jobs.queue.get_connection")
+    def test_terminal_draft_is_left_alone(
+        self, mock_get_connection: MagicMock, mock_update: MagicMock
+    ):
+        """An orphaned export job must not fail an already-ready draft."""
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchone.return_value = ("ready",)
+
+        _finalize_draft_for_lost_job(
+            9, "export_report", {"draft_id": "11111111-1111-1111-1111-111111111111"}
+        )
+
+        mock_update.assert_not_called()
+
+    @patch("app.jobs.queue.get_connection")
+    def test_session_payload_is_skipped(self, mock_get_connection: MagicMock):
+        """Drafter jobs surface via the job row; the session is not touched."""
+        _finalize_draft_for_lost_job(
+            9, "drafter_draft", {"session_id": "22222222-2222-2222-2222-222222222222"}
+        )
+        mock_get_connection.assert_not_called()
+
+    @patch("app.jobs.queue.get_connection")
+    def test_missing_draft_row_is_noop(self, mock_get_connection: MagicMock):
+        conn = _mock_conn(mock_get_connection)
+        conn.execute.return_value.fetchone.return_value = None
+        # Must not raise.
+        _finalize_draft_for_lost_job(9, "parse_draft", {"draft_id": "gone"})
+
+    @patch("app.jobs.queue.get_connection")
+    def test_db_error_is_swallowed(self, mock_get_connection: MagicMock):
+        mock_get_connection.side_effect = RuntimeError("db down")
+        # Best-effort: must not raise out of the reaper.
+        _finalize_draft_for_lost_job(9, "parse_draft", {"draft_id": "abc"})
+
+
+# ---------------------------------------------------------------------------
+# Worker-loop wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerReaperWiring:
+    @patch("app.jobs.worker.JobQueue")
+    def test_startup_pass_runs_before_first_claim(self, mock_queue_cls: MagicMock):
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        queue_instance.reap_stale_jobs.return_value = ReapStats()
+        order: list[str] = []
+        stop = threading.Event()
+
+        queue_instance.reap_stale_jobs.side_effect = lambda **_kw: (
+            order.append("reap"),
+            ReapStats(),
+        )[1]
+
+        def claim_side_effect(*_a, **_kw):
+            order.append("claim")
+            stop.set()
+            return None
+
+        queue_instance.claim_next.side_effect = claim_side_effect
+
+        JobWorker(worker_id="t", poll_interval=0.01).run_forever(stop)
+
+        assert order[:2] == ["reap", "claim"], (
+            "startup reaper pass must run before the first claim"
+        )
+
+    @patch("app.jobs.worker.JobQueue")
+    def test_interval_gating_skips_back_to_back_passes(self, mock_queue_cls: MagicMock):
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        queue_instance.reap_stale_jobs.return_value = ReapStats()
+        stop = threading.Event()
+
+        ticks = {"n": 0}
+
+        def claim_side_effect(*_a, **_kw):
+            ticks["n"] += 1
+            if ticks["n"] >= 3:
+                stop.set()
+            return None
+
+        queue_instance.claim_next.side_effect = claim_side_effect
+        # Avoid real sleeping between iterations.
+        stop.wait = lambda timeout=None: stop.is_set()  # type: ignore[method-assign]
+
+        JobWorker(worker_id="t", poll_interval=0.01, reap_interval=3600.0).run_forever(stop)
+
+        assert queue_instance.claim_next.call_count == 3
+        # Only the startup pass within a 1h interval.
+        assert queue_instance.reap_stale_jobs.call_count == 1
+
+    @patch("app.jobs.worker.JobQueue")
+    def test_elapsed_interval_triggers_second_pass(self, mock_queue_cls: MagicMock):
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        queue_instance.reap_stale_jobs.return_value = ReapStats()
+        stop = threading.Event()
+
+        ticks = {"n": 0}
+
+        def claim_side_effect(*_a, **_kw):
+            ticks["n"] += 1
+            if ticks["n"] >= 2:
+                stop.set()
+            return None
+
+        queue_instance.claim_next.side_effect = claim_side_effect
+        stop.wait = lambda timeout=None: stop.is_set()  # type: ignore[method-assign]
+
+        worker = JobWorker(worker_id="t", poll_interval=0.01, reap_interval=0.0)
+        # reap_interval=0 → every loop iteration is past the deadline.
+        worker.run_forever(stop)
+
+        assert queue_instance.reap_stale_jobs.call_count == 2
+
+    @patch("app.jobs.worker.JobQueue")
+    def test_reaper_failure_does_not_block_dispatch(self, mock_queue_cls: MagicMock):
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        queue_instance.reap_stale_jobs.side_effect = RuntimeError("reaper db down")
+        stop = threading.Event()
+
+        def claim_side_effect(*_a, **_kw):
+            stop.set()
+            return None
+
+        queue_instance.claim_next.side_effect = claim_side_effect
+
+        # Must not raise, and the claim must still happen.
+        JobWorker(worker_id="t", poll_interval=0.01).run_forever(stop)
+        queue_instance.claim_next.assert_called_once()
+
+    @patch("app.jobs.worker.record_metric")
+    @patch("app.jobs.worker.JobQueue")
+    def test_pass_outcomes_are_metered(self, mock_queue_cls: MagicMock, mock_metric: MagicMock):
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        queue_instance.reap_stale_jobs.return_value = ReapStats(recovered=2, exhausted=1)
+
+        worker = JobWorker(worker_id="t", poll_interval=0.01)
+        worker._maybe_reap()
+
+        labels = {
+            (c.args[0], c.args[2].get("outcome"), c.args[1]) for c in mock_metric.call_args_list
+        }
+        assert ("jobs_reaped", "recovered", 2.0) in labels
+        assert ("jobs_reaped", "exhausted", 1.0) in labels
+
+    @patch("app.jobs.worker.JobQueue")
+    def test_timeouts_are_passed_through(self, mock_queue_cls: MagicMock):
+        queue_instance = MagicMock()
+        mock_queue_cls.return_value = queue_instance
+        queue_instance.reap_stale_jobs.return_value = ReapStats()
+
+        worker = JobWorker(worker_id="t")
+        worker._maybe_reap()
+
+        kwargs = queue_instance.reap_stale_jobs.call_args.kwargs
+        assert kwargs["claimed_timeout_s"] == worker.claimed_timeout_s
+        assert kwargs["running_timeout_s"] == worker.running_timeout_s
+
+    def test_env_overrides_are_read(self, monkeypatch):
+        monkeypatch.setenv("JOB_REAPER_INTERVAL_S", "120")
+        monkeypatch.setenv("JOB_REAPER_CLAIMED_TIMEOUT_S", "300")
+        monkeypatch.setenv("JOB_REAPER_RUNNING_TIMEOUT_S", "900")
+
+        worker = JobWorker(worker_id="t")
+
+        assert worker.reap_interval == 120.0
+        assert worker.claimed_timeout_s == 300
+        assert worker.running_timeout_s == 900
+
+    def test_invalid_env_falls_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("JOB_REAPER_INTERVAL_S", "not-a-number")
+        monkeypatch.setenv("JOB_REAPER_RUNNING_TIMEOUT_S", "-5")
+
+        worker = JobWorker(worker_id="t")
+
+        assert worker.reap_interval == 60.0
+        assert worker.running_timeout_s == 1800
+
+    def test_failed_pass_backs_off_to_next_interval(self):
+        """The deadline advances even when the pass raises (no hot loop)."""
+        worker = JobWorker(worker_id="t", reap_interval=3600.0)
+        with patch("app.jobs.worker.JobQueue") as mock_queue_cls:
+            mock_queue_cls.return_value.reap_stale_jobs.side_effect = RuntimeError("boom")
+            worker._maybe_reap()
+            assert worker._next_reap_at > time.monotonic()
+            # Second call inside the interval: no new attempt.
+            worker._maybe_reap()
+            assert mock_queue_cls.return_value.reap_stale_jobs.call_count == 1


### PR DESCRIPTION
Closes #852

## DoD status

| DoD item | Status |
|---|---|
| Startup + periodic reaper returns stale `claimed`/`running` jobs to a retryable state per retry policy | ✅ `JobQueue.reap_stale_jobs()`; worker runs a pass at startup (before the first claim) and every 60s (`JOB_REAPER_INTERVAL_S`) in both inproc and standalone modes |
| Reaper bounded + observable (recovered vs exhausted) | ✅ `LIMIT 100` per pass, `FOR UPDATE SKIP LOCKED` (replica-safe), per-job WARN/ERROR logs + pass-summary log, `jobs_reaped` metric labelled `outcome=recovered/exhausted`, Estonian `error_message` on the row |
| Drafter `extract_json` parse failures / `{"error": ...}` payloads raise instead of persisting empty clauses | ✅ `LLMOutputError` + `_require_llm_json()` in all four LLM-consuming drafter handlers; stub payloads still pass (keyless local dev) |
| Drafting output validation requires clause text before success | ✅ non-blank `text` per section + non-empty clause list; persist step moved inside the retry-gated region |
| `submit_review` atomically claims `integrated_draft_id IS NULL` before creating draft/graph/job | ✅ per-session `pg_advisory_xact_lock` + under-lock recheck + conditional `UPDATE … WHERE integrated_draft_id IS NULL` |
| Double-click/retry POSTs idempotent | ✅ losers (and stale-snapshot repeats) render the existing state; fast path when already linked |
| **Comment 1 — E6:** pre-try precondition failures mark the domain row failed on the final attempt | ✅ extract + analyze preconditions moved inside the gated try; `DecryptionError` on final attempt → draft `failed` → retry button renders |
| **Comment 2 — admin retry aligns with retry policy + confirm** | ✅ `attempts` preserved (was reset to 0 → poison jobs retryable forever); each click = exactly one extra attempt, counter doubles as audit trail (`4/3`); `hx_confirm` added like the purge button |
| **Comment 3 — stop-grace ≥ 30s** | ✅ `stop_grace_period: 35s` on the compose `app` service (see Coolify note below) |
| **Residual from #867:** integrated-review docx cleanup | ✅ `_trigger_integrated_review` renders into a request-scoped 0600 temp file removed in `finally`; only the Fernet-encrypted copy persists |

## Verification

- Stale `claimed`/`running` re-pended vs failed per budget — `tests/test_jobs_reaper.py::TestReapStaleJobs`
- Crash simulation: claimed row + dead worker → recovered and immediately re-claimable; fresh rows untouched — `TestCrashRecoveryRoundTrip`
- Malformed LLM JSON / blank clause text / empty clause list → job fails (retryable), never silent blank success; final attempt abandons — `tests/test_drafter_llm_output_validation.py`
- Pre-try `DecryptionError` on final attempt → draft `failed` (not stuck), earlier attempts don't flip — `tests/test_docs_precondition_gating.py`
- Concurrent/double `submit_review` → exactly one integrated draft + graph + job — `tests/test_drafter_review_submit_idempotent.py`
- Admin retry preserves budget + confirm present — `tests/test_admin_job_retry_budget.py`
- Integrated-review export leaves no stray file (success + builder-raise paths) — `TestIntegratedReviewTempfile`
- Baseline: `ruff check` ✅ · `pyright` 0 errors ✅ · `pytest -q` **4329 passed, 45 skipped** ✅

## Reaper threshold rationale

- **`claimed` > 10 min** (`JOB_REAPER_CLAIMED_TIMEOUT_S=600`): claim→running is one immediate UPDATE in the worker tick, so realistic staleness is milliseconds; 10 min is pure margin.
- **`running` > 30 min** (`JOB_REAPER_RUNNING_TIMEOUT_S=1800`): running jobs hold no DB lock, so age is the only stall signal and the threshold must exceed the longest *legitimate* handler runtime or a slow-but-alive job gets double-run. Worst case today is `drafter_draft` (one sequential LLM call per section; tens of sections for VTK/full-law), which can legitimately run for many minutes. 30 min clears it with room while keeping the stuck-pipeline window to a single pass.
- **Re-pend is immediate** (no exponential backoff): the lost attempt wasn't the job's fault, so it shouldn't wait 2^n minutes after a deploy — but it still **consumes an attempt**, so a job that repeatedly kills its worker (OOM) is bounded by `max_attempts` like any other poison job.
- **Exhaustion handles the domain row**: draft-pipeline payloads flip the draft to `failed` (only from `uploaded/parsing/extracting/analyzing` — an orphaned `export_report` can't fail a `ready` draft), which is exactly the state the `/drafts/{id}/retry` button requires. Drafter session jobs already surface the failure through the job row in `step_status_fragment`; abandoning a session over an infrastructure failure would destroy user work, so the reaper deliberately leaves sessions alone.
- No migration needed: `claimed_at`/`started_at` have existed since migration 005 (the prompt's contingency slot 041 was not used).

## Coolify stop-grace note (production)

Production does **not** read `docker/docker-compose.yml`. The app's lifespan shutdown joins the worker + scheduler threads against a shared **30s** deadline, but Docker's default SIGTERM grace is **10s**, so every deploy could SIGKILL a mid-job worker — that is the main producer of the orphans this reaper recovers. To get the same protection on Coolify, set the application's stop grace to ≥ 35s: **Application → Advanced → Custom Docker Options → `--stop-timeout 35`** (or `stop_grace_period: 35s` in the compose for compose-based deploys). The reaper makes deploy kills recoverable either way; the grace setting shrinks its steady-state workload.

## Review round 1 (commit 64df956)

**F1 [P1] — integrated-review drafts skipped `draft_versions` v1 creation: VALID, PRE-EXISTING.** Verified via `git log -p`: merged main `7ad47ba` already had `create_draft` + `graph_uri` patch with no `create_draft_version` call in `_trigger_integrated_review`; the function's only prior touches are Phase 3A Batch 2 (`47f28ab`) and an i18n pass — #618 PR-B retrofitted version bookkeeping into `app/docs/upload.py::_create_new_draft` but never into this path. Commit `0ac7f22` (this PR) only wrapped the docx build in a temp file and did not introduce the gap — fixed here anyway as part of this PR's blast radius. Fix mirrors the upload path exactly: `create_draft_version(v1, reading_stage="vtk", status="uploaded", created_by=session owner, graph_uri=final URI, storage_path)` in the **same transaction** as the draft insert, plus the `draft.version.create` audit entry. Tests prove same-connection/before-commit insert, upload-path field parity, the audit entry, and — with the **real** `get_latest_version` (unpatched) — that a subsequent `analyze_impact` binds `impact_reports.draft_version_id` to the v1 row (NOT NULL), which also unblocks stale-annotation reconciliation and the §4.2 status mirror for drafter-generated drafts.

**F2 [P2] — single-clause regeneration could persist blank text: VALID.** `{"text": ""}` passed `_require_llm_json` (no `error` key) and `result.get("text", fallback)` returned the present-but-blank value, overwriting a good clause. `drafter_regenerate_clause` now applies the same nonblank contract as `drafter_draft`: blank/whitespace-only output raises `LLMOutputError` **before** the clause list is mutated (retry-gating engages, existing clause untouched); stub payloads keep the existing text. Tests: blank + whitespace-only → job fails, nothing persisted; valid regeneration still applies; stub keeps prior text.

Gates after the round: `ruff check` ✅ · `pyright` 0 errors ✅ · `pytest -q` **4337 passed, 45 skipped** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
