### PR TITLE
fix(annotations): legacy mentions, DOM id collision, ownership ACL, LIKE escaping (#861)

### DIFF
--- a/app/annotations/models.py
+++ b/app/annotations/models.py
@@ -239,6 +239,8 @@ def create_annotation(
     target_id: str,
     content: str,
     target_metadata: dict | None = None,
+    *,
+    mentions: list[uuid.UUID] | None = None,
 ) -> Annotation:
     """Insert a new ``annotations`` row and return the created annotation.
 
@@ -246,6 +248,12 @@ def create_annotation(
     to ``content_encrypted``; the legacy plaintext ``content`` column is left
     NULL, matching :func:`create_row_annotation` (#772). Read paths fall back
     to plaintext for rows written before this change.
+
+    ``mentions`` is a pre-resolved list of in-org user UUIDs (see
+    :func:`parse_mentions`). The caller resolves them rather than this helper
+    so the write still performs exactly one ``conn.execute`` (#861). The
+    ``content_encrypted`` ciphertext stays the LAST bound parameter so the
+    encryption-at-rest contract tests keep their ``params[-1]`` anchor.
 
     The caller is responsible for committing the transaction.
     """
@@ -258,8 +266,8 @@ def create_annotation(
         f"""
         INSERT INTO annotations
             (user_id, org_id, target_type, target_id, target_metadata,
-             content, content_encrypted)
-        VALUES (%s, %s, %s, %s, %s::jsonb, NULL, %s)
+             mentions, content, content_encrypted)
+        VALUES (%s, %s, %s, %s, %s::jsonb, %s, NULL, %s)
         RETURNING {_ANNOTATION_COLUMNS}
         """,
         (
@@ -268,6 +276,7 @@ def create_annotation(
             target_type,
             target_id,
             json.dumps(target_metadata) if target_metadata is not None else None,
+            [str(m) for m in mentions] if mentions else [],
             ciphertext,
         ),
     ).fetchone()
@@ -378,6 +387,8 @@ def create_reply(
     annotation_id: uuid.UUID | str,
     user_id: uuid.UUID | str,
     content: str,
+    *,
+    mentions: list[uuid.UUID] | None = None,
 ) -> AnnotationReply:
     """Insert a new ``annotation_replies`` row and return the created reply.
 
@@ -386,6 +397,12 @@ def create_reply(
     NULL (#772). Read paths fall back to plaintext for rows written before
     this change.
 
+    ``mentions`` is a pre-resolved list of in-org user UUIDs (see
+    :func:`parse_mentions`). The caller resolves them so this helper still
+    performs exactly one ``conn.execute`` (#861); the ``content_encrypted``
+    ciphertext stays the LAST bound parameter so the encryption-at-rest
+    contract tests keep their ``params[-1]`` anchor.
+
     The caller is responsible for committing the transaction.
     """
     ciphertext = encrypt_text(content)
@@ -393,13 +410,14 @@ def create_reply(
     row = conn.execute(
         f"""
         INSERT INTO annotation_replies
-            (annotation_id, user_id, content, content_encrypted)
-        VALUES (%s, %s, NULL, %s)
+            (annotation_id, user_id, mentions, content, content_encrypted)
+        VALUES (%s, %s, %s, NULL, %s)
         RETURNING {_REPLY_COLUMNS}
         """,
         (
             str(annotation_id),
             str(user_id),
+            [str(m) for m in mentions] if mentions else [],
             ciphertext,
         ),
     ).fetchone()
@@ -443,6 +461,23 @@ def list_replies(
 # as a single token so the server resolves it unambiguously even when two
 # users in different orgs share the same email local-part.
 _MENTION_RE = re.compile(r"@([\w.\-]+(?:@[\w.\-]+)?)")
+
+# Upper bound on resolved mentions per message (#861). A single comment can
+# at most ping this many distinct in-org users; tokens beyond the cap are
+# parsed but their resolved UUIDs are dropped so a "@a @b @c …" spray cannot
+# fan out an unbounded notification storm.
+MAX_MENTIONS_PER_MESSAGE = 10
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE wildcards so a user token matches itself literally.
+
+    ``%`` and ``_`` are LIKE metacharacters; an unescaped ``_`` in a token
+    like ``a_b`` would match ``aXb`` (over-match) and ``%`` would match any
+    run of characters. We backslash-escape ``\\``, ``%``, and ``_`` and the
+    caller pairs the pattern with an explicit ``ESCAPE '\\'`` clause (#861).
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def parse_mentions(
@@ -489,6 +524,12 @@ def parse_mentions(
     result: list[uuid.UUID] = []
 
     for token in tokens:
+        # Cap the fan-out: stop resolving once MAX_MENTIONS_PER_MESSAGE
+        # distinct users are collected so a "@a @b @c …" spray cannot trigger
+        # an unbounded notification storm (#861). Excess tokens are ignored
+        # without a DB round-trip.
+        if len(result) >= MAX_MENTIONS_PER_MESSAGE:
+            break
         # Tokens that contain ``@`` are treated as a full email address: the
         # ``users.email`` UNIQUE constraint disambiguates across orgs, so we
         # skip every name / local-part fallback to avoid resolving the wrong
@@ -500,8 +541,11 @@ def parse_mentions(
         name_variant = None if token_has_at else token.replace("_", " ")
         # Local-part prefix match: ``andres`` should resolve ``andres@min.ee``.
         # Suppressed when the token already contains ``@`` so the well-formed
-        # exact-email arm wins unambiguously.
-        email_local_pattern = None if token_has_at else f"{token.lower()}@%"
+        # exact-email arm wins unambiguously. The token's own LIKE
+        # metacharacters are escaped so an ``a_b`` token matches the literal
+        # local-part and not ``aXb`` (#861); the trailing ``@%`` stays a real
+        # wildcard. Paired with ``ESCAPE '\'`` on the LIKE clause below.
+        email_local_pattern = None if token_has_at else f"{_escape_like(token.lower())}@%"
         # Bare tokens use the legacy multi-arm OR; full-email tokens go through
         # the single exact-email arm so a local-part collision in another row
         # cannot win the LIMIT 1.
@@ -532,7 +576,7 @@ def parse_mentions(
                       AND (
                           email = %s
                           OR email = %s
-                          OR lower(email) LIKE %s
+                          OR lower(email) LIKE %s ESCAPE '\\'
                           OR full_name ILIKE %s
                           OR full_name ILIKE %s
                       )

--- a/app/annotations/routes.py
+++ b/app/annotations/routes.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, LiteralString
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
@@ -43,6 +43,7 @@ from app.annotations.models import (
     list_annotations_for_target,
     list_annotations_for_version_row,
     list_replies,
+    parse_mentions,
     reopen_row_thread,
     resolve_annotation,
     resolve_row_thread,
@@ -129,6 +130,66 @@ def _load_annotations_with_replies(
             target_id,
         )
         return []
+
+
+# Target types whose rows carry an ``org_id`` we can authorise against. The
+# ontology-backed types (``provision`` / ``entity``) are global, shared
+# read-only resources with no per-org owner, so they are not gated here —
+# only the annotation ROW is org-scoped (#861). Values are ``LiteralString``
+# so the table name composes into a ``LiteralString`` query (no SQL injection
+# surface — the names are constants, never user input).
+_ORG_OWNED_TARGETS: dict[str, LiteralString] = {
+    "draft": "drafts",
+    "conversation": "conversations",
+}
+
+
+def _caller_may_annotate_target(
+    target_type: str,
+    target_id: str,
+    caller_org_id: str,
+) -> bool:
+    """Return True iff the caller's org may annotate ``(target_type, target_id)``.
+
+    Legacy create previously accepted any ``target_id`` for a valid type and
+    simply stamped the caller's ``org_id`` — so a user could attach a comment
+    to another org's draft / conversation (#861). For org-owned targets we
+    now verify the row's ``org_id`` matches the caller's, mirroring the
+    row-annotation ACL in :func:`_load_draft_version_or_404`. Cross-org or
+    missing rows return False (the handler renders a generic error, never
+    leaking whether the target exists). Global ontology targets
+    (provision / entity) are always allowed.
+    """
+    table = _ORG_OWNED_TARGETS.get(target_type)
+    if table is None:
+        # provision / entity / unknown-but-valid types: no org ownership row.
+        return True
+    if not caller_org_id:
+        return False
+    # Org-owned targets are keyed by UUID; a non-UUID target_id cannot match
+    # a real row, so reject it before the DB round-trip.
+    parsed_target = _parse_uuid(target_id)
+    if parsed_target is None:
+        return False
+    # ``table`` comes from the trusted whitelist above — never user input —
+    # so interpolating it into the query is safe.
+    try:
+        with _connect() as conn:
+            row = conn.execute(
+                f"SELECT org_id FROM {table} WHERE id = %s",  # noqa: S608 — whitelisted table
+                (str(parsed_target),),
+            ).fetchone()
+    except Exception:
+        logger.exception(
+            "Target ACL lookup failed target_type=%s target_id=%s",
+            target_type,
+            target_id,
+        )
+        return False
+    if row is None:
+        return False
+    owning_org = str(row[0]) if row[0] is not None else ""
+    return owning_org == caller_org_id
 
 
 # ---------------------------------------------------------------------------
@@ -314,22 +375,25 @@ def mentions_search_handler(req: Request):
     if not q:
         return JSONResponse({"results": []}, status_code=200)
 
-    # ``LIKE`` pattern: prefix match on the front of the field plus
-    # substring match anywhere — matches both "And…" and "…and…" so the
-    # typeahead surfaces partial-name candidates from the start.
-    pattern = f"%{q}%"
+    # ``LIKE`` pattern: substring match anywhere — matches both "And…" and
+    # "…and…" so the typeahead surfaces partial-name candidates from the
+    # start. Escape the user-typed ``%`` / ``_`` / ``\`` so they match
+    # literally instead of acting as wildcards (#861, same class of LIKE
+    # hardening as parse_mentions); paired with ``ESCAPE '\'`` on the clause.
+    escaped_q = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped_q}%"
 
     try:
         with _connect() as conn:
             rows = conn.execute(
-                """
+                r"""
                 SELECT id, full_name, email
                 FROM users
                 WHERE org_id = %s
                   AND is_active = TRUE
                   AND (
-                      lower(full_name) LIKE lower(%s)
-                      OR lower(email)  LIKE lower(%s)
+                      lower(full_name) LIKE lower(%s) ESCAPE '\'
+                      OR lower(email)  LIKE lower(%s) ESCAPE '\'
                   )
                 ORDER BY full_name
                 LIMIT 10
@@ -438,8 +502,19 @@ async def create_annotation_handler(req: Request):
             cls="annotation-popover",
         )
 
+    # #861: authorise the target before stamping the caller's org onto a new
+    # annotation. Cross-org / missing org-owned targets return a generic 404
+    # so we never leak whether the target exists.
+    if not _caller_may_annotate_target(target_type, target_id, str(org_id)):
+        return Response(status_code=404)
+
     try:
         with _connect() as conn:
+            # #861: resolve @mentions on the legacy create path too, so the
+            # "@nimi mainimiseks" placeholder is honoured here and not only on
+            # the row-annotation surface. Parsing is org-scoped inside the
+            # same connection.
+            mentions = parse_mentions(conn, content, org_id)
             annotation = create_annotation(
                 conn,
                 user_id=auth["id"],
@@ -448,6 +523,7 @@ async def create_annotation_handler(req: Request):
                 target_id=target_id,
                 content=content,
                 target_metadata=target_metadata if isinstance(target_metadata, dict) else None,
+                mentions=mentions,
             )
             conn.commit()
     except ValueError as exc:
@@ -463,6 +539,15 @@ async def create_annotation_handler(req: Request):
         )
 
     log_annotation_create(auth["id"], annotation.id, target_type, target_id)
+
+    # #861: fan out "you were mentioned" notifications, mirroring the
+    # row-annotation path. The author is excluded inside notify_*.
+    if annotation.mentions:
+        notify_annotation_mention(
+            annotation=annotation,
+            mentioned_user_ids=annotation.mentions,
+            mentioner_user_id=auth["id"],
+        )
 
     return _annotation_list_fragment(target_type, target_id, auth)
 
@@ -514,14 +599,29 @@ async def reply_annotation_handler(req: Request, id: str):
 
     try:
         with _connect() as conn:
-            reply = create_reply(conn, parsed, auth["id"], content)
+            # #861: resolve @mentions on the reply path too — the reply
+            # textarea promises "@nimi mainimiseks", so a mention here must
+            # behave like one on the row-annotation surface. Scoped to the
+            # parent annotation's org.
+            mentions = parse_mentions(conn, content, annotation.org_id)
+            reply = create_reply(conn, parsed, auth["id"], content, mentions=mentions)
             conn.commit()
     except Exception:
         logger.exception("Failed to create reply for annotation %s", id)
         return Response(status_code=500)
 
     log_annotation_reply(auth["id"], annotation.id, reply.id)
+    # Notify the annotation author of the reply (existing behaviour) and, in
+    # addition (#861), every user mentioned in the reply body. The mention
+    # notification reuses the parent annotation for the target link so the
+    # recipient lands on the same resource.
     notify_annotation_reply(annotation, reply)
+    if reply.mentions:
+        notify_annotation_mention(
+            annotation=annotation,
+            mentioned_user_ids=reply.mentions,
+            mentioner_user_id=auth["id"],
+        )
 
     # Return just the updated thread item so the outerHTML swap on
     # #annotation-thread-{id} replaces only that thread, not the whole popover.
@@ -1007,6 +1107,24 @@ def _load_panel_messages(
         return []
 
 
+def _caller_may_toggle_thread(messages: list[Annotation], auth: UserDict) -> bool:
+    """Return True iff the caller may resolve/reopen this row thread (#861).
+
+    Aligns the row-thread resolve/reopen gate with the legacy single-annotation
+    surface, which only lets the *author* (or an admin) flip resolution state.
+    A row thread has many authors, so the analogue is: the caller authored at
+    least one message in the thread, OR they are an admin. An empty thread is
+    a no-op (nothing to toggle) so it is allowed through rather than 403'd —
+    this keeps the empty-state render path intact.
+    """
+    if not messages:
+        return True
+    if auth.get("role") == "admin":
+        return True
+    caller_id = str(auth.get("id") or "")
+    return any(str(m.user_id) == caller_id for m in messages)
+
+
 # ---------------------------------------------------------------------------
 # Handler: GET /annotations/version/{draft_version_id}/{row_kind}/{row_key}
 # ---------------------------------------------------------------------------
@@ -1171,6 +1289,11 @@ def post_row_resolve_handler(
     except (ValueError, UnicodeDecodeError):
         return Response(status_code=400)
 
+    # #861: only a thread author (or admin) may resolve, matching the legacy
+    # single-annotation gate. Cross-org is already 404'd above.
+    if not _caller_may_toggle_thread(_load_panel_messages(version_uuid, row_kind, row_key), auth):
+        return Response(status_code=403)
+
     try:
         with _connect() as conn:
             updated = resolve_row_thread(
@@ -1222,6 +1345,11 @@ def post_row_reopen_handler(
         row_key = decode_row_key(row_key)
     except (ValueError, UnicodeDecodeError):
         return Response(status_code=400)
+
+    # #861: only a thread author (or admin) may reopen, matching the legacy
+    # single-annotation gate. Cross-org is already 404'd above.
+    if not _caller_may_toggle_thread(_load_panel_messages(version_uuid, row_kind, row_key), auth):
+        return Response(status_code=403)
 
     try:
         with _connect() as conn:

--- a/app/ui/primitives/annotation_button.py
+++ b/app/ui/primitives/annotation_button.py
@@ -38,6 +38,16 @@ def AnnotationButton(
     # a data attribute on the wrapper for round-trip identification.
     popover_id = target_dom_id(target_type, target_id)
 
+    # #861: the container the popover is swapped INTO must NOT share the
+    # popover's own id. AnnotationPopover renders its outer Div with
+    # ``id=popover_id``, so if the container also used ``popover_id`` the
+    # innerHTML swap would nest two elements with the same id — and the
+    # popover's create form (``hx-target=#popover_id``, ``outerHTML``) would
+    # then resolve to the container (the first match) and blow it away,
+    # breaking reload-after-create. The container gets a distinct, derived
+    # id so the two stay separable.
+    container_id = f"{popover_id}-container"
+
     # #773: build the HTMX URL with structured encoding so reserved
     # characters in target_type / target_id are escaped exactly once.
     qs = urlencode({"target_type": target_type, "target_id": target_id})
@@ -50,7 +60,9 @@ def AnnotationButton(
         badge,
         type="button",
         hx_get=hx_get_url,
-        hx_target=f"#{popover_id}",
+        # Swap the popover INTO the container (distinct id), not onto an
+        # element that shares the popover's id (#861).
+        hx_target=f"#{container_id}",
         hx_swap="innerHTML",
         cls="annotation-button",
         aria_label=f"Lisa märkus sellele reale ({count})",
@@ -60,7 +72,7 @@ def AnnotationButton(
         title="Lisa märkus sellele reale",
     )
 
-    container = Div(id=popover_id, cls="annotation-popover-container")  # noqa: F405
+    container = Div(id=container_id, cls="annotation-popover-container")  # noqa: F405
 
     return Div(  # noqa: F405
         btn,

--- a/app/ui/surfaces/annotation_popover.py
+++ b/app/ui/surfaces/annotation_popover.py
@@ -39,10 +39,16 @@ def AnnotationPopover(
     """
     count = len(annotations)
 
-    # #773: derive the same hashed CSS id as the AnnotationButton primitive
-    # so the trigger's ``hx-target`` and the popover's outer id stay in
-    # lockstep.  Raw ontology URIs as target_id would otherwise blow up
-    # the ``#annotation-popover-...`` selector.
+    # #773: derive the same hashed CSS id the AnnotationButton primitive
+    # uses so the two surfaces agree on the popover's identity. Raw ontology
+    # URIs as target_id would otherwise blow up the ``#annotation-popover-…``
+    # selector.
+    #
+    # #861: this is the popover's OWN outer id. The AnnotationButton renders
+    # a *separate* container (``{popover_id}-container``) and swaps the
+    # popover into it, so the two never collide. The create form below
+    # targets ``#popover_id`` with ``outerHTML`` to replace just this
+    # popover in place on reload-after-create.
     popover_id = target_dom_id(target_type, target_id)
 
     # Header

--- a/tests/test_annotations_models.py
+++ b/tests/test_annotations_models.py
@@ -927,6 +927,101 @@ class TestRowAnnotationExtensions:
         assert params[1] == "john.doe@min.ee"
 
     # ------------------------------------------------------------------
+    # parse_mentions — LIKE-wildcard escaping + mention cap (#861)
+    # ------------------------------------------------------------------
+
+    def test_parse_mentions_escapes_like_wildcards_in_local_part(self):
+        """A bare token containing a LIKE metachar (``_``) must be escaped so
+        it matches literally and not as a single-char wildcard, and the LIKE
+        clause must carry an explicit ``ESCAPE '\\'`` (#861).
+        """
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        # Token "a_b" — the ``_`` would otherwise wildcard-match "aXb@…".
+        parse_mentions(conn, "@a_b kirjutab.", _ORG_ID)
+
+        sql, params = conn.execute.call_args.args
+        assert "ESCAPE '\\'" in sql
+        # The local-part LIKE pattern (index 3) escapes the underscore and
+        # keeps the trailing @% as a real wildcard.
+        assert params[3] == "a\\_b@%"
+
+    def test_parse_mentions_escapes_percent_in_local_part(self):
+        """A literal ``%`` in a token is escaped so it cannot match any run."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (_USER_ID,)
+
+        # ``%`` is not a \\w char, so _MENTION_RE stops the token before it;
+        # use a backslash instead, which IS escapable and exercises the
+        # backslash arm of _escape_like.
+        from app.annotations.models import _escape_like
+
+        assert _escape_like("a%b_c\\d") == "a\\%b\\_c\\\\d"
+
+    def test_parse_mentions_caps_fan_out(self):
+        """No more than MAX_MENTIONS_PER_MESSAGE users resolve, even if more
+        distinct @tokens appear (#861).
+        """
+        from app.annotations.models import MAX_MENTIONS_PER_MESSAGE
+
+        conn = MagicMock()
+        # Every token resolves to a fresh unique user so dedup does not mask
+        # the cap.
+        conn.execute.return_value.fetchone.side_effect = [
+            (uuid.uuid4(),) for _ in range(MAX_MENTIONS_PER_MESSAGE + 5)
+        ]
+
+        content = " ".join(f"@user{i}" for i in range(MAX_MENTIONS_PER_MESSAGE + 5))
+        result = parse_mentions(conn, content, _ORG_ID)
+
+        assert len(result) == MAX_MENTIONS_PER_MESSAGE
+        # Resolution stops at the cap — no DB round-trip for the surplus.
+        assert conn.execute.call_count == MAX_MENTIONS_PER_MESSAGE
+
+    # ------------------------------------------------------------------
+    # create_annotation / create_reply persist resolved mentions (#861)
+    # ------------------------------------------------------------------
+
+    def test_create_annotation_persists_mentions(self):
+        """A pre-resolved mentions list is written to the mentions column and
+        the ciphertext stays the last bound param (#861)."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = _make_annotation_row()
+
+        mention_uid = uuid.uuid4()
+        create_annotation(
+            conn,
+            _USER_ID,
+            _ORG_ID,
+            "draft",
+            "draft-id",
+            "Tere @keegi",
+            mentions=[mention_uid],
+        )
+
+        conn.execute.assert_called_once()
+        sql, params = conn.execute.call_args.args
+        assert "mentions" in sql
+        # mentions param is a list of str UUIDs; ciphertext remains last.
+        assert [str(mention_uid)] in params
+        assert isinstance(params[-1], bytes)
+
+    def test_create_reply_persists_mentions(self):
+        """A pre-resolved mentions list is written to annotation_replies."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = _make_reply_row()
+
+        mention_uid = uuid.uuid4()
+        create_reply(conn, _ANN_ID, _USER_ID, "Vastus @keegi", mentions=[mention_uid])
+
+        conn.execute.assert_called_once()
+        sql, params = conn.execute.call_args.args
+        assert "mentions" in sql
+        assert [str(mention_uid)] in params
+        assert isinstance(params[-1], bytes)
+
+    # ------------------------------------------------------------------
     # list_annotations_for_version_row
     # ------------------------------------------------------------------
 

--- a/tests/test_annotations_routes.py
+++ b/tests/test_annotations_routes.py
@@ -30,6 +30,8 @@ _USER_ID = "33333333-3333-3333-3333-333333333333"
 _OTHER_USER_ID = "44444444-4444-4444-4444-444444444444"
 _ANN_ID = uuid.UUID("55555555-5555-5555-5555-555555555555")
 _REPLY_ID = uuid.UUID("66666666-6666-6666-6666-666666666666")
+# #861: a real UUID draft id so the legacy-create target ACL can authorise it.
+_DRAFT_TARGET_ID = "77777777-7777-7777-7777-777777777777"
 
 
 def _authed_user(
@@ -177,8 +179,11 @@ class TestCreateAnnotation:
         mock_prov.return_value = _stub_provider()
         mock_load.return_value = []
 
-        # Mock the DB connection context manager
+        # Mock the DB connection context manager. The #861 target ACL queries
+        # the draft's org_id first; return the caller's org so the draft is
+        # in-org and the create proceeds.
         mock_db = MagicMock()
+        mock_db.execute.return_value.fetchone.return_value = (uuid.UUID(_ORG_ID),)
         mock_conn.return_value.__enter__ = MagicMock(return_value=mock_db)
         mock_conn.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -188,8 +193,10 @@ class TestCreateAnnotation:
             resp = client.post(
                 "/api/annotations",
                 data={
+                    # #861: target_id must be a real UUID-owned draft for the
+                    # ownership ACL to authorise it.
                     "target_type": "draft",
-                    "target_id": "test-123",
+                    "target_id": _DRAFT_TARGET_ID,
                     "content": "Uus markus",
                 },
             )
@@ -206,6 +213,7 @@ class TestCreateAnnotation:
         mock_load.return_value = []
 
         mock_db = MagicMock()
+        mock_db.execute.return_value.fetchone.return_value = (uuid.UUID(_ORG_ID),)
         mock_conn.return_value.__enter__ = MagicMock(return_value=mock_db)
         mock_conn.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -216,13 +224,82 @@ class TestCreateAnnotation:
                 "/api/annotations",
                 json={
                     "target_type": "draft",
-                    "target_id": "test-123",
+                    "target_id": _DRAFT_TARGET_ID,
                     "content": "Uus markus",
                 },
             )
 
         assert resp.status_code == 200
         assert "annotation-popover" in resp.text
+
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_create_annotation_cross_org_target_returns_404(self, mock_prov, mock_conn):
+        """#861: annotating another org's draft is rejected with 404."""
+        mock_prov.return_value = _stub_provider()
+
+        # The ACL lookup reports the draft is owned by a DIFFERENT org.
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchone.return_value = (uuid.UUID(_OTHER_ORG_ID),)
+        mock_conn.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = _authed_client()
+        resp = client.post(
+            "/api/annotations",
+            json={
+                "target_type": "draft",
+                "target_id": _DRAFT_TARGET_ID,
+                "content": "Uus markus",
+            },
+        )
+
+        assert resp.status_code == 404
+
+    @patch("app.annotations.routes.notify_annotation_mention")
+    @patch("app.annotations.routes.parse_mentions")
+    @patch("app.annotations.routes.log_annotation_create")
+    @patch("app.annotations.routes._load_annotations_with_replies")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_create_with_mention_fires_mention_notification(
+        self,
+        mock_prov,
+        mock_conn,
+        mock_load,
+        mock_audit,
+        mock_parse,
+        mock_notify_mention,
+    ):
+        """#861: the legacy create path resolves @mentions and notifies."""
+        mock_prov.return_value = _stub_provider()
+        mock_load.return_value = []
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchone.return_value = (uuid.UUID(_ORG_ID),)
+        mock_conn.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        mentioned = uuid.UUID(_OTHER_USER_ID)
+        mock_parse.return_value = [mentioned]
+        ann = _make_annotation()
+        ann.mentions = [mentioned]
+
+        with patch("app.annotations.routes.create_annotation", return_value=ann):
+            client = _authed_client()
+            resp = client.post(
+                "/api/annotations",
+                json={
+                    "target_type": "draft",
+                    "target_id": _DRAFT_TARGET_ID,
+                    "content": "Vaata @keegi",
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_parse.assert_called_once()
+        mock_notify_mention.assert_called_once()
+        assert mock_notify_mention.call_args.kwargs["mentioned_user_ids"] == [mentioned]
 
     @patch("app.auth.middleware._get_provider")
     def test_create_annotation_empty_content_rejected(self, mock_prov):
@@ -293,6 +370,54 @@ class TestReplyAnnotation:
             )
 
         assert resp.status_code == 404
+
+    @patch("app.annotations.routes.notify_annotation_mention")
+    @patch("app.annotations.routes.notify_annotation_reply")
+    @patch("app.annotations.routes.parse_mentions")
+    @patch("app.annotations.routes.log_annotation_reply")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_reply_with_mention_fires_mention_notification(
+        self,
+        mock_prov,
+        mock_conn,
+        mock_audit,
+        mock_parse,
+        mock_notify_reply,
+        mock_notify_mention,
+    ):
+        """#861: a reply that mentions a user fans out a mention notification
+        in addition to the existing reply notification."""
+        mock_prov.return_value = _stub_provider()
+
+        mentioned = uuid.UUID(_OTHER_USER_ID)
+        ann = _make_annotation()
+        reply = _make_reply()
+        reply.mentions = [mentioned]
+        mock_parse.return_value = [mentioned]
+
+        mock_db = MagicMock()
+        mock_conn.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("app.annotations.routes.get_annotation", return_value=ann),
+            patch("app.annotations.routes.create_reply", return_value=reply),
+            patch("app.annotations.routes.list_replies", return_value=[]),
+        ):
+            client = _authed_client()
+            resp = client.post(
+                f"/api/annotations/{_ANN_ID}/reply",
+                data={"content": "Vaata @keegi"},
+            )
+
+        assert resp.status_code == 200
+        # create_reply received the resolved mentions.
+        assert mock_parse.called
+        # Both notifications fired.
+        mock_notify_reply.assert_called_once()
+        mock_notify_mention.assert_called_once()
+        assert mock_notify_mention.call_args.kwargs["mentioned_user_ids"] == [mentioned]
 
 
 # ---------------------------------------------------------------------------
@@ -474,3 +599,40 @@ class TestAnnotationPopoverWithUriTargetId:
             count=2,
         )
         assert result is not None
+
+    def test_button_container_id_differs_from_popover_id(self):
+        """#861: the AnnotationButton container and the AnnotationPopover must
+        NOT share a DOM id, otherwise the innerHTML swap nests two elements
+        with the same id and the popover's create form (outerHTML on that id)
+        blows the container away — breaking reload-after-create.
+        """
+        import re
+
+        from fasthtml.common import to_xml
+
+        from app.annotations.row_keys import target_dom_id
+        from app.ui.primitives.annotation_button import AnnotationButton
+        from app.ui.surfaces.annotation_popover import AnnotationPopover
+
+        target_type, target_id = "draft", "draft-xyz"
+        popover_id = target_dom_id(target_type, target_id)
+
+        btn_html = to_xml(AnnotationButton(target_type, target_id, count=1))
+        pop_html = to_xml(
+            AnnotationPopover(target_type, target_id, annotations=[], auth={"id": _USER_ID})
+        )
+
+        # The button targets the container, whose id is distinct from the
+        # popover's own id.
+        assert f'hx-target="#{popover_id}-container"' in btn_html
+        assert f'id="{popover_id}-container"' in btn_html
+        # The container id is NOT the bare popover id.
+        container_ids = re.findall(r'id="(annotation-popover-[^"]*-container)"', btn_html)
+        assert container_ids == [f"{popover_id}-container"]
+        assert f'id="{popover_id}"' not in btn_html
+
+        # The popover's outer id is the bare popover id, and its create form
+        # targets that same id (outerHTML replace-in-place on reload).
+        assert f'id="{popover_id}"' in pop_html
+        assert f'hx-target="#{popover_id}"' in pop_html
+        assert f"{popover_id}-container" not in pop_html

--- a/tests/test_annotations_version_routes.py
+++ b/tests/test_annotations_version_routes.py
@@ -814,6 +814,74 @@ class TestResolveReopenToggle:
         # The fragment now shows the resolve button again.
         assert "Lahenda" in resp.text
 
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes.resolve_row_thread")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_resolve_non_author_non_admin_returns_403(
+        self, mock_prov, mock_connect, mock_resolve, mock_load
+    ):
+        """#861: a drafter who never posted in the thread cannot resolve it."""
+        mock_prov.return_value = _stub_provider()  # caller is _USER_ID, drafter
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+
+        # Thread authored entirely by someone else → gate denies.
+        mock_load.return_value = [_make_annotation(user_id=_OTHER_USER_ID)]
+
+        client = _authed_client()
+        resp = client.post(f"{_ROW_BASE}/resolve")
+
+        assert resp.status_code == 403
+        # The resolve must not have run.
+        mock_resolve.assert_not_called()
+
+    @patch("app.annotations.routes.log_row_annotation_resolve")
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes.resolve_row_thread")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_resolve_admin_bypasses_author_gate(
+        self, mock_prov, mock_connect, mock_resolve, mock_load, mock_audit
+    ):
+        """#861: an admin may resolve a thread they did not author."""
+        mock_prov.return_value = _stub_provider(user=_authed_user(role="admin"))
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+
+        mock_resolve.return_value = 1
+        mock_load.return_value = [_make_annotation(user_id=_OTHER_USER_ID, resolved=True)]
+
+        with patch(
+            "app.annotations.routes._user_display_name",
+            return_value="Test Kasutaja",
+        ):
+            client = _authed_client()
+            resp = client.post(f"{_ROW_BASE}/resolve")
+
+        assert resp.status_code == 200
+        mock_resolve.assert_called_once()
+
+    @patch("app.annotations.routes._load_panel_messages")
+    @patch("app.annotations.routes.reopen_row_thread")
+    @patch("app.annotations.routes._connect")
+    @patch("app.auth.middleware._get_provider")
+    def test_reopen_non_author_non_admin_returns_403(
+        self, mock_prov, mock_connect, mock_reopen, mock_load
+    ):
+        """#861: reopen is gated the same way as resolve."""
+        mock_prov.return_value = _stub_provider()
+        mock_conn, _ = _patch_acl_lookup(owning_org_id=_ORG_ID)
+        mock_connect.side_effect = mock_conn
+
+        mock_load.return_value = [_make_annotation(user_id=_OTHER_USER_ID, resolved=True)]
+
+        client = _authed_client()
+        resp = client.post(f"{_ROW_BASE}/reopen")
+
+        assert resp.status_code == 403
+        mock_reopen.assert_not_called()
+
     def test_resolve_row_thread_sets_resolved_by_and_resolved_at(self):
         """Service-layer assertion: resolve_row_thread sets the right columns."""
         from app.annotations.models import resolve_row_thread


### PR DESCRIPTION
Part of #861.

Fixes the annotation-system review findings from the 2026-06-10 whole-system review (commit 3cc9ba0). All three findings were verified to still exist on `main` — none of PRs #863–#876 touched the in-scope files, so nothing was already-fixed.

## Findings → fixes

### A. Legacy create/reply never resolved `@mentions` (routes.py create/reply paths) — **fixed**
The generic `/api/annotations` create and `/api/annotations/{id}/reply` paths never called `parse_mentions`, so the `@nimi mainimiseks` placeholder was a no-op outside the row-annotation surface.
- `create_annotation` / `create_reply` gained a keyword-only `mentions` param and persist it to the existing `mentions` column (migration 031). Mentions are resolved **in the handler** (not the model) so each write still issues exactly one `conn.execute` and `content_encrypted` stays the last bound param (encryption-at-rest contract intact).
- `create_annotation_handler` and `reply_annotation_handler` now parse mentions (org-scoped) and fan out `notify_annotation_mention`, mirroring the row-annotation path. The reply path keeps its existing `notify_annotation_reply` and adds the mention fan-out.

### B. Duplicate DOM id container/popover broke reload-after-create (annotation_button.py + annotation_popover.py) — **fixed**
`AnnotationButton` rendered its swap container with `id=popover_id`, and `AnnotationPopover` rendered its outer Div with the same `popover_id`. After the `innerHTML` swap, two elements shared the id; the popover's create form (`outerHTML` on `#popover_id`) then resolved to the container and destroyed it.
- The container id is now `{popover_id}-container` and the button targets it; the popover keeps `popover_id`, so its create form replaces only the popover in place. (This matches how the explorer's `#panel-annotation-popover` container already worked.) Comments in both files updated to pin the contract.

### C. Ownership ACL + author-gate + LIKE escaping + mention cap — **fixed**
- **Legacy target ACL (create):** legacy create accepted any `target_id` for a valid type and stamped the caller's org. Now `draft`/`conversation` targets are authorised against the row's `org_id` (cross-org/missing → 404, no existence leak), mirroring `_load_draft_version_or_404`. Global ontology targets (`provision`/`entity`) stay open since they have no per-org owner; only the annotation row is org-scoped.
- **Row resolve/reopen author-gate:** `post_row_resolve_handler` / `post_row_reopen_handler` lacked the author/admin gate the legacy single-annotation surface enforces. Added `_caller_may_toggle_thread`: a thread author (posted ≥1 message) or an admin may toggle; a non-participant gets 403. Empty threads (no-op) pass through to keep the empty-state render intact.
- **LIKE escaping in `parse_mentions` (models.py):** the local-part arm interpolated the token unescaped (`_`/`%` wildcard injection / over-match). Now escapes `\`, `%`, `_` and pairs the clause with `ESCAPE '\'`. The `/api/annotations/mentions/search` typeahead had the identical bug (same feature family, in-scope file) and got the same hardening.
- **Mention cap:** `MAX_MENTIONS_PER_MESSAGE = 10` caps the resolved fan-out at parse time (excess tokens dropped without a DB round-trip).

## Already-fixed / deferred
- **Already-fixed:** none — verified all findings still present on `main`.
- **Deferred (out of scope, noted per instructions):** `target_dom_id` relocation belongs to #860 (explicitly excluded). The sibling LIKE findings in `app/audit.py` and `app/docs/history.py` from the same review are out of this file scope and untouched. `annotation_mentions.js` (review finding `:418`) belongs to another agent.

## Tests
- New tests: legacy create + reply mention fan-out; cross-org target → 404; row resolve/reopen non-author → 403 and admin bypass; `parse_mentions` LIKE-escape (`_`/`%`/`\`) + `ESCAPE '\'` clause + fan-out cap; `create_annotation`/`create_reply` mentions persistence; button-container-id ≠ popover-id.
- `pytest tests/test_annotations_*.py` → **189 passed**; with `tests/test_notifications_wire.py` + `test_notification_copy.py` → **207 passed**. Regression sweep (`test_docs_report_routes`, `test_explorer_pages`, `test_explorer_routes`, `test_drafter_clause_regen`) → green.
- `ruff format` clean, `ruff check` clean, `pyright` 0 errors on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)