### PR TITLE
fix(admin): budget-bar math, audit search escaping+scoping, analytics refresh, health payload (#861)

### DIFF
--- a/app/admin/analytics.py
+++ b/app/admin/analytics.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import threading
 from datetime import UTC, date, datetime
 from urllib.parse import urlencode
 
@@ -87,6 +88,30 @@ _METRIC_COLORS: dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
+# Refresh wiring (#861-C)
+# ---------------------------------------------------------------------------
+#
+# REFRESH MATERIALIZED VIEW CONCURRENTLY can take seconds on a busy database,
+# so it must run off the request path. The project's ``FOR UPDATE SKIP
+# LOCKED`` queue would be the natural home, but its handler registry
+# (``app/jobs/registry.py``) is deliberately framework-free — it must NOT
+# import FastHTML/Starlette so the standalone worker can stay slim — and this
+# module imports ``fasthtml.common`` at the top. Wiring a queue handler would
+# therefore mean a new framework-free handler module, which is out of scope
+# for this fix. Per the issue's sanctioned fallback we instead run the
+# refresh on a short-lived daemon thread and record the real completion
+# timestamp; the request returns immediately and the page polls the timestamp
+# on reload.
+#
+# The completion timestamp is a marker row in the ``metrics`` table
+# (``recorded_at`` defaults to ``now()`` at commit), read back by
+# ``_get_last_refresh`` — the *real* completion time, not the unreliable
+# ``pg_stat_all_tables.last_analyze`` proxy (which reflects ANALYZE, not
+# REFRESH, and also fires on autoanalyze).
+_REFRESH_METRIC_NAME = "usage_daily_refresh_ms"
+
+
+# ---------------------------------------------------------------------------
 # Data helpers
 # ---------------------------------------------------------------------------
 
@@ -94,16 +119,54 @@ _METRIC_COLORS: dict[str, str] = {
 def _refresh_usage_daily() -> bool:
     """Refresh the ``usage_daily`` materialized view concurrently.
 
+    On success also writes a ``usage_daily_refresh_ms`` marker row into the
+    ``metrics`` table (with ``recorded_at`` defaulting to ``now()`` at commit
+    time) so :func:`_get_last_refresh` can read back the real completion
+    timestamp (#861-C). The marker INSERT shares the refresh connection and
+    is committed atomically with it, so a recorded timestamp always implies a
+    completed refresh.
+
     Returns True on success, False on error. Errors are logged but never
     propagated so callers can degrade gracefully.
     """
     try:
         with _connect() as conn:
             conn.execute("REFRESH MATERIALIZED VIEW CONCURRENTLY usage_daily")
+            # Marker row: value carries no meaning beyond "a refresh finished";
+            # ``recorded_at`` (default now()) is the signal we read back.
+            conn.execute(
+                "INSERT INTO metrics (name, value, labels) VALUES (%s, %s, %s::jsonb)",
+                (_REFRESH_METRIC_NAME, 0, '{"source": "refresh_usage_daily"}'),
+            )
             conn.commit()
         return True
     except Exception:
         logger.exception("Failed to refresh usage_daily materialized view")
+        return False
+
+
+def trigger_usage_daily_refresh() -> bool:
+    """Start a background ``usage_daily`` refresh; return whether it launched.
+
+    Runs :func:`_refresh_usage_daily` on a short-lived daemon thread so the
+    HTTP request returns immediately (#861-C). Returns ``True`` when the
+    thread was started, ``False`` if the thread could not be launched
+    (logged, never raised) so the caller can degrade to a failure flash.
+
+    Clean, framework-free signature so it can later be wrapped as a REST
+    endpoint or MCP tool (Phase 5). The actual completion timestamp is
+    recorded by the thread and surfaced via :func:`_get_last_refresh`.
+    """
+    try:
+        thread = threading.Thread(
+            target=_refresh_usage_daily,
+            name="usage-daily-refresh",
+            daemon=True,
+        )
+        thread.start()
+        return True
+    except Exception:
+        logger.exception("Failed to start usage_daily refresh thread")
         return False
 
 
@@ -187,15 +250,30 @@ def _get_usage_by_org(days: int = 30) -> list[dict]:  # type: ignore[type-arg]
 
 
 def _get_last_refresh() -> datetime | None:
-    """Return the last successful refresh timestamp of ``usage_daily``.
+    """Return the last successful refresh-completion timestamp of ``usage_daily``.
 
-    Reads ``pg_stat_all_tables.last_analyze`` for the materialized view
-    as a best-effort proxy — Postgres updates that statistic on every
-    REFRESH.  Returns ``None`` if the view does not exist or the system
-    catalog query fails.
+    Reads the ``recorded_at`` of the most recent ``usage_daily_refresh_ms``
+    marker row that :func:`_refresh_usage_daily` writes on every successful
+    refresh (#861-C) — this is the *real* completion time, not a statistics
+    proxy.
+
+    Falls back to ``pg_stat_all_tables.last_analyze`` only when no marker row
+    exists yet (e.g. the first page load after deploy, before any refresh has
+    run through the new code path). Returns ``None`` when neither signal is
+    available or the query fails.
     """
     try:
         with _connect() as conn:
+            row = conn.execute(
+                "SELECT recorded_at FROM metrics "
+                "WHERE name = %s "
+                "ORDER BY recorded_at DESC LIMIT 1",
+                (_REFRESH_METRIC_NAME,),
+            ).fetchone()
+            if row and row[0]:
+                return row[0]
+
+            # Legacy fallback: best-effort proxy from the planner stats.
             row = conn.execute(
                 "SELECT GREATEST("
                 "  COALESCE(last_analyze, '-infinity'::timestamptz), "
@@ -387,9 +465,23 @@ def admin_analytics_page(req: Request):
         summary = _usage_summary(data)
         last_refresh = _get_last_refresh()
 
-        # ---- Optional flash banner from a successful refresh redirect ----
+        # ---- Optional flash banner from a refresh redirect ----
+        # #861-C: the refresh now runs as a background job, so the common
+        # outcome is "queued". The legacy ``ok`` state is still honoured for
+        # any in-flight redirect/bookmark.
         flash_banner: object | None = None
-        if req.query_params.get("refreshed") == "ok":
+        refreshed_flag = req.query_params.get("refreshed")
+        if refreshed_flag == "queued":
+            flash_banner = Alert(
+                P(  # noqa: F405
+                    "Andmete värskendamine pandi taustatööde järjekorda. "
+                    "Värskendatud andmed ilmuvad mõne hetke pärast — "
+                    "laadi leht uuesti."
+                ),
+                variant="info",
+                title="Värskendamine järjekorras",
+            )
+        elif refreshed_flag == "ok":
             ts_raw = req.query_params.get("refreshed_at", "")
             flash_banner = Alert(
                 P(  # noqa: F405
@@ -398,7 +490,7 @@ def admin_analytics_page(req: Request):
                 variant="success",
                 title="Värskendatud",
             )
-        elif req.query_params.get("refreshed") == "fail":
+        elif refreshed_flag == "fail":
             flash_banner = Alert(
                 P("Andmete värskendamine ebaõnnestus. Proovi uuesti."),  # noqa: F405
                 variant="danger",
@@ -660,25 +752,25 @@ def admin_analytics_page(req: Request):
 
 
 def admin_analytics_refresh(req: Request):
-    """POST /admin/analytics/refresh — refresh ``usage_daily`` on demand.
+    """POST /admin/analytics/refresh — start a ``usage_daily`` refresh.
 
-    Redirects back to ``/admin/analytics`` with a flash banner indicating
-    success or failure.  Preserves the active ``?window=`` selection so
-    the admin lands on the same view they triggered the refresh from.
+    The REFRESH runs off the request path on a background thread (#861-C) so
+    a slow concurrent refresh never blocks the request thread. Redirects back
+    to ``/admin/analytics`` with a flash banner; the ``?window=`` selection
+    is preserved so the admin lands on the same view they triggered the
+    refresh from. The real completion timestamp is recorded by the refresh
+    and surfaced via ``_get_last_refresh`` on the next page load.
     """
     try:
-        from app.admin.analytics import _refresh_usage_daily, _resolve_window
-        from app.ui.time import format_tallinn
+        from app.admin.analytics import _resolve_window, trigger_usage_daily_refresh
 
         # Window can ride on the query string (``?window=…``) so plain
         # form posts that put the selection in the URL keep working.
         slug, _days = _resolve_window(req.query_params.get("window"))
 
-        ok = _refresh_usage_daily()
-        flash = "ok" if ok else "fail"
+        started = trigger_usage_daily_refresh()
+        flash = "queued" if started else "fail"
         params = {"window": slug, "refreshed": flash}
-        if ok:
-            params["refreshed_at"] = format_tallinn(datetime.now(UTC))
         qs = urlencode(params)
         return RedirectResponse(f"/admin/analytics?{qs}", status_code=303)
     except Exception:

--- a/app/admin/audit.py
+++ b/app/admin/audit.py
@@ -261,17 +261,35 @@ def _get_audit_orgs() -> list[dict]:  # type: ignore[type-arg]
         return []
 
 
-def _get_audit_entry(entry_id: int) -> dict | None:  # type: ignore[type-arg]
-    """Return a single audit entry by id, or None if not found."""
+def _get_audit_entry(entry_id: int, *, org_id: str | None = None) -> dict | None:  # type: ignore[type-arg]
+    """Return a single audit entry by id, or None if not found / out of scope.
+
+    When *org_id* is given the row must also satisfy ``u.org_id = %s`` — the
+    SAME join + predicate the list query applies via
+    :func:`_build_audit_where` (``audit_log a LEFT JOIN users u ON
+    u.id = a.user_id``). This keeps the detail endpoint from leaking another
+    org's audit JSON to an org-scoped admin (#886 review): an out-of-scope id
+    returns ``None``, indistinguishable from a genuinely missing row so the
+    HTMX fragment never reveals that the id exists. ``org_id=None`` (platform
+    admin / explicit cross-org) imposes no org constraint.
+
+    Note: like the list path, an ``org_id`` filter excludes user-less system
+    events (``a.user_id IS NULL`` => ``u.org_id`` is NULL), so the two paths
+    show exactly the same set of rows to a scoped admin.
+    """
+    sql = (
+        "SELECT a.id, a.user_id, u.full_name, a.action, a.detail, a.created_at "
+        "FROM audit_log a "
+        "LEFT JOIN users u ON u.id = a.user_id "
+        "WHERE a.id = %s"
+    )
+    params: list = [entry_id]
+    if org_id:
+        sql += " AND u.org_id = %s"
+        params.append(org_id)
     try:
         with _connect() as conn:
-            row = conn.execute(
-                "SELECT a.id, a.user_id, u.full_name, a.action, a.detail, a.created_at "
-                "FROM audit_log a "
-                "LEFT JOIN users u ON u.id = a.user_id "
-                "WHERE a.id = %s",
-                (entry_id,),
-            ).fetchone()
+            row = conn.execute(sql, params).fetchone()
             if not row:
                 return None
             return {
@@ -410,24 +428,34 @@ def _format_detail_json(detail: object) -> str:
         return str(detail)
 
 
-def _audit_detail_cell(entry: dict) -> object:  # type: ignore[type-arg]
+def _audit_detail_cell(entry: dict, org_param: str | None = None) -> object:  # type: ignore[type-arg]
     """Render the ``Detailid`` table cell with a server-side expander.
 
     The cell shows a one-line Estonian summary by default; clicking the
     disclosure triangle fetches the formatted JSON via HTMX from
     ``/admin/audit/detail/{id}``.  Empty details render as an em-dash.
+
+    ``org_param`` is the active ``?org=`` value (from :func:`_org_query_value`)
+    threaded onto the ``hx_get`` so the detail fragment resolves the SAME org
+    scope as the list view (#886 review) — otherwise expanding a row in an
+    explicit ``?org=all`` / specific-org view would default the fragment back
+    to the admin's own org and wrongly report "Kirjet ei leitud." for a
+    legitimately-visible row.
     """
     detail = entry.get("detail")
     if detail is None:
         return "—"
     summary = _summarize_detail(entry.get("action", ""), detail)
     target_id = f"audit-detail-{entry['id']}"
+    detail_url = f"/admin/audit/detail/{entry['id']}"
+    if org_param:
+        detail_url += "?" + urlencode({"org": org_param})
     return Details(  # noqa: F405
         Summary(summary),  # noqa: F405
         Div(  # noqa: F405
             P("Laen detaile…", cls="muted-text"),  # noqa: F405
             id=target_id,
-            hx_get=f"/admin/audit/detail/{entry['id']}",
+            hx_get=detail_url,
             hx_trigger="toggle from:closest details once",
             hx_swap="innerHTML",
         ),
@@ -493,20 +521,37 @@ def _resolve_org_scope(
     return str(own_org) if own_org else None
 
 
+def _org_query_value(filters: dict) -> str | None:  # type: ignore[type-arg]
+    """Return the ``org`` value a URL should carry for *filters*, or None.
+
+    Single source of truth for the org URL param (#861-B, #886 review),
+    shared by pagination/CSV links and the detail-expander ``hx_get`` so they
+    can't drift. Emits the *effective* org only when it was an explicit choice
+    (``org_present``) or the ``all`` cross-org sentinel; for the resolved
+    *default* own-org scope it returns None so the param is omitted and the
+    next request re-derives the same scope via :func:`_resolve_org_scope`
+    (which keeps the default off the "narrowing filter" path).
+    """
+    org_effective = filters.get("org_effective")
+    if org_effective is None:
+        # Legacy callers that never set ``org_effective`` (e.g. raw test
+        # dicts) fall back to the request value with the old semantics.
+        org_raw = filters.get("org")
+        return str(org_raw) if org_raw else None
+    is_all = str(org_effective).strip().lower() in _ORG_ALL_TOKENS
+    explicit = bool(filters.get("org_present"))
+    if explicit or is_all:
+        return str(org_effective)
+    return None
+
+
 def _filter_querystring(filters: dict) -> str:  # type: ignore[type-arg]
     """Encode filters (incl. repeated ``actions``) into a stable query string.
 
     Used both for pagination links and the CSV export href so a filtered
-    view round-trips across page navigation and downloads.
-
-    Org handling (#861-B, #886 review): the *effective* org scope must
-    survive pagination so page 2 does not widen back to all orgs — but it
-    must NOT promote the resolved *default* own-org scope into an explicit
-    ``?org=`` filter (that would flip page 2 into the "over-filtered" empty
-    state and mislabel the export). So we emit ``org=`` only when the scope
-    was either an explicit choice (``org_present``) or the ``all`` cross-org
-    sentinel; for the default own-org case we omit it, and page 2 re-derives
-    the same own-org scope via :func:`_resolve_org_scope`.
+    view round-trips across page navigation and downloads. Org handling is
+    delegated to :func:`_org_query_value` so every URL builder applies the
+    identical effective-vs-default policy (#861-B, #886 review).
     """
     parts: list[tuple[str, str]] = []
     for key in ("action", "user", "from", "to", "query"):
@@ -514,19 +559,9 @@ def _filter_querystring(filters: dict) -> str:  # type: ignore[type-arg]
         if val:
             parts.append((key, str(val)))
 
-    org_effective = filters.get("org_effective")
-    if org_effective is None:
-        # Legacy callers that never set ``org_effective`` (e.g. raw test
-        # dicts) fall back to the request value with the old semantics.
-        org_raw = filters.get("org")
-        if org_raw:
-            parts.append(("org", str(org_raw)))
-    else:
-        is_all = str(org_effective).strip().lower() in _ORG_ALL_TOKENS
-        explicit = bool(filters.get("org_present"))
-        if explicit or is_all:
-            parts.append(("org", str(org_effective)))
-        # else: resolved default own-org — omit so it stays the baseline.
+    org_out = _org_query_value(filters)
+    if org_out:
+        parts.append(("org", org_out))
 
     for act in filters.get("actions", []) or []:
         if act:
@@ -778,6 +813,9 @@ def _audit_results_content(
             Column(key="action", label="Tegevus", sortable=False),
             Column(key="detail", label="Detailid", sortable=False),
         ]
+        # The expander fragment must resolve the same org scope as the list,
+        # so carry the active org value onto each detail ``hx_get`` (#886).
+        org_param = _org_query_value(filters)
         rows = []
         for entry in entries:
             ts = entry["created_at"]
@@ -786,7 +824,7 @@ def _audit_results_content(
                     "time": format_tallinn(ts),
                     "user_name": entry["user_name"],
                     "action": entry["action"],
-                    "detail": _audit_detail_cell(entry),
+                    "detail": _audit_detail_cell(entry, org_param),
                 }
             )
         body = DataTable(columns=columns, rows=rows)
@@ -937,9 +975,23 @@ def admin_audit_detail(req: Request):
     Returns a small ``<pre>`` block (or a one-line muted message when the
     entry is missing or has no detail).  Used by the inline expander on
     the audit table; not a full PageShell.
+
+    The detail row is held to the SAME org scope as the list/export paths
+    (#886 review): the caller's scope is resolved via
+    :func:`_resolve_org_scope` (own-org default; explicit ``?org=`` override;
+    platform admins without ``org_id`` => all). An id outside that scope is
+    treated exactly like a missing row ("Kirjet ei leitud."), so the fragment
+    never leaks the existence — or contents — of another org's audit entry.
     """
     try:
-        from app.admin.audit import _format_detail_json, _get_audit_entry
+        from app.admin.audit import (
+            _extract_filters,
+            _format_detail_json,
+            _get_audit_entry,
+            _resolve_org_scope,
+        )
+
+        auth = req.scope.get("auth")
 
         raw_id = req.path_params.get("id", "")
         try:
@@ -949,7 +1001,11 @@ def admin_audit_detail(req: Request):
                 content="Vigane ID.", status_code=400, media_type="text/plain; charset=utf-8"
             )
 
-        entry = _get_audit_entry(entry_id)
+        # Same org-scope resolution as the list path. The expander link carries
+        # the active ?org= so an explicitly-scoped view stays coherent.
+        org_filter = _resolve_org_scope(_extract_filters(req), auth)
+
+        entry = _get_audit_entry(entry_id, org_id=org_filter)
         if entry is None:
             return P("Kirjet ei leitud.", cls="muted-text")  # noqa: F405
 

--- a/app/admin/audit.py
+++ b/app/admin/audit.py
@@ -497,15 +497,37 @@ def _filter_querystring(filters: dict) -> str:  # type: ignore[type-arg]
     """Encode filters (incl. repeated ``actions``) into a stable query string.
 
     Used both for pagination links and the CSV export href so a filtered
-    view round-trips across page navigation and downloads. The org value
-    (including the ``all`` cross-org sentinel) is preserved so an explicit
-    org scope survives pagination (#861-B).
+    view round-trips across page navigation and downloads.
+
+    Org handling (#861-B, #886 review): the *effective* org scope must
+    survive pagination so page 2 does not widen back to all orgs — but it
+    must NOT promote the resolved *default* own-org scope into an explicit
+    ``?org=`` filter (that would flip page 2 into the "over-filtered" empty
+    state and mislabel the export). So we emit ``org=`` only when the scope
+    was either an explicit choice (``org_present``) or the ``all`` cross-org
+    sentinel; for the default own-org case we omit it, and page 2 re-derives
+    the same own-org scope via :func:`_resolve_org_scope`.
     """
     parts: list[tuple[str, str]] = []
-    for key in ("action", "user", "org", "from", "to", "query"):
+    for key in ("action", "user", "from", "to", "query"):
         val = filters.get(key)
         if val:
             parts.append((key, str(val)))
+
+    org_effective = filters.get("org_effective")
+    if org_effective is None:
+        # Legacy callers that never set ``org_effective`` (e.g. raw test
+        # dicts) fall back to the request value with the old semantics.
+        org_raw = filters.get("org")
+        if org_raw:
+            parts.append(("org", str(org_raw)))
+    else:
+        is_all = str(org_effective).strip().lower() in _ORG_ALL_TOKENS
+        explicit = bool(filters.get("org_present"))
+        if explicit or is_all:
+            parts.append(("org", str(org_effective)))
+        # else: resolved default own-org — omit so it stays the baseline.
+
     for act in filters.get("actions", []) or []:
         if act:
             parts.append(("actions", act))
@@ -515,10 +537,17 @@ def _filter_querystring(filters: dict) -> str:  # type: ignore[type-arg]
 def _has_narrowing_filter(filters: dict) -> bool:  # type: ignore[type-arg]
     """True when the admin applied a result-narrowing filter (#861-B).
 
-    Used only to pick the empty-state copy. The org dimension is excluded:
-    the viewer always resolves *some* org scope (own org or the ``all``
-    cross-org view) by default, so it is not a user-applied narrowing of an
-    otherwise-empty log. A *specific* org chosen explicitly still counts.
+    Used only to pick the empty-state copy. The org dimension counts ONLY
+    when the request *explicitly* supplied a specific org (``org_present``
+    is set AND the value is a real org, not blank/the ``all`` sentinel). The
+    resolved default scope (own-org-by-default, or the cross-org view) must
+    NOT count — otherwise an org admin with an empty log would get the
+    "over-filtered" empty state and a "clear filters" button that just
+    reloads the identical default scope, a no-op loop (#886 review).
+
+    This reads ``filters["org"]`` / ``filters["org_present"]`` — the *actual
+    request* signal, which the page handler leaves untouched — not the
+    resolved ``org_effective``.
     """
     if filters.get("action") or filters.get("actions"):
         return True
@@ -526,6 +555,8 @@ def _has_narrowing_filter(filters: dict) -> bool:  # type: ignore[type-arg]
         return True
     if filters.get("query"):
         return True
+    if not filters.get("org_present"):
+        return False
     org_val = (filters.get("org") or "").strip()
     return bool(org_val) and org_val.lower() not in _ORG_ALL_TOKENS
 
@@ -657,12 +688,16 @@ def _audit_filter_form(
 def _csv_export_link(filters: dict) -> object:  # type: ignore[type-arg]
     """Render an export-to-CSV link that respects the current filter set.
 
-    Labelled "Ekspordi filtreeritud vaade" when any filter is active so it
-    is obvious the download is scoped, not a full dump.
+    The href always carries the *effective* org scope (via
+    :func:`_filter_querystring`) so the download matches the on-screen view.
+    The label says "Ekspordi filtreeritud vaade" only when a real
+    result-narrowing filter is active (an explicit org or any other filter),
+    not merely because the default org scope is present (#886 review) — the
+    org-scoped default is still the baseline view, not a user-applied filter.
     """
     qs = _filter_querystring(filters)
     href = f"/admin/audit/export?{qs}" if qs else "/admin/audit/export"
-    label = "Ekspordi filtreeritud vaade" if qs else "Ekspordi CSV"
+    label = "Ekspordi filtreeritud vaade" if _has_narrowing_filter(filters) else "Ekspordi CSV"
     return A(  # noqa: F405
         label,
         href=href,
@@ -682,9 +717,11 @@ def _filter_summary_text(filters: dict, total: int) -> str:  # type: ignore[type
         active.append("tegevus: " + ", ".join(actions))
     if filters.get("user"):
         active.append("kasutaja valitud")
-    # #861-B: surface the org scope explicitly so the admin always knows
-    # whether they are seeing one org or the whole platform.
-    org_val = (filters.get("org") or "").strip()
+    # #861-B: surface the *effective* org scope (``org_effective``, falling
+    # back to the raw ``org``) so the admin always knows whether they are
+    # seeing one org or the whole platform — even when the scope came from
+    # the default-to-own-org policy rather than an explicit ?org= (#886 review).
+    org_val = (filters.get("org_effective") or filters.get("org") or "").strip()
     if org_val and org_val.lower() not in _ORG_ALL_TOKENS:
         active.append("organisatsioon valitud")
     elif org_val.lower() in _ORG_ALL_TOKENS:
@@ -816,12 +853,15 @@ def admin_audit_page(req: Request):
         user_filter = filters["user"] or None
         # #861-B: default to the admin's own org, honour explicit ?org= override.
         org_filter = _resolve_org_scope(filters, auth)
-        # Pin the resolved scope back onto ``filters`` so pagination links,
-        # the CSV-export href, and the result summary all carry the effective
-        # org (otherwise page 2 would silently widen back to all orgs). The
-        # ``all`` sentinel makes the cross-org view round-trip explicitly.
-        filters["org"] = org_filter or "all"
-        filters["org_present"] = True
+        # Record the *resolved* scope under a separate key so URL builders
+        # (pagination links, CSV-export href) and the result summary carry the
+        # effective org — page 2 must not silently widen back to all orgs. We
+        # deliberately do NOT clobber ``filters["org"]`` / ``filters["org_present"]``:
+        # those keep reflecting the actual request so ``_has_narrowing_filter``
+        # can still tell an explicit specific-org filter from the resolved
+        # default (#886 review). The ``all`` sentinel round-trips the cross-org
+        # view explicitly.
+        filters["org_effective"] = org_filter or "all"
         date_from = _parse_date(filters["from"])
         date_to = _parse_date(filters["to"])
         query_filter = filters["query"] or None

--- a/app/admin/audit.py
+++ b/app/admin/audit.py
@@ -1,4 +1,19 @@
-"""Admin audit log page, filtering helpers, and CSV export."""
+"""Admin audit log page, filtering helpers, and CSV export.
+
+Org-scoping policy (#861-B)
+---------------------------
+The audit viewer is reachable only by the system ``admin`` role (every
+``/admin/audit*`` route is wrapped in ``require_role("admin")``), so the
+caller is always cross-org capable. To avoid silently dumping every
+organisation's audit trail by default, the viewer **defaults to the
+admin's own organisation** (``auth["org_id"]``) and only widens to other
+orgs — or to all orgs — when the request carries an explicit ``?org=``
+override (``?org=<uuid>`` for one org, ``?org=all`` / ``?org=*`` for the
+full cross-org view). An admin with no ``org_id`` on their token (a pure
+platform admin) sees all orgs by default since there is no home org to
+scope to. The org-filter dropdown in the UI sets the same ``?org=``
+param, so the default and the override share one code path.
+"""
 
 from __future__ import annotations
 
@@ -48,6 +63,28 @@ def _parse_actions(value: str | list[str] | None) -> list[str]:
     if isinstance(value, str):
         return [v.strip() for v in value.split(",") if v.strip()]
     return [str(v).strip() for v in value if str(v).strip()]
+
+
+# Backslash is the ESCAPE character we pair with every ILIKE pattern below
+# (``... ILIKE %s ESCAPE '\'``), so it must be escaped first — otherwise
+# escaping ``%``/``_`` would double-process the backslashes we just added.
+_LIKE_ESCAPE_CHAR = "\\"
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE/ILIKE wildcards so a user search is matched literally.
+
+    Postgres ``ILIKE`` treats ``%`` (any run) and ``_`` (any single char)
+    as wildcards. A raw user query of e.g. ``100%`` or ``user_id`` would
+    otherwise silently match far more than intended (#861-B). We escape
+    the ESCAPE char itself, then ``%`` and ``_``, and pair the resulting
+    pattern with an explicit ``ESCAPE '\\'`` clause at the call site.
+    """
+    return (
+        value.replace(_LIKE_ESCAPE_CHAR, _LIKE_ESCAPE_CHAR * 2)
+        .replace("%", _LIKE_ESCAPE_CHAR + "%")
+        .replace("_", _LIKE_ESCAPE_CHAR + "_")
+    )
 
 
 def _build_audit_where(
@@ -104,8 +141,11 @@ def _build_audit_where(
 
         params.append(datetime.combine(date_to + timedelta(days=1), datetime.min.time()))
     if query:
-        clauses.append("a.detail::text ILIKE %s")
-        params.append(f"%{query}%")
+        # Escape LIKE wildcards and pair the pattern with an explicit ESCAPE
+        # clause so ``%``/``_``/``\`` in the user's query match literally
+        # rather than acting as wildcards (#861-B).
+        clauses.append("a.detail::text ILIKE %s ESCAPE '\\'")
+        params.append(f"%{_escape_like(query)}%")
 
     where = " AND ".join(clauses) if clauses else "TRUE"
     return where, params
@@ -400,12 +440,22 @@ def _audit_detail_cell(entry: dict) -> object:  # type: ignore[type-arg]
 # ---------------------------------------------------------------------------
 
 
+# Explicit ``?org=`` values that mean "show every organisation" rather
+# than scope to a specific one (#861-B).
+_ORG_ALL_TOKENS = frozenset({"all", "*", "koik", "kõik"})
+
+
 def _extract_filters(req: Request) -> dict:  # type: ignore[type-arg]
     """Extract filter values from query params.
 
     ``actions`` (plural) accepts multi-select values via repeated
     ``actions=...`` query params; the legacy ``action`` (singular) is
     still honoured for backward compatibility and merged in.
+
+    ``org_present`` records whether the request carried an explicit
+    ``?org=`` key at all — :func:`_resolve_org_scope` uses it to tell
+    "admin explicitly asked for all orgs" (``?org=`` present, blank/``all``)
+    apart from "no choice yet, default to own org" (key absent).
     """
     actions = req.query_params.getlist("actions") if hasattr(req.query_params, "getlist") else []
     return {
@@ -413,17 +463,43 @@ def _extract_filters(req: Request) -> dict:  # type: ignore[type-arg]
         "actions": [a for a in actions if a],
         "user": req.query_params.get("user", ""),
         "org": req.query_params.get("org", ""),
+        "org_present": "org" in req.query_params,
         "from": req.query_params.get("from", ""),
         "to": req.query_params.get("to", ""),
         "query": req.query_params.get("query", ""),
     }
 
 
+def _resolve_org_scope(
+    filters: dict,  # type: ignore[type-arg]
+    auth: dict | None,  # type: ignore[type-arg]
+) -> str | None:
+    """Resolve the org_id the audit query should be scoped to (#861-B).
+
+    Policy (see module docstring): default to the admin's own org; honour
+    an explicit ``?org=`` override (a UUID for one org, blank or an
+    ``_ORG_ALL_TOKENS`` value for all orgs). Returns ``None`` to mean
+    "no org predicate" (i.e. all organisations).
+    """
+    raw = (filters.get("org") or "").strip()
+    if filters.get("org_present"):
+        # Admin explicitly chose. Blank or an "all" token => no scoping;
+        # any other value => scope to that org.
+        if not raw or raw.lower() in _ORG_ALL_TOKENS:
+            return None
+        return raw
+    # No explicit choice: default to the admin's own org when known.
+    own_org = auth.get("org_id") if auth else None
+    return str(own_org) if own_org else None
+
+
 def _filter_querystring(filters: dict) -> str:  # type: ignore[type-arg]
     """Encode filters (incl. repeated ``actions``) into a stable query string.
 
     Used both for pagination links and the CSV export href so a filtered
-    view round-trips across page navigation and downloads.
+    view round-trips across page navigation and downloads. The org value
+    (including the ``all`` cross-org sentinel) is preserved so an explicit
+    org scope survives pagination (#861-B).
     """
     parts: list[tuple[str, str]] = []
     for key in ("action", "user", "org", "from", "to", "query"):
@@ -436,17 +512,42 @@ def _filter_querystring(filters: dict) -> str:  # type: ignore[type-arg]
     return urlencode(parts)
 
 
+def _has_narrowing_filter(filters: dict) -> bool:  # type: ignore[type-arg]
+    """True when the admin applied a result-narrowing filter (#861-B).
+
+    Used only to pick the empty-state copy. The org dimension is excluded:
+    the viewer always resolves *some* org scope (own org or the ``all``
+    cross-org view) by default, so it is not a user-applied narrowing of an
+    otherwise-empty log. A *specific* org chosen explicitly still counts.
+    """
+    if filters.get("action") or filters.get("actions"):
+        return True
+    if filters.get("user") or filters.get("from") or filters.get("to"):
+        return True
+    if filters.get("query"):
+        return True
+    org_val = (filters.get("org") or "").strip()
+    return bool(org_val) and org_val.lower() not in _ORG_ALL_TOKENS
+
+
 def _audit_filter_form(
     filters: dict,  # type: ignore[type-arg]
     actions: list[str],
     users: list[dict],  # type: ignore[type-arg]
     orgs: list[dict] | None = None,  # type: ignore[type-arg]
+    effective_org: str | None = None,
 ) -> object:
     """Render the audit log filter controls.
 
     The action picker is a native multi-select so admins can OR several
     action types together; the org dropdown is rendered only when more
     than one org has audit traffic (single-org admins do not need it).
+
+    ``effective_org`` is the org the view is *actually* scoped to after
+    :func:`_resolve_org_scope` applies the default-to-own-org policy
+    (#861-B). The dropdown pre-selects it so the admin sees that they are
+    looking at one org by default; choosing "Kõik organisatsioonid"
+    (value ``all``) is the explicit opt-in to the cross-org view.
     """
     selected_actions = set(filters.get("actions") or [])
     if filters.get("action"):
@@ -491,9 +592,14 @@ def _audit_filter_form(
     # deployments would just see a useless one-item filter.
     org_list = orgs or []
     if len(org_list) > 1:
-        org_options = [Option("Kõik organisatsioonid", value="")]  # noqa: F405
+        # value="all" is the explicit cross-org opt-in (#861-B); a specific
+        # org is selected when it matches the resolved effective scope.
+        all_selected = "selected" if effective_org is None else None
+        org_options = [
+            Option("Kõik organisatsioonid", value="all", selected=all_selected)  # noqa: F405
+        ]
         for o in org_list:
-            selected = "selected" if filters.get("org") == o["id"] else None
+            selected = "selected" if effective_org == o["id"] else None
             org_options.append(Option(o["name"], value=o["id"], selected=selected))  # noqa: F405
         fields.append(
             Div(  # noqa: F405
@@ -576,8 +682,13 @@ def _filter_summary_text(filters: dict, total: int) -> str:  # type: ignore[type
         active.append("tegevus: " + ", ".join(actions))
     if filters.get("user"):
         active.append("kasutaja valitud")
-    if filters.get("org"):
+    # #861-B: surface the org scope explicitly so the admin always knows
+    # whether they are seeing one org or the whole platform.
+    org_val = (filters.get("org") or "").strip()
+    if org_val and org_val.lower() not in _ORG_ALL_TOKENS:
         active.append("organisatsioon valitud")
+    elif org_val.lower() in _ORG_ALL_TOKENS:
+        active.append("kõik organisatsioonid")
     if filters.get("from") or filters.get("to"):
         rng = f"{filters.get('from') or '…'}–{filters.get('to') or '…'}"
         active.append(f"kuupäev: {rng}")
@@ -605,8 +716,10 @@ def _audit_results_content(
     if not entries:
         # Empty state — distinguish "no audit traffic at all" from "no
         # match for current filters" so the admin knows whether to widen
-        # the search or move on.
-        has_active_filter = bool(_filter_querystring(filters))
+        # the search or move on. The org scope is excluded from this check
+        # (#861-B): it is always resolved to *some* default, so an empty
+        # result under the default scope is "log empty", not "over-filtered".
+        has_active_filter = _has_narrowing_filter(filters)
         if has_active_filter:
             empty_msg = "Praeguste filtritega ei leitud kirjeid."
             empty_hint = A(  # noqa: F405
@@ -686,6 +799,7 @@ def admin_audit_page(req: Request):
             _get_audit_users,
             _get_distinct_actions,
             _parse_date,
+            _resolve_org_scope,
         )
 
         filters = _extract_filters(req)
@@ -700,7 +814,14 @@ def admin_audit_page(req: Request):
         action_filter = filters["action"] or None
         actions_multi = filters["actions"] or None
         user_filter = filters["user"] or None
-        org_filter = filters["org"] or None
+        # #861-B: default to the admin's own org, honour explicit ?org= override.
+        org_filter = _resolve_org_scope(filters, auth)
+        # Pin the resolved scope back onto ``filters`` so pagination links,
+        # the CSV-export href, and the result summary all carry the effective
+        # org (otherwise page 2 would silently widen back to all orgs). The
+        # ``all`` sentinel makes the cross-org view round-trip explicitly.
+        filters["org"] = org_filter or "all"
+        filters["org_present"] = True
         date_from = _parse_date(filters["from"])
         date_to = _parse_date(filters["to"])
         query_filter = filters["query"] or None
@@ -727,7 +848,7 @@ def admin_audit_page(req: Request):
             entries, page, total_pages, per_page, total, filters
         )
 
-        filter_form = _audit_filter_form(filters, actions, users, orgs)
+        filter_form = _audit_filter_form(filters, actions, users, orgs, effective_org=org_filter)
         export_link = _csv_export_link(filters)
         summary_text = _filter_summary_text(filters, total)
 
@@ -822,15 +943,19 @@ def admin_audit_export(req: Request):
             _extract_filters,
             _get_all_filtered_entries,
             _parse_date,
+            _resolve_org_scope,
         )
         from app.ui.time import format_tallinn
 
+        auth = req.scope.get("auth")
         filters = _extract_filters(req)
 
         action_filter = filters["action"] or None
         actions_multi = filters["actions"] or None
         user_filter = filters["user"] or None
-        org_filter = filters["org"] or None
+        # #861-B: the export must honour the same default-to-own-org scoping
+        # as the page so it can never silently dump every org's audit trail.
+        org_filter = _resolve_org_scope(filters, auth)
         date_from = _parse_date(filters["from"])
         date_to = _parse_date(filters["to"])
         query_filter = filters["query"] or None

--- a/app/admin/cost_dashboard.py
+++ b/app/admin/cost_dashboard.py
@@ -42,6 +42,14 @@ _FEATURE_LABELS: dict[str, str] = {
 _WINDOW_CHOICES: tuple[str, ...] = ("7d", "30d", "90d", "ytd")
 _DEFAULT_WINDOW = "30d"
 
+# ``ORG_MAX_MONTHLY_COST_USD`` is a *monthly* budget, so a "% of monthly
+# budget" reading only makes sense for the ~30-day window. For 7d/90d/ytd
+# the comparison is misleading — 90d/ytd routinely exceed 100% and 7d
+# under-reads — so the budget bar + utilisation badge are shown only when
+# the active window equals ``_BUDGET_WINDOW`` (#861-A). Other windows
+# render a neutral, clearly-labelled spend column instead.
+_BUDGET_WINDOW = "30d"
+
 # Estonian labels for the window selector tabs.
 _WINDOW_LABELS: dict[str, str] = {
     "7d": "Viimased 7 päeva",
@@ -544,6 +552,7 @@ def admin_cost_page(req: Request):
     try:
         from app.admin._shared import _tooltip
         from app.admin.cost_dashboard import (
+            _BUDGET_WINDOW,
             _csv_export_link,
             _empty_state,
             _feature_label,
@@ -591,41 +600,76 @@ def admin_cost_page(req: Request):
         toolbar_children.append(_csv_export_link(window, effective_org_id))
         toolbar = Div(*toolbar_children, cls="cost-toolbar")  # noqa: F405
 
-        # ---- Card 1: Cost by org with progress bars ----
+        # ---- Card 1: Cost by org ----
+        # The monthly budget only maps cleanly onto the ~30-day window, so the
+        # budget/utilisation columns appear only for ``_BUDGET_WINDOW`` (#861-A).
+        # Other windows show spend without a spurious "% of monthly budget".
+        show_budget = window == _BUDGET_WINDOW
         if org_costs:
-            org_columns = [
-                Column(key="org_name", label="Organisatsioon", sortable=False),
-                Column(key="cost", label="Kulu (USD)", sortable=False),
-                Column(key="budget", label="Eelarve (USD)", sortable=False),
-                Column(key="progress", label="Kasutus", sortable=False),
-                Column(key="pct", label="Protsent", sortable=False),
-            ]
-            org_rows = []
-            for oc in org_costs:
-                pct = (oc["cost_usd"] / oc["budget_usd"] * 100) if oc["budget_usd"] > 0 else 0
-                variant = "danger" if pct >= 90 else ("warning" if pct >= 70 else "default")
-                org_rows.append(
+            if show_budget:
+                org_columns = [
+                    Column(key="org_name", label="Organisatsioon", sortable=False),
+                    Column(key="cost", label="Kulu (USD)", sortable=False),
+                    Column(key="budget", label="Kuueelarve (USD)", sortable=False),
+                    Column(key="progress", label="Eelarve kasutus", sortable=False),
+                    Column(key="pct", label="Protsent eelarvest", sortable=False),
+                ]
+                org_rows = []
+                for oc in org_costs:
+                    pct = (oc["cost_usd"] / oc["budget_usd"] * 100) if oc["budget_usd"] > 0 else 0
+                    variant = "danger" if pct >= 90 else ("warning" if pct >= 70 else "default")
+                    org_rows.append(
+                        {
+                            "org_name": oc["org_name"],
+                            "cost": f"${oc['cost_usd']:.4f}",
+                            "budget": f"${oc['budget_usd']:.2f}",
+                            "progress": _progress_bar(oc["cost_usd"], oc["budget_usd"]),
+                            "pct": Badge(f"{pct:.0f}%", variant=variant),
+                        }
+                    )
+            else:
+                # Spend-only view: no %-of-monthly-budget bar for non-month
+                # windows. Show the period spend's share of the period total
+                # as a clearly-labelled alternative bar.
+                period_total = sum(oc["cost_usd"] for oc in org_costs) or 1.0
+                org_columns = [
+                    Column(key="org_name", label="Organisatsioon", sortable=False),
+                    Column(key="cost", label="Kulu (USD)", sortable=False),
+                    Column(key="share", label="Osakaal perioodist", sortable=False),
+                ]
+                org_rows = [
                     {
                         "org_name": oc["org_name"],
                         "cost": f"${oc['cost_usd']:.4f}",
-                        "budget": f"${oc['budget_usd']:.2f}",
-                        "progress": _progress_bar(oc["cost_usd"], oc["budget_usd"]),
-                        "pct": Badge(f"{pct:.0f}%", variant=variant),
+                        "share": _progress_bar(oc["cost_usd"], period_total),
                     }
-                )
+                    for oc in org_costs
+                ]
             org_table: object = DataTable(columns=org_columns, rows=org_rows)
         else:
             org_table = _empty_state()
+
+        if show_budget:
+            org_card_tip = "Valitud ajavahemiku kulu vs kuueelarve organisatsioonide lõikes"
+            org_card_note: object = ""
+        else:
+            org_card_tip = "Valitud ajavahemiku kulu organisatsioonide lõikes"
+            # Make it explicit that the monthly-budget comparison is hidden
+            # because the active window is not a calendar month.
+            org_card_note = P(  # noqa: F405
+                "Eelarve kasutust näidatakse ainult 30 päeva vaates (kuueelarve põhjal).",
+                cls="muted-text",
+            )
 
         org_card = Card(
             CardHeader(
                 H3(  # noqa: F405
                     "Kulu organisatsioonide kaupa",
-                    _tooltip("Valitud ajavahemiku kulu vs eelarve organisatsioonide lõikes"),
+                    _tooltip(org_card_tip),
                     cls="card-title",
                 )
             ),
-            CardBody(org_table),
+            CardBody(org_card_note, org_table),
         )
 
         # ---- Card 2: Cost by feature ----

--- a/app/admin/health.py
+++ b/app/admin/health.py
@@ -454,21 +454,53 @@ def admin_health_page(req: Request):
         return _render_admin_error_page(title="Süsteemi tervis", user=auth, theme=theme)
 
 
-def health_check(req: Request):
-    """GET /api/health — JSON health check endpoint (unauthenticated).
+def _health_request_is_admin(req: Request) -> bool:
+    """Best-effort: is this ``/api/health`` request from an authenticated admin?
 
-    Returns a JSON response suitable for Coolify or uptime monitoring:
-    {"status": "ok", "jena": true/false, "postgres": true/false}
+    ``/api/health`` is in the auth Beforeware's ``SKIP_PATHS`` (so uptime
+    monitors can hit it anonymously), which means ``req.scope['auth']`` is
+    normally *not* populated even for a logged-in admin. We therefore resolve
+    the caller directly here (#861-D): trust a pre-populated ``scope['auth']``
+    if present, otherwise validate the ``access_token`` cookie read-only via
+    the JWT provider. Any failure is swallowed and treated as "not admin" so
+    the public probe can never 500 on a bad/missing cookie.
+    """
+    auth = req.scope.get("auth")
+    if isinstance(auth, dict) and auth.get("role") == "admin":
+        return True
+    try:
+        token = req.cookies.get("access_token")
+        if not token:
+            return False
+        from app.auth.middleware import _get_provider
+
+        user = _get_provider().get_current_user(token)
+        return bool(user and user.get("role") == "admin")
+    except Exception:
+        logger.debug("health_check admin detection failed", exc_info=True)
+        return False
+
+
+def health_check(req: Request):
+    """GET /api/health — JSON health check endpoint.
+
+    Unauthenticated callers (Coolify, uptime monitors) get a deliberately
+    minimal ``{"status": "ok"|"degraded"}`` payload — no version, git SHA,
+    or per-subsystem breakdown is exposed publicly (#861-D).
+
+    Authenticated **admins** get the richer payload (per-subsystem
+    reachability + version/SHA/build time) so the endpoint stays useful for
+    operators; the same detail is also on the authenticated
+    ``/admin/health/aggregator`` page.
     """
     jena_ok = jena_check_health()
     pg_ok = _check_postgres()
     overall = "ok" if (jena_ok and pg_ok) else "degraded"
 
-    return JSONResponse(
-        {
-            "status": overall,
-            "jena": jena_ok,
-            "postgres": pg_ok,
-            "version": read_version(),
-        }
-    )
+    payload: dict[str, Any] = {"status": overall}
+    if _health_request_is_admin(req):
+        payload["jena"] = jena_ok
+        payload["postgres"] = pg_ok
+        payload["version"] = read_version()
+
+    return JSONResponse(payload)

--- a/tests/test_admin_analytics.py
+++ b/tests/test_admin_analytics.py
@@ -46,9 +46,15 @@ class TestRefreshUsageDaily:
 
         result = _refresh_usage_daily()
         assert result is True
-        mock_conn.execute.assert_called_once()
-        sql = mock_conn.execute.call_args[0][0]
-        assert "REFRESH MATERIALIZED VIEW CONCURRENTLY usage_daily" in sql
+        # Two statements: the REFRESH, then the completion-marker INSERT
+        # whose recorded_at is the real refresh timestamp (#861-C).
+        assert mock_conn.execute.call_count == 2
+        refresh_sql = mock_conn.execute.call_args_list[0][0][0]
+        assert "REFRESH MATERIALIZED VIEW CONCURRENTLY usage_daily" in refresh_sql
+        marker_sql = mock_conn.execute.call_args_list[1][0][0]
+        assert "INSERT INTO metrics" in marker_sql
+        marker_params = mock_conn.execute.call_args_list[1][0][1]
+        assert marker_params[0] == "usage_daily_refresh_ms"
         mock_conn.commit.assert_called_once()
 
     @patch("app.admin.analytics._connect")
@@ -154,16 +160,40 @@ class TestGetUsageByOrg:
 
 class TestGetLastRefresh:
     @patch("app.admin.analytics._connect")
-    def test_returns_timestamp_when_present(self, mock_connect: MagicMock):
+    def test_returns_marker_timestamp_when_present(self, mock_connect: MagicMock):
+        """#861-C: prefers the real refresh-marker row over the stats proxy."""
         from app.admin.analytics import _get_last_refresh
 
         ts = datetime(2026, 4, 8, 12, 30)
         mock_conn = MagicMock()
         mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
         mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        # First query (metrics marker) returns the real timestamp.
         mock_conn.execute.return_value.fetchone.return_value = (ts,)
 
         assert _get_last_refresh() == ts
+        # The first query reads the marker row from the metrics table.
+        first_sql = mock_conn.execute.call_args_list[0][0][0]
+        assert "FROM metrics" in first_sql
+        first_params = mock_conn.execute.call_args_list[0][0][1]
+        assert first_params == ("usage_daily_refresh_ms",)
+
+    @patch("app.admin.analytics._connect")
+    def test_falls_back_to_stats_proxy_without_marker(self, mock_connect: MagicMock):
+        """#861-C: legacy fallback when no marker row exists yet."""
+        from app.admin.analytics import _get_last_refresh
+
+        ts = datetime(2026, 4, 8, 12, 30)
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        # First call (marker) → None; second call (pg_stat proxy) → timestamp.
+        mock_conn.execute.return_value.fetchone.side_effect = [None, (ts,)]
+
+        assert _get_last_refresh() == ts
+        assert mock_conn.execute.call_count == 2
+        second_sql = mock_conn.execute.call_args_list[1][0][0]
+        assert "pg_stat_all_tables" in second_sql
 
     @patch("app.admin.analytics._connect")
     def test_returns_none_on_error(self, mock_connect: MagicMock):
@@ -390,6 +420,27 @@ class TestAnalyticsPageRender:
     @patch("app.admin.analytics._get_last_refresh")
     @patch("app.admin.analytics._get_usage_by_org")
     @patch("app.admin.analytics._get_usage_data")
+    def test_refresh_queued_flash(
+        self,
+        mock_data: MagicMock,
+        mock_org: MagicMock,
+        mock_refresh: MagicMock,
+    ):
+        """#861-C: the async refresh redirect surfaces a 'queued' banner."""
+        mock_data.return_value = []
+        mock_org.return_value = []
+        mock_refresh.return_value = None
+
+        from app.admin.analytics import admin_analytics_page
+
+        req = Request(_scope(query="window=30d&refreshed=queued"))
+        result = admin_analytics_page(req)
+        html = to_xml(result)
+        assert "taustatööde järjekorda" in html
+
+    @patch("app.admin.analytics._get_last_refresh")
+    @patch("app.admin.analytics._get_usage_by_org")
+    @patch("app.admin.analytics._get_usage_data")
     def test_refresh_failure_flash(
         self,
         mock_data: MagicMock,
@@ -423,9 +474,12 @@ class TestAnalyticsPageRender:
 
 
 class TestAnalyticsRefreshHandler:
-    @patch("app.admin.analytics._refresh_usage_daily")
-    def test_success_redirects_with_ok_flash(self, mock_refresh: MagicMock):
-        mock_refresh.return_value = True
+    # #861-C: the refresh now runs off the request path on a background
+    # thread, so the handler returns ``refreshed=queued`` on a successful
+    # launch rather than ``ok`` after a synchronous REFRESH.
+    @patch("app.admin.analytics.trigger_usage_daily_refresh")
+    def test_success_redirects_with_queued_flash(self, mock_trigger: MagicMock):
+        mock_trigger.return_value = True
 
         from app.admin.analytics import admin_analytics_refresh
 
@@ -436,12 +490,13 @@ class TestAnalyticsRefreshHandler:
         assert response.status_code == 303
         location = response.headers["location"]
         assert "/admin/analytics?" in location
-        assert "refreshed=ok" in location
+        assert "refreshed=queued" in location
         assert "window=7d" in location
+        mock_trigger.assert_called_once()
 
-    @patch("app.admin.analytics._refresh_usage_daily")
-    def test_failure_redirects_with_fail_flash(self, mock_refresh: MagicMock):
-        mock_refresh.return_value = False
+    @patch("app.admin.analytics.trigger_usage_daily_refresh")
+    def test_failed_launch_redirects_with_fail_flash(self, mock_trigger: MagicMock):
+        mock_trigger.return_value = False
 
         from app.admin.analytics import admin_analytics_refresh
 
@@ -453,7 +508,7 @@ class TestAnalyticsRefreshHandler:
         assert "refreshed=fail" in response.headers["location"]
         assert "window=30d" in response.headers["location"]
 
-    @patch("app.admin.analytics._refresh_usage_daily", side_effect=Exception("boom"))
+    @patch("app.admin.analytics.trigger_usage_daily_refresh", side_effect=Exception("boom"))
     def test_unexpected_error_redirects_with_fail_flash(self, _mock: MagicMock):
         from app.admin.analytics import admin_analytics_refresh
 
@@ -463,6 +518,30 @@ class TestAnalyticsRefreshHandler:
         response = admin_analytics_refresh(req)
         assert response.status_code == 303
         assert "refreshed=fail" in response.headers["location"]
+
+
+class TestTriggerUsageDailyRefresh:
+    """Cover the background-thread launcher itself (#861-C)."""
+
+    @patch("app.admin.analytics.threading.Thread")
+    def test_launches_daemon_thread(self, mock_thread_cls: MagicMock):
+        from app.admin.analytics import _refresh_usage_daily, trigger_usage_daily_refresh
+
+        mock_thread = MagicMock()
+        mock_thread_cls.return_value = mock_thread
+
+        assert trigger_usage_daily_refresh() is True
+        # The refresh runs on a started daemon thread, not inline.
+        _, kwargs = mock_thread_cls.call_args
+        assert kwargs["target"] is _refresh_usage_daily
+        assert kwargs["daemon"] is True
+        mock_thread.start.assert_called_once()
+
+    @patch("app.admin.analytics.threading.Thread", side_effect=RuntimeError("no threads"))
+    def test_returns_false_when_thread_cannot_start(self, _mock: MagicMock):
+        from app.admin.analytics import trigger_usage_daily_refresh
+
+        assert trigger_usage_daily_refresh() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_admin_audit_enhanced.py
+++ b/tests/test_admin_audit_enhanced.py
@@ -855,6 +855,212 @@ class TestAuditDetailFragment:
 
 
 # ---------------------------------------------------------------------------
+# Detail-endpoint org scoping (#886 review)
+# ---------------------------------------------------------------------------
+
+
+def _detail_request(entry_id: str, *, query_string: str = "", org_id: str | None) -> Request:
+    """Build an /admin/audit/detail/{id} Request with a controllable scope.
+
+    ``org_id=None`` models a platform admin (no home org); otherwise the
+    admin is bound to that org.
+    """
+    auth: dict[str, object] = {"role": "admin", "id": "a-1", "email": "a@b.ee"}
+    if org_id is not None:
+        auth["org_id"] = org_id
+    req = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": f"/admin/audit/detail/{entry_id}",
+            "headers": [],
+            "query_string": query_string.encode(),
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 12345),
+            "auth": auth,
+            "path_params": {"id": entry_id},
+        }
+    )
+    return req
+
+
+class TestGetAuditEntryScoping:
+    """#886: the single-row fetch must apply the SAME org predicate as the list."""
+
+    @patch("app.admin.audit._connect")
+    def test_no_org_id_has_no_org_predicate(self, mock_connect: MagicMock):
+        from app.admin.audit import _get_audit_entry
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = None
+
+        _get_audit_entry(5)
+        sql = mock_conn.execute.call_args[0][0]
+        params = mock_conn.execute.call_args[0][1]
+        assert "u.org_id" not in sql
+        assert list(params) == [5]
+
+    @patch("app.admin.audit._connect")
+    def test_org_id_adds_predicate_and_param(self, mock_connect: MagicMock):
+        from app.admin.audit import _get_audit_entry
+
+        mock_conn = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = None
+
+        _get_audit_entry(5, org_id="home-org")
+        sql = mock_conn.execute.call_args[0][0]
+        params = mock_conn.execute.call_args[0][1]
+        # Same join + predicate the list path uses.
+        assert "LEFT JOIN users u ON u.id = a.user_id" in sql
+        assert "u.org_id = %s" in sql
+        assert list(params) == [5, "home-org"]
+
+
+class TestAuditDetailOrgScoping:
+    """#886: the HTMX detail endpoint enforces the list's org scope and treats
+    an out-of-scope id exactly like a missing row (no existence leak)."""
+
+    @patch("app.admin.audit._get_audit_entry")
+    def test_own_org_admin_can_expand_own_org_entry(self, mock_entry: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_detail
+
+        mock_entry.return_value = {
+            "id": 5,
+            "user_id": "u-1",
+            "user_name": "Alice",
+            "action": "doc.upload",
+            "detail": {"filename": "x.docx"},
+            "created_at": datetime(2025, 6, 15, 12, 0),
+        }
+        result = admin_audit_detail(_detail_request("5", org_id="home-org"))
+        html = to_xml(result)
+        assert "x.docx" in html
+        # The fetch was scoped to the admin's own org.
+        assert mock_entry.call_args.kwargs.get("org_id") == "home-org"
+
+    @patch("app.admin.audit._get_audit_entry", return_value=None)
+    def test_own_org_admin_other_org_id_gets_not_found(self, mock_entry: MagicMock):
+        """An org admin requesting another org's id: the scoped fetch returns
+        None (the DB predicate excludes it), so the handler shows the
+        not-found branch — identical to a genuinely missing row, no 403 body."""
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_detail
+
+        result = admin_audit_detail(_detail_request("999", org_id="home-org"))
+        html = to_xml(result)
+        assert "Kirjet ei leitud" in html
+        # The fetch was scoped to own-org; the foreign id simply did not match.
+        assert mock_entry.call_args.kwargs.get("org_id") == "home-org"
+        # Same not-found copy as TestAuditDetailFragment — no distinct 403.
+        assert "keelatud" not in html.lower()
+
+    @patch("app.admin.audit._get_audit_entry")
+    def test_platform_admin_reads_any_entry(self, mock_entry: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_detail
+
+        mock_entry.return_value = {
+            "id": 7,
+            "user_id": "u-9",
+            "user_name": "Bob",
+            "action": "draft.create",
+            "detail": {"title": "Foo"},
+            "created_at": datetime(2025, 6, 15, 12, 0),
+        }
+        # Platform admin: no org_id, no ?org= => no scoping predicate.
+        result = admin_audit_detail(_detail_request("7", org_id=None))
+        html = to_xml(result)
+        assert "Foo" in html
+        assert mock_entry.call_args.kwargs.get("org_id") is None
+
+    @patch("app.admin.audit._get_audit_entry")
+    def test_explicit_org_all_imposes_no_scope(self, mock_entry: MagicMock):
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_detail
+
+        mock_entry.return_value = {
+            "id": 8,
+            "user_id": "u-3",
+            "user_name": "Cara",
+            "action": "doc.upload",
+            "detail": {"filename": "y.docx"},
+            "created_at": datetime(2025, 6, 15, 12, 0),
+        }
+        # Org admin who explicitly opted into the cross-org view.
+        result = admin_audit_detail(
+            _detail_request("8", query_string="org=all", org_id="home-org")
+        )
+        html = to_xml(result)
+        assert "y.docx" in html
+        # ?org=all => cross-org => no org predicate on the fetch.
+        assert mock_entry.call_args.kwargs.get("org_id") is None
+
+    @patch("app.admin.audit._get_audit_entry")
+    def test_explicit_specific_org_scopes_fetch(self, mock_entry: MagicMock):
+        from app.admin.audit import admin_audit_detail
+
+        mock_entry.return_value = None
+        # Platform admin drilling into one specific org's entry.
+        admin_audit_detail(_detail_request("9", query_string="org=other-org", org_id=None))
+        assert mock_entry.call_args.kwargs.get("org_id") == "other-org"
+
+
+class TestAuditDetailExpanderUrl:
+    """#886: the list expander hx_get must carry the active org so the
+    fragment resolves the same scope as the list it was rendered in."""
+
+    def _render_list(self, req, *, org_rows: bool = True) -> str:
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_page
+
+        entries = [
+            {
+                "id": 42,
+                "user_id": "u-1",
+                "user_name": "U",
+                "action": "doc.upload",
+                "detail": {"filename": "z.docx"},
+                "created_at": datetime(2026, 4, 8, 9, 0),
+                "org_id": "home-org",
+            }
+        ]
+        orgs = (
+            [{"id": "home-org", "name": "Home"}, {"id": "other-org", "name": "Other"}]
+            if org_rows
+            else []
+        )
+        with (
+            patch("app.admin.audit._get_audit_log_page", return_value=(entries, 1)),
+            patch("app.admin.audit._get_distinct_actions", return_value=[]),
+            patch("app.admin.audit._get_audit_users", return_value=[]),
+            patch("app.admin.audit._get_audit_orgs", return_value=orgs),
+        ):
+            return to_xml(admin_audit_page(req))
+
+    def test_explicit_all_expander_carries_org(self):
+        html = self._render_list(_audit_scope("org=all", org_id="home-org"))
+        assert "/admin/audit/detail/42?org=all" in html
+
+    def test_default_own_org_expander_omits_org(self):
+        # Default scope: the expander omits ?org= (the fragment re-defaults to
+        # own-org), matching the pagination/CSV omission policy.
+        html = self._render_list(_audit_scope("", org_id="home-org"))
+        assert "/admin/audit/detail/42" in html
+        assert "/admin/audit/detail/42?org=" not in html
+
+
+# ---------------------------------------------------------------------------
 # CSV export
 # ---------------------------------------------------------------------------
 

--- a/tests/test_admin_audit_enhanced.py
+++ b/tests/test_admin_audit_enhanced.py
@@ -416,14 +416,26 @@ class TestHasNarrowingFilter:
         from app.admin.audit import _has_narrowing_filter
 
         base = {"action": "", "actions": [], "user": "", "from": "", "to": "", "query": ""}
-        assert _has_narrowing_filter({**base, "org": "all"}) is False
-        assert _has_narrowing_filter({**base, "org": ""}) is False
+        assert _has_narrowing_filter({**base, "org": "all", "org_present": True}) is False
+        assert _has_narrowing_filter({**base, "org": "", "org_present": True}) is False
 
-    def test_specific_org_is_narrowing(self):
+    def test_explicit_specific_org_is_narrowing(self):
         from app.admin.audit import _has_narrowing_filter
 
         base = {"action": "", "actions": [], "user": "", "from": "", "to": "", "query": ""}
-        assert _has_narrowing_filter({**base, "org": "org-7"}) is True
+        # An explicitly-chosen specific org narrows the result set.
+        assert _has_narrowing_filter({**base, "org": "org-7", "org_present": True}) is True
+
+    def test_resolved_default_org_is_not_narrowing(self):
+        """#886 review: a specific org that came from the default-to-own-org
+        resolution (org_present=False) must NOT count as a narrowing filter —
+        otherwise an org admin with an empty log gets an "over-filtered" empty
+        state and a clear-filters button that just reloads the same scope."""
+        from app.admin.audit import _has_narrowing_filter
+
+        base = {"action": "", "actions": [], "user": "", "from": "", "to": "", "query": ""}
+        # Own-org UUID resolved as the default — org_present is False.
+        assert _has_narrowing_filter({**base, "org": "own-org", "org_present": False}) is False
 
     def test_other_filters_are_narrowing(self):
         from app.admin.audit import _has_narrowing_filter
@@ -436,6 +448,7 @@ class TestHasNarrowingFilter:
             "to": "",
             "query": "",
             "org": "all",
+            "org_present": True,
         }
         assert _has_narrowing_filter({**base, "query": "x"}) is True
         assert _has_narrowing_filter({**base, "action": "user.login"}) is True
@@ -522,6 +535,147 @@ class TestAuditPageOrgScoping:
         admin_audit_page(Request(scope))
         # Cross-org opt-in => no org predicate.
         assert mock_page.call_args.kwargs.get("org_id") is None
+
+
+def _audit_scope(query_string: str = "", *, org_id: str | None = "home-org") -> Request:
+    """Admin Request for the audit page; ``org_id=None`` => platform admin."""
+    auth: dict[str, object] = {
+        "role": "admin",
+        "id": "a-1",
+        "email": "a@b.ee",
+        "full_name": "Admin User",
+    }
+    if org_id is not None:
+        auth["org_id"] = org_id
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/admin/audit",
+            "headers": [],
+            "query_string": query_string.encode(),
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 12345),
+            "auth": auth,
+        }
+    )
+
+
+class TestAuditEmptyStateOrgScoping:
+    """#886 review: the empty-state copy must not treat the resolved default
+    org scope as a user-applied filter (the no-op clear-filters loop)."""
+
+    @patch("app.admin.audit._get_audit_orgs")
+    @patch("app.admin.audit._get_audit_users")
+    @patch("app.admin.audit._get_distinct_actions")
+    @patch("app.admin.audit._get_audit_log_page")
+    def test_default_scope_empty_log_shows_plain_empty_copy(
+        self,
+        mock_page: MagicMock,
+        mock_actions: MagicMock,
+        mock_users: MagicMock,
+        mock_orgs: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_page
+
+        mock_page.return_value = ([], 0)
+        mock_actions.return_value = []
+        mock_users.return_value = []
+        mock_orgs.return_value = []
+
+        # Org admin, no ?org= — scoped to own org by default, empty log.
+        html = to_xml(admin_audit_page(_audit_scope("")))
+        # Plain "log is empty" copy, NOT the over-filtered variant, and NO
+        # clear-filters button (it would just reload the identical scope).
+        assert "Auditilogis kirjeid ei leitud" in html
+        assert "Praeguste filtritega" not in html
+        assert "Tühjenda filtrid" not in html
+
+    @patch("app.admin.audit._get_audit_orgs")
+    @patch("app.admin.audit._get_audit_users")
+    @patch("app.admin.audit._get_distinct_actions")
+    @patch("app.admin.audit._get_audit_log_page")
+    def test_explicit_org_empty_result_shows_filtered_empty_state(
+        self,
+        mock_page: MagicMock,
+        mock_actions: MagicMock,
+        mock_users: MagicMock,
+        mock_orgs: MagicMock,
+    ):
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_page
+
+        mock_page.return_value = ([], 0)
+        mock_actions.return_value = []
+        mock_users.return_value = []
+        mock_orgs.return_value = []
+
+        # Platform admin explicitly picks a specific org that has no rows.
+        html = to_xml(admin_audit_page(_audit_scope("org=other-org", org_id=None)))
+        assert "Praeguste filtritega ei leitud kirjeid" in html
+        assert "Tühjenda filtrid" in html
+        assert "Auditilogis kirjeid ei leitud" not in html
+
+
+class TestAuditPaginationScopePreservation:
+    """#886 review: pagination + CSV links must carry the *effective* org so
+    page 2 / the export does not silently widen back to all orgs."""
+
+    def _render(self, req, rows: int) -> str:
+        from fasthtml.common import to_xml
+
+        from app.admin.audit import admin_audit_page
+
+        entries = [
+            {
+                "id": i,
+                "user_id": "u-1",
+                "user_name": "U",
+                "action": "user.login",
+                "detail": {"x": 1},
+                "created_at": datetime(2026, 4, 8, 9, 0),
+                "org_id": "home-org",
+            }
+            for i in range(rows)
+        ]
+        with (
+            patch("app.admin.audit._get_audit_log_page", return_value=(entries, rows)),
+            patch("app.admin.audit._get_distinct_actions", return_value=[]),
+            patch("app.admin.audit._get_audit_users", return_value=[]),
+            patch(
+                "app.admin.audit._get_audit_orgs",
+                return_value=[
+                    {"id": "home-org", "name": "Home"},
+                    {"id": "other-org", "name": "Other"},
+                ],
+            ),
+        ):
+            return to_xml(admin_audit_page(req))
+
+    def test_default_own_org_pagination_keeps_scope(self):
+        # 60 rows over 25/page => multiple pages, so pagination links render.
+        html = self._render(_audit_scope(""), rows=60)
+        # Page-2 link must re-resolve to the same own-org scope. We emit it by
+        # omitting ?org= (page 2 re-defaults to own-org) — so the page-2 href
+        # must NOT carry an explicit foreign org and must point back to the
+        # audit page.
+        assert "/admin/audit?" in html
+        assert "org=other-org" not in html
+
+    def test_explicit_all_pagination_preserves_cross_org(self):
+        html = self._render(_audit_scope("org=all", org_id="home-org"), rows=60)
+        # The cross-org opt-in must survive pagination as org=all.
+        assert "org=all" in html
+
+    def test_explicit_specific_org_csv_link_carries_org(self):
+        html = self._render(_audit_scope("org=other-org", org_id=None), rows=5)
+        # The CSV export href is scoped to the chosen org.
+        assert "/admin/audit/export?" in html
+        assert "org=other-org" in html
 
 
 class TestFilterQuerystring:

--- a/tests/test_admin_audit_enhanced.py
+++ b/tests/test_admin_audit_enhanced.py
@@ -101,6 +101,22 @@ class TestBuildAuditWhere:
         assert "a.detail::text ILIKE %s" in where
         assert "%draft%" in params
 
+    def test_query_filter_has_escape_clause(self):
+        """#861-B: the ILIKE pattern must carry an explicit ESCAPE clause."""
+        from app.admin.audit import _build_audit_where
+
+        where, _params = _build_audit_where(query="draft")
+        assert "ILIKE %s ESCAPE '\\'" in where
+
+    def test_query_filter_escapes_like_wildcards(self):
+        """#861-B: %, _ and \\ in a user query must be matched literally."""
+        from app.admin.audit import _build_audit_where
+
+        _where, params = _build_audit_where(query="100%_x\\y")
+        # The bound pattern is wrapped in %...% but the user's own wildcards
+        # are backslash-escaped so they cannot act as wildcards.
+        assert params[-1] == "%100\\%\\_x\\\\y%"
+
     def test_combined_filters(self):
         from app.admin.audit import _build_audit_where
 
@@ -326,6 +342,186 @@ class TestExtractFilters:
         req = _make_request("/admin/audit", "org=org-42")
         f = _extract_filters(req)
         assert f["org"] == "org-42"
+
+    def test_org_present_flag_tracks_explicit_param(self):
+        """#861-B: ``org_present`` distinguishes a blank ?org= from no ?org=."""
+        from app.admin.audit import _extract_filters
+
+        # Present but blank (explicit "all orgs" opt-in).
+        f_blank = _extract_filters(_make_request("/admin/audit", "org="))
+        assert f_blank["org_present"] is True
+        # Absent entirely (default-to-own-org).
+        f_absent = _extract_filters(_make_request("/admin/audit", "user=u-1"))
+        assert f_absent["org_present"] is False
+
+
+# ---------------------------------------------------------------------------
+# Org-scoping policy + LIKE escaping (#861-B)
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeLike:
+    def test_escapes_percent_underscore_backslash(self):
+        from app.admin.audit import _escape_like
+
+        assert _escape_like("100%") == "100\\%"
+        assert _escape_like("a_b") == "a\\_b"
+        # Backslash escaped first so it is not double-processed.
+        assert _escape_like("a\\b") == "a\\\\b"
+
+    def test_plain_text_unchanged(self):
+        from app.admin.audit import _escape_like
+
+        assert _escape_like("draft.upload") == "draft.upload"
+
+
+class TestResolveOrgScope:
+    def test_defaults_to_own_org_when_no_param(self):
+        from app.admin.audit import _resolve_org_scope
+
+        filters = {"org": "", "org_present": False}
+        auth = {"role": "admin", "org_id": "own-org"}
+        assert _resolve_org_scope(filters, auth) == "own-org"
+
+    def test_platform_admin_without_org_sees_all_by_default(self):
+        from app.admin.audit import _resolve_org_scope
+
+        filters = {"org": "", "org_present": False}
+        auth = {"role": "admin"}  # no org_id
+        assert _resolve_org_scope(filters, auth) is None
+
+    def test_explicit_org_override_wins(self):
+        from app.admin.audit import _resolve_org_scope
+
+        filters = {"org": "picked-org", "org_present": True}
+        auth = {"role": "admin", "org_id": "own-org"}
+        assert _resolve_org_scope(filters, auth) == "picked-org"
+
+    def test_explicit_all_token_returns_none(self):
+        from app.admin.audit import _resolve_org_scope
+
+        auth = {"role": "admin", "org_id": "own-org"}
+        for token in ("all", "*", ""):
+            filters = {"org": token, "org_present": True}
+            assert _resolve_org_scope(filters, auth) is None
+
+    def test_no_auth_returns_none(self):
+        from app.admin.audit import _resolve_org_scope
+
+        assert _resolve_org_scope({"org": "", "org_present": False}, None) is None
+
+
+class TestHasNarrowingFilter:
+    def test_all_org_is_not_narrowing(self):
+        from app.admin.audit import _has_narrowing_filter
+
+        base = {"action": "", "actions": [], "user": "", "from": "", "to": "", "query": ""}
+        assert _has_narrowing_filter({**base, "org": "all"}) is False
+        assert _has_narrowing_filter({**base, "org": ""}) is False
+
+    def test_specific_org_is_narrowing(self):
+        from app.admin.audit import _has_narrowing_filter
+
+        base = {"action": "", "actions": [], "user": "", "from": "", "to": "", "query": ""}
+        assert _has_narrowing_filter({**base, "org": "org-7"}) is True
+
+    def test_other_filters_are_narrowing(self):
+        from app.admin.audit import _has_narrowing_filter
+
+        base = {
+            "action": "",
+            "actions": [],
+            "user": "",
+            "from": "",
+            "to": "",
+            "query": "",
+            "org": "all",
+        }
+        assert _has_narrowing_filter({**base, "query": "x"}) is True
+        assert _has_narrowing_filter({**base, "action": "user.login"}) is True
+
+
+class TestAuditPageOrgScoping:
+    """End-to-end: the page handler applies the default-to-own-org policy."""
+
+    @patch("app.admin.audit._get_audit_orgs")
+    @patch("app.admin.audit._get_audit_users")
+    @patch("app.admin.audit._get_distinct_actions")
+    @patch("app.admin.audit._get_audit_log_page")
+    def test_default_scopes_query_to_own_org(
+        self,
+        mock_page: MagicMock,
+        mock_actions: MagicMock,
+        mock_users: MagicMock,
+        mock_orgs: MagicMock,
+    ):
+        from app.admin.audit import admin_audit_page
+
+        mock_page.return_value = ([], 0)
+        mock_actions.return_value = []
+        mock_users.return_value = []
+        mock_orgs.return_value = []
+
+        # Admin with an org_id, no ?org= override.
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/admin/audit",
+            "headers": [],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 12345),
+            "auth": {
+                "role": "admin",
+                "id": "a-1",
+                "org_id": "home-org",
+                "email": "a@b.ee",
+                "full_name": "Admin User",
+            },
+        }
+        admin_audit_page(Request(scope))
+        # The DB query must have been scoped to the admin's own org.
+        assert mock_page.call_args.kwargs.get("org_id") == "home-org"
+
+    @patch("app.admin.audit._get_audit_orgs")
+    @patch("app.admin.audit._get_audit_users")
+    @patch("app.admin.audit._get_distinct_actions")
+    @patch("app.admin.audit._get_audit_log_page")
+    def test_explicit_all_widens_to_cross_org(
+        self,
+        mock_page: MagicMock,
+        mock_actions: MagicMock,
+        mock_users: MagicMock,
+        mock_orgs: MagicMock,
+    ):
+        from app.admin.audit import admin_audit_page
+
+        mock_page.return_value = ([], 0)
+        mock_actions.return_value = []
+        mock_users.return_value = []
+        mock_orgs.return_value = []
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/admin/audit",
+            "headers": [],
+            "query_string": b"org=all",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("127.0.0.1", 12345),
+            "auth": {
+                "role": "admin",
+                "id": "a-1",
+                "org_id": "home-org",
+                "email": "a@b.ee",
+                "full_name": "Admin User",
+            },
+        }
+        admin_audit_page(Request(scope))
+        # Cross-org opt-in => no org predicate.
+        assert mock_page.call_args.kwargs.get("org_id") is None
 
 
 class TestFilterQuerystring:

--- a/tests/test_admin_cost_dashboard.py
+++ b/tests/test_admin_cost_dashboard.py
@@ -899,3 +899,87 @@ class TestCostDashboardAuth:
         response = client.get("/admin/costs/export?format=csv&window=30d")
         assert response.status_code == 303
         assert response.headers["location"] == "/auth/login"
+
+
+# ---------------------------------------------------------------------------
+# Budget-bar window awareness (#861-A)
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetBarWindowScoping:
+    """The monthly budget bar/% must only appear in the 30-day window.
+
+    For 7d/90d/ytd, dividing window spend by the monthly budget produces a
+    misleading % (often >100% for 90d/ytd), so those windows show spend
+    without a %-of-monthly-budget bar.
+    """
+
+    def _patch_all(self):
+        # Helper returning the seven page-data patchers as a list so each
+        # test can enter them with a single ExitStack-free loop.
+        return [
+            patch("app.admin.cost_dashboard._get_orgs_for_filter", return_value=[]),
+            patch("app.admin.cost_dashboard._get_monthly_trend", return_value=[]),
+            patch("app.admin.cost_dashboard._get_daily_trend", return_value=[]),
+            patch("app.admin.cost_dashboard._get_top_users", return_value=[]),
+            patch("app.admin.cost_dashboard._get_cost_by_model", return_value=[]),
+            patch("app.admin.cost_dashboard._get_cost_by_feature", return_value=[]),
+        ]
+
+    def _render(self, window: str, org_costs: list[dict]) -> str:  # type: ignore[type-arg]
+        from fasthtml.common import to_xml
+
+        from app.admin.cost_dashboard import admin_cost_page
+
+        patchers = self._patch_all()
+        for p in patchers:
+            p.start()
+        org_patch = patch("app.admin.cost_dashboard._get_cost_by_org", return_value=org_costs)
+        org_patch.start()
+        try:
+            req = _make_request("/admin/costs", f"window={window}")
+            return to_xml(admin_cost_page(req))
+        finally:
+            org_patch.stop()
+            for p in patchers:
+                p.stop()
+
+    def test_month_window_shows_budget_columns(self):
+        html = self._render(
+            "30d",
+            [{"org_name": "Org A", "cost_usd": 20.0, "budget_usd": 50.0}],
+        )
+        # Budget utilisation columns + a percentage badge are present.
+        assert "Protsent eelarvest" in html
+        assert "Eelarve kasutus" in html
+        assert "Kuueelarve" in html
+        assert "40%" in html  # 20/50
+
+    def test_long_window_hides_budget_percentage(self):
+        # 90d spend far exceeds the monthly budget — the old code would have
+        # rendered a spurious >100% badge here.
+        html = self._render(
+            "90d",
+            [{"org_name": "Org A", "cost_usd": 140.0, "budget_usd": 50.0}],
+        )
+        assert "Protsent eelarvest" not in html
+        # The budget-utilisation column header is gone (the note text
+        # "Eelarve kasutust …" legitimately contains the substring, so we
+        # match the column-header form ">Eelarve kasutus<").
+        assert ">Eelarve kasutus<" not in html
+        # No spurious over-budget percentage badge (280% = 140/50). The
+        # badge wraps its text in a <span>, so match the badge form.
+        assert ">280%<" not in html
+        # The spend-only alternative + explanatory note are shown instead.
+        assert "Osakaal perioodist" in html
+        assert "Eelarve kasutust näidatakse ainult 30 päeva vaates" in html
+        # The raw spend is still surfaced.
+        assert "140" in html
+
+    def test_ytd_window_hides_budget_percentage(self):
+        html = self._render(
+            "ytd",
+            [{"org_name": "Org A", "cost_usd": 500.0, "budget_usd": 50.0}],
+        )
+        assert "Protsent eelarvest" not in html
+        assert "Osakaal perioodist" in html

--- a/tests/test_admin_health.py
+++ b/tests/test_admin_health.py
@@ -346,3 +346,119 @@ class TestAdminHealthPage:
         assert "Süsteemi tervis" in html
         # The shared error banner copy.
         assert "Andmete laadimine ebaõnnestus" in html
+
+
+# ---------------------------------------------------------------------------
+# /api/health public-payload reduction (#861-D)
+# ---------------------------------------------------------------------------
+
+
+def _health_request(*, auth: dict | None = None, cookies: dict | None = None) -> Request:  # type: ignore[type-arg]
+    """Build an ``/api/health`` Request, optionally with an auth scope/cookie."""
+    headers: list[tuple[bytes, bytes]] = []
+    if cookies:
+        cookie_str = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        headers.append((b"cookie", cookie_str.encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/health",
+        "headers": headers,
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+    }
+    if auth is not None:
+        scope["auth"] = auth
+    return Request(scope)
+
+
+class TestHealthCheckPayload:
+    @patch("app.admin.health._check_postgres", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    def test_unauthenticated_payload_is_status_only(
+        self, mock_jena: MagicMock, mock_pg: MagicMock
+    ):
+        """#861-D: anonymous callers must not see version/SHA/subsystems."""
+        import json
+
+        from app.admin.health import health_check
+
+        resp = health_check(_health_request())
+        body = json.loads(bytes(resp.body).decode())
+        assert body == {"status": "ok"}
+        assert "version" not in body
+        assert "jena" not in body
+        assert "postgres" not in body
+
+    @patch("app.admin.health._check_postgres", return_value=False)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    def test_unauthenticated_degraded_status_still_minimal(
+        self, mock_jena: MagicMock, mock_pg: MagicMock
+    ):
+        import json
+
+        from app.admin.health import health_check
+
+        resp = health_check(_health_request())
+        body = json.loads(bytes(resp.body).decode())
+        assert body == {"status": "degraded"}
+
+    @patch("app.admin.health._check_postgres", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    def test_admin_scope_gets_detailed_payload(self, mock_jena: MagicMock, mock_pg: MagicMock):
+        """An admin (resolved via scope) gets the rich payload (#861-D)."""
+        import json
+
+        from app.admin.health import health_check
+
+        resp = health_check(_health_request(auth={"role": "admin", "id": "a-1"}))
+        body = json.loads(bytes(resp.body).decode())
+        assert body["status"] == "ok"
+        assert body["jena"] is True
+        assert body["postgres"] is True
+        assert "version" in body
+        assert set(body["version"]) >= {"app", "sha", "built_at"}
+
+    @patch("app.admin.health._check_postgres", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    def test_non_admin_scope_gets_minimal_payload(self, mock_jena: MagicMock, mock_pg: MagicMock):
+        import json
+
+        from app.admin.health import health_check
+
+        resp = health_check(_health_request(auth={"role": "drafter", "id": "d-1"}))
+        body = json.loads(bytes(resp.body).decode())
+        assert body == {"status": "ok"}
+
+    @patch("app.admin.health._check_postgres", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    def test_admin_cookie_gets_detailed_payload(self, mock_jena: MagicMock, mock_pg: MagicMock):
+        """When scope['auth'] is absent (the live SKIP_PATHS case), the
+        handler resolves an admin from the access_token cookie (#861-D)."""
+        import json
+
+        from app.admin import health as health_mod
+
+        provider = MagicMock()
+        provider.get_current_user.return_value = {"role": "admin", "id": "a-1"}
+        with patch("app.auth.middleware._get_provider", return_value=provider):
+            resp = health_mod.health_check(_health_request(cookies={"access_token": "tok"}))
+        body = json.loads(bytes(resp.body).decode())
+        assert "version" in body
+        provider.get_current_user.assert_called_once_with("tok")
+
+    @patch("app.admin.health._check_postgres", return_value=True)
+    @patch("app.admin.health.jena_check_health", return_value=True)
+    def test_bad_cookie_does_not_500(self, mock_jena: MagicMock, mock_pg: MagicMock):
+        """A malformed/expired cookie must degrade to the public payload,
+        never raise (#861-D)."""
+        import json
+
+        from app.admin import health as health_mod
+
+        with patch("app.auth.middleware._get_provider", side_effect=Exception("boom")):
+            resp = health_mod.health_check(_health_request(cookies={"access_token": "bad"}))
+        body = json.loads(bytes(resp.body).decode())
+        assert body == {"status": "ok"}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -62,6 +62,10 @@ class TestDashboardAuth:
 
 
 class TestHealthCheck:
+    # #861-D: the unauthenticated /api/health payload is reduced to
+    # ``{"status": ...}`` — no version/SHA or per-subsystem breakdown is
+    # exposed publicly. The detailed breakdown is covered (incl. the
+    # admin-only path) in tests/test_admin_health.py::TestHealthCheckPayload.
     @patch("app.admin.health.jena_check_health")
     @patch("app.admin.health._check_postgres")
     def test_health_returns_json(self, mock_pg: MagicMock, mock_jena: MagicMock):
@@ -74,9 +78,8 @@ class TestHealthCheck:
         response = client.get("/api/health")
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "ok"
-        assert data["jena"] is True
-        assert data["postgres"] is True
+        # Public payload is status-only.
+        assert data == {"status": "ok"}
 
     @patch("app.admin.health.jena_check_health")
     @patch("app.admin.health._check_postgres")
@@ -90,9 +93,7 @@ class TestHealthCheck:
         response = client.get("/api/health")
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "degraded"
-        assert data["jena"] is False
-        assert data["postgres"] is True
+        assert data == {"status": "degraded"}
 
     def test_health_no_auth_required(self):
         """Health check must be accessible without cookies."""
@@ -104,8 +105,10 @@ class TestHealthCheck:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] in {"ok", "degraded"}
-        assert "jena" in data
-        assert "postgres" in data
+        # No subsystem detail leaks to anonymous callers (#861-D).
+        assert "jena" not in data
+        assert "postgres" not in data
+        assert "version" not in data
 
     def test_ping_no_auth_required(self):
         """/api/ping is a lightweight liveness probe that must work anon."""

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -125,8 +125,15 @@ class TestReadVersion:
         assert v2["app"] == "1.0.0"
 
 
-class TestHealthEndpointIncludesVersion:
-    def test_health_payload_has_version_block(self):
+class TestHealthEndpointVersionGating:
+    """#861-D: the unauthenticated /api/health payload must NOT leak the
+    version/git-SHA block; the rich payload (incl. version) is admin-only.
+
+    ``read_version`` itself is exercised directly by the tests above; here we
+    only assert the public endpoint's reduced contract.
+    """
+
+    def test_unauthenticated_health_payload_has_no_version_block(self):
         # Using importlib avoids shadowing the ``app`` package name with
         # the ASGI ``app`` object. We import the main module first (which
         # registers admin routes), then pull out the ASGI callable by
@@ -146,9 +153,6 @@ class TestHealthEndpointIncludesVersion:
 
         assert response.status_code == 200
         data = response.json()
-        assert "version" in data
-        version = data["version"]
-        assert set(version.keys()) == {"app", "sha", "built_at"}
-        assert isinstance(version["app"], str)
-        assert isinstance(version["sha"], str)
-        assert isinstance(version["built_at"], str)
+        # Public callers see status only — no version, git SHA, or
+        # per-subsystem breakdown.
+        assert data == {"status": "ok"}


### PR DESCRIPTION
Part of #861.

Fixes four admin-panel review findings. Each finding was re-verified against the review commit `3cc9ba0`; none were already fixed by PRs #868–#876 (those merges did not touch `app/admin/{cost_dashboard,audit,analytics,health}.py`).

## Finding A — budget bar divides window spend by monthly budget (cost_dashboard)
The org card divided the **window** spend (7d/90d/ytd) by the **monthly** `ORG_MAX_MONTHLY_COST_USD`, producing spurious >100% readings for longer windows.

**Fix:** budget-utilisation % + progress bar now render **only** for the 30-day window (`_BUDGET_WINDOW`). For 7d/90d/ytd the org card shows a spend-only view (`Kulu (USD)` + a clearly-labelled `Osakaal perioodist` share-of-period bar) plus an Estonian note: *"Eelarve kasutust näidatakse ainult 30 päeva vaates (kuueelarve põhjal)."* No `%`-of-monthly-budget badge is emitted for non-month windows.

- `app/admin/cost_dashboard.py`: `_BUDGET_WINDOW` constant; window-aware Card 1 rendering.

## Finding B — audit search escaping + cross-org scoping policy (audit)
1. **LIKE escaping:** the detail search built `ILIKE %s` with `%{query}%` and no escaping, so `%`/`_`/`\` in a user query acted as wildcards. Added `_escape_like()` (escapes `\` first, then `%`/`_`) and an explicit `ILIKE %s ESCAPE '\'` clause.
2. **Org-scoping policy** (checked `app/auth`: `VALID_ROLES = ("drafter","reviewer","org_admin","admin")`; all `/admin/audit*` routes are `require_role("admin")`): the viewer now **defaults to the admin's own org** (`auth["org_id"]`) and only widens on an explicit `?org=` override — `?org=<uuid>` for one org, `?org=all`/`*` for the full cross-org view. A pure platform admin (no `org_id`) defaults to all orgs. The resolved scope is pinned into pagination/export links so it survives navigation; the dropdown pre-selects it and `Kõik organisatsioonid` (value `all`) is the explicit cross-org opt-in. Policy documented in the module docstring.

- `app/admin/audit.py`: `_escape_like`, `_resolve_org_scope`, `_has_narrowing_filter`, `org_present` flag; wired into `admin_audit_page` + `admin_audit_export`.

## Finding C — analytics refresh off the request path + real timestamp (analytics)
`_refresh_usage_daily` ran `REFRESH … CONCURRENTLY` synchronously in the request, and `_get_last_refresh` read `pg_stat_all_tables.last_analyze` (a proxy that reflects ANALYZE/autoanalyze, not REFRESH).

**Fix:**
- The manual refresh now runs on a **short-lived daemon thread** (`trigger_usage_daily_refresh`); the POST returns immediately and the page surfaces a `Värskendamine järjekorras` banner.
- `_refresh_usage_daily` writes a `usage_daily_refresh_ms` **marker row** into the existing `metrics` table (committed atomically with the REFRESH); `_get_last_refresh` reads that row's `recorded_at` as the **real completion timestamp**, falling back to the old stats proxy only when no marker exists yet.

**Choice of mechanism (per the issue's sanctioned fallback):** full `FOR UPDATE SKIP LOCKED` queue wiring would require either importing FastHTML into the standalone worker via `app/jobs/registry.py` — which is *deliberately* framework-free (it must not pull in FastHTML/Starlette) and `analytics.py` imports `fasthtml.common` — or a new framework-free handler module, which is out of this fix's file scope. The threaded refresh keeps the request non-blocking and records the real timestamp without violating the registry contract. **No `registry.py` change was needed.**

- `app/admin/analytics.py`: `trigger_usage_daily_refresh`, marker-row write, marker-first `_get_last_refresh`, `queued` flash.

## Finding D — unauthenticated /api/health leaks version + git SHA (health)
`health_check` returned `{status, jena, postgres, version:{app,sha,built_at}}` to **anyone** (the route is in `SKIP_PATHS`, so `scope['auth']` is never populated there).

**Fix:** the public payload is reduced to `{"status": "ok"|"degraded"}`. The detailed payload (subsystem reachability + version/SHA/build time) is returned only to authenticated **admins**, detected via `scope['auth']` or — since the route skips the beforeware — a read-only validation of the `access_token` cookie through the existing JWT provider (`_health_request_is_admin`). Any cookie error degrades to the public payload (never 500s).

- `app/admin/health.py`: `_health_request_is_admin`, admin-gated payload.

## Already-fixed items
None — all four findings were still present at HEAD.

## Out-of-scope test files touched (Finding D contract change)
Two test files outside the declared scope asserted the **old, now-insecure** `/api/health` contract (version/subsystems exposed anonymously) and would otherwise fail CI. Minimal contract-only updates were applied so the suite stays green; flagged here for visibility:
- `tests/test_version.py` — `TestHealthEndpointIncludesVersion` → `TestHealthEndpointVersionGating`: asserts the anonymous payload is `{status}` only.
- `tests/test_dashboard.py` — `TestHealthCheck`: anonymous payload is `{status}` only (no `jena`/`postgres`/`version`).

`tests/conftest.py` and all non-test app code outside the four modules were left untouched.

## Tests
New coverage: budget-bar window gating (`TestBudgetBarWindowScoping`); LIKE escaping + org-scope policy + page-level scoping (`TestEscapeLike`, `TestResolveOrgScope`, `TestHasNarrowingFilter`, `TestAuditPageOrgScoping`); threaded refresh + marker-timestamp read (`TestTriggerUsageDailyRefresh`, updated `TestGetLastRefresh`/`TestRefreshUsageDaily`/`TestAnalyticsRefreshHandler`, `queued` flash); health payload gating (`TestHealthCheckPayload`).

```
uv run ruff check  → All checks passed!
uv run pyright     → 0 errors, 0 warnings, 0 informations
pytest (4 admin suites)                              → 174 passed
pytest (admin + dashboard + version + auth + smoke)  → 373 passed
pytest (jobs/worker/queue/registry)                  → 161 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)