### PR TITLE
fix(chat): decryption sentinel, message ordering, transcript-export audit (#861)

### DIFF
--- a/app/chat/audit.py
+++ b/app/chat/audit.py
@@ -62,3 +62,24 @@ def log_chat_conversation_delete(
             "conversation_id": str(conv_id),
         },
     )
+
+
+def log_chat_transcript_export(
+    user_id: str | uuid.UUID | None,
+    conv_id: str | uuid.UUID,
+    export_format: str,
+) -> None:
+    """Record a transcript export (download) of a chat conversation.
+
+    Chat transcripts may contain pre-publication draft content, so taking a
+    copy out of the system is an access event we audit alongside creation
+    and deletion. *export_format* is the file extension (``"md"`` / ``"docx"``).
+    """
+    log_action(
+        str(user_id) if user_id else None,
+        "chat.conversation.export",
+        {
+            "conversation_id": str(conv_id),
+            "format": export_format,
+        },
+    )

--- a/app/chat/handlers.py
+++ b/app/chat/handlers.py
@@ -62,6 +62,7 @@ from starlette.responses import JSONResponse, RedirectResponse, Response
 from app.auth.audit import log_action
 from app.auth.helpers import require_auth as _require_auth
 from app.auth.policy import can_access_conversation
+from app.chat.audit import log_chat_transcript_export
 from app.chat.export import conversation_to_docx_bytes, conversation_to_markdown
 from app.chat.models import (
     Conversation,
@@ -210,14 +211,14 @@ def _set_message_pinned(conn: Any, msg_id: uuid.UUID, pinned: bool) -> None:
 def _delete_messages_after_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Message) -> int:
     """Drop every row newer than the pivot in *conv_id*.
 
-    The real :func:`delete_messages_after` takes a ``datetime`` boundary
-    (that's the schema-level truth — there is no "delete after message X"
-    primitive). The pivot ``Message`` is the anchor for both edit (the
-    user message whose reply should be regenerated) and regenerate (the
-    assistant reply's preceding user message); we look up its
-    ``created_at`` and delegate.
+    The real :func:`delete_messages_after` bounds on the compound
+    ``(created_at, id)`` key. The pivot ``Message`` is the anchor for both
+    edit (the user message whose reply should be regenerated) and regenerate
+    (the assistant reply's preceding user message); we pass its
+    ``created_at`` *and* ``id`` so same-tick rows on the wrong side of the
+    boundary are not dropped (#861).
     """
-    return int(delete_messages_after(conn, conv_id, pivot_msg.created_at) or 0)
+    return int(delete_messages_after(conn, conv_id, pivot_msg.created_at, pivot_msg.id) or 0)
 
 
 def _delete_messages_from_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Message) -> int:
@@ -228,7 +229,7 @@ def _delete_messages_from_pivot(conn: Any, conv_id: uuid.UUID, pivot_msg: Messag
     message, so the orphan assistant reply itself must be removed before
     the next turn — otherwise it survives a reload (issue #737).
     """
-    return int(delete_messages_from(conn, conv_id, pivot_msg.created_at) or 0)
+    return int(delete_messages_from(conn, conv_id, pivot_msg.created_at, pivot_msg.id) or 0)
 
 
 def _resolve_regenerate_pivot(
@@ -930,6 +931,7 @@ def export_md_handler(req: Request, conv_id: str):
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
         return auth_or_redirect
+    auth = auth_or_redirect
 
     loaded = _load_conversation_or_404(req, conv_id)
     if isinstance(loaded, Response):
@@ -945,6 +947,7 @@ def export_md_handler(req: Request, conv_id: str):
 
     markdown = conversation_to_markdown(conversation, messages)
     filename = _export_filename(conversation, "md")
+    log_chat_transcript_export(auth.get("id"), parsed_conv, "md")
     return Response(
         content=markdown,
         media_type="text/markdown; charset=utf-8",
@@ -957,6 +960,7 @@ def export_docx_handler(req: Request, conv_id: str):
     auth_or_redirect = _require_auth(req)
     if isinstance(auth_or_redirect, Response):
         return auth_or_redirect
+    auth = auth_or_redirect
 
     loaded = _load_conversation_or_404(req, conv_id)
     if isinstance(loaded, Response):
@@ -977,6 +981,7 @@ def export_docx_handler(req: Request, conv_id: str):
         return Response(status_code=500)
 
     filename = _export_filename(conversation, "docx")
+    log_chat_transcript_export(auth.get("id"), parsed_conv, "docx")
     return Response(
         content=payload,
         media_type=("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -97,6 +97,14 @@ class Message:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+# Rendered in place of a message body when ``content_encrypted`` is present
+# but cannot be decrypted (rotated-away key or tampered ciphertext). A
+# visible sentinel — rather than an empty string — so a failed decrypt is
+# obvious to the reader instead of looking like a blank message, while still
+# letting the rest of the conversation load (raising here would take the
+# whole transcript down over a single bad row).
+_UNDECRYPTABLE_CONTENT = "[sõnumit ei õnnestunud dekrüpteerida]"
+
 # Migration 017 adds ``is_pinned``, ``is_archived``, ``pinned_at`` and
 # ``title_is_custom``. They are appended at the end of the SELECT list so
 # pre-017 test fixtures (which build 7-tuple rows) still map cleanly via
@@ -212,10 +220,15 @@ def _is_missing_v037_column_error(exc: BaseException) -> bool:
 def _decode_encrypted_text(ciphertext: bytes | memoryview | None) -> str | None:
     """Decrypt a BYTEA column; return ``None`` on NULL or decrypt failure.
 
-    Fallback semantics: the caller uses ``None`` to signal "fall back to
-    plaintext column". We log decrypt failures loudly because they can only
-    mean the key rotated or the ciphertext got corrupted — both operator
-    problems that a silent fall-through would hide.
+    ``None`` is overloaded to mean both "column was NULL" and "decrypt
+    failed". Callers that must distinguish the two (the message-body path,
+    where NULL is an invariant violation but a decrypt failure should render
+    a visible sentinel) check the NULL case *before* calling this helper.
+
+    Migration 026 dropped the plaintext payload columns, so there is no
+    plaintext to fall back to — a decrypt failure can only mean the key
+    rotated or the ciphertext got corrupted, both operator problems we log
+    loudly rather than hide.
     """
     if ciphertext is None:
         return None
@@ -223,7 +236,7 @@ def _decode_encrypted_text(ciphertext: bytes | memoryview | None) -> str | None:
     try:
         return decrypt_text(raw)
     except DecryptionError:
-        logger.exception("Failed to decrypt message column — falling back to plaintext")
+        logger.exception("Failed to decrypt message column (rotated key or tampered ciphertext)")
         return None
 
 
@@ -328,7 +341,12 @@ def _row_to_message(row: tuple[Any, ...]) -> Message:
             f"messages.id={msg_id}: content_encrypted IS NULL — "
             "encryption-at-rest invariant violated (see migration 026)"
         )
-    content = _decode_encrypted_text(content_encrypted) or ""
+    # NULL was rejected above, so a ``None`` return here means decryption
+    # failed (rotated key / tampered ciphertext). Surface a visible sentinel
+    # instead of a blank body — an empty string would render as a silently
+    # missing message and the loud log below would be the only clue (#861).
+    decrypted_content = _decode_encrypted_text(content_encrypted)
+    content = decrypted_content if decrypted_content is not None else _UNDECRYPTABLE_CONTENT
 
     tool_input = _decode_encrypted_json(tool_input_encrypted)
     if tool_input is not None and not isinstance(tool_input, dict):
@@ -838,7 +856,7 @@ def list_messages(
             SELECT {_MESSAGE_COLUMNS}
             FROM messages
             WHERE conversation_id = %s
-            ORDER BY created_at ASC
+            ORDER BY created_at ASC, id ASC
             """,
             (str(conversation_id),),
         ).fetchall()
@@ -863,7 +881,7 @@ def list_messages(
                     SELECT {_MESSAGE_COLUMNS_PRE037}
                     FROM messages
                     WHERE conversation_id = %s
-                    ORDER BY created_at ASC
+                    ORDER BY created_at ASC, id ASC
                     """,
                     (str(conversation_id),),
                 ).fetchall()
@@ -889,7 +907,7 @@ def list_messages(
                     SELECT {_MESSAGE_COLUMNS_PRE036}
                     FROM messages
                     WHERE conversation_id = %s
-                    ORDER BY created_at ASC
+                    ORDER BY created_at ASC, id ASC
                     """,
                     (str(conversation_id),),
                 ).fetchall()
@@ -919,7 +937,7 @@ def list_messages(
                     SELECT {_MESSAGE_COLUMNS_PRE017}
                     FROM messages
                     WHERE conversation_id = %s
-                    ORDER BY created_at ASC
+                    ORDER BY created_at ASC, id ASC
                     """,
                     (str(conversation_id),),
                 ).fetchall()
@@ -1018,7 +1036,7 @@ def list_pinned_messages(
             SELECT {_MESSAGE_COLUMNS}
             FROM messages
             WHERE conversation_id = %s AND is_pinned = TRUE
-            ORDER BY created_at ASC
+            ORDER BY created_at ASC, id ASC
             """,
             (str(conv_id),),
         ).fetchall()
@@ -1035,27 +1053,33 @@ def delete_messages_after(
     conn: Any,
     conv_id: uuid.UUID | str,
     after_created_at: datetime,
+    after_id: uuid.UUID | str,
 ) -> int:
-    """Delete all messages strictly after *after_created_at* in the thread.
+    """Delete all messages strictly after the boundary in the thread.
 
     Used by the edit-and-resend flow to drop downstream messages when the
-    user rewrites an earlier turn. The boundary message itself
-    (``created_at == after_created_at``) is kept. Returns the number of
-    rows deleted; returns ``0`` on DB error (logged) so callers can treat
-    the operation as a no-op.
+    user rewrites an earlier turn. The boundary message itself is kept.
+
+    The comparison is the compound ``(created_at, id)`` tuple so it agrees
+    with the ``ORDER BY created_at ASC, id ASC`` read ordering: when two
+    rows share a ``created_at`` tick, only the rows that sort *after* the
+    boundary (by id) are removed, leaving the boundary turn and its same-tick
+    predecessors intact (#861). Returns the number of rows deleted; returns
+    ``0`` on DB error (logged) so callers can treat the operation as a no-op.
     """
     try:
         cursor = conn.execute(
             """
             DELETE FROM messages
-            WHERE conversation_id = %s AND created_at > %s
+            WHERE conversation_id = %s AND (created_at, id) > (%s, %s)
             """,
-            (str(conv_id), after_created_at),
+            (str(conv_id), after_created_at, str(after_id)),
         )
     except Exception:
         logger.exception(
-            "Failed to delete messages after %s for conversation=%s",
+            "Failed to delete messages after (%s, %s) for conversation=%s",
             after_created_at,
+            after_id,
             conv_id,
         )
         return 0
@@ -1068,8 +1092,9 @@ def delete_messages_from(
     conn: Any,
     conv_id: uuid.UUID | str,
     from_created_at: datetime,
+    from_id: uuid.UUID | str,
 ) -> int:
-    """Delete every message at or after *from_created_at* (inclusive).
+    """Delete every message at or after the boundary (inclusive).
 
     The companion of :func:`delete_messages_after`. Where the latter keeps
     the boundary message (used by the edit / regenerate-from-a-user-turn
@@ -1078,21 +1103,27 @@ def delete_messages_from(
     user turn we cannot regenerate "from the user message", so we drop the
     orphan assistant reply (and anything after it) outright before the
     next turn replays — otherwise the stale reply would survive a reload
-    (issue #737). Returns the number of rows deleted; returns ``0`` on DB
-    error (logged) so callers can treat the operation as a no-op.
+    (issue #737).
+
+    The comparison is the compound ``(created_at, id)`` tuple so it agrees
+    with the ``ORDER BY created_at ASC, id ASC`` read ordering when rows
+    share a ``created_at`` tick (#861). Returns the number of rows deleted;
+    returns ``0`` on DB error (logged) so callers can treat the operation as
+    a no-op.
     """
     try:
         cursor = conn.execute(
             """
             DELETE FROM messages
-            WHERE conversation_id = %s AND created_at >= %s
+            WHERE conversation_id = %s AND (created_at, id) >= (%s, %s)
             """,
-            (str(conv_id), from_created_at),
+            (str(conv_id), from_created_at, str(from_id)),
         )
     except Exception:
         logger.exception(
-            "Failed to delete messages from %s for conversation=%s",
+            "Failed to delete messages from (%s, %s) for conversation=%s",
             from_created_at,
+            from_id,
             conv_id,
         )
         return 0
@@ -1138,13 +1169,15 @@ def fork_conversation(
 
     The caller is responsible for committing the transaction.
     """
-    # Look up the fork point so we can bound the message copy by
-    # ``created_at``. Looking up the message (rather than filtering by
-    # id alone) lets us copy a contiguous time-ordered slice instead of
-    # relying on the caller to know the insertion order.
+    # Look up the fork point so we can bound the message copy by the
+    # compound ``(created_at, id)`` key. Bounding by the tuple (rather than
+    # ``created_at`` alone) copies a contiguous slice in the same order
+    # ``list_messages`` reads — and stays complementary with
+    # :func:`delete_messages_after`, which keeps the boundary row: the fork
+    # copies up to and including that same row (#861).
     boundary = conn.execute(
         """
-        SELECT created_at, conversation_id
+        SELECT created_at, id, conversation_id
         FROM messages
         WHERE id = %s
         """,
@@ -1152,7 +1185,7 @@ def fork_conversation(
     ).fetchone()
     if boundary is None:
         raise ValueError(f"Message {up_to_message_id} not found")
-    boundary_created_at, boundary_conv_id = boundary
+    boundary_created_at, boundary_id, boundary_conv_id = boundary
     if coerce_uuid(boundary_conv_id) != coerce_uuid(source_conv_id):
         raise ValueError(
             f"Message {up_to_message_id} does not belong to conversation {source_conv_id}"
@@ -1198,10 +1231,10 @@ def fork_conversation(
                 rag_context_encrypted, is_pinned, is_truncated, created_at,
                 tool_use_id, ontology_version
             FROM messages
-            WHERE conversation_id = %s AND created_at <= %s
-            ORDER BY created_at ASC
+            WHERE conversation_id = %s AND (created_at, id) <= (%s, %s)
+            ORDER BY created_at ASC, id ASC
             """,
-            (str(new_conv.id), str(source_conv_id), boundary_created_at),
+            (str(new_conv.id), str(source_conv_id), boundary_created_at, str(boundary_id)),
         )
     except Exception as exc:
         # Migration-037 fallback for fork — if the ``ontology_version``
@@ -1233,10 +1266,10 @@ def fork_conversation(
                         rag_context_encrypted, is_pinned, is_truncated, created_at,
                         tool_use_id
                     FROM messages
-                    WHERE conversation_id = %s AND created_at <= %s
-                    ORDER BY created_at ASC
+                    WHERE conversation_id = %s AND (created_at, id) <= (%s, %s)
+                    ORDER BY created_at ASC, id ASC
                     """,
-                    (str(new_conv.id), str(source_conv_id), boundary_created_at),
+                    (str(new_conv.id), str(source_conv_id), boundary_created_at, str(boundary_id)),
                 )
             except Exception as exc2:
                 # Cascading fallback — if v036 columns are also missing,
@@ -1264,10 +1297,10 @@ def fork_conversation(
                         content_encrypted, tool_input_encrypted, tool_output_encrypted,
                         rag_context_encrypted, is_pinned, is_truncated, created_at
                     FROM messages
-                    WHERE conversation_id = %s AND created_at <= %s
-                    ORDER BY created_at ASC
+                    WHERE conversation_id = %s AND (created_at, id) <= (%s, %s)
+                    ORDER BY created_at ASC, id ASC
                     """,
-                    (str(new_conv.id), str(source_conv_id), boundary_created_at),
+                    (str(new_conv.id), str(source_conv_id), boundary_created_at, str(boundary_id)),
                 )
         elif _is_missing_v036_column_error(exc):
             logger.warning(
@@ -1291,10 +1324,10 @@ def fork_conversation(
                     content_encrypted, tool_input_encrypted, tool_output_encrypted,
                     rag_context_encrypted, is_pinned, is_truncated, created_at
                 FROM messages
-                WHERE conversation_id = %s AND created_at <= %s
-                ORDER BY created_at ASC
+                WHERE conversation_id = %s AND (created_at, id) <= (%s, %s)
+                ORDER BY created_at ASC, id ASC
                 """,
-                (str(new_conv.id), str(source_conv_id), boundary_created_at),
+                (str(new_conv.id), str(source_conv_id), boundary_created_at, str(boundary_id)),
             )
         else:
             raise

--- a/tests/test_chat_core_sweep.py
+++ b/tests/test_chat_core_sweep.py
@@ -1,0 +1,181 @@
+"""Regression sweep for chat-core review findings (#861).
+
+Covers three findings in ``app.chat.models`` / ``app.chat.handlers`` /
+``app.chat.audit``:
+
+A. A decrypt failure on ``content_encrypted`` must render a *visible*
+   Estonian sentinel rather than a silently-empty body, while a NULL
+   ``content_encrypted`` keeps raising (the encryption-at-rest invariant).
+B. Message ordering carries an ``id`` tiebreaker and the delete /
+   fork boundaries use the compound ``(created_at, id)`` tuple so they
+   agree with that ordering when rows share a ``created_at`` tick.
+C. The transcript-export action is audited, and the message-send audit
+   helper is retained as the correct (currently unwired) primitive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.chat.audit import log_chat_transcript_export
+from app.chat.models import (
+    _UNDECRYPTABLE_CONTENT,
+    _row_to_message,
+    delete_messages_after,
+    delete_messages_from,
+    list_messages,
+)
+
+_CONV_ID = uuid.UUID("77777777-7777-7777-7777-777777777777")
+
+
+@pytest.fixture(autouse=True)
+def _fernet_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a deterministic Fernet key for the encryption-path tests."""
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("STORAGE_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    import app.storage.encrypted as encrypted_module
+
+    monkeypatch.setattr(encrypted_module, "_fernet", None)
+
+
+def _message_row(content_encrypted: Any) -> tuple[Any, ...]:
+    """Build a minimal v017-shaped ``messages`` row for ``_row_to_message``."""
+    now = datetime.now(UTC)
+    return (
+        uuid.uuid4(),  # id
+        _CONV_ID,  # conversation_id
+        "assistant",  # role
+        None,  # tool_name
+        None,  # tokens_input
+        None,  # tokens_output
+        None,  # model
+        now,  # created_at
+        content_encrypted,
+        None,  # tool_input_encrypted
+        None,  # tool_output_encrypted
+        None,  # rag_context_encrypted
+        False,  # is_pinned
+        False,  # is_truncated
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding A — decryption sentinel
+# ---------------------------------------------------------------------------
+
+
+class TestDecryptionSentinel:
+    def test_decrypt_failure_renders_visible_sentinel(self):
+        """A non-NULL ciphertext that cannot be decrypted (e.g. encrypted
+        under a now-rotated-away key) must surface the Estonian sentinel,
+        NOT an empty string (#861)."""
+        # Ciphertext from a *different* key — the installed key cannot
+        # decrypt it, so ``decrypt_text`` raises ``DecryptionError``.
+        foreign = Fernet(Fernet.generate_key()).encrypt(b"salajane sisu")
+
+        msg = _row_to_message(_message_row(foreign))
+
+        assert msg.content == _UNDECRYPTABLE_CONTENT
+        assert msg.content != ""
+
+    def test_sentinel_is_estonian_and_visible(self):
+        assert _UNDECRYPTABLE_CONTENT == "[sõnumit ei õnnestunud dekrüpteerida]"
+
+    def test_null_content_still_raises(self):
+        """The NULL path keeps its hard error — that is an invariant
+        violation (a regression that re-introduces a NULL write), distinct
+        from an operational decrypt failure."""
+        with pytest.raises(ValueError, match="content_encrypted IS NULL"):
+            _row_to_message(_message_row(None))
+
+    def test_valid_ciphertext_round_trips(self):
+        """Positive control: a ciphertext under the installed key decodes
+        to its plaintext, never the sentinel."""
+        from app.storage import encrypt_text
+
+        msg = _row_to_message(_message_row(encrypt_text("§ 1. Tekst")))
+
+        assert msg.content == "§ 1. Tekst"
+        assert msg.content != _UNDECRYPTABLE_CONTENT
+
+
+# ---------------------------------------------------------------------------
+# Finding B — ordering tiebreaker + compound boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestOrderingTiebreaker:
+    def test_list_messages_orders_by_created_at_then_id(self):
+        """The read ordering must include the ``id`` tiebreaker so same-tick
+        rows have a stable, total order (#861)."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+
+        list_messages(conn, _CONV_ID)
+
+        sql = conn.execute.call_args.args[0]
+        assert "ORDER BY created_at ASC, id ASC" in sql
+
+    def test_delete_after_boundary_is_compound_and_keeps_same_tick_predecessor(self):
+        """``delete_messages_after`` must compare the compound tuple so a
+        same-tick row that sorts *before* the boundary id is preserved."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.rowcount = 1
+        conn.execute.return_value = cursor
+        boundary_ts = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+        boundary_id = uuid.uuid4()
+
+        delete_messages_after(conn, _CONV_ID, boundary_ts, boundary_id)
+
+        sql, params = conn.execute.call_args.args
+        assert "(created_at, id) > (%s, %s)" in sql
+        assert params == (str(_CONV_ID), boundary_ts, str(boundary_id))
+
+    def test_delete_from_boundary_is_compound_inclusive(self):
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.rowcount = 2
+        conn.execute.return_value = cursor
+        boundary_ts = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+        boundary_id = uuid.uuid4()
+
+        delete_messages_from(conn, _CONV_ID, boundary_ts, boundary_id)
+
+        sql, params = conn.execute.call_args.args
+        assert "(created_at, id) >= (%s, %s)" in sql
+        assert params == (str(_CONV_ID), boundary_ts, str(boundary_id))
+
+
+# ---------------------------------------------------------------------------
+# Finding C — transcript-export audit
+# ---------------------------------------------------------------------------
+
+
+class TestTranscriptExportAudit:
+    @patch("app.chat.audit.log_action")
+    def test_export_audit_payload(self, mock_log):
+        user_id = uuid.uuid4()
+        conv_id = uuid.uuid4()
+
+        log_chat_transcript_export(user_id, conv_id, "md")
+
+        mock_log.assert_called_once()
+        args = mock_log.call_args[0]
+        assert args[0] == str(user_id)
+        assert args[1] == "chat.conversation.export"
+        assert args[2]["conversation_id"] == str(conv_id)
+        assert args[2]["format"] == "md"
+
+    @patch("app.chat.audit.log_action")
+    def test_export_audit_none_user(self, mock_log):
+        log_chat_transcript_export(None, uuid.uuid4(), "docx")
+        assert mock_log.call_args[0][0] is None
+        assert mock_log.call_args[0][2]["format"] == "docx"

--- a/tests/test_chat_handlers.py
+++ b/tests/test_chat_handlers.py
@@ -838,6 +838,37 @@ class TestExport:
             # .docx files are ZIP archives — check the magic number.
             assert resp.content[:2] == b"PK"
 
+    def test_export_md_audits_transcript_export(self, provider_patch, mock_conn):
+        conv = _make_conversation(title="Vestlus AI-ga")
+        msg = _make_message(role="user", content="Tere")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers.log_chat_transcript_export") as mock_audit,
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}/export.md")
+            assert resp.status_code == 200
+            mock_audit.assert_called_once()
+            args = mock_audit.call_args.args
+            assert args[0] == _USER_ID
+            assert args[1] == _CONV_ID
+            assert args[2] == "md"
+
+    def test_export_docx_audits_transcript_export(self, provider_patch, mock_conn):
+        conv = _make_conversation(title="Testvestlus")
+        msg = _make_message(role="user", content="Tere")
+        with (
+            patch("app.chat.handlers.get_conversation", return_value=conv),
+            patch("app.chat.handlers.list_messages", return_value=[msg]),
+            patch("app.chat.handlers.log_chat_transcript_export") as mock_audit,
+        ):
+            client = _authed_client()
+            resp = client.get(f"/chat/{_CONV_ID}/export.docx")
+            assert resp.status_code == 200
+            mock_audit.assert_called_once()
+            assert mock_audit.call_args.args[2] == "docx"
+
     def test_export_md_cross_org_404(self, provider_patch, mock_conn):
         conv = _make_conversation(org_id=_OTHER_ORG_ID, user_id=_OTHER_USER_ID)
         with patch("app.chat.handlers.get_conversation", return_value=conv):

--- a/tests/test_chat_models.py
+++ b/tests/test_chat_models.py
@@ -608,27 +608,30 @@ class TestListPinnedMessages:
 
 
 class TestDeleteMessagesAfter:
-    def test_delete_uses_strict_greater_than(self):
-        """Messages *at* the boundary created_at must NOT be deleted."""
+    def test_delete_uses_compound_strict_greater_than(self):
+        """Rows after the compound ``(created_at, id)`` boundary are deleted;
+        the boundary row and same-tick predecessors are kept (#861)."""
         conn = MagicMock()
         cursor = MagicMock()
         cursor.rowcount = 3
         conn.execute.return_value = cursor
         boundary = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+        boundary_id = uuid.uuid4()
 
-        result = delete_messages_after(conn, uuid.uuid4(), boundary)
+        result = delete_messages_after(conn, uuid.uuid4(), boundary, boundary_id)
 
         assert result == 3
         sql, params = conn.execute.call_args.args
         assert "DELETE" in sql
-        assert "created_at > %s" in sql
+        assert "(created_at, id) > (%s, %s)" in sql
         assert params[1] == boundary
+        assert params[2] == str(boundary_id)
 
     def test_returns_zero_on_db_error(self):
         conn = MagicMock()
         conn.execute.side_effect = RuntimeError("boom")
 
-        result = delete_messages_after(conn, uuid.uuid4(), datetime.now(UTC))
+        result = delete_messages_after(conn, uuid.uuid4(), datetime.now(UTC), uuid.uuid4())
         assert result == 0
 
 
@@ -638,28 +641,31 @@ class TestDeleteMessagesAfter:
 
 
 class TestDeleteMessagesFrom:
-    def test_delete_uses_inclusive_greater_or_equal(self):
+    def test_delete_uses_compound_inclusive_greater_or_equal(self):
         """Unlike :func:`delete_messages_after`, the boundary row IS deleted —
-        used by the regenerate flow's orphan-assistant fallback (#737)."""
+        used by the regenerate flow's orphan-assistant fallback (#737). The
+        comparison is the compound ``(created_at, id)`` tuple (#861)."""
         conn = MagicMock()
         cursor = MagicMock()
         cursor.rowcount = 4
         conn.execute.return_value = cursor
         boundary = datetime(2026, 4, 14, 10, 0, 0, tzinfo=UTC)
+        boundary_id = uuid.uuid4()
 
-        result = delete_messages_from(conn, uuid.uuid4(), boundary)
+        result = delete_messages_from(conn, uuid.uuid4(), boundary, boundary_id)
 
         assert result == 4
         sql, params = conn.execute.call_args.args
         assert "DELETE" in sql
-        assert "created_at >= %s" in sql
+        assert "(created_at, id) >= (%s, %s)" in sql
         assert params[1] == boundary
+        assert params[2] == str(boundary_id)
 
     def test_returns_zero_on_db_error(self):
         conn = MagicMock()
         conn.execute.side_effect = RuntimeError("boom")
 
-        result = delete_messages_from(conn, uuid.uuid4(), datetime.now(UTC))
+        result = delete_messages_from(conn, uuid.uuid4(), datetime.now(UTC), uuid.uuid4())
         assert result == 0
 
 
@@ -682,7 +688,7 @@ class TestForkConversation:
         new_row = _make_conversation_row(conv_id=new_conv_id, title="Jätk: Algvestlus")
 
         fetchone_results = [
-            (boundary_created_at, source_conv_id),  # boundary lookup
+            (boundary_created_at, boundary_msg_id, source_conv_id),  # boundary lookup
             source_row,  # get_conversation(source)
             new_row,  # create_conversation(new)
         ]
@@ -699,12 +705,13 @@ class TestForkConversation:
         assert new_conv.id == new_conv_id
         assert new_conv.title == "Jätk: Algvestlus"
 
-        # Final call should be the INSERT ... SELECT with created_at bound.
+        # Final call should be the INSERT ... SELECT bound on the compound
+        # ``(created_at, id)`` key (#861).
         final_call = conn.execute.call_args_list[-1]
         sql = final_call.args[0]
         params = final_call.args[1]
         assert "INSERT INTO messages" in sql
-        assert "created_at <= %s" in sql
+        assert "(created_at, id) <= (%s, %s)" in sql
         assert "content_encrypted" in sql
         assert "tool_input_encrypted" in sql
         assert "tool_output_encrypted" in sql
@@ -713,6 +720,7 @@ class TestForkConversation:
             str(new_conv_id),
             str(source_conv_id),
             boundary_created_at,
+            str(boundary_msg_id),
         )
 
     def test_fork_title_prefixes_jatk(self):
@@ -725,7 +733,7 @@ class TestForkConversation:
         new_row = _make_conversation_row(title="Jätk: Maksureform")
 
         conn.execute.return_value.fetchone.side_effect = [
-            (created_at, source_conv_id),
+            (created_at, boundary_msg_id, source_conv_id),
             source_row,
             new_row,
         ]
@@ -767,6 +775,7 @@ class TestForkConversation:
 
         conn.execute.return_value.fetchone.return_value = (
             datetime.now(UTC),
+            uuid.uuid4(),
             other_conv_id,
         )
 

--- a/tests/test_chat_outdated_ontology.py
+++ b/tests/test_chat_outdated_ontology.py
@@ -813,7 +813,7 @@ class TestForkPreservesOntologyVersion:
         )
 
         conn.execute.return_value.fetchone.side_effect = [
-            (boundary_created_at, source_conv_id),
+            (boundary_created_at, boundary_msg_id, source_conv_id),
             source_conv_row,
             new_conv_row,
         ]
@@ -868,7 +868,7 @@ class TestForkPreservesOntologyVersion:
         # 5: pre-037 INSERT (succeeds).
         fetchone_results = iter(
             [
-                (boundary_created_at, source_conv_id),
+                (boundary_created_at, boundary_msg_id, source_conv_id),
                 source_conv_row,
                 new_conv_row,
             ]


### PR DESCRIPTION
Part of #861.

Fixes three review findings in the chat-core modules (`app/chat/models.py`, `app/chat/handlers.py`, `app/chat/audit.py`). All pointers were verified against the current `origin/main` — none were already fixed by PRs #868–#876.

## Finding A — decryption sentinel (`models.py`)
> "Decryption failure renders content as `""` with a stale 'plaintext fallback' log — return a visible sentinel or raise like the NULL path."

**Status: fixed.**

Inspected the NULL path first (`_row_to_message`, line ~326): a NULL `content_encrypted` raises `ValueError` because it is an encryption-at-rest *invariant violation* (a regression that re-introduces a NULL write). A decrypt failure is operationally different — it means a key rotated away or the ciphertext was tampered, and raising would take the **whole transcript** down over a single bad row (one bad message → `list_messages` returns `[]` → empty history). So a decrypt failure now renders a **visible Estonian sentinel** while the rest of the conversation still loads:

- Added `_UNDECRYPTABLE_CONTENT = "[sõnumit ei õnnestunud dekrüpteerida]"`.
- The content call site now distinguishes the two cases: NULL is rejected above, so a `None` return from `_decode_encrypted_text` there can only mean decrypt failure → render the sentinel instead of `or ""`.
- The JSON columns (`tool_input`/`tool_output`/`rag_context`) keep their `None`-on-failure semantics (absent → no payload), unchanged.
- Fixed the misleading log: "falling back to plaintext" was stale (migration 026 dropped the plaintext columns) → now "Failed to decrypt message column (rotated key or tampered ciphertext)".

## Finding B — ordering tiebreaker + compound delete boundary (`models.py`)
> "Message ordering tiebreaker (created_at, id) and compound delete boundary."

**Status: fixed.**

- Added the `id` tiebreaker to **all six** message orderings: `list_messages` main SELECT + its three schema-fallback SELECTs (pre-037 / pre-036 / pre-017), `list_pinned_messages`, and the fork copy → `ORDER BY created_at ASC, id ASC`.
- Made the delete boundaries compound so they agree with the new ordering when rows share a `created_at` tick:
  - `delete_messages_after`: `(created_at, id) > (%s, %s)` — keeps the boundary row + same-tick predecessors.
  - `delete_messages_from`: `(created_at, id) >= (%s, %s)` — inclusive of the boundary.
  - Both gained a `boundary_id` parameter, threaded from the pivot `Message` in the `handlers.py` wrappers (`_delete_messages_after_pivot` / `_delete_messages_from_pivot`).
- `fork_conversation`: the boundary lookup now also selects `id`, and all four copy queries (v037 + three migration fallbacks) bound on `(created_at, id) <= (%s, %s)`. This stays **complementary** with `delete_messages_after` (which keeps the boundary): a fork-at-X keeps X in the original and copies X into the fork.

The only callers of the delete functions are the two handler wrappers (both updated); no other call sites exist.

## Finding C — transcript-export audit + `log_chat_message_send` (`handlers.py`, `audit.py`)
> "Audit transcript export + actually call log_chat_message_send or delete it."

**Status: transcript-export audit fixed; `log_chat_message_send` retained, its wiring deferred (out of scope) — see below.**

- **Transcript export (fully in scope):** added `log_chat_transcript_export(user_id, conv_id, format)` → `chat.conversation.export`, called from both `export_md_handler` and `export_docx_handler` (after a successful render, before returning). Matches the existing `log_chat_conversation_create` / `…delete` pattern. Justified by the audit-everything posture: transcripts can contain pre-publication draft content, so taking a copy out of the system is an access event.
- **`log_chat_message_send`:** investigated whether it is redundant. It is **not** — there is currently **no** `chat.message.send` audit event anywhere, and the genuine user-send path (`app/chat/orchestrator.py::_persist_user_message`) does no auditing at all. The `chat.message.edit` and `chat.message.regenerate` events already in `handlers.py` are distinct semantic actions, not sends. So the helper is the correct primitive and is kept.

  The finding said to wire it "at the right spot in handlers.py", but `handlers.py` has **no message-send endpoint** — sends happen over the chat WebSocket in `orchestrator.py`. Wiring the actual call requires editing `orchestrator.py` (out of this PR's strict file scope; `_persist_user_message` would also need to surface the new message id, which it currently discards). **Deferred** with this pointer for the follow-up: call `log_chat_message_send(ctx.user_id, ctx.conversation_id, <new_msg_id>)` from `_phase_persist_user_message` / `_persist_user_message`.

## Tests
New `tests/test_chat_core_sweep.py` (11 tests): decrypt-failure → sentinel, NULL → raise, valid ciphertext round-trip, ordering tiebreaker in `list_messages` SQL, compound delete boundaries, export-audit payload. Updated existing tests for the new signatures/SQL: `tests/test_chat_models.py` (delete + fork compound boundaries, 3-tuple boundary lookup), `tests/test_chat_handlers.py` (two new export-audit integration tests), `tests/test_chat_outdated_ontology.py` (3-tuple fork boundary mocks).

```
uv run ruff format <touched>   # 1 reformatted, 6 unchanged
uv run ruff check <touched>    # All checks passed!
uv run pyright app/chat/{models,handlers,audit}.py  # 0 errors, 0 warnings
uv run pytest -k chat          # 627 passed, 8 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)