### PR TITLE
fix(misc): email escaping, §-resolver edge cases, SPARQL client pooling, history query (#861)

### DIFF
--- a/app/analyysikeskus/history.py
+++ b/app/analyysikeskus/history.py
@@ -778,12 +778,24 @@ def list_impact_reports(
 ) -> list[ImpactReportRow]:
     """Return historical ``impact_reports`` rows touching *input_uri*, newest-first.
 
-    Scans the JSONB ``report_data`` for the URI as a string match. The
-    intent is "did any analysis report mention this entity"; a stable
-    structured key (e.g. ``report_data.affected[].entity_uri``) would
-    let us use a JSON-path index but is not pinned yet — we use
-    ``report_data::text ILIKE`` so the query works against the schema
-    today. The result list is capped at :data:`_MAX_IMPACT_REPORTS`.
+    The intent is "did any analysis report mention this entity". The
+    ``report_data`` JSONB stores entity URIs in a small, stable set of
+    array-of-object fields (``affected_entities[].uri``,
+    ``conflicts[].conflicting_entity``, ``eu_compliance[].eu_act`` /
+    ``estonian_provision``, ``gaps[].topic_cluster``, and the v2
+    ``sanctions_delta.rows[].provision_uri`` /
+    ``burden_delta.rows[].provision_uri``). We match with the JSONB
+    containment operator ``@>`` against those paths, which the GIN
+    index ``idx_impact_reports_report_data`` (migration 042) accelerates
+    — replacing the previous ``report_data::text ILIKE %uri%``
+    full-table scan. Containment also matches on a *URI field* rather
+    than a coincidental substring of some label literal, so it is both
+    faster and more precise.
+
+    Every value is passed as a bound parameter (psycopg adapts the dict
+    to ``jsonb``), so there are no ILIKE wildcards to escape and no
+    injection surface — the previous ``ILIKE %uri%`` wildcard-escaping
+    hazard is removed entirely by dropping the text-cast scan.
 
     Args:
         input_uri: The entity URI to search for. Empty input ⇒ ``[]``.
@@ -799,28 +811,45 @@ def list_impact_reports(
     if not uri:
         return []
 
-    sql = """
+    # One containment probe per URI-bearing path. Postgres BitmapOrs the
+    # per-branch GIN index scans, so the whole predicate stays indexed.
+    # ``Jsonb`` wraps each value so psycopg sends a typed ``jsonb``
+    # parameter (no ``::text`` cast, no string interpolation).
+    from psycopg.types.json import Jsonb
+
+    containment_params = [
+        Jsonb({"affected_entities": [{"uri": uri}]}),
+        Jsonb({"conflicts": [{"conflicting_entity": uri}]}),
+        Jsonb({"eu_compliance": [{"eu_act": uri}]}),
+        Jsonb({"eu_compliance": [{"estonian_provision": uri}]}),
+        Jsonb({"gaps": [{"topic_cluster": uri}]}),
+        Jsonb({"sanctions_delta": {"rows": [{"provision_uri": uri}]}}),
+        Jsonb({"burden_delta": {"rows": [{"provision_uri": uri}]}}),
+    ]
+    containment_clause = " OR ".join("ir.report_data @> %s" for _ in containment_params)
+
+    sql = f"""
         SELECT ir.id, ir.draft_id, d.title, ir.generated_at,
                dv.version_number
         FROM impact_reports ir
         JOIN drafts d ON d.id = ir.draft_id
         LEFT JOIN draft_versions dv ON dv.id = ir.draft_version_id
-        WHERE ir.report_data::text ILIKE %s
+        WHERE {containment_clause}
         ORDER BY ir.generated_at DESC NULLS LAST
         LIMIT %s
     """
-    pattern = f"%{uri}%"
+    params = (*containment_params, _MAX_IMPACT_REPORTS)
 
     try:
         if db_connection is not None:
             with db_connection.cursor() as cur:
-                cur.execute(sql, (pattern, _MAX_IMPACT_REPORTS))
+                cur.execute(sql, params)
                 rows = cur.fetchall()
         else:
             from app.db import get_connection
 
             with get_connection() as conn, conn.cursor() as cur:
-                cur.execute(sql, (pattern, _MAX_IMPACT_REPORTS))
+                cur.execute(sql, params)
                 rows = cur.fetchall()
     except Exception:
         logger.warning("list_impact_reports: query failed for %r", uri, exc_info=True)

--- a/app/analyysikeskus/input_parser.py
+++ b/app/analyysikeskus/input_parser.py
@@ -53,10 +53,22 @@ from app.docs.reference_resolver import _HUMAN_ABBREV_ALIASES
 _CELEX_RE = re.compile(r"^\d{5}[A-Z]\d{1,4}$", re.IGNORECASE)
 _CELEX_SCAN_RE = re.compile(r"\b\d{5}[A-Z]\d{1,4}\b", re.IGNORECASE)
 
-# Estonian court case numbers: ``3-1-1-63-15``, ``3-2-1-4-13``, ``5-19-1-2``…
-# A run of digit groups joined by hyphens, at least three groups, last
-# group typically a 2-digit year but we don't enforce that.
-_EE_CASE_RE = re.compile(r"^\d+-\d+-\d+(?:-\d+)*$")
+# Estonian court case numbers: ``3-1-1-63-15``, ``3-2-1-4-13``,
+# ``5-19-1-2``, ``3-20-1044``… A run of digit groups joined by hyphens,
+# at least three groups. The leading group is a single-digit court-type
+# code (1–9), which is the key signal that distinguishes a case number
+# from an ISO date like ``2026-06-10`` (whose leading group is the
+# 4-digit year). We cap the first group at two digits as headroom while
+# still excluding any 4-digit year prefix.
+_EE_CASE_RE = re.compile(r"^\d{1,2}-\d+-\d+(?:-\d+)*$")
+
+# Strict ISO calendar date (``YYYY-MM-DD``): a 4-digit year, a 1–12
+# month, a 1–31 day. Used as a belt-and-braces guard so a date never
+# parses as a court case number even if a future case format widened
+# the leading group. Anchored fullmatch at the call site.
+_ISO_DATE_RE = re.compile(
+    r"^\d{4}-(?:0?[1-9]|1[0-2])-(?:0?[1-9]|[12]\d|3[01])$",
+)
 
 # CJEU / EU General Court case numbers: ``C-131/12``, ``T-99/04``,
 # ``F-1/05``, ``C-362/14`` … letter + dash + digits + slash + digits.
@@ -76,9 +88,9 @@ _SECTION_RE = re.compile(
     ^\s*
     (?P<law>[A-Za-zÕÄÖÜŠŽõäöüšž][\wÕÄÖÜŠŽõäöüšž]*)   # law short name, e.g. AvTS / KarS / KOKS
     \s+§\s*
-    (?P<section>\d+(?:[.\^]\d+)?)                       # section number, optional .N / ^N suffix
-    (?:\s+lg\s*(?P<lg>\d+))?                            # optional 'lg N'
-    (?:\s+p\s*(?P<p>\d+))?                              # optional 'p N'
+    (?P<section>\d+(?:[.\^]\d+|[⁰¹²³⁴⁵⁶⁷⁸⁹]+)?)        # section + optional .N/^N/superscript
+    (?:\s+lg\.?\s*(?P<lg>\d+))?                         # optional 'lg N' / 'lg. N'
+    (?:\s+p\.?\s*(?P<p>\d+))?                           # optional 'p N' / 'p. N'
     \s*$
     """,
     re.IGNORECASE | re.VERBOSE,
@@ -215,8 +227,11 @@ def parse_user_reference(sisend: str) -> list[ExtractedRef]:
 
     # 2. Court case numbers — Estonian (``3-1-1-63-15``) or CJEU
     #    (``C-131/12``). Exact-match only: we don't want a stray number
-    #    range inside prose to be misread as a case number.
-    if _EE_CASE_RE.fullmatch(text) or _EU_CASE_RE.fullmatch(text):
+    #    range inside prose to be misread as a case number. An ISO date
+    #    (``2026-06-10``) is explicitly excluded so it never lands here.
+    if not _ISO_DATE_RE.fullmatch(text) and (
+        _EE_CASE_RE.fullmatch(text) or _EU_CASE_RE.fullmatch(text)
+    ):
         return [_ref(text, "court_decision")]
 
     # 3. §-reference — ``AvTS § 35``, ``KarS § 133 lg 2 p 1`` … The
@@ -279,6 +294,29 @@ def _ref(ref_text: str, ref_type: str, *, confidence: float = 1.0) -> ExtractedR
     )
 
 
+# Unicode superscript digits → ASCII, so a section typed as ``113¹``
+# canonicalises to the caret form ``113^1`` that the resolver and
+# ontology literal probing share.
+_SUPERSCRIPT_DIGITS = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹", "0123456789")
+
+
+def _canonical_section(section: str) -> str:
+    """Canonicalise a captured section to ``N`` or ``N^M``.
+
+    Folds a Unicode-superscript index (``113¹``) to the caret form
+    (``113^1``); a dotted index (``113.1``) likewise; bare digits pass
+    through unchanged. Keeps the §-reference spelling stable regardless
+    of how the user typed the superscript.
+    """
+    m = re.match(r"^(\d+)([⁰¹²³⁴⁵⁶⁷⁸⁹]+)$", section)
+    if m:
+        return f"{m.group(1)}^{m.group(2).translate(_SUPERSCRIPT_DIGITS)}"
+    dotted = re.match(r"^(\d+)\.(\d+)$", section)
+    if dotted:
+        return f"{dotted.group(1)}^{dotted.group(2)}"
+    return section
+
+
 def _canonical_provision_text(
     law_short: str,
     section: str,
@@ -288,11 +326,12 @@ def _canonical_provision_text(
     """Render a canonical ``"Law § N[ lg N][ p N]"`` provision string.
 
     The ontology stores provision literals in a consistent shape; the
-    user's typing may differ in spacing ("§35", "lg2"). Re-spelling
-    here gives the resolver its best shot at an exact literal match
-    before it falls back to the law short-name lookup.
+    user's typing may differ in spacing ("§35", "lg2") or superscript
+    spelling ("§ 113¹" vs "§ 113^1"). Re-spelling here gives the
+    resolver its best shot at an exact literal match before it falls
+    back to the law short-name lookup.
     """
-    out = f"{law_short} § {section}"
+    out = f"{law_short} § {_canonical_section(section)}"
     if lg:
         out += f" lg {lg}"
     if p:

--- a/app/docs/reference_resolver.py
+++ b/app/docs/reference_resolver.py
@@ -93,18 +93,121 @@ _LAW_SUFFIX_RE = re.compile(
 )
 
 
+# Unicode superscript digits (``¹²³…``) → their ASCII counterparts.
+# Estonian section numbers carry a superscript index for inserted
+# provisions: ``§ 113¹`` is "paragrahv sada kolmteist üks" (the §113
+# that was inserted after the original §113). We normalise the
+# superscript to the caret form ``113^1`` so it matches the
+# input-parser convention (``_SECTION_RE`` already accepts ``113^1`` /
+# ``113.1``) and so the corpus's ``estleg:paragrahv`` literal forms can
+# be probed in both shapes.
+_SUPERSCRIPT_DIGITS = str.maketrans("⁰¹²³⁴⁵⁶⁷⁸⁹", "0123456789")
+
+
+def _normalise_section_number(raw: str) -> str | None:
+    """Canonicalise a captured section token to ``N`` or ``N^M``.
+
+    Accepts the base digits optionally followed by a superscript index
+    in any of three spellings:
+
+      * Unicode superscript — ``113¹``  → ``113^1``
+      * caret form          — ``113^1`` → ``113^1``
+      * dotted form         — ``113.1`` → ``113^1``
+
+    Returns ``None`` for anything that is not a digit-run with an
+    optional all-digit superscript (the injection guard — the result
+    is interpolated into the URI guess and SPARQL literals).
+    """
+    token = (raw or "").strip()
+    if not token:
+        return None
+    # Fold any Unicode superscript digits to ASCII, tagging them so we
+    # know a superscript boundary even without an explicit ^/. marker.
+    folded = token.translate(_SUPERSCRIPT_DIGITS)
+    if folded != token:
+        # The original carried Unicode superscripts: split the base from
+        # the (now-ASCII) superscript run. Re-scan the original so we
+        # only treat the trailing superscript glyphs as the index.
+        m = re.match(r"^(\d+)([⁰¹²³⁴⁵⁶⁷⁸⁹]+)$", token)
+        if not m:
+            return None
+        base = m.group(1)
+        sup = m.group(2).translate(_SUPERSCRIPT_DIGITS)
+        return f"{base}^{sup}"
+    # ASCII path: bare digits, or base + caret/dot + digits.
+    m = re.match(r"^(\d+)(?:[.^](\d+))?$", folded)
+    if not m:
+        return None
+    base, sup = m.group(1), m.group(2)
+    return f"{base}^{sup}" if sup else base
+
+
+# ASCII digit → Unicode superscript, for rendering ``113^1`` back to the
+# human-facing ``113¹`` in result labels.
+_ASCII_TO_SUPERSCRIPT = str.maketrans("0123456789", "⁰¹²³⁴⁵⁶⁷⁸⁹")
+
+
+def _section_display(section: str) -> str:
+    """Render a canonical section (``N`` / ``N^M``) for a user label.
+
+    Plain sections render verbatim; a superscript index renders with
+    Unicode superscript glyphs (``113^1`` → ``113¹``) so the result
+    card reads the way an Estonian lawyer wrote the reference.
+    """
+    base, sep, sup = section.partition("^")
+    if not sep:
+        return base
+    return base + sup.translate(_ASCII_TO_SUPERSCRIPT)
+
+
+def _paragrahv_literals(section: str) -> list[str]:
+    """Candidate ``estleg:paragrahv`` literal spellings to probe.
+
+    The corpus stores the section marker as ``"§ N."`` (with a trailing
+    period) and, in some rows, ``"§ N"`` (without) — the spike pinned
+    both forms for plain sections. For a superscript section we don't
+    know which spelling the corpus uses, so we widen the probe to the
+    caret, the bare-digit-concatenation, and the Unicode-superscript
+    forms, each with and without the trailing period.
+
+    Every returned literal is built from a validated ``section`` (digits
+    plus an optional all-digit superscript) so the strings only ever
+    contain digits, ``^``, superscript glyphs, ``§``, spaces and a
+    period — safe to interpolate into a SPARQL ``VALUES`` clause.
+    """
+    base, sep, sup = section.partition("^")
+    if not sep:
+        forms = [base]
+    else:
+        forms = [
+            section,  # 113^1
+            base + sup,  # 1131
+            base + sup.translate(_ASCII_TO_SUPERSCRIPT),  # 113¹
+        ]
+    literals: list[str] = []
+    for form in forms:
+        literals.append(f"§ {form}.")
+        literals.append(f"§ {form}")
+    return literals
+
+
 # Decomposition of provision references. Captures:
 #   1. act half (everything before the §/paragrahv marker)
-#   2. section number (digits only)
+#   2. section number (digits, optionally with a superscript index)
 #   3. optional lõige number
 #   4. optional punkt number
 #
 # The Estonian inflection space is wide: ``lõige`` (nom.), ``lõike``
 # (gen./part.), ``lõikest`` (elative), ``lõikele`` (allative), the
-# bare abbrev ``lg``. Likewise for ``punkt`` → ``punkti``,
-# ``punktist``, ``p``. We use loose stems (``l(õi|oi|õ|o)[gk]`` for
-# lõige; ``p(unkt[…])?``) and then allow any letters before the
+# bare abbrev ``lg`` (and its dotted ``lg.`` spelling). Likewise for
+# ``punkt`` → ``punkti``, ``punktist``, ``p`` / ``p.``. We use loose
+# stems (``l(õi|oi|õ|o)[gk]`` for lõige; ``p(unkt[…])?``), allow a
+# trailing ``.`` (the abbreviation dot), then any letters before the
 # digit.
+#
+# The section number tolerates a superscript index — Unicode
+# ``§ 113¹`` or the ASCII ``§ 113^1`` / ``§ 113.1`` spellings — captured
+# raw here and canonicalised by :func:`_normalise_section_number`.
 _PROVISION_RE = re.compile(
     r"""
     ^\s*
@@ -112,16 +215,16 @@ _PROVISION_RE = re.compile(
     \s+
     (?:§(?:-s|-st|-le|-ni)?|paragrahv[ia]?|paragrahvist|paragrahvile)
     \s*
-    (?P<num>\d+)                                     # section number
+    (?P<num>\d+(?:[.^]\d+|[⁰¹²³⁴⁵⁶⁷⁸⁹]+)?)           # section number + optional superscript
     (?:
         \s*
-        (?:lg|l(?:õi|oi|õ|o)[gk][a-zõöäü]*)         # lg / lõige / lõike / lõikest …
+        (?:lg|l(?:õi|oi|õ|o)[gk][a-zõöäü]*)\.?        # lg / lg. / lõige / lõike / lõikest …
         \s*
         (?P<lg>\d+)
     )?
     (?:
         \s*
-        (?:p|punkt[a-zõöäü]*)                       # p / punkt / punkti / punktist …
+        (?:p|punkt[a-zõöäü]*)\.?                       # p / p. / punkt / punkti / punktist …
         \s*
         (?P<p>\d+)
     )?
@@ -567,22 +670,31 @@ class ReferenceResolver:
             return _unresolved(ref)
 
         act_text = match.group("act").strip()
-        num = match.group("num")
+        raw_num = match.group("num")
 
-        # Hard injection guard: only accept digits in the section number.
-        if not num or not num.isdigit():
+        # Hard injection guard: accept only a digit run plus an optional
+        # all-digit superscript index. ``section`` is the canonical
+        # ``N`` / ``N^M`` form; ``base`` is the leading digits used for
+        # the (proven) URI-guess fast path.
+        section = _normalise_section_number(raw_num)
+        if section is None:
             self._log_miss(ref, tried_keys=["non_digit_section"], candidates=0)
             return _unresolved(ref)
+        base = section.split("^", 1)[0]
+        has_superscript = "^" in section
 
         token, title, _ = self._resolve_law_half(act_text)
         if title is None:
-            self._log_miss(ref, tried_keys=[act_text, num], candidates=0)
+            self._log_miss(ref, tried_keys=[act_text, section], candidates=0)
             return _unresolved(ref)
 
-        # URI-guess fast path. Only attempt when TOKEN is known and num
-        # is purely digits (validated above).
-        if token:
-            guess_uri = f"{ESTLEG_NS}{token}_Par_{num}"
+        # URI-guess fast path. Only attempt for plain-digit sections —
+        # the corpus ``_Par_N`` URI shape for superscript sections is
+        # not pinned, so we route those through the literal-probe
+        # structural query / partial-match path instead of guessing a
+        # URI that would never hit.
+        if token and not has_superscript:
+            guess_uri = f"{ESTLEG_NS}{token}_Par_{base}"
             ask_sparql = PREFIXES + f"\nASK {{ <{guess_uri}> ?p ?o }}\n"
             try:
                 hit = self._sparql.ask(ask_sparql)
@@ -590,7 +702,7 @@ class ReferenceResolver:
                 logger.warning(
                     "resolve: URI-guess ASK failed token=%s num=%s: %s",
                     token,
-                    num,
+                    base,
                     exc,
                 )
                 hit = False
@@ -598,21 +710,24 @@ class ReferenceResolver:
                 return ResolvedRef(
                     extracted=ref,
                     entity_uri=guess_uri,
-                    matched_label=f"{title} § {num}",
+                    matched_label=f"{title} § {base}",
                     match_score=1.0,
                 )
 
         # Structural fallback: single-arm sourceAct + paragrahv match.
-        # Both literal forms (``"§ N."`` and ``"§ N"``) per spike.
-        # ``num`` is digits-only, validated above — safe to interpolate.
+        # Probe every plausible ``estleg:paragrahv`` literal spelling
+        # (with/without the trailing period; for superscript sections
+        # also the caret and Unicode forms). ``section`` is validated
+        # digits-plus-optional-superscript above — safe to interpolate;
         # ``actLit`` is bound via the SparqlClient escape helper.
+        par_literals = " ".join(f'"{lit}"' for lit in _paragrahv_literals(section))
         struct_sparql = (
             PREFIXES
             + f"""
             SELECT ?p WHERE {{
               ?p estleg:paragrahv ?par ;
                  estleg:sourceAct  ?actLit .
-              VALUES ?par {{ "§ {num}." "§ {num}" }}
+              VALUES ?par {{ {par_literals} }}
             }}
             LIMIT 1
             """
@@ -623,6 +738,7 @@ class ReferenceResolver:
             logger.warning("resolve: provision SPARQL failed: %s", exc)
             rows = []
 
+        section_display = _section_display(section)
         if rows:
             row = rows[0]
             uri = row.get("p")
@@ -630,7 +746,7 @@ class ReferenceResolver:
                 return ResolvedRef(
                     extracted=ref,
                     entity_uri=uri,
-                    matched_label=f"{title} § {num}",
+                    matched_label=f"{title} § {section_display}",
                     match_score=1.0,
                 )
 
@@ -639,18 +755,18 @@ class ReferenceResolver:
         # only" instead of treating it like a clean miss.
         self._log_miss(
             ref,
-            tried_keys=[token or "", title, num],
+            tried_keys=[token or "", title, section],
             candidates=0,
         )
         return ResolvedRef(
             extracted=ref,
             entity_uri=None,
-            matched_label=f"{title} (sätet § {num} ei leitud)",
+            matched_label=f"{title} (sätet § {section_display} ei leitud)",
             match_score=0.5,
             partial_match={
                 "act_token": token,
                 "act_title": title,
-                "section": num,
+                "section": section,
             },
         )
 

--- a/app/email/templates.py
+++ b/app/email/templates.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import html
+
 
 def password_reset(*, full_name: str, reset_url: str) -> tuple[str, str, str]:
     subject = "Parooli lähtestamine — Seadusloome"
-    html = f"""\
-<p>Tere {full_name},</p>
+    # Escape every user-controlled value before interpolating into the
+    # HTML body. ``full_name`` originates from the user record and could
+    # carry ``<``/``&``/``"`` that would otherwise inject markup; the
+    # reset URL is escaped in both attribute and text position.
+    name_html = html.escape(full_name)
+    url_attr = html.escape(reset_url, quote=True)
+    url_text = html.escape(reset_url)
+    html_body = f"""\
+<p>Tere {name_html},</p>
 
 <p>Saime taotluse teie parooli lähtestamiseks Seadusloome platvormil.
 Uue parooli määramiseks klõpsake allpool oleval lingil:</p>
 
-<p><a href="{reset_url}">{reset_url}</a></p>
+<p><a href="{url_attr}">{url_text}</a></p>
 
 <p>Link kehtib 1 tunni. Kui te ei taotlenud lähtestamist, võite selle e-kirja eirata —
 teie parool jääb muutmata.</p>
@@ -32,20 +41,27 @@ teie parool jääb muutmata.
 Lugupidamisega,
 Seadusloome
 """
-    return subject, html, text
+    return subject, html_body, text
 
 
 def password_reset_admin(
     *, full_name: str, reset_url: str, admin_name: str
 ) -> tuple[str, str, str]:
     subject = "Administraator on lähtestanud teie parooli — Seadusloome"
-    html = f"""\
-<p>Tere {full_name},</p>
+    # Escape every user-controlled value (recipient name + the
+    # admin-supplied name) before HTML interpolation; the reset URL is
+    # escaped for both attribute and text position.
+    name_html = html.escape(full_name)
+    admin_html = html.escape(admin_name)
+    url_attr = html.escape(reset_url, quote=True)
+    url_text = html.escape(reset_url)
+    html_body = f"""\
+<p>Tere {name_html},</p>
 
-<p>Administraator <strong>{admin_name}</strong> on algatanud teie parooli lähtestamise
+<p>Administraator <strong>{admin_html}</strong> on algatanud teie parooli lähtestamise
 Seadusloome platvormil. Uue parooli määramiseks klõpsake allpool oleval lingil:</p>
 
-<p><a href="{reset_url}">{reset_url}</a></p>
+<p><a href="{url_attr}">{url_text}</a></p>
 
 <p>Link kehtib 1 tunni.</p>
 
@@ -64,4 +80,4 @@ Link kehtib 1 tunni.
 Lugupidamisega,
 Seadusloome
 """
-    return subject, html, text
+    return subject, html_body, text

--- a/app/ontology/sparql_client.py
+++ b/app/ontology/sparql_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 import time
 
 import httpx
@@ -16,6 +17,71 @@ logger = logging.getLogger(__name__)
 # Default connection settings (from jena_loader.py conventions)
 _DEFAULT_JENA_URL = "http://localhost:3030"
 _DEFAULT_JENA_DATASET = "ontology"
+
+
+# ---------------------------------------------------------------------------
+# Shared httpx.Client (connection pooling)
+# ---------------------------------------------------------------------------
+#
+# Every ``SparqlClient`` instance (there are ~30 short-lived ones across the
+# app — one per analyysikeskus helper call, etc.) routes its HTTP through a
+# single process-wide ``httpx.Client``.  A bare ``httpx.post`` opens and tears
+# down a fresh TCP+TLS connection on every call; a pooled client keeps
+# keep-alive connections to Fuseki warm, which matters under the 5–50
+# concurrent-user load and the multi-query Analüüsikeskus pages.
+#
+# Lazy-init singleton (mirrors the ``ClaudeProvider`` / ``VoyageProvider`` /
+# resolver pattern documented in CLAUDE.md): the client is constructed on the
+# first real request behind a thread-safe lock, so importing this module never
+# opens sockets and tests that never hit the network never pay for one.
+
+# Bound the pool so a burst of concurrent SPARQL calls can't exhaust file
+# descriptors against a single Fuseki host.  ``max_connections`` is the hard
+# ceiling; ``max_keepalive_connections`` is how many idle connections we keep
+# warm between requests.
+_HTTP_LIMITS = httpx.Limits(max_connections=20, max_keepalive_connections=10)
+
+# Overall ceiling for a single request when a caller does not pass its own
+# per-instance timeout.  Individual ``SparqlClient`` instances override this
+# per-request via ``self.timeout`` (see :meth:`SparqlClient._execute`).
+_DEFAULT_TIMEOUT = 30.0
+
+_shared_client: httpx.Client | None = None
+_shared_client_lock = threading.Lock()
+
+
+def _get_shared_http_client() -> httpx.Client:
+    """Return the process-wide pooled :class:`httpx.Client`, building it once.
+
+    Double-checked locking so the first concurrent burst of SPARQL calls
+    constructs exactly one client.  The client carries connection-pool
+    limits and a default timeout; per-request timeouts still win when a
+    caller passes one to :meth:`httpx.Client.post`.
+    """
+    global _shared_client
+    if _shared_client is not None:
+        return _shared_client
+    with _shared_client_lock:
+        if _shared_client is None:
+            _shared_client = httpx.Client(
+                limits=_HTTP_LIMITS,
+                timeout=httpx.Timeout(_DEFAULT_TIMEOUT),
+            )
+    return _shared_client
+
+
+def close_shared_http_client() -> None:
+    """Close and drop the shared client (process shutdown / test teardown).
+
+    Safe to call when no client was ever built — it is a no-op in that
+    case.  The next call to :func:`_get_shared_http_client` rebuilds a
+    fresh pool.
+    """
+    global _shared_client
+    with _shared_client_lock:
+        client, _shared_client = _shared_client, None
+    if client is not None:
+        client.close()
 
 
 def _sanitize_sparql_value(value: str) -> str:
@@ -125,7 +191,7 @@ class SparqlClient:
         start = time.perf_counter()
         status = "error"
         try:
-            response = httpx.post(
+            response = _get_shared_http_client().post(
                 self.endpoint,
                 data={"query": sparql},
                 headers={"Accept": "application/sparql-results+json"},
@@ -269,12 +335,28 @@ class SparqlClient:
         data = self._execute(sparql, on_error="swallow", operation="ask")
         return bool(data.get("boolean", False))
 
-    def count(self, sparql: str) -> int:
+    def count(self, sparql: str, *, on_error: str = "swallow") -> int:
         """Execute a SPARQL SELECT query that returns a single count value.
 
         Expects the query to project a ``?count`` variable.
+
+        Parameters
+        ----------
+        on_error:
+            Forwarded to :meth:`query` / :meth:`_execute`.  ``"swallow"``
+            (the default, legacy behaviour) means a dead Jena yields
+            ``0`` — convenient for display paths that can tolerate a
+            zero count.  ``"raise"`` re-raises the underlying
+            :class:`httpx.HTTPError` so a caller can tell "Jena says
+            there are 0 rows" apart from "Jena was unreachable" and
+            avoid rendering an outage as a truthful ``total: 0`` (which
+            misleads pagination — see ``app/explorer/routes.py``).
+
+        Note that a genuine empty result (Jena reachable, zero rows)
+        still returns ``0`` under ``on_error="raise"`` — only transport
+        failures propagate, never an empty binding set.
         """
-        rows = self.query(sparql, operation="count")
+        rows = self.query(sparql, operation="count", on_error=on_error)
         if rows and "count" in rows[0]:
             try:
                 return int(rows[0]["count"])

--- a/migrations/042_impact_reports_report_data_gin.sql
+++ b/migrations/042_impact_reports_report_data_gin.sql
@@ -1,0 +1,44 @@
+-- =============================================================================
+-- Migration 042: GIN index on impact_reports.report_data for containment lookups
+-- =============================================================================
+--
+-- ``app.analyysikeskus.history.list_impact_reports`` answers "did any analysis
+-- report mention this entity URI" for the Ajalooline kehtivus workflow.  It
+-- previously matched with ``report_data::text ILIKE '%<uri>%'`` — a cast to
+-- text plus a leading-wildcard LIKE, which forces a sequential scan of every
+-- impact_reports row and re-serialises each JSONB blob to text on the way.
+--
+-- The query now uses the JSONB containment operator ``@>`` against the small,
+-- stable set of URI-bearing paths in report_data:
+--
+--     report_data @> '{"affected_entities":   [{"uri": "<uri>"}]}'
+--  OR report_data @> '{"conflicts":           [{"conflicting_entity": "<uri>"}]}'
+--  OR report_data @> '{"eu_compliance":       [{"eu_act": "<uri>"}]}'
+--  OR report_data @> '{"eu_compliance":       [{"estonian_provision": "<uri>"}]}'
+--  OR report_data @> '{"gaps":                [{"topic_cluster": "<uri>"}]}'
+--  OR report_data @> '{"sanctions_delta": {"rows": [{"provision_uri": "<uri>"}]}}'
+--  OR report_data @> '{"burden_delta":    {"rows": [{"provision_uri": "<uri>"}]}}'
+--
+-- A GIN index on the column accelerates every ``@>`` branch; Postgres BitmapOrs
+-- the per-branch index scans so the whole OR predicate stays indexed instead of
+-- degrading to a seqscan.
+--
+-- INDEX CHOICE: jsonb_ops vs jsonb_path_ops
+-- -----------------------------------------
+-- The default ``jsonb_ops`` opclass indexes every key AND every value, and
+-- supports the existence operators (``?`` / ``?&`` / ``?|``) in addition to
+-- containment (``@>``).  ``jsonb_path_ops`` is smaller and faster for ``@>``
+-- alone but supports neither the existence operators nor the cheap top-level
+-- key lookups that other report_data consumers may want later.  At the
+-- impact_reports table's modest row count the size difference is immaterial, so
+-- we use the default ``jsonb_ops`` for its broader operator coverage and to
+-- keep the index reusable by future report_data queries.
+--
+-- IF NOT EXISTS makes the statement idempotent (safe to re-apply).  The index
+-- is built without CONCURRENTLY: the migration runner wraps each file in a
+-- single transaction (CONCURRENTLY cannot run inside one) and impact_reports is
+-- small enough that the brief ShareLock on build is a non-event.
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_impact_reports_report_data
+    ON impact_reports USING gin (report_data);

--- a/tests/test_misc_backend_sweep.py
+++ b/tests/test_misc_backend_sweep.py
@@ -1,0 +1,459 @@
+"""Backend review-sweep tests for issue #861.
+
+Covers five independent findings, one section each:
+
+* **A** — ``app.email.templates`` HTML-escapes interpolated user values
+  (recipient + admin names, reset URL) so a crafted name can't inject
+  markup into the password-reset emails.
+* **B** — ``app.docs.reference_resolver`` provision regex accepts dotted
+  subsection abbreviations (``lg. 2`` / ``p. 1``) and superscript section
+  numbers (Unicode ``§ 113¹`` and ASCII ``§ 113^1`` / ``§ 113.1``), with
+  regression coverage for the plain forms.
+* **C** — ``app.analyysikeskus.input_parser`` no longer mis-parses an ISO
+  date (``2026-06-10``) as an Estonian court case number, while real case
+  formats (``3-1-1-63-15``, ``3-20-1044``, ``5-19-1-2``) still match.
+* **E** — ``app.analyysikeskus.history.list_impact_reports`` matches via
+  indexed JSONB containment instead of a ``report_data::text ILIKE``
+  full-table scan, with bound ``jsonb`` parameters (no wildcard surface).
+
+(Finding **D**, the SPARQL client's shared pooled ``httpx.Client`` and
+``count(on_error=...)`` passthrough, is covered in
+``tests/test_sparql_client.py``.)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# A. Email templates HTML-escape interpolated values
+# ---------------------------------------------------------------------------
+
+
+class TestEmailTemplateEscaping:
+    def test_password_reset_escapes_name_markup(self):
+        from app.email.templates import password_reset
+
+        _subject, html, text = password_reset(
+            full_name="<script>alert(1)</script> & Co",
+            reset_url="https://example.com/auth/reset/abc",
+        )
+        # The raw tag must not survive into the HTML body.
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+        assert "&amp; Co" in html
+        # The plain-text part is not HTML and is intentionally left raw.
+        assert "<script>alert(1)</script> & Co" in text
+
+    def test_password_reset_escapes_url_in_attribute(self):
+        from app.email.templates import password_reset
+
+        # A double-quote in the URL must not break out of the href="" attr.
+        _subject, html, _text = password_reset(
+            full_name="Mari",
+            reset_url='https://example.com/r"onmouseover=alert(1)',
+        )
+        assert 'href="https://example.com/r"onmouseover=alert(1)"' not in html
+        assert "&quot;onmouseover=alert(1)" in html
+
+    def test_password_reset_admin_escapes_admin_name(self):
+        from app.email.templates import password_reset_admin
+
+        _subject, html, _text = password_reset_admin(
+            full_name="Mari",
+            reset_url="https://example.com/auth/reset/xyz",
+            admin_name="<b>Boss</b>",
+        )
+        assert "<b>Boss</b>" not in html
+        assert "&lt;b&gt;Boss&lt;/b&gt;" in html
+        # The legitimate surrounding <strong> markup is still present.
+        assert "<strong>" in html
+
+    def test_plain_names_unchanged(self):
+        """Escaping is a no-op for ordinary Estonian names."""
+        from app.email.templates import password_reset, password_reset_admin
+
+        _s1, html1, _t1 = password_reset(
+            full_name="Mari Maasikas",
+            reset_url="https://example.com/auth/reset/abc",
+        )
+        assert "Mari Maasikas" in html1
+        _s2, html2, _t2 = password_reset_admin(
+            full_name="Mari",
+            reset_url="https://example.com/auth/reset/abc",
+            admin_name="Henrik Aavik",
+        )
+        assert "Henrik Aavik" in html2
+
+
+# ---------------------------------------------------------------------------
+# B. Reference-resolver provision regex — dotted abbrevs + superscripts
+# ---------------------------------------------------------------------------
+
+ESTLEG = "https://data.riik.ee/ontology/estleg#"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_resolver_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the resolver's HMAC secret so miss-log ref_ids are stable."""
+    from app.docs.reference_resolver import _REF_HASH_SECRET_ENV
+
+    monkeypatch.setenv(_REF_HASH_SECRET_ENV, "test-secret-deterministic")
+
+
+class TestSectionNumberNormalisation:
+    def test_plain_digits(self):
+        from app.docs.reference_resolver import _normalise_section_number
+
+        assert _normalise_section_number("143") == "143"
+
+    def test_unicode_superscript(self):
+        from app.docs.reference_resolver import _normalise_section_number
+
+        assert _normalise_section_number("113¹") == "113^1"
+        assert _normalise_section_number("113²³") == "113^23"
+
+    def test_caret_and_dot_forms(self):
+        from app.docs.reference_resolver import _normalise_section_number
+
+        assert _normalise_section_number("113^1") == "113^1"
+        assert _normalise_section_number("113.1") == "113^1"
+
+    def test_rejects_non_digit(self):
+        from app.docs.reference_resolver import _normalise_section_number
+
+        assert _normalise_section_number("") is None
+        assert _normalise_section_number("12a") is None
+        assert _normalise_section_number("a12") is None
+
+    def test_paragrahv_literals_plain(self):
+        from app.docs.reference_resolver import _paragrahv_literals
+
+        assert _paragrahv_literals("143") == ["§ 143.", "§ 143"]
+
+    def test_paragrahv_literals_superscript_widened(self):
+        from app.docs.reference_resolver import _paragrahv_literals
+
+        lits = _paragrahv_literals("113^1")
+        # Caret, concatenated, and Unicode forms, each with/without period.
+        assert "§ 113^1." in lits
+        assert "§ 1131" in lits
+        assert "§ 113¹" in lits
+
+    def test_section_display_superscript(self):
+        from app.docs.reference_resolver import _section_display
+
+        assert _section_display("113^1") == "113¹"
+        assert _section_display("143") == "143"
+
+
+class TestProvisionRegexDottedAndSuperscript:
+    def _router(self, ask: bool = False, provision_rows=None):
+        sparql = MagicMock()
+
+        def _query(q, bindings=None, **kwargs):
+            if "LegalProvision_" in q and "?cls" in q:
+                return [
+                    {
+                        "prov": f"{ESTLEG}KRIMIN_Par_1",
+                        "cls": f"{ESTLEG}LegalProvision_KRIMIN",
+                        "actLit": "Karistusseadustik",
+                    }
+                ]
+            if "estleg:paragrahv ?par" in q:
+                return provision_rows or []
+            return []
+
+        sparql.query.side_effect = _query
+        sparql.ask.return_value = ask
+        return sparql
+
+    def _ref(self, text):
+        from app.docs.entity_extractor import ExtractedRef
+
+        return ExtractedRef(ref_text=text, ref_type="provision", confidence=0.9, location={})
+
+    def test_dotted_lg_abbreviation_parses(self):
+        """``KarS § 211 lg. 2`` resolves the section (ASK hit) — the dotted
+        ``lg.`` must not break the parse."""
+        from app.docs.reference_resolver import ReferenceResolver
+
+        resolver = ReferenceResolver(sparql_client=self._router(ask=True))
+        result = resolver.resolve([self._ref("KarS § 211 lg. 2")])
+        assert result[0].entity_uri == f"{ESTLEG}KRIMIN_Par_211"
+
+    def test_dotted_punkt_abbreviation_parses(self):
+        from app.docs.reference_resolver import ReferenceResolver
+
+        resolver = ReferenceResolver(sparql_client=self._router(ask=True))
+        result = resolver.resolve([self._ref("KarS § 211 lg. 2 p. 1")])
+        assert result[0].entity_uri == f"{ESTLEG}KRIMIN_Par_211"
+
+    def test_superscript_section_unicode_partial_match(self):
+        """``KarS § 113¹`` with no matching section yields a partial match
+        carrying the canonical caret section — not a regex miss."""
+        from app.docs.reference_resolver import ReferenceResolver
+
+        resolver = ReferenceResolver(sparql_client=self._router(ask=False, provision_rows=[]))
+        result = resolver.resolve([self._ref("KarS § 113¹")])
+        assert result[0].partial_match is not None
+        assert result[0].partial_match["section"] == "113^1"
+        assert result[0].partial_match["act_token"] == "KRIMIN"
+        # The user-facing label renders the superscript back.
+        assert "113¹" in (result[0].matched_label or "")
+
+    def test_superscript_section_ascii_caret(self):
+        from app.docs.reference_resolver import ReferenceResolver
+
+        resolver = ReferenceResolver(sparql_client=self._router(ask=False, provision_rows=[]))
+        result = resolver.resolve([self._ref("KarS § 113^1")])
+        assert result[0].partial_match is not None
+        assert result[0].partial_match["section"] == "113^1"
+
+    def test_superscript_section_probes_widened_literals(self):
+        """The structural SPARQL for a superscript section must probe the
+        caret / concatenated / Unicode literal spellings."""
+        from app.docs.reference_resolver import ReferenceResolver
+
+        captured: list[str] = []
+
+        sparql = MagicMock()
+
+        def _query(q, bindings=None, **kwargs):
+            captured.append(q)
+            if "LegalProvision_" in q and "?cls" in q:
+                return [
+                    {
+                        "prov": f"{ESTLEG}KRIMIN_Par_1",
+                        "cls": f"{ESTLEG}LegalProvision_KRIMIN",
+                        "actLit": "Karistusseadustik",
+                    }
+                ]
+            if "estleg:paragrahv ?par" in q:
+                return [{"p": f"{ESTLEG}KRIMIN_Par_113_1"}]
+            return []
+
+        sparql.query.side_effect = _query
+        sparql.ask.return_value = False
+        resolver = ReferenceResolver(sparql_client=sparql)
+
+        result = resolver.resolve([self._ref("KarS § 113¹")])
+        structural = [q for q in captured if "estleg:paragrahv ?par" in q]
+        assert structural, "structural query should run for superscript section"
+        assert "§ 113^1" in structural[0]
+        assert "§ 1131" in structural[0]
+        assert "§ 113¹" in structural[0]
+        # The row hit means we get a resolved URI, not a partial match.
+        assert result[0].entity_uri == f"{ESTLEG}KRIMIN_Par_113_1"
+
+    def test_plain_section_regression_uri_guess(self):
+        """Regression: a plain ``KarS § 211`` still takes the URI-guess path."""
+        from app.docs.reference_resolver import ReferenceResolver
+
+        sparql = self._router(ask=True)
+        resolver = ReferenceResolver(sparql_client=sparql)
+        result = resolver.resolve([self._ref("KarS § 211")])
+        assert result[0].entity_uri == f"{ESTLEG}KRIMIN_Par_211"
+        assert result[0].match_score == 1.0
+        # URI guess only fires for plain sections.
+        assert sparql.ask.call_count == 1
+
+    def test_superscript_skips_uri_guess(self):
+        """A superscript section must NOT attempt the (unproven) URI guess."""
+        from app.docs.reference_resolver import ReferenceResolver
+
+        sparql = self._router(ask=True, provision_rows=[])
+        resolver = ReferenceResolver(sparql_client=sparql)
+        resolver.resolve([self._ref("KarS § 113¹")])
+        assert sparql.ask.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# C. input_parser — ISO dates are not court case numbers
+# ---------------------------------------------------------------------------
+
+
+class TestIsoDateNotCaseNumber:
+    @pytest.mark.parametrize(
+        "iso_date",
+        ["2026-06-10", "2024-01-01", "1999-12-31", "2026-6-1"],
+    )
+    def test_iso_date_does_not_parse_as_case(self, iso_date: str):
+        from app.analyysikeskus.input_parser import parse_user_reference
+
+        refs = parse_user_reference(iso_date)
+        types = [r.ref_type for r in refs]
+        assert "court_decision" not in types
+
+    @pytest.mark.parametrize(
+        "case_number",
+        ["3-1-1-63-15", "3-2-1-4-13", "5-19-1-2", "3-20-1044"],
+    )
+    def test_real_case_numbers_still_match(self, case_number: str):
+        from app.analyysikeskus.input_parser import parse_user_reference
+
+        refs = parse_user_reference(case_number)
+        assert [r.ref_type for r in refs] == ["court_decision"]
+        assert refs[0].ref_text == case_number
+
+    def test_cjeu_case_still_matches(self):
+        from app.analyysikeskus.input_parser import parse_user_reference
+
+        refs = parse_user_reference("C-131/12")
+        assert [r.ref_type for r in refs] == ["court_decision"]
+
+    def test_invalid_month_day_is_not_a_date_but_also_not_a_case(self):
+        """``2026-13-99`` is neither a valid ISO date nor (4-digit-prefix) a
+        case number, so it falls through to the empty result."""
+        from app.analyysikeskus.input_parser import parse_user_reference
+
+        refs = parse_user_reference("2026-13-99")
+        assert [r.ref_type for r in refs] == []
+
+    def test_section_superscript_via_input_parser(self):
+        """Finding B lockstep: ``KarS § 113¹`` parses into provision+law with
+        the canonical caret section in the provision text."""
+        from app.analyysikeskus.input_parser import parse_user_reference
+
+        refs = parse_user_reference("KarS § 113¹")
+        types = [r.ref_type for r in refs]
+        assert types == ["provision", "law"]
+        provision = next(r for r in refs if r.ref_type == "provision")
+        assert "§ 113^1" in provision.ref_text
+
+    def test_dotted_lg_via_input_parser(self):
+        from app.analyysikeskus.input_parser import parse_user_reference
+
+        refs = parse_user_reference("KarS § 211 lg. 2")
+        provision = next(r for r in refs if r.ref_type == "provision")
+        assert "lg 2" in provision.ref_text
+
+
+# ---------------------------------------------------------------------------
+# E. list_impact_reports — indexed JSONB containment, no ::text ILIKE
+# ---------------------------------------------------------------------------
+
+
+class TestListImpactReportsContainment:
+    _URI = "https://data.riik.ee/ontology/estleg#Provision_1"
+
+    def _conn_capturing(self, rows):
+        captured: dict[str, Any] = {}
+        stub_conn = MagicMock()
+        stub_cur = MagicMock()
+        stub_conn.cursor.return_value.__enter__.return_value = stub_cur
+        stub_conn.cursor.return_value.__exit__.return_value = None
+
+        def _execute(sql, params):
+            captured["sql"] = sql
+            captured["params"] = params
+
+        stub_cur.execute.side_effect = _execute
+        stub_cur.fetchall.return_value = rows
+        return stub_conn, captured
+
+    def test_uses_containment_not_text_ilike(self):
+        from app.analyysikeskus.history import list_impact_reports
+
+        conn, captured = self._conn_capturing([])
+        list_impact_reports(self._URI, db_connection=conn)
+        sql = captured["sql"]
+        assert isinstance(sql, str)
+        # The full-table-scan text cast + ILIKE must be gone.
+        assert "::text" not in sql
+        assert "ILIKE" not in sql.upper()
+        # Replaced by JSONB containment.
+        assert "@>" in sql
+
+    def test_binds_jsonb_params_no_wildcards(self):
+        from psycopg.types.json import Jsonb
+
+        from app.analyysikeskus.history import list_impact_reports
+
+        conn, captured = self._conn_capturing([])
+        list_impact_reports(self._URI, db_connection=conn)
+        params = captured["params"]
+        assert isinstance(params, tuple)
+        # Every containment param is a typed Jsonb wrapper carrying the URI,
+        # never a ``%...%`` LIKE pattern string.
+        jsonb_params = [p for p in params if isinstance(p, Jsonb)]
+        assert len(jsonb_params) >= 5
+        for p in params:
+            assert not (isinstance(p, str) and "%" in p)
+
+    def test_containment_covers_known_uri_paths(self):
+        """The probes cover the documented URI-bearing report_data paths."""
+        import json
+
+        from psycopg.types.json import Jsonb
+
+        from app.analyysikeskus.history import list_impact_reports
+
+        conn, captured = self._conn_capturing([])
+        list_impact_reports(self._URI, db_connection=conn)
+        # Serialise each Jsonb's payload to a comparable string blob.
+        blobs = [
+            json.dumps(p.obj, sort_keys=True) for p in captured["params"] if isinstance(p, Jsonb)
+        ]
+        joined = " ".join(blobs)
+        for key in (
+            "affected_entities",
+            "conflicting_entity",
+            "eu_act",
+            "estonian_provision",
+            "topic_cluster",
+        ):
+            assert key in joined
+
+    def test_returns_parsed_rows(self):
+        from datetime import datetime
+
+        from app.analyysikeskus.history import list_impact_reports
+
+        gen_at = datetime(2024, 3, 1, 12, 30)
+        conn, _ = self._conn_capturing(
+            [
+                (
+                    "11111111-1111-1111-1111-111111111111",
+                    "22222222-2222-2222-2222-222222222222",
+                    "Eelnõu pealkiri",
+                    gen_at,
+                    3,
+                )
+            ]
+        )
+        rows = list_impact_reports(self._URI, db_connection=conn)
+        assert len(rows) == 1
+        assert rows[0].draft_title == "Eelnõu pealkiri"
+        assert rows[0].version_number == 3
+
+    def test_blank_uri_skips_query(self):
+        from app.analyysikeskus.history import list_impact_reports
+
+        conn = MagicMock()
+        assert list_impact_reports("   ", db_connection=conn) == []
+        conn.cursor.assert_not_called()
+
+
+class TestMigration042:
+    def _path(self):
+        from pathlib import Path
+
+        return (
+            Path(__file__).parent.parent / "migrations" / "042_impact_reports_report_data_gin.sql"
+        )
+
+    def test_exists(self):
+        assert self._path().exists()
+
+    def test_is_idempotent(self):
+        body = self._path().read_text().lower()
+        assert "create index if not exists" in body
+
+    def test_gin_index_on_report_data(self):
+        body = self._path().read_text().lower()
+        assert "using gin (report_data)" in body
+        assert "idx_impact_reports_report_data" in body

--- a/tests/test_sparql_client.py
+++ b/tests/test_sparql_client.py
@@ -7,7 +7,37 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from app.ontology.sparql_client import SparqlClient, _extract_bindings, _sanitize_sparql_value
+import app.ontology.sparql_client as sparql_mod
+from app.ontology.sparql_client import (
+    SparqlClient,
+    _extract_bindings,
+    _get_shared_http_client,
+    _sanitize_sparql_value,
+    close_shared_http_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_http_client():
+    """Drop the pooled client around each test so a mocked ``post`` from
+    one test never leaks into the next, and so the lazy-init path is
+    exercised fresh."""
+    close_shared_http_client()
+    yield
+    close_shared_http_client()
+
+
+def _patch_post(**kwargs):
+    """Patch the pooled client's ``post`` method.
+
+    ``_execute`` now routes through the shared ``httpx.Client`` instead
+    of the module-level ``httpx.post`` (connection pooling — see the
+    SparqlClient docstring), so tests patch the bound method on the
+    singleton. ``return_value`` / ``side_effect`` keyword semantics are
+    identical to patching a free function.
+    """
+    return patch.object(_get_shared_http_client(), "post", **kwargs)
+
 
 # ---------------------------------------------------------------------------
 # _extract_bindings
@@ -174,7 +204,7 @@ class TestSparqlClientQuery:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             result = client.query("SELECT ?s ?label WHERE { ?s rdfs:label ?label }")
 
         assert len(result) == 1
@@ -184,8 +214,7 @@ class TestSparqlClientQuery:
     def test_connection_error_returns_empty(self):
         client = SparqlClient()
 
-        with patch(
-            "app.ontology.sparql_client.httpx.post",
+        with _patch_post(
             side_effect=httpx.ConnectError("Connection refused"),
         ):
             result = client.query("SELECT ?s WHERE { ?s ?p ?o }")
@@ -195,8 +224,7 @@ class TestSparqlClientQuery:
     def test_timeout_returns_empty(self):
         client = SparqlClient()
 
-        with patch(
-            "app.ontology.sparql_client.httpx.post",
+        with _patch_post(
             side_effect=httpx.ReadTimeout("Timed out"),
         ):
             result = client.query("SELECT ?s WHERE { ?s ?p ?o }")
@@ -211,7 +239,7 @@ class TestSparqlClientQuery:
             "Server error", request=MagicMock(), response=mock_response
         )
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             result = client.query("SELECT ?s WHERE { ?s ?p ?o }")
 
         assert result == []
@@ -222,7 +250,7 @@ class TestSparqlClientQuery:
         mock_response.json.return_value = {"results": {"bindings": []}}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             result = client.query("SELECT ?s WHERE { ?s ?p ?o }")
 
         assert result == []
@@ -241,8 +269,7 @@ class TestSparqlClientQueryOnErrorRaise:
 
     def test_connection_error_raises_when_on_error_is_raise(self):
         client = SparqlClient()
-        with patch(
-            "app.ontology.sparql_client.httpx.post",
+        with _patch_post(
             side_effect=httpx.ConnectError("Connection refused"),
         ):
             with pytest.raises(httpx.ConnectError):
@@ -253,8 +280,7 @@ class TestSparqlClientQueryOnErrorRaise:
 
     def test_timeout_raises_when_on_error_is_raise(self):
         client = SparqlClient()
-        with patch(
-            "app.ontology.sparql_client.httpx.post",
+        with _patch_post(
             side_effect=httpx.ReadTimeout("Timed out"),
         ):
             with pytest.raises(httpx.TimeoutException):
@@ -270,7 +296,7 @@ class TestSparqlClientQueryOnErrorRaise:
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "Server error", request=MagicMock(), response=mock_response
         )
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             with pytest.raises(httpx.HTTPStatusError):
                 client.query(
                     "SELECT ?s WHERE { ?s ?p ?o }",
@@ -289,7 +315,7 @@ class TestSparqlClientQueryOnErrorRaise:
         mock_response = MagicMock()
         mock_response.json.return_value = {"results": {"bindings": []}}
         mock_response.raise_for_status = MagicMock()
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             result = client.query(
                 "SELECT ?s WHERE { ?s ?p ?o }",
                 on_error="raise",
@@ -299,8 +325,7 @@ class TestSparqlClientQueryOnErrorRaise:
     def test_default_swallow_preserves_legacy_behaviour(self):
         """Without ``on_error`` the legacy behaviour is preserved: log + empty."""
         client = SparqlClient()
-        with patch(
-            "app.ontology.sparql_client.httpx.post",
+        with _patch_post(
             side_effect=httpx.ConnectError("Connection refused"),
         ):
             # No on_error kwarg → swallows + returns empty (legacy).
@@ -319,7 +344,7 @@ class TestSparqlClientAsk:
         mock_response.json.return_value = {"boolean": True}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             assert client.ask("ASK { ?s ?p ?o }") is True
 
     def test_ask_false(self):
@@ -328,14 +353,13 @@ class TestSparqlClientAsk:
         mock_response.json.return_value = {"boolean": False}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             assert client.ask("ASK { ?s ?p ?o }") is False
 
     def test_ask_error_returns_false(self):
         client = SparqlClient()
 
-        with patch(
-            "app.ontology.sparql_client.httpx.post",
+        with _patch_post(
             side_effect=httpx.ConnectError("Connection refused"),
         ):
             assert client.ask("ASK { ?s ?p ?o }") is False
@@ -355,7 +379,7 @@ class TestSparqlClientCount:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             assert client.count("SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }") == 42
 
     def test_count_empty_returns_zero(self):
@@ -364,7 +388,7 @@ class TestSparqlClientCount:
         mock_response.json.return_value = {"results": {"bindings": []}}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             assert client.count("SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }") == 0
 
     def test_count_invalid_value_returns_zero(self):
@@ -375,5 +399,90 @@ class TestSparqlClientCount:
         }
         mock_response.raise_for_status = MagicMock()
 
-        with patch("app.ontology.sparql_client.httpx.post", return_value=mock_response):
+        with _patch_post(return_value=mock_response):
             assert client.count("SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }") == 0
+
+
+class TestSparqlClientCountOnError:
+    """``count(on_error=...)`` lets a caller tell a real zero apart from an
+    outage so pagination never renders a dead Jena as a truthful
+    ``total: 0``."""
+
+    def test_default_swallow_returns_zero_on_outage(self):
+        """Legacy default: a transport failure yields ``0`` (no raise)."""
+        client = SparqlClient()
+        with _patch_post(side_effect=httpx.ConnectError("refused")):
+            assert client.count("SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }") == 0
+
+    def test_on_error_raise_propagates_outage(self):
+        """``on_error='raise'`` re-raises the httpx error instead of 0."""
+        client = SparqlClient()
+        with _patch_post(side_effect=httpx.ConnectError("refused")):
+            with pytest.raises(httpx.ConnectError):
+                client.count(
+                    "SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }",
+                    on_error="raise",
+                )
+
+    def test_on_error_raise_still_zero_on_genuine_empty(self):
+        """A reachable Jena with zero rows is a real ``0``, not an error."""
+        client = SparqlClient()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": {"bindings": []}}
+        mock_response.raise_for_status = MagicMock()
+        with _patch_post(return_value=mock_response):
+            assert (
+                client.count(
+                    "SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }",
+                    on_error="raise",
+                )
+                == 0
+            )
+
+
+# ---------------------------------------------------------------------------
+# Shared pooled httpx.Client (lazy-init singleton)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedHttpClient:
+    def test_lazy_init_builds_once_and_is_shared(self):
+        """No client exists until first use; then every caller shares one."""
+        # The autouse fixture closed any prior client, so we start cold.
+        assert sparql_mod._shared_client is None
+        first = _get_shared_http_client()
+        second = _get_shared_http_client()
+        assert first is second
+        assert isinstance(first, httpx.Client)
+
+    def test_pool_limits_configured(self):
+        """The pool carries bounded connection limits (FD-exhaustion guard)."""
+        # Assert on the module-level limits the pool is built from rather
+        # than httpx's private ``Client._limits`` attribute.
+        assert sparql_mod._HTTP_LIMITS.max_connections == 20
+        assert sparql_mod._HTTP_LIMITS.max_keepalive_connections == 10
+        # The built client is a real httpx.Client wired to that pool.
+        assert isinstance(_get_shared_http_client(), httpx.Client)
+
+    def test_distinct_sparqlclients_reuse_one_pool(self):
+        """Two SparqlClient instances issue requests through the same pool."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": {"bindings": []}}
+        mock_response.raise_for_status = MagicMock()
+        a = SparqlClient(jena_url="http://a:3030", dataset="x")
+        b = SparqlClient(jena_url="http://b:3030", dataset="y")
+        with _patch_post(return_value=mock_response) as post:
+            a.query("SELECT ?s WHERE { ?s ?p ?o }")
+            b.query("SELECT ?s WHERE { ?s ?p ?o }")
+        # Both calls landed on the single pooled client's post.
+        assert post.call_count == 2
+        # Each instance targeted its own endpoint via the shared pool.
+        endpoints = {call.args[0] for call in post.call_args_list}
+        assert endpoints == {"http://a:3030/x/sparql", "http://b:3030/y/sparql"}
+
+    def test_close_is_idempotent_when_never_built(self):
+        """Closing before any client was built is a no-op, not an error."""
+        close_shared_http_client()
+        assert sparql_mod._shared_client is None
+        # Calling again must not raise.
+        close_shared_http_client()


### PR DESCRIPTION
Part of #861. Five independent backend review findings, each in its own non-overlapping file scope. Pointers were from review commit 3cc9ba0 (2026-06-10); all five were re-verified as **still live** on `main` — none had been fixed by PRs #868–#876 (the most recent commit touching any of these files predates that wave).

## Findings → fixes

### A. `html.escape()` interpolated names in email templates (`app/email/templates.py:9`) — FIXED
Both `password_reset` and `password_reset_admin` interpolated `full_name` / `admin_name` straight into the HTML body, and the reset URL into both the `href` attribute and link text. Now every user-controlled value is `html.escape()`d (URL escaped with `quote=True` in attribute position). The plain-text alternative part is intentionally left raw (it is not HTML). The local `html` variable was renamed to `html_body` to free the `html` module name.

### B. Reference resolver: dotted abbreviations (`lg. 2`) + superscript sections (`§ 113¹`) (`app/docs/reference_resolver.py:108`) — FIXED
- `_PROVISION_RE` now allows a trailing `.` after the `lg` / `punkt` stems (`lg.`, `p.`) and a superscript index on the section number: Unicode `§ 113¹`, ASCII `§ 113^1`, dotted `§ 113.1`.
- New `_normalise_section_number` canonicalises the captured token to `N` or `N^M` (and is the injection guard — rejects anything that is not digits + optional all-digit superscript).
- Plain-digit sections keep the proven URI-guess fast path; superscript sections skip the (unproven corpus URI shape) guess and go to a structural query whose `estleg:paragrahv` literal probe is widened to the caret / concatenated / Unicode forms (each ±trailing period) via `_paragrahv_literals`.
- `_section_display` renders `113^1` back to `113¹` in result labels / partial-match copy.
- **Lockstep** change in `app/analyysikeskus/input_parser.py` (`_SECTION_RE` + new `_canonical_section`) since its docstring pins it to mirror the resolver pattern; it now also accepts `lg.`/`p.` and superscripts and canonicalises to the caret form.
- Regression coverage added for the plain forms (`KarS § 211`, `§ 143` both literal forms).

### C. `_EE_CASE_RE` matches ISO dates (`app/analyysikeskus/input_parser.py:59`) — FIXED
ISO dates like `2026-06-10` matched the old `^\d+-\d+-\d+(?:-\d+)*$`. Tightened to `^\d{1,2}-…` (Estonian case numbers start with a single/double-digit court-type code, never a 4-digit year) **and** added an explicit strict `_ISO_DATE_RE` guard (4-digit year + valid month + valid day) checked before the case branch. Real formats `3-1-1-63-15`, `3-2-1-4-13`, `5-19-1-2`, `3-20-1044` and CJEU `C-131/12` still match; tests cover both directions.

### D. SPARQL client: shared `httpx.Client` with limits; `count()` gains on_error passthrough (`app/ontology/sparql_client.py:128,272`) — FIXED
- All `SparqlClient` instances (~30 short-lived ones across the app) now route HTTP through a process-wide pooled `httpx.Client` built by `_get_shared_http_client()` — the lazy-init singleton pattern (thread-safe double-checked lock; client constructed on first real call so stub users never open a socket), with bounded `httpx.Limits(max_connections=20, max_keepalive_connections=10)` and a default `httpx.Timeout`. Per-instance `self.timeout` still wins per-request. Added `close_shared_http_client()` for teardown.
- `count(..., on_error="swallow"|"raise")` forwards to `query()`/`_execute()`. Default stays `"swallow"` (legacy: dead Jena ⇒ `0`); callers that must not render an outage as a truthful `total: 0` (e.g. explorer pagination) can pass `"raise"`. A genuine empty result still returns `0` under `"raise"` — only transport failures propagate.

### E. `impact_reports` lookup: indexed JSON-path query + escape ILIKE wildcards (`app/analyysikeskus/history.py:808-812`) — FIXED
`list_impact_reports` replaced the `report_data::text ILIKE '%uri%'` full-table scan with bound JSONB `@>` containment over the stable URI-bearing `report_data` paths (`affected_entities[].uri`, `conflicts[].conflicting_entity`, `eu_compliance[].eu_act`/`estonian_provision`, `gaps[].topic_cluster`, plus v2 `sanctions_delta`/`burden_delta` `rows[].provision_uri`). Each value is a typed `psycopg ... Jsonb` parameter — **no ILIKE wildcards remain to escape**, and containment matches a URI *field* not a coincidental label substring. New **migration `042_impact_reports_report_data_gin.sql`** adds an idempotent (`CREATE INDEX IF NOT EXISTS`) GIN index `idx_impact_reports_report_data` (default `jsonb_ops` for broad operator coverage); Postgres BitmapOrs the per-branch index scans so the whole OR predicate stays indexed.

## Already-fixed items
None — all five findings were live on `main` at branch time.

## Deferred / out-of-scope notes
- **Explorer `count()` call sites** (`app/explorer/routes.py:306,521`): the new `count(on_error="raise")` capability is in place, but wiring the explorer pagination endpoints to *pass* `on_error="raise"` touches `app/explorer/routes.py`, which is outside this PR's file scope — deferred.
- **Shutdown wiring for `close_shared_http_client()`**: the ASGI lifespan lives in `app/main.py` (out of scope). The function exists for test teardown and future wiring; an unclosed pooled client is reclaimed on process exit, so this is a cleanliness follow-up, not a leak in practice.

## Tests
- New `tests/test_misc_backend_sweep.py` (38 tests): email escaping (A), section normalisation + dotted/superscript provision resolution + plain-form regression (B), ISO-date-vs-case-number both directions (C), `list_impact_reports` containment/no-ILIKE/Jsonb-params (E), migration 042 idempotency.
- Extended `tests/test_sparql_client.py`: pooled-client lazy-init/sharing/limits + `count(on_error=...)` passthrough; all 16 existing HTTP-mock sites repointed to the pooled client's `post` via a `_patch_post` helper + autouse reset fixture.
- Full suite: **4721 passed, 50 skipped**. `ruff format` + `ruff check` + `pyright` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)