### PR TITLE
fix(deploy): optional LibreOffice, image pinning, Tika limits, entrypoint hardening (#861)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: install dependencies with uv
-FROM python:3.13-slim AS builder
+FROM python:3.13-slim@sha256:f82c96458eedc847b233e582eb31336f4954b39cae020b6dcf5b3ed0e5cbcd74 AS builder
 
 # Build metadata — populated by CI via --build-arg (see .github/workflows/ci.yml).
 # Defaults let local `docker build` work without explicit args; in that case we
@@ -8,7 +8,7 @@ FROM python:3.13-slim AS builder
 ARG GIT_SHA=dev
 ARG BUILD_TIME=unknown
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.5 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.5@sha256:555ac94f9a22e656fc5f2ce5dfee13b04e94d099e46bb8dd3a73ec7263f2e484 /uv /usr/local/bin/uv
 
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
@@ -41,7 +41,7 @@ RUN printf '{"app": "0.1.0", "sha": "%s", "built_at": "%s"}\n' \
     cat /app/VERSION.json
 
 # Runtime stage
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:f82c96458eedc847b233e582eb31336f4954b39cae020b6dcf5b3ed0e5cbcd74
 
 # Install curl for HEALTHCHECK, git for the sync pipeline, and git-lfs for
 # large ontology files.
@@ -65,13 +65,23 @@ RUN apt-get update && \
 # automatically. Must run as root, before the USER appuser switch below.
 RUN git lfs install --system
 
-# §4.3 LibreOffice base image (Eelnõud sprint plan 2026-05-02).
-# Installed here so the deploy risk is validated independently before any
-# code that calls `soffice --headless --convert-to pdf` ships (#613 PDF export).
-# Nothing in the app uses LibreOffice yet — this is a pure infrastructure step.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libreoffice-core libreoffice-writer \
-    && rm -rf /var/lib/apt/lists/*
+# §4.3 LibreOffice — optional, ~500 MB.  Off by default.
+#
+# Enable for production (Coolify "Additional Build Arguments"):
+#   --build-arg INSTALL_LIBREOFFICE=true
+#
+# Enable for local builds:
+#   docker build --build-arg INSTALL_LIBREOFFICE=true -f docker/Dockerfile .
+#
+# Required only when PDF-export via `soffice --headless --convert-to pdf`
+# ships in the app (#613). Gated here so all other containers stay lean
+# until that feature lands.
+ARG INSTALL_LIBREOFFICE=false
+RUN if [ "$INSTALL_LIBREOFFICE" = "true" ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends libreoffice-core libreoffice-writer \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 WORKDIR /app
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -156,8 +156,15 @@ services:
       # instead of sizing itself against the host RAM.  The container hard
       # limit is set via deploy.resources.limits.memory below.
       # 512m heap + ~100m metaspace/native ≈ fits in 768m container limit.
-      # Adjust TIKA_JAVA_ARGS if you raise/lower the memory limit.
-      JAVA_OPTS: "-Xms128m -Xmx512m"
+      # Adjust these values if you raise/lower the memory limit.
+      #
+      # JAVA_TOOL_OPTIONS, not JAVA_OPTS: the official apache/tika-docker
+      # entrypoint invokes `java` directly without shell-expanding $JAVA_OPTS,
+      # so JAVA_OPTS is silently ignored. JAVA_TOOL_OPTIONS is read by HotSpot
+      # itself at JVM startup regardless of how java is invoked — the JVM
+      # prints "Picked up JAVA_TOOL_OPTIONS: ..." at boot, which also serves
+      # as confirmation that the flags were applied.
+      JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m"
     deploy:
       resources:
         limits:
@@ -175,7 +182,14 @@ services:
     restart: unless-stopped
 
   jena:
-    image: apache/jena-fuseki:5.4.0
+    # stain/jena-fuseki matches the exact digest running in production
+    # (read off the prod VPS).  The previous reference, apache/jena-fuseki:5.4.0,
+    # does not exist on Docker Hub — the apache/ namespace for Fuseki is not
+    # published there, which is also why the anonymous-token grant came back
+    # empty during the #861 digest-pinning pass.  A Fuseki version upgrade is
+    # tracked separately; do not change this image without a dedicated upgrade
+    # PR and testing against the fuseki-config assembler.
+    image: stain/jena-fuseki:latest@sha256:b1d0c96f19adddef417520184471ac816cf36c6e72936a88ea02b29f4305929a
     ports:
       # #853 / H2: loopback-only, same rationale as postgres above. Even
       # though the write endpoints are now behind fuseki:allowedUsers

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -116,7 +116,7 @@ services:
   #   restart: unless-stopped
 
   postgres:
-    image: pgvector/pgvector:pg18
+    image: pgvector/pgvector:pg18@sha256:42e7f6b4e1eceb02ff14e3e6bc6108bbe259abbe83879dc1845d0da1ddeb555d
     ports:
       # #853 / H2: bind to the loopback interface only. A bare "5432:5432"
       # publishes Postgres on 0.0.0.0, i.e. every interface of the host —
@@ -145,12 +145,27 @@ services:
   tika:
     # Local dev only. In production, Tika is a separate Coolify application
     # with network alias `seadusloome-tika` (set TIKA_URL accordingly).
-    image: apache/tika:3.3.0.0-full
+    image: apache/tika:3.3.0.0-full@sha256:ecdd37e204308266b1f8e28569f8516ebd5b96d7a4518a71d3904710b20c03b3
     ports:
       # #853 / H2: loopback-only for local curl testing; internal-only in
       # prod (separate Coolify app, reached via TIKA_URL). See the matrix
       # at the top of this file.
       - "127.0.0.1:9998:9998"
+    environment:
+      # Bound the JVM heap so the JVM honours the container memory limit
+      # instead of sizing itself against the host RAM.  The container hard
+      # limit is set via deploy.resources.limits.memory below.
+      # 512m heap + ~100m metaspace/native ≈ fits in 768m container limit.
+      # Adjust TIKA_JAVA_ARGS if you raise/lower the memory limit.
+      JAVA_OPTS: "-Xms128m -Xmx512m"
+    deploy:
+      resources:
+        limits:
+          # Hard cap: Tika OOMs without a limit on multi-document bursts.
+          # 768 MB covers a 512 MB heap + JVM overhead; raise to 1g if
+          # parsing large PDFs regularly.  Production: set the equivalent
+          # limit in the Coolify service "Resources" tab.
+          memory: 768m
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:9998/tika || exit 1"]
       interval: 10s

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,22 @@
 # Coolify will mark the container unhealthy and roll back to the
 # previous working image — much better than starting with a half-built
 # schema.
-set -e
+#
+# set -e  : abort on any non-zero exit (prevents starting uvicorn after a
+#           failed migration)
+# set -u  : treat unset variables as errors — catches missing required env
+#           vars like DATABASE_URL before they cause a cryptic psycopg
+#           OperationalError deep inside the migration runner.
+set -eu
+
+# Guard: DATABASE_URL must be set and non-empty.  Without it the migration
+# runner connects to nothing and silently exits 0 (psycopg falls back to
+# libpq env vars, which are also unset, producing a confusing error).
+# Fail loud here so Coolify's rollback logic kicks in immediately.
+if [ -z "${DATABASE_URL:-}" ]; then
+    echo "[entrypoint] ERROR: DATABASE_URL is not set. Aborting." >&2
+    exit 1
+fi
 
 echo "[entrypoint] Running database migrations..."
 python /app/scripts/migrate.py


### PR DESCRIPTION
## Summary

Deploy-layer hardening from the 2026-06-10 system review (#861). Three files changed: `docker/Dockerfile`, `docker/docker-compose.yml`, `docker/entrypoint.sh`.

## Finding-by-finding status

### A — LibreOffice behind ARG (Dockerfile:68-84) — FIXED

`libreoffice-core libreoffice-writer` was unconditionally installed (~500 MB) in the runtime image even though no code calls `soffice` yet.

**Fix:** Added `ARG INSTALL_LIBREOFFICE=false` immediately before the install block; the `RUN` is now `if [ "$INSTALL_LIBREOFFICE" = "true" ]`. Default builds (CI, Coolify without the arg) skip it entirely. Comment documents how to enable:
- Coolify "Additional Build Arguments": `--build-arg INSTALL_LIBREOFFICE=true`
- Local: `docker build --build-arg INSTALL_LIBREOFFICE=true -f docker/Dockerfile .`

The `git-lfs` install block immediately above is untouched (critical for the 2026-05-27 LFS fix).

### B — Digest-pin base images — FIXED (all five images pinned)

Digests resolved via Docker Hub token endpoint + registry manifest API. A post-merge code review found that `apache/jena-fuseki:5.4.0` does not exist on Docker Hub at all (the `apache/` Fuseki namespace is not published there — also the root cause of the empty token grant during the initial pinning pass). Corrected to `stain/jena-fuseki` at the digest prod runs.

| Image | Digest |
|---|---|
| `python:3.13-slim` (builder + runtime stages) | `sha256:f82c96...d74` |
| `ghcr.io/astral-sh/uv:0.11.5` | `sha256:555ac9...484` |
| `pgvector/pgvector:pg18` | `sha256:42e7f6...55d` |
| `apache/tika:3.3.0.0-full` | `sha256:ecdd37...3b3` |
| `stain/jena-fuseki:latest` | `sha256:b1d0c9...29a` — matches exact digest running in production (read off prod VPS); digest pullability verified via registry HEAD before committing |

The jena image comment documents: (a) the digest matches prod exactly, (b) the prior `apache/jena-fuseki:5.4.0` reference never existed on Docker Hub, (c) a Fuseki version upgrade is a separate decision.

### C — Tika mem_limit + JVM_ARGS — FIXED

Added to the `tika` service in `docker-compose.yml`:

- `environment.JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m"` — **not** `JAVA_OPTS`. The official apache/tika-docker entrypoint is `exec java -cp "..." org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@` — it never shell-expands `$JAVA_OPTS`, so `JAVA_OPTS` is silently ignored. `JAVA_TOOL_OPTIONS` is read by HotSpot itself at JVM startup regardless of invocation path; the JVM logs `Picked up JAVA_TOOL_OPTIONS: ...` on boot, which doubles as confirmation the flags applied.
- `deploy.resources.limits.memory: 768m` — hard container cap (512 MB heap + ~256 MB JVM overhead). Raise to `1g` if large-PDF parsing becomes routine.

Production note is in the compose comment: set the equivalent limit in Coolify service "Resources" tab for the separate Tika Coolify app.

### D — set -eu + DATABASE_URL guard + stop_grace_period — PARTIALLY FIXED (stop_grace already done)

- **stop_grace_period: 35s** — already added by #852 (`docker-compose.yml` line 66). Not re-applied.
- **set -eu** — added to `entrypoint.sh` (was `set -e` only). `-u` makes unset variable references an immediate error.
- **DATABASE_URL guard** — explicit `[ -z "${DATABASE_URL:-}" ]` check with a clear `>&2` error message before invoking the migration runner. Previously a missing `DATABASE_URL` produced a cryptic psycopg connection error inside `migrate.py`; now the container exits 1 immediately with a human-readable message, triggering Coolify's unhealthy-rollback path.

## Validation

```
sh -n docker/entrypoint.sh                                                    # OK
python -c "import yaml; yaml.safe_load(open('docker/docker-compose.yml'))"   # OK — services: app, postgres, tika, jena
```

Spot-check assertions from the YAML parse:
- `tika.environment` contains `JAVA_TOOL_OPTIONS` and does **not** contain `JAVA_OPTS`
- `tika.deploy.resources.limits.memory` = `768m`
- `jena.image` = `stain/jena-fuseki:latest@sha256:b1d0c96f...`
- `stain/jena-fuseki` digest HEAD: HTTP 200, `docker-content-digest: sha256:b1d0c96f19adddef417520184471ac816cf36c6e72936a88ea02b29f4305929a`

Dockerfile structural invariants: git-lfs untouched, `ARG INSTALL_LIBREOFFICE=false` present, both `FROM` lines digest-pinned, uv `COPY` digest-pinned.

## Coolify compatibility

- No service names, volume names, or network names renamed.
- All healthchecks (pg_isready, `/tika`, `/$/ping`, `/api/ping`) preserved unchanged.
- `deploy.resources` is standard Compose spec; Coolify's compose-based apps honour it.
- `ARG INSTALL_LIBREOFFICE=false` default means Coolify builds without the arg continue to produce a lean image — no Coolify UI change required unless PDF export (#613) is enabled.

Part of #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)