### PR TITLE
fix(frontend): chat.js escaping/stream-gating, mentions instance lifecycle (#861)

### DIFF
--- a/app/static/js/annotation_mentions.js
+++ b/app/static/js/annotation_mentions.js
@@ -63,6 +63,13 @@
   // Track widget instances by textarea so we don't double-bind.
   const INSTANCES = new WeakMap();
 
+  // A parallel, *iterable* registry of every textarea that currently holds a
+  // live instance. The WeakMap above can't be walked, but HTMX cleanup needs
+  // to find-and-destroy instances whose textarea is being swapped out — each
+  // attach() registers 3 global listeners + a <ul> appended to <body> that
+  // would otherwise leak on every popover swap (issue #861-D).
+  const LIVE_TEXTAREAS = new Set();
+
   /** Remove every child of an element without using innerHTML. */
   function clearChildren(el) {
     while (el.firstChild) el.removeChild(el.firstChild);
@@ -431,10 +438,44 @@
         window.removeEventListener("scroll", onScrollOrResize, true);
         list.remove();
         INSTANCES.delete(textarea);
+        LIVE_TEXTAREAS.delete(textarea);
       },
     };
     INSTANCES.set(textarea, instance);
+    LIVE_TEXTAREAS.add(textarea);
     return instance;
+  }
+
+  /** Tear down the instance bound to a single textarea, if any. */
+  function destroyOne(textarea) {
+    const instance = INSTANCES.get(textarea);
+    if (instance) instance.destroy();
+  }
+
+  /**
+   * Destroy every live instance whose textarea sits inside *root* (inclusive).
+   * Used on HTMX swap/cleanup so popovers removed from the DOM also drop their
+   * global listeners + the orphan list element they appended to <body>.
+   */
+  function destroyWithin(root) {
+    if (!root || typeof root.contains !== "function") return;
+    // Snapshot first — destroy() mutates LIVE_TEXTAREAS during iteration.
+    for (const textarea of Array.from(LIVE_TEXTAREAS)) {
+      if (root === textarea || root.contains(textarea)) {
+        destroyOne(textarea);
+      }
+    }
+  }
+
+  /**
+   * Sweep for instances whose textarea has been detached from the document
+   * (a swap that replaced an ancestor we never saw a cleanup event for).
+   * Belt-and-braces backstop alongside the targeted destroyWithin() calls.
+   */
+  function destroyDetached() {
+    for (const textarea of Array.from(LIVE_TEXTAREAS)) {
+      if (!textarea.isConnected) destroyOne(textarea);
+    }
   }
 
   function attachAll(root) {
@@ -449,11 +490,28 @@
     attachAll(document);
   }
 
-  // Re-scan after every HTMX swap so newly-rendered popovers get bound.
+  // HTMX is about to remove a specific element from the DOM — tear down any
+  // instance bound to it (or to a descendant textarea) so its global
+  // listeners + orphan <body> list don't leak (issue #861-D).
+  document.body.addEventListener("htmx:beforeCleanupElement", (ev) => {
+    destroyWithin(ev.target);
+  });
+
+  // HTMX is about to replace a swap target's contents — destroy instances
+  // living inside the outgoing markup before it's discarded. Pairs with the
+  // afterSwap re-scan below, which re-binds the incoming markup.
+  document.body.addEventListener("htmx:beforeSwap", (ev) => {
+    destroyWithin(ev.target);
+  });
+
+  // Re-scan after every HTMX swap so newly-rendered popovers get bound. Also
+  // sweep for any instance whose textarea ended up detached without a
+  // cleanup event firing (belt-and-braces).
   document.body.addEventListener("htmx:afterSwap", (ev) => {
+    destroyDetached();
     attachAll(ev.target || document);
   });
 
   // Expose for manual rebinds / debugging.
-  window.AnnotationMentions = { attach, attachAll };
+  window.AnnotationMentions = { attach, attachAll, destroyWithin, destroyDetached };
 })();

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -301,6 +301,10 @@
       // re-sends manually if they want another attempt.
       if (brokenMidStream) {
         brokenMidStream = false;
+        // Stop the orphaned thinking ticker/watchdog timers and drop the
+        // animated "Mõtlen..." visuals — the turn they belonged to died with
+        // the old socket, so they must not survive the reconnect.
+        clearThinking();
         if (pendingBubble) {
           const chatBubble = pendingBubble.querySelector('.chat-bubble');
           const note = document.createElement('p');
@@ -669,7 +673,10 @@
     const spinner = '<span class="chat-tool-spinner" aria-hidden="true"></span>';
 
     const summary = document.createElement('summary');
-    summary.innerHTML = spinner + label;
+    // ``label`` falls back to the raw server-supplied tool name for unknown
+    // tools (see toolLabel), so it MUST be escaped before going into
+    // innerHTML — only the static spinner span is trusted markup.
+    summary.innerHTML = spinner + escapeHtml(label);
     details.appendChild(summary);
 
     const pre = document.createElement('pre');
@@ -801,7 +808,11 @@
         if (inputEl) inputEl.value = suggestion;
         // Remove chip container after use
         if (chipsDiv.parentNode) chipsDiv.parentNode.removeChild(chipsDiv);
-        sendMessage();
+        // Gate on the streaming flag like every other send path — clicking
+        // a follow-up while a reply is still streaming would otherwise
+        // interleave two turns. sendMessage() also re-checks below, but
+        // guarding here keeps the chip text in the input for the user.
+        if (!streaming) sendMessage();
       });
       chipsDiv.appendChild(btn);
     }
@@ -1026,6 +1037,13 @@
 
   function sendMessage() {
     if (!inputEl) return;
+    // Hard gate on the streaming flag: a second turn started while one is
+    // still in flight interleaves deltas and corrupts the bubble buffers.
+    // Call sites also guard with ``if (!streaming)``; this is the
+    // defence-in-depth backstop so no path can bypass it. Composes with
+    // stop-generation — the user must stop the live reply (Stop button /
+    // Esc) before a new turn is accepted.
+    if (streaming) return;
     const text = inputEl.value.trim();
     if (!text) return;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
@@ -1375,6 +1393,17 @@
    *   (the regenerate flow).
    */
   function replayFromPivot(pivotMsgId, newUserText) {
+    // Gate on the streaming flag BEFORE any DOM mutation: this function
+    // destructively trims sibling bubbles and resets the buffers, which
+    // would corrupt a reply that is still streaming. Composes with
+    // stop-generation — the user must stop the live turn first. We surface
+    // a toast rather than silently dropping, since regenerate/edit are
+    // explicit user actions.
+    if (streaming) {
+      showToast('Oodake, kuni praegune vastus on valmis', 'warning');
+      return;
+    }
+
     const pivotEl = messagesEl
       ? messagesEl.querySelector('[data-message-id="' + pivotMsgId + '"]')
       : null;

--- a/tests/test_annotation_mentions_js.py
+++ b/tests/test_annotation_mentions_js.py
@@ -1,0 +1,104 @@
+"""Static guard tests for the @mention typeahead client (annotation_mentions.js).
+
+This repo has no JS test runner, so — like ``tests/test_chat_js_ontology_rewrite.py``
+— these tests read the shipped bundle and assert that the load-bearing
+behaviour is present and wired up. They fail loudly if a refactor drops it.
+
+Focus: issue #861-D. Each ``attach()`` registers three *global* listeners
+(``document`` click, ``window`` resize, ``window`` scroll-capture) plus a
+``<ul>`` appended to ``document.body``. When HTMX swaps a popover out the
+textarea leaves the DOM but those globals + the list element leak. The file
+already exposes an ``instance.destroy()`` that unwinds all of them; this
+guards that a destroy path is actually wired to the HTMX swap lifecycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_MENTIONS_JS = (
+    Path(__file__).resolve().parent.parent / "app" / "static" / "js" / "annotation_mentions.js"
+)
+
+
+def _source() -> str:
+    return _MENTIONS_JS.read_text(encoding="utf-8")
+
+
+def test_mentions_js_exists():
+    assert _MENTIONS_JS.is_file(), f"missing {_MENTIONS_JS}"
+
+
+def test_destroy_unwinds_all_global_listeners_and_list():
+    """The destroy() teardown must remove every global listener + the list."""
+    src = _source()
+    destroy = src[src.index("destroy()") :]
+    destroy = destroy[: destroy.index("};")]
+    # All three global listeners registered in attach() must be removed.
+    assert 'document.removeEventListener("click", onDocClick)' in destroy
+    assert 'window.removeEventListener("resize", onScrollOrResize)' in destroy
+    assert 'window.removeEventListener("scroll", onScrollOrResize, true)' in destroy
+    # The orphan list element appended to <body> must be removed.
+    assert "list.remove()" in destroy
+    # And both instance registries must drop the entry.
+    assert "INSTANCES.delete(textarea)" in destroy
+    assert "LIVE_TEXTAREAS.delete(textarea)" in destroy
+
+
+def test_live_textareas_registry_is_iterable():
+    """A WeakMap can't be walked; an iterable registry must back the sweep."""
+    src = _source()
+    # An iterable Set tracks live textareas so HTMX cleanup can find them.
+    assert "LIVE_TEXTAREAS = new Set()" in src
+    # attach() must register the textarea in that iterable set.
+    attach_body = src[src.index("function attach(textarea)") :]
+    attach_body = attach_body[: attach_body.index("function attachAll")]
+    assert "LIVE_TEXTAREAS.add(textarea)" in attach_body
+
+
+def test_destroy_within_targets_swapped_subtree():
+    """destroyWithin(root) must tear down instances inside the outgoing markup."""
+    src = _source()
+    assert "function destroyWithin(root)" in src
+    body = src[src.index("function destroyWithin(root)") :]
+    body = body[: body.index("function destroyDetached")]
+    # Walks the iterable registry and destroys textareas inside root.
+    assert "LIVE_TEXTAREAS" in body
+    assert "root.contains(textarea)" in body
+    # Snapshots the set first since destroy() mutates it during iteration.
+    assert "Array.from(LIVE_TEXTAREAS)" in body
+
+
+def test_destroy_wired_to_htmx_cleanup_events():
+    """The destroy path must be bound to HTMX's swap/cleanup lifecycle."""
+    src = _source()
+    # Per-element removal hook — the precise HTMX cleanup event.
+    assert 'addEventListener("htmx:beforeCleanupElement"' in src
+    # Swap-target content replacement hook.
+    assert 'addEventListener("htmx:beforeSwap"' in src
+    # Both must invoke the targeted teardown.
+    cleanup_idx = src.index('addEventListener("htmx:beforeCleanupElement"')
+    cleanup_block = src[cleanup_idx : cleanup_idx + 200]
+    assert "destroyWithin(ev.target)" in cleanup_block
+    beforeswap_idx = src.index('addEventListener("htmx:beforeSwap"')
+    beforeswap_block = src[beforeswap_idx : beforeswap_idx + 200]
+    assert "destroyWithin(ev.target)" in beforeswap_block
+
+
+def test_after_swap_sweeps_detached_then_rebinds():
+    """afterSwap must sweep detached instances AND re-bind the new markup."""
+    src = _source()
+    idx = src.index('addEventListener("htmx:afterSwap"')
+    block = src[idx : idx + 200]
+    # Belt-and-braces detached sweep before the re-scan re-binds incoming nodes.
+    assert "destroyDetached()" in block
+    assert "attachAll(ev.target" in block
+
+
+def test_destroy_helpers_exposed_for_debugging():
+    """The public surface should expose the teardown helpers (matches attach/attachAll)."""
+    src = _source()
+    expose = src[src.index("window.AnnotationMentions") :]
+    expose = expose[: expose.index("\n")]
+    assert "destroyWithin" in expose
+    assert "destroyDetached" in expose

--- a/tests/test_chat_js_ontology_rewrite.py
+++ b/tests/test_chat_js_ontology_rewrite.py
@@ -52,3 +52,83 @@ def test_rewrite_is_wired_into_render_buffer():
     render = src[src.index("function renderBuffer") :]
     render = render[: render.index("function rewriteOntologyUris")]
     assert "rewriteOntologyUris(" in render
+
+
+# ---------------------------------------------------------------------------
+# Finding #861-A — escape the fallback tool label before innerHTML.
+#
+# ``toolLabel()`` returns ``TOOL_LABELS[name] || name``; for an unknown tool
+# the raw, server-supplied name is returned and then interpolated into the
+# tool-activity <summary> via innerHTML. That value MUST be HTML-escaped or a
+# crafted tool name injects markup into the chat transcript.
+# ---------------------------------------------------------------------------
+
+
+def _slice_fn(src: str, name: str) -> str:
+    """Return the source of one function declaration up to the next one."""
+    start = src.index("function " + name)
+    rest = src[start + len("function " + name) :]
+    nxt = rest.find("\n  function ")
+    return rest if nxt < 0 else rest[:nxt]
+
+
+def test_tool_activity_summary_escapes_fallback_label():
+    body = _slice_fn(_source(), "createToolActivity")
+    # The innerHTML sink for the label must pass through escapeHtml.
+    assert "summary.innerHTML" in body
+    assert "escapeHtml(label)" in body
+    # And must NOT interpolate the raw label into innerHTML anymore.
+    assert "spinner + label" not in body
+
+
+# ---------------------------------------------------------------------------
+# Finding #861-B — clear the stale thinking indicator on WS reconnect.
+#
+# When the socket dies mid-stream, the elapsed ticker + watchdog timers and
+# the animated "Mõtlen..." bubble belong to a turn the server will not
+# resume. The reconnect ``open`` handler must call clearThinking() so those
+# orphaned timers/visuals don't survive into the recovered session.
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_clears_thinking_indicator():
+    src = _source()
+    # Isolate the open handler's broken-mid-stream recovery block.
+    open_idx = src.index("ws.addEventListener('open'")
+    close_idx = src.index("ws.addEventListener('close'")
+    open_block = src[open_idx:close_idx]
+    assert "brokenMidStream" in open_block
+    # The recovery branch must tear down the thinking timers/visuals.
+    recovery = open_block[open_block.index("if (brokenMidStream)") :]
+    assert "clearThinking()" in recovery
+
+
+# ---------------------------------------------------------------------------
+# Finding #861-C — gate sendMessage/replayFromPivot on the streaming flag.
+#
+# Starting a new turn (send, follow-up chip, regenerate, edit) while a reply
+# is still streaming interleaves deltas and corrupts the per-message buffers.
+# Both entry points must bail when ``streaming`` is true; this composes with
+# stop-generation (the user stops the live reply first).
+# ---------------------------------------------------------------------------
+
+
+def test_send_message_gated_on_streaming():
+    body = _slice_fn(_source(), "sendMessage")
+    # The very first guard inside sendMessage must short-circuit on streaming.
+    assert "if (streaming) return;" in body
+
+
+def test_replay_from_pivot_gated_on_streaming():
+    body = _slice_fn(_source(), "replayFromPivot")
+    # replayFromPivot trims sibling bubbles + resets buffers, so it must bail
+    # BEFORE any DOM mutation when a reply is still streaming.
+    assert "if (streaming)" in body
+    guard = body[: body.index("nextElementSibling")]
+    assert "if (streaming)" in guard
+
+
+def test_follow_up_chip_gated_on_streaming():
+    body = _slice_fn(_source(), "appendFollowUps")
+    # The follow-up chip click handler must not fire a send mid-stream.
+    assert "if (!streaming) sendMessage()" in body


### PR DESCRIPTION
Part of #861. Frontend review-finding fixes scoped to `app/static/js/chat.js`, `app/static/js/annotation_mentions.js`, and their Python-side static JS-guard tests. No out-of-scope files touched. Verified each finding still existed against `origin/main` (none were already fixed by PRs #868–#876 — last commit on `chat.js` was #841, on `annotation_mentions.js` was #825).

## Findings → fixes

**A — `chat.js`: escape fallback tool label before innerHTML (`:672`)** — *fixed.*
`createToolActivity()` interpolated `label` into the tool-activity `<summary>` via `innerHTML`. `toolLabel()` returns the raw, server-supplied tool name for unknown tools, so a crafted name could inject markup. Now `summary.innerHTML = spinner + escapeHtml(label);` — reuses the file's existing `escapeHtml()` helper; only the static spinner span stays trusted. (`completeToolActivity` already used `textContent`, so it was safe.)

**B — `chat.js`: `clearThinking()` on reconnect (`:302`)** — *fixed.*
On a mid-stream socket death the elapsed ticker + two watchdog timers and the animated "Mõtlen..." bubble belonged to a turn the server won't resume, but they survived the reconnect. The `brokenMidStream` recovery branch in the `open` handler now calls `clearThinking()` (which clears all three timers and removes the thinking visuals) before unlocking the input.

**C — `chat.js`: gate `sendMessage`/`replayFromPivot` on streaming (`:804`)** — *fixed.*
Starting a new turn mid-stream interleaves deltas and corrupts the per-message buffers. The other `sendMessage` call sites already guarded with `if (!streaming)`, but the follow-up chip path (`appendFollowUps`, `:804`) and `replayFromPivot` (regenerate/edit) did not.
- `sendMessage()` now bails first thing when `streaming` (defence-in-depth backstop so no path can bypass it).
- The follow-up chip click handler also gets a call-site `if (!streaming)` guard (keeps the chip text in the input).
- `replayFromPivot()` bails **before any DOM mutation** when streaming (it destructively trims sibling bubbles + resets buffers), surfacing an Estonian toast.
- Composes with stop-generation: the user stops the live reply (Stop button / Esc, which flip `streaming` off via the `done`/`stopped` handlers) before a new turn is accepted.

**D — `annotation_mentions.js`: destroy instances on HTMX swap (`:418`)** — *fixed.*
Each `attach()` registered 3 global listeners (`document` click, `window` resize, `window` scroll-capture) + a `<ul>` appended to `document.body`, none cleaned up when HTMX swapped a popover out. The existing `instance.destroy()` already unwinds all of them but was never called. Added:
- an iterable `LIVE_TEXTAREAS` `Set` (the `INSTANCES` `WeakMap` can't be walked), kept in sync in `attach()`/`destroy()`;
- `destroyWithin(root)` (tears down instances inside the outgoing markup) and `destroyDetached()` (sweeps instances whose textarea is no longer `isConnected`);
- listeners on `htmx:beforeCleanupElement` (precise per-element hook) and `htmx:beforeSwap` (target content replacement), plus a `htmx:afterSwap` detached-sweep backstop before the existing re-bind.

## Already-fixed
None — all four findings were still present on `origin/main`.

## Deferred
None — all four findings were fixable entirely within the JS scope.

## Tests
Static JS-guard tests follow the existing read-the-bundle assertion pattern (no JS runner in this repo):
- extended `tests/test_chat_js_ontology_rewrite.py` with guards for A/B/C (escape sink, reconnect clear, both streaming gates, follow-up chip gate);
- added `tests/test_annotation_mentions_js.py` with guards for D (destroy unwinds all globals + list, iterable registry, `destroyWithin` subtree targeting, HTMX-event wiring, afterSwap sweep+rebind, exposed helpers).

```
uv run pytest tests/test_chat_js_ontology_rewrite.py tests/test_annotation_mentions_js.py tests/test_annotation_mentions.py -q
26 passed

# broader regression check (routes serving these files / rendering popovers)
uv run pytest tests/test_chat_routes.py tests/test_chat_actions.py tests/test_annotations_routes.py tests/test_annotation_mentions.py tests/test_chat_js_ontology_rewrite.py tests/test_annotation_mentions_js.py -q
142 passed

uv run ruff format <touched .py>   # 1 reformatted, 1 unchanged
uv run ruff check  <touched .py>   # All checks passed!
uv run pyright     <touched .py>   # 0 errors, 0 warnings
node --check app/static/js/chat.js                  # OK
node --check app/static/js/annotation_mentions.js   # OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)