### PR TITLE
fix(db+metrics): connection pool, metrics label hygiene, flush race (#861)

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -2,11 +2,39 @@
 
 Every module that needs a PostgreSQL connection should import from here
 rather than duplicating the ``DATABASE_URL`` lookup and ``psycopg.connect`` call.
+
+A process-wide :class:`psycopg_pool.ConnectionPool` backs :func:`get_connection`
+so the dashboard's ~10 serial widget queries, a document-detail render's 3
+queries, every metric flush and every job-poll reuse pooled connections
+instead of paying a fresh TCP+TLS+auth handshake each time.
+
+The pool is created lazily on first use behind a thread-safe lock (the same
+double-checked-locking singleton pattern as ``ClaudeProvider`` /
+``SparqlClient``) so importing this module never opens a socket — stub-mode
+callers and unit tests that monkeypatch :func:`get_connection` never touch a
+real database.
+
+``get_connection()`` keeps its original public contract: it returns a
+``psycopg`` connection usable BOTH as a context manager
+(``with get_connection() as conn: ...`` — the connection is committed/rolled
+back and returned to the pool on exit) AND as a bare handle
+(``conn = get_connection(); ...; conn.close()`` — ``close()`` returns it to the
+pool). The advisory-lock holder in ``app/sync/orchestrator.py`` relies on the
+bare form.
 """
 
+from __future__ import annotations
+
+import atexit
 import os
+import threading
+import time
+from typing import TYPE_CHECKING, Any
 
 import psycopg
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
 
 # Dev-only fallback. In any non-development environment a missing
 # DATABASE_URL is a hard failure so we don't silently talk to a local DB.
@@ -26,6 +54,186 @@ def _load_database_url() -> str:
 DATABASE_URL = _load_database_url()
 
 
+# ---------------------------------------------------------------------------
+# Connection pool
+# ---------------------------------------------------------------------------
+#
+# Sizing: defaults of 1/10 are deliberately conservative. The background job
+# worker thread holds a connection only for the duration of a single
+# ``FOR UPDATE SKIP LOCKED`` claim (claim -> commit -> release in one short
+# ``with`` block), and the WebSocket DB watcher loops likewise check out a
+# connection per poll iteration (each offloaded via ``asyncio.to_thread``) and
+# return it immediately -- neither holds a pooled connection across iterations.
+# The one genuinely long-lived holder is the sync advisory-lock connection,
+# which uses the *bare* form and is closed (returned) the moment the sync
+# finishes. With 5-50 concurrent officials a max of 10 leaves ample headroom
+# under Postgres' default ``max_connections`` while collapsing the
+# connection-per-query storm that motivated this change. Override with
+# ``DB_POOL_MIN`` / ``DB_POOL_MAX`` per deployment.
+_POOL_MIN = max(0, int(os.environ.get("DB_POOL_MIN", "1")))
+_POOL_MAX = max(1, int(os.environ.get("DB_POOL_MAX", "10")))
+# Seconds getconn() blocks waiting for the pool to hand back a connection
+# before raising PoolTimeout. psycopg_pool always routes getconn through its
+# background maintenance worker, so this also bounds how long a *single* call
+# waits when Postgres is unreachable. Kept short (2s): with max_size=10 and
+# short-lived checkouts a longer wait only signals pathological saturation or a
+# dead DB (a healthy pool hands back a connection instantly). The circuit
+# breaker below keeps a dead DB from making *every* subsequent call pay even
+# this wait. Raise ``DB_POOL_TIMEOUT`` in production if a connection-storm
+# warm-up is expected.
+_POOL_TIMEOUT = float(os.environ.get("DB_POOL_TIMEOUT", "2"))
+# Per-attempt TCP/auth connect timeout, applied via the libpq ``connect_timeout``
+# keyword so a dead host fails in seconds rather than the OS default (~75s).
+_CONNECT_TIMEOUT = int(os.environ.get("DB_CONNECT_TIMEOUT", "5"))
+# Circuit breaker: when a checkout fails (PoolTimeout / OperationalError) the
+# DB is treated as unavailable for this cooldown, during which get_connection()
+# fails *immediately* instead of making each caller wait DB_POOL_TIMEOUT again.
+# This restores the near-instant failure of the old bare ``psycopg.connect`` on
+# an unreachable DB (so a DB-less environment — e.g. the unit-test CI job that
+# runs without a Postgres service — does not serialise into one timeout per
+# call) while still pooling normally when the DB is up. Kept short so a
+# transient blip self-heals within a couple of seconds of DB recovery.
+_BREAKER_COOLDOWN = float(os.environ.get("DB_BREAKER_COOLDOWN", "2"))
+
+_pool: ConnectionPool | None = None
+_pool_lock = threading.Lock()
+_unavailable_until = 0.0
+
+
+def _create_pool() -> ConnectionPool:
+    """Construct the process-wide connection pool.
+
+    Imported lazily so the ``psycopg_pool`` dependency is only loaded when a
+    real connection is first opened -- never at import time, so stub-mode
+    callers and tests that patch :func:`get_connection` stay decoupled from it.
+    """
+    from psycopg_pool import ConnectionPool
+
+    return ConnectionPool(
+        conninfo=DATABASE_URL,
+        min_size=min(_POOL_MIN, _POOL_MAX),
+        max_size=_POOL_MAX,
+        # Block (rather than raise) for up to DB_POOL_TIMEOUT seconds if every
+        # pooled connection is checked out before giving up.
+        timeout=_POOL_TIMEOUT,
+        # Bound each underlying connection attempt so an unreachable host can't
+        # wedge a caller (or interpreter shutdown) for the OS default.
+        kwargs={"connect_timeout": _CONNECT_TIMEOUT},
+        open=True,
+    )
+
+
+def _get_pool() -> ConnectionPool:
+    """Return the lazily-initialised singleton pool (double-checked lock)."""
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                _pool = _create_pool()
+    return _pool
+
+
+def _reset_pool() -> None:
+    """Close and drop the singleton pool (for tests / clean shutdown)."""
+    global _pool, _unavailable_until
+    with _pool_lock:
+        _unavailable_until = 0.0
+        if _pool is not None:
+            try:
+                _pool.close()
+            finally:
+                _pool = None
+
+
+# Close the pool on interpreter shutdown so its background maintenance thread
+# stops and psycopg_pool doesn't emit an "unclosed pool" warning. No-op when
+# the pool was never opened (the common case for stub-mode / test processes).
+atexit.register(_reset_pool)
+
+
+class _PooledConnection:
+    """Context-manager + bare-handle wrapper around a pooled connection.
+
+    Forwards every attribute (``execute``, ``cursor``, ``commit``, ...) to the
+    underlying ``psycopg`` connection so existing call sites are untouched.
+    The connection is returned to the pool exactly once, whether the caller
+    leaves a ``with`` block (``__exit__``) or calls ``close()`` on a bare
+    handle -- never both, never neither.
+
+    On ``with``-block exit psycopg's own transaction semantics are preserved:
+    a clean exit commits, an exception rolls back, before the connection goes
+    back to the pool.
+    """
+
+    __slots__ = ("_conn", "_pool", "_returned")
+
+    def __init__(self, pool: ConnectionPool, conn: psycopg.Connection) -> None:  # type: ignore[type-arg]
+        self._pool = pool
+        self._conn = conn
+        self._returned = False
+
+    # -- bare-handle / attribute forwarding ---------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached for attributes not defined on the wrapper itself
+        # (``_conn`` / ``_pool`` / ``_returned`` live in ``__slots__``).
+        return getattr(self._conn, name)
+
+    def close(self) -> None:
+        """Return the connection to the pool (idempotent)."""
+        self._return()
+
+    def _return(self) -> None:
+        if self._returned:
+            return
+        self._returned = True
+        self._pool.putconn(self._conn)
+
+    # -- context-manager protocol -------------------------------------------
+
+    def __enter__(self) -> psycopg.Connection:  # type: ignore[type-arg]
+        return self._conn
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        # Mirror psycopg.Connection.__exit__: commit on success, roll back on
+        # error, then hand the connection back to the pool.
+        try:
+            if not self._conn.closed:
+                if exc_type is None:
+                    self._conn.commit()
+                else:
+                    self._conn.rollback()
+        finally:
+            self._return()
+        return False
+
+
 def get_connection() -> psycopg.Connection:  # type: ignore[type-arg]
-    """Return a new ``psycopg`` connection using the shared ``DATABASE_URL``."""
-    return psycopg.connect(DATABASE_URL)
+    """Return a pooled ``psycopg`` connection using the shared ``DATABASE_URL``.
+
+    The return value behaves like the bare ``psycopg.connect(...)`` result it
+    replaced: use it as a context manager (``with get_connection() as conn:`` --
+    committed/rolled-back and returned to the pool on exit) or as a plain handle
+    (call ``conn.close()`` to return it to the pool).
+
+    A short circuit breaker (``_BREAKER_COOLDOWN``) trips on a checkout failure
+    so that, while the DB is unreachable, callers fail fast instead of each
+    waiting ``DB_POOL_TIMEOUT`` — matching the near-instant failure of the old
+    bare ``psycopg.connect``.
+    """
+    global _unavailable_until
+
+    if time.monotonic() < _unavailable_until:
+        raise psycopg.OperationalError(
+            "database unavailable (connection pool circuit breaker open)"
+        )
+
+    pool = _get_pool()
+    try:
+        conn = pool.getconn()
+    except Exception:
+        # Trip the breaker so the next callers within the cooldown fail fast
+        # rather than each blocking for the full pool timeout.
+        _unavailable_until = time.monotonic() + _BREAKER_COOLDOWN
+        raise
+    return _PooledConnection(pool, conn)  # type: ignore[return-value]

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -75,7 +75,12 @@ _MAX_LABEL_LEN = 200
 # DELETE on every batch. The (name, recorded_at) index from migration 011 plus
 # the recorded_at index from migration 043 keep the sweep cheap.
 _RETENTION_SWEEP_INTERVAL = 3600.0  # seconds — at most one sweep per hour
-_last_retention_sweep: float = 0.0
+# ``None`` means "never swept yet" so the first flush always prunes. We must NOT
+# use 0.0 as a "long ago" sentinel: ``time.monotonic()`` is relative to an
+# arbitrary (often boot-relative) epoch, so on a freshly-booted host ``now``
+# can be < _RETENTION_SWEEP_INTERVAL and ``now - 0.0`` would wrongly throttle
+# the very first sweep.
+_last_retention_sweep: float | None = None
 
 
 def _retention_days() -> int:
@@ -102,7 +107,10 @@ def _maybe_prune(conn: Any) -> None:
 
     now = time.monotonic()
     with _lock:
-        if now - _last_retention_sweep < _RETENTION_SWEEP_INTERVAL:
+        # None => never swept => always due. Otherwise enforce the interval.
+        if _last_retention_sweep is not None and (
+            now - _last_retention_sweep < _RETENTION_SWEEP_INTERVAL
+        ):
             return
         _last_retention_sweep = now
 

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -6,7 +6,7 @@ Provides:
   Never blocks the caller; flushes every ``_FLUSH_INTERVAL`` seconds or when
   the buffer reaches ``_FLUSH_SIZE`` entries.
 - ``MetricsMiddleware`` — Starlette ASGI middleware that records per-request
-  latency with route path and method as labels.
+  latency labelled with the *matched route template* and method.
 - ``track_duration(name, **labels)`` — context manager that measures a code
   block's wall-clock duration in milliseconds and records it.
 """
@@ -16,6 +16,7 @@ from __future__ import annotations
 import atexit
 import json
 import logging
+import os
 import threading
 import time
 from collections import deque
@@ -25,6 +26,7 @@ from typing import Any
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.routing import Match
 
 from app.db import get_connection as _connect
 
@@ -34,24 +36,104 @@ logger = logging.getLogger(__name__)
 # Buffered metric recording
 # ---------------------------------------------------------------------------
 
-_BUFFER: deque[tuple[str, float, str | None]] = deque()
+# A bounded deque drops the oldest entries once full, so a DB outage can never
+# let buffered telemetry grow without limit (metrics are best-effort, not
+# durable — losing the oldest few under sustained failure is acceptable).
+_BUFFER_MAXLEN = 10_000
+_BUFFER: deque[tuple[str, float, str | None]] = deque(maxlen=_BUFFER_MAXLEN)
 _FLUSH_INTERVAL = 10.0  # seconds
 _FLUSH_SIZE = 100  # flush if buffer hits this many entries
 _lock = threading.Lock()
 _flush_timer: threading.Timer | None = None
 
+# Single-flight guard: only one flush touches Postgres at a time. A flush that
+# blocks (down DB / saturated pool waiting up to DB_POOL_TIMEOUT) would
+# otherwise let every subsequent record_metric queue ANOTHER blocking flush,
+# stacking N concurrent waits. With this flag the others no-op instead.
+_flush_in_progress = False
+
+# Failure backoff: after a flush can't reach Postgres we suppress further flush
+# attempts for _FLUSH_BACKOFF seconds so we stop hammering an unavailable DB.
+# Buffering still works (the deque just fills); the next flush after the
+# cooldown drains it. Combined with the single-flight guard this caps the cost
+# of a DB outage at one DB_POOL_TIMEOUT-bounded wait per cooldown window.
+_FLUSH_BACKOFF = 30.0  # seconds
+_flush_suppressed_until: float = 0.0
+
+# Cap on any single label value so an unexpectedly long route template (mounts,
+# catch-all paths) can never write an unbounded string into the labels JSONB.
+_MAX_LABEL_LEN = 200
+
+# ---------------------------------------------------------------------------
+# Retention — self-contained, piggybacked on the flush path
+# ---------------------------------------------------------------------------
+#
+# ``metrics`` is an append-only sink; without pruning it grows forever. We
+# delete rows older than ``METRICS_RETENTION_DAYS`` (0 disables retention)
+# opportunistically from inside ``_flush_buffer``, but at most once every
+# ``_RETENTION_SWEEP_INTERVAL`` seconds so a busy flush path doesn't issue a
+# DELETE on every batch. The (name, recorded_at) index from migration 011 plus
+# the recorded_at index from migration 043 keep the sweep cheap.
+_RETENTION_SWEEP_INTERVAL = 3600.0  # seconds — at most one sweep per hour
+_last_retention_sweep: float = 0.0
+
+
+def _retention_days() -> int:
+    """Days of metrics history to keep; 0 (or invalid) disables retention."""
+    raw = os.environ.get("METRICS_RETENTION_DAYS", "30")
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 0
+
+
+def _maybe_prune(conn: Any) -> None:
+    """Delete metrics older than the retention window, throttled per interval.
+
+    Runs on the existing flush connection so retention never opens its own.
+    Note the ``%s::interval`` cast: Postgres rejects the bare ``interval %s``
+    placeholder form, so the parameter is bound as text and cast server-side.
+    """
+    global _last_retention_sweep
+
+    days = _retention_days()
+    if days <= 0:
+        return
+
+    now = time.monotonic()
+    with _lock:
+        if now - _last_retention_sweep < _RETENTION_SWEEP_INTERVAL:
+            return
+        _last_retention_sweep = now
+
+    conn.execute(
+        "DELETE FROM metrics WHERE recorded_at < now() - %s::interval",
+        (f"{days} days",),
+    )
+
+
+def _flush_suppressed() -> bool:
+    """True while the post-failure flush cooldown is still in effect."""
+    return time.monotonic() < _flush_suppressed_until
+
 
 def _flush_buffer() -> None:
     """Bulk-INSERT all buffered metrics into Postgres."""
-    global _flush_timer
-    items: list[tuple[str, float, str | None]] = []
+    global _flush_timer, _flush_in_progress, _flush_suppressed_until
+
+    # Claim the single-flight slot and drain the buffer atomically. If another
+    # flush is already running, or the failure cooldown is active, leave the
+    # buffer intact and bail (the entries flush on a later attempt).
     with _lock:
+        _flush_timer = None
+        if _flush_in_progress or _flush_suppressed():
+            return
+        if not _BUFFER:
+            return
+        items: list[tuple[str, float, str | None]] = []
         while _BUFFER:
             items.append(_BUFFER.popleft())
-        _flush_timer = None
-
-    if not items:
-        return
+        _flush_in_progress = True
 
     try:
         with _connect() as conn:
@@ -60,18 +142,38 @@ def _flush_buffer() -> None:
                 "INSERT INTO metrics (name, value, labels) VALUES (%s, %s, %s::jsonb)",
                 items,
             )
+            _maybe_prune(conn)
             conn.commit()
+        # Clear any prior cooldown on a successful round-trip.
+        with _lock:
+            _flush_suppressed_until = 0.0
     except Exception:
-        logger.debug("Failed to flush %d metrics", len(items), exc_info=True)
+        # Re-buffer what we couldn't write (newest entries win if the deque is
+        # full) and open the cooldown so we stop hammering an unavailable DB.
+        with _lock:
+            _BUFFER.extendleft(reversed(items))
+            _flush_suppressed_until = time.monotonic() + _FLUSH_BACKOFF
+        logger.debug("Failed to flush %d metrics; backing off", len(items), exc_info=True)
+    finally:
+        with _lock:
+            _flush_in_progress = False
 
 
 def _schedule_flush() -> None:
-    """Schedule a deferred flush if one isn't already pending."""
+    """Schedule a deferred flush if one isn't already pending.
+
+    The check-and-set of ``_flush_timer`` runs entirely under ``_lock`` so two
+    concurrent callers can't both observe ``None`` and start duplicate timers.
+    Skipped while a flush is in flight or the failure cooldown is active.
+    """
     global _flush_timer
-    if _flush_timer is None:
-        _flush_timer = threading.Timer(_FLUSH_INTERVAL, _flush_buffer)
-        _flush_timer.daemon = True
-        _flush_timer.start()
+    with _lock:
+        if _flush_timer is not None or _flush_in_progress or _flush_suppressed():
+            return
+        timer = threading.Timer(_FLUSH_INTERVAL, _flush_buffer)
+        timer.daemon = True
+        _flush_timer = timer
+    timer.start()
 
 
 def record_metric(name: str, value: float, labels: dict[str, Any] | None = None) -> None:
@@ -81,7 +183,12 @@ def record_metric(name: str, value: float, labels: dict[str, Any] | None = None)
         with _lock:
             _BUFFER.append((name, value, labels_json))
             buf_len = len(_BUFFER)
+            # Don't open a fresh (potentially blocking) flush while one is
+            # already running or during the post-failure cooldown.
+            skip_flush = _flush_in_progress or _flush_suppressed()
 
+        if skip_flush:
+            return
         if buf_len >= _FLUSH_SIZE:
             # Flush immediately in a background thread
             threading.Thread(target=_flush_buffer, daemon=True).start()
@@ -91,8 +198,23 @@ def record_metric(name: str, value: float, labels: dict[str, Any] | None = None)
         logger.debug("Failed to buffer metric %s", name, exc_info=True)
 
 
+# Final flush deadline at interpreter shutdown. A healthy DB drains the buffer
+# in milliseconds; if Postgres is unreachable the daemon flusher thread is
+# abandoned after this many seconds so a dead DB never wedges process exit.
+_SHUTDOWN_FLUSH_TIMEOUT = 3.0
+
+
+def _flush_on_shutdown() -> None:
+    """Best-effort final flush, time-bounded so it can't block exit."""
+    if not _BUFFER:
+        return
+    worker = threading.Thread(target=_flush_buffer, daemon=True)
+    worker.start()
+    worker.join(_SHUTDOWN_FLUSH_TIMEOUT)
+
+
 # Flush remaining metrics on interpreter shutdown
-atexit.register(_flush_buffer)
+atexit.register(_flush_on_shutdown)
 
 
 # ---------------------------------------------------------------------------
@@ -100,11 +222,43 @@ atexit.register(_flush_buffer)
 # ---------------------------------------------------------------------------
 
 
-class MetricsMiddleware(BaseHTTPMiddleware):
-    """Record ``http_request_duration_ms`` for every request.
+def _matched_route_template(request: Request) -> str | None:
+    """Return the matched route's template (e.g. ``/drafts/{id}``), or None.
 
-    Labels include ``method``, ``path``, and ``status``.  Static-file
-    requests (``/static/...``) are excluded to avoid flooding the table.
+    Records the *template* rather than ``request.url.path`` so an attacker
+    can't blow up label cardinality by hitting ``/x/<random>`` a million times:
+    every variable segment collapses to its placeholder. Returns ``None`` when
+    no route matched (a 404 / unrouted path) so those are never recorded.
+    """
+    scope = request.scope
+    # A matched route always populates ``endpoint`` in this Starlette version;
+    # its absence means the request 404'd before reaching any handler.
+    if scope.get("endpoint") is None:
+        return None
+
+    for route in request.app.routes:
+        try:
+            match, _ = route.matches(scope)
+        except Exception:
+            continue
+        if match is Match.FULL:
+            template = getattr(route, "path_format", None) or getattr(route, "path", None)
+            if isinstance(template, str) and template:
+                return template[:_MAX_LABEL_LEN]
+            return None
+    return None
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Record ``http_request_duration_ms`` for every authenticated request.
+
+    Labels include ``method``, ``route`` (the matched template, not the raw
+    path), and ``status``.  Requests are skipped to keep the table clean and
+    bounded:
+
+    * ``/static/...`` asset requests (high volume, no signal);
+    * unrouted paths / 404s (attacker-chosen paths carry no real route);
+    * unauthenticated requests (pre-auth probing shouldn't pollute metrics).
     """
 
     async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[type-arg]
@@ -115,12 +269,22 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         response: Response = await call_next(request)
         duration_ms = (time.perf_counter() - start) * 1000
 
+        # Routing + the auth Beforeware run downstream of this middleware, so
+        # ``endpoint`` and ``auth`` are populated by the time ``call_next``
+        # returns.
+        if not request.scope.get("auth"):
+            return response
+
+        route_template = _matched_route_template(request)
+        if route_template is None:
+            return response
+
         record_metric(
             "http_request_duration_ms",
             round(duration_ms, 2),
             {
                 "method": request.method,
-                "path": request.url.path,
+                "route": route_template,
                 "status": response.status_code,
             },
         )

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -95,7 +95,16 @@ def _retention_days() -> int:
 def _maybe_prune(conn: Any) -> None:
     """Delete metrics older than the retention window, throttled per interval.
 
-    Runs on the existing flush connection so retention never opens its own.
+    Runs on the existing flush connection (its own committed transaction — see
+    ``_flush_buffer``) so retention never opens its own and a prune failure
+    cannot roll back the metric rows that were just flushed.
+
+    Concurrency + retry shape: the sweep slot is *claimed* eagerly under
+    ``_lock`` (so two concurrent flushers never both issue the DELETE), but the
+    timestamp is only allowed to *stick* once the DELETE commits. On failure the
+    claim is rolled back to its previous value so the next flush retries instead
+    of waiting a whole ``_RETENTION_SWEEP_INTERVAL``.
+
     Note the ``%s::interval`` cast: Postgres rejects the bare ``interval %s``
     placeholder form, so the parameter is bound as text and cast server-side.
     """
@@ -112,12 +121,31 @@ def _maybe_prune(conn: Any) -> None:
             now - _last_retention_sweep < _RETENTION_SWEEP_INTERVAL
         ):
             return
+        # Claim the slot so a concurrent flusher skips, remembering the prior
+        # value so we can roll the claim back if the DELETE fails.
+        previous_sweep = _last_retention_sweep
         _last_retention_sweep = now
 
-    conn.execute(
-        "DELETE FROM metrics WHERE recorded_at < now() - %s::interval",
-        (f"{days} days",),
-    )
+    try:
+        conn.execute(
+            "DELETE FROM metrics WHERE recorded_at < now() - %s::interval",
+            (f"{days} days",),
+        )
+        conn.commit()
+    except Exception:
+        # Clear the aborted transaction so the caller's connection is reusable
+        # (a failed statement leaves it in InFailedSqlTransaction until rollback).
+        try:
+            conn.rollback()
+        except Exception:
+            logger.debug("metrics retention rollback failed", exc_info=True)
+        # The prune didn't happen — release the claim (restore the prior value,
+        # which is either None == "due now" or a valid earlier timestamp, both
+        # correct on any monotonic epoch) so the next flush retries.
+        with _lock:
+            if _last_retention_sweep == now:
+                _last_retention_sweep = previous_sweep
+        raise
 
 
 def _flush_suppressed() -> bool:
@@ -150,14 +178,23 @@ def _flush_buffer() -> None:
                 "INSERT INTO metrics (name, value, labels) VALUES (%s, %s, %s::jsonb)",
                 items,
             )
-            _maybe_prune(conn)
+            # Commit the INSERT *before* attempting retention so the metric rows
+            # are durable regardless of what the prune does next.
             conn.commit()
+            # Prune is best-effort and isolated: a retention failure must not
+            # lose the just-committed rows nor trip the flush-failure backoff
+            # below (the INSERT succeeded — the DB is clearly reachable).
+            try:
+                _maybe_prune(conn)
+            except Exception:
+                logger.debug("metrics retention prune failed", exc_info=True)
         # Clear any prior cooldown on a successful round-trip.
         with _lock:
             _flush_suppressed_until = 0.0
     except Exception:
-        # Re-buffer what we couldn't write (newest entries win if the deque is
-        # full) and open the cooldown so we stop hammering an unavailable DB.
+        # The INSERT itself failed: re-buffer what we couldn't write (newest
+        # entries win if the deque is full) and open the cooldown so we stop
+        # hammering an unavailable DB.
         with _lock:
             _BUFFER.extendleft(reversed(items))
             _flush_suppressed_until = time.monotonic() + _FLUSH_BACKOFF

--- a/migrations/043_metrics_retention_index.sql
+++ b/migrations/043_metrics_retention_index.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- Migration 043: Index for metrics retention sweeps
+-- Ticket #861
+-- =============================================================================
+--
+-- The metrics retention sweep in app/metrics.py (_maybe_prune) issues:
+--
+--     DELETE FROM metrics WHERE recorded_at < now() - $1::interval;
+--
+-- Migration 011 created idx_metrics_name_recorded_at on (name, recorded_at),
+-- whose LEADING column is `name`. A name-agnostic delete keyed solely on
+-- `recorded_at` cannot use that index efficiently and falls back to a
+-- sequential scan that grows with the table. This single-column index lets
+-- the planner satisfy the retention predicate with an index range scan.
+--
+-- IF NOT EXISTS keeps the migration idempotent (re-applicable).
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_metrics_recorded_at
+    ON metrics (recorded_at);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "bcrypt",
     "authlib",
     "requests",
-    "psycopg[binary]>=3.2.0",
+    "psycopg[binary,pool]>=3.2.0",
     "httpx",
     "python-docx",
     "anthropic>=0.93.0",

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -140,6 +140,9 @@ def test_checkout_failure_trips_breaker_for_fast_subsequent_failures(
 ):
     """A getconn failure trips the breaker; the next call fails immediately."""
     monkeypatch.setattr(db, "_BREAKER_COOLDOWN", 30.0)
+    # Pin the clock so the second call is unambiguously inside the cooldown,
+    # independent of wall-clock / boot-relative monotonic values.
+    monkeypatch.setattr(db.time, "monotonic", lambda: 10_000.0)
     pool = MagicMock(name="ConnectionPool")
     pool.getconn.side_effect = RuntimeError("pool timeout")
 

--- a/tests/test_db_pool.py
+++ b/tests/test_db_pool.py
@@ -1,0 +1,190 @@
+"""Tests for the connection pool behind app.db.get_connection (#861).
+
+These tests stub the pool with a MagicMock so no real Postgres is needed; they
+verify the wrapper contract that every existing call site depends on:
+
+* ``with get_connection() as conn:`` commits on a clean exit, rolls back on an
+  exception, and returns the connection to the pool exactly once;
+* a bare ``conn = get_connection()`` handle returns to the pool on ``close()``;
+* the pool is a lazily-initialised, thread-safe singleton.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import psycopg
+import pytest
+
+import app.db as db
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Ensure each test starts and ends with no live pool singleton."""
+    db._reset_pool()
+    yield
+    db._reset_pool()
+
+
+def _fake_pool() -> tuple[MagicMock, MagicMock]:
+    """Return (pool, conn) where pool.getconn() always hands out *conn*."""
+    conn = MagicMock(name="connection")
+    conn.closed = False
+    pool = MagicMock(name="ConnectionPool")
+    pool.getconn.return_value = conn
+    return pool, conn
+
+
+def test_get_connection_is_lazy_singleton():
+    pool, _conn = _fake_pool()
+    with patch.object(db, "_create_pool", return_value=pool) as create:
+        assert db._pool is None  # not created at import / fixture time
+        db.get_connection()
+        db.get_connection()
+        # Pool constructed exactly once despite two checkouts.
+        create.assert_called_once()
+    assert db._pool is pool
+
+
+def test_context_manager_commits_and_returns_to_pool():
+    pool, conn = _fake_pool()
+    with patch.object(db, "_create_pool", return_value=pool):
+        with db.get_connection():
+            pass
+        conn.commit.assert_called_once()
+        conn.rollback.assert_not_called()
+        # Returned to the pool exactly once.
+        pool.putconn.assert_called_once_with(conn)
+
+
+def test_context_manager_rolls_back_on_exception():
+    pool, conn = _fake_pool()
+    with patch.object(db, "_create_pool", return_value=pool):
+        with pytest.raises(ValueError):
+            with db.get_connection():
+                raise ValueError("boom")
+        conn.rollback.assert_called_once()
+        conn.commit.assert_not_called()
+        pool.putconn.assert_called_once_with(conn)
+
+
+def test_bare_handle_returns_to_pool_on_close():
+    pool, conn = _fake_pool()
+    with patch.object(db, "_create_pool", return_value=pool):
+        handle = db.get_connection()
+        # Attribute access forwards to the underlying connection.
+        handle.execute("SELECT 1")
+        conn.execute.assert_called_once_with("SELECT 1")
+        handle.close()
+        pool.putconn.assert_called_once_with(conn)
+
+
+def test_return_is_idempotent():
+    """A double close() must return the connection only once."""
+    pool, _conn = _fake_pool()
+    with patch.object(db, "_create_pool", return_value=pool):
+        handle = db.get_connection()
+        handle.close()
+        handle.close()
+        pool.putconn.assert_called_once()
+
+
+def test_exit_returns_to_pool_even_if_commit_fails():
+    pool, conn = _fake_pool()
+    conn.commit.side_effect = RuntimeError("commit failed")
+    with patch.object(db, "_create_pool", return_value=pool):
+        with pytest.raises(RuntimeError):
+            with db.get_connection():
+                pass
+        # Connection still handed back so the pool isn't leaked.
+        pool.putconn.assert_called_once_with(conn)
+
+
+def test_pool_sizing_env(monkeypatch: pytest.MonkeyPatch):
+    """_create_pool honours DB_POOL_MIN / DB_POOL_MAX / DB_POOL_TIMEOUT."""
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        def close(self) -> None:
+            pass
+
+    # _POOL_MIN/_POOL_MAX/_POOL_TIMEOUT are read at import time, so patch the
+    # module globals the factory actually reads.
+    monkeypatch.setattr(db, "_POOL_MIN", 2)
+    monkeypatch.setattr(db, "_POOL_MAX", 7)
+    monkeypatch.setattr(db, "_POOL_TIMEOUT", 5.0)
+    monkeypatch.setattr(db, "_CONNECT_TIMEOUT", 4)
+    with patch("psycopg_pool.ConnectionPool", _FakePool):
+        pool = db._create_pool()
+
+    assert isinstance(pool, _FakePool)
+    assert captured["min_size"] == 2
+    assert captured["max_size"] == 7
+    assert captured["timeout"] == 5.0
+    assert captured["kwargs"] == {"connect_timeout": 4}
+    assert captured["conninfo"] == db.DATABASE_URL
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def test_checkout_failure_trips_breaker_for_fast_subsequent_failures(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A getconn failure trips the breaker; the next call fails immediately."""
+    monkeypatch.setattr(db, "_BREAKER_COOLDOWN", 30.0)
+    pool = MagicMock(name="ConnectionPool")
+    pool.getconn.side_effect = RuntimeError("pool timeout")
+
+    with patch.object(db, "_create_pool", return_value=pool):
+        # First call hits the pool (and pays its wait), then trips the breaker.
+        with pytest.raises(RuntimeError):
+            db.get_connection()
+        assert pool.getconn.call_count == 1
+
+        # While the breaker is open the pool is NOT consulted again — the call
+        # fails fast with an OperationalError instead of waiting on getconn.
+        with pytest.raises(psycopg.OperationalError):
+            db.get_connection()
+        assert pool.getconn.call_count == 1
+
+
+def test_breaker_reopens_after_cooldown(monkeypatch: pytest.MonkeyPatch):
+    """Once the cooldown elapses, get_connection consults the pool again."""
+    monkeypatch.setattr(db, "_BREAKER_COOLDOWN", 30.0)
+    pool, conn = _fake_pool()
+    pool.getconn.side_effect = [RuntimeError("boom"), conn]
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(db.time, "monotonic", lambda: fake_now[0])
+
+    with patch.object(db, "_create_pool", return_value=pool):
+        with pytest.raises(RuntimeError):
+            db.get_connection()
+        # Still in cooldown -> fast fail, pool untouched.
+        with pytest.raises(psycopg.OperationalError):
+            db.get_connection()
+        # Advance past the cooldown; the pool is consulted again and succeeds.
+        fake_now[0] += 31.0
+        handle = db.get_connection()
+        handle.close()
+        assert pool.getconn.call_count == 2
+
+
+def test_reset_pool_clears_breaker(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "_BREAKER_COOLDOWN", 30.0)
+    pool = MagicMock(name="ConnectionPool")
+    pool.getconn.side_effect = RuntimeError("boom")
+    with patch.object(db, "_create_pool", return_value=pool):
+        with pytest.raises(RuntimeError):
+            db.get_connection()
+    # _reset_pool (autouse teardown also does this) must clear the open breaker.
+    db._reset_pool()
+    assert db._unavailable_until == 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,18 +2,60 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from starlette.testclient import TestClient
+
+import app.metrics as _metrics
+
+# Captured before any test patches the module attribute, so the dedupe test can
+# exercise the genuine implementation despite the autouse no-op patch below.
+_REAL_SCHEDULE_FLUSH = _metrics._schedule_flush
+
+
+@pytest.fixture(autouse=True)
+def _no_background_flush():
+    """Neutralise the background flusher so buffer tests are hermetic (#877).
+
+    ``record_metric`` schedules a ``threading.Timer`` (or, at ``_FLUSH_SIZE``,
+    spawns a flusher thread) that can partially drain the module-global
+    ``_BUFFER`` between a test's ``record_metric`` calls and its explicit
+    ``_flush_buffer()``. Patching ``_schedule_flush`` to a no-op keeps the
+    buffer untouched until the test flushes it deterministically.
+    """
+    import app.metrics as m
+
+    with patch.object(m, "_schedule_flush", lambda: None):
+        m._BUFFER.clear()
+        # Reset cross-test flush/retention state so a failure-backoff, an
+        # in-flight flag, or a retention sweep from one test can't affect another.
+        m._flush_suppressed_until = 0.0
+        m._flush_in_progress = False
+        m._last_retention_sweep = 0.0
+        yield
+        m._BUFFER.clear()
+        m._flush_suppressed_until = 0.0
+        m._flush_in_progress = False
+        m._last_retention_sweep = 0.0
+
+
+def _authenticated_user() -> dict[str, Any]:
+    return {
+        "id": "uid-1",
+        "email": "kasutaja@seadusloome.ee",
+        "full_name": "Test Kasutaja",
+        "role": "drafter",
+        "org_id": None,
+        "must_change_password": False,
+    }
 
 
 class TestRecordMetric:
     @patch("app.metrics._connect")
     def test_buffers_then_flushes(self, mock_connect: MagicMock):
         import app.metrics as m
-
-        # Clear any entries buffered by prior tests
-        m._BUFFER.clear()
 
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
@@ -43,8 +85,6 @@ class TestRecordMetric:
     def test_buffers_null_labels(self, mock_connect: MagicMock):
         import app.metrics as m
 
-        m._BUFFER.clear()
-
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
@@ -70,8 +110,6 @@ class TestRecordMetric:
     def test_bulk_flushes_multiple_rows(self, mock_connect: MagicMock):
         import app.metrics as m
 
-        m._BUFFER.clear()
-
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
@@ -92,44 +130,227 @@ class TestRecordMetric:
         mock_conn.commit.assert_called_once()
 
 
+class TestRetention:
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "7"})
+    @patch("app.metrics._connect")
+    def test_prune_runs_with_interval_cast(self, mock_connect: MagicMock):
+        import app.metrics as m
+
+        # Force the throttle to allow a sweep this flush.
+        m._last_retention_sweep = 0.0
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        m.record_metric("ret_metric", 1.0)
+        m._flush_buffer()
+
+        # The DELETE must be issued on the flush connection, and must bind the
+        # window as text cast with ``%s::interval`` (never ``interval %s``).
+        delete_calls = [
+            c for c in mock_conn.execute.call_args_list if "DELETE FROM metrics" in c[0][0]
+        ]
+        assert len(delete_calls) == 1
+        sql, params = delete_calls[0][0]
+        assert "%s::interval" in sql
+        assert "interval %s" not in sql
+        assert params == ("7 days",)
+
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "0"})
+    @patch("app.metrics._connect")
+    def test_retention_disabled(self, mock_connect: MagicMock):
+        import app.metrics as m
+
+        m._last_retention_sweep = 0.0
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        m.record_metric("ret_metric", 1.0)
+        m._flush_buffer()
+
+        delete_calls = [
+            c for c in mock_conn.execute.call_args_list if "DELETE FROM metrics" in c[0][0]
+        ]
+        assert delete_calls == []
+
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "7"})
+    @patch("app.metrics._connect")
+    def test_retention_throttled_to_one_sweep_per_interval(self, mock_connect: MagicMock):
+        import time
+
+        import app.metrics as m
+
+        # Pretend a sweep just happened: the next flush must NOT prune.
+        m._last_retention_sweep = time.monotonic()
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        m.record_metric("ret_metric", 1.0)
+        m._flush_buffer()
+
+        delete_calls = [
+            c for c in mock_conn.execute.call_args_list if "DELETE FROM metrics" in c[0][0]
+        ]
+        assert delete_calls == []
+
+
+class TestScheduleFlush:
+    def test_check_and_set_under_lock_starts_one_timer(self):
+        """Two _schedule_flush calls must start exactly one timer (#861).
+
+        The check-and-set of ``_flush_timer`` lives under ``_lock``; with a
+        fake Timer we confirm the second call observes the pending timer and
+        does not start a duplicate.
+        """
+        import app.metrics as m
+
+        started: list[Any] = []
+
+        class _FakeTimer:
+            def __init__(self, *_a: Any, **_k: Any) -> None:
+                self.daemon = False
+
+            def start(self) -> None:
+                started.append(self)
+
+            def cancel(self) -> None:
+                pass
+
+        m._flush_timer = None
+        try:
+            with patch("app.metrics.threading.Timer", _FakeTimer):
+                # Call the real implementation (the autouse fixture patches the
+                # module attribute, but _REAL_SCHEDULE_FLUSH is the unpatched
+                # function object captured at import time).
+                _REAL_SCHEDULE_FLUSH()
+                _REAL_SCHEDULE_FLUSH()
+            assert len(started) == 1
+        finally:
+            m._flush_timer = None
+
+
+def _middleware_app(*, authenticated: bool):
+    """Minimal Starlette app wrapping the real MetricsMiddleware.
+
+    Keeps the middleware logic (route-template extraction, auth gate, 404/static
+    skips) under test without dragging in the production app's DB-backed
+    handlers. A tiny beforeware-equivalent sets ``scope['auth']`` so the
+    authenticated path can be exercised deterministically.
+    """
+    from starlette.applications import Starlette
+    from starlette.responses import PlainTextResponse
+    from starlette.routing import Route
+
+    from app.metrics import MetricsMiddleware
+
+    async def item(request: Any) -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    class _AuthScope:
+        """Inner ASGI app (runs downstream of MetricsMiddleware) that stamps
+        ``scope['auth']`` just like the real Beforeware does."""
+
+        def __init__(self, app: Any) -> None:
+            self.app = app
+
+        async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+            if scope.get("type") == "http" and authenticated:
+                scope["auth"] = _authenticated_user()
+            await self.app(scope, receive, send)
+
+    app = Starlette(
+        routes=[
+            Route("/drafts/{draft_id}", item),
+            Route("/static/x.css", item),
+        ]
+    )
+    app.add_middleware(_AuthScope)
+    app.add_middleware(MetricsMiddleware)
+    return app
+
+
 class TestMetricsMiddleware:
     @patch("app.metrics.record_metric")
-    def test_records_request_duration(self, mock_record: MagicMock):
-        from app.main import app
-
+    def test_records_route_template_for_authenticated_request(self, mock_record: MagicMock):
+        app = _middleware_app(authenticated=True)
         client = TestClient(app, follow_redirects=False)
-        # /api/ping is unauthenticated
-        response = client.get("/api/ping")
+        response = client.get("/drafts/abc-123")
         assert response.status_code == 200
 
-        # The middleware should have recorded at least one metric
         calls = [c for c in mock_record.call_args_list if c[0][0] == "http_request_duration_ms"]
-        assert len(calls) >= 1
+        assert len(calls) == 1
         metric_call = calls[0]
-        assert metric_call[0][0] == "http_request_duration_ms"
         assert isinstance(metric_call[0][1], float)
         labels = metric_call[0][2]
         assert labels["method"] == "GET"
-        assert labels["path"] == "/api/ping"
+        # The matched route TEMPLATE is recorded, not the raw attacker path.
+        assert labels["route"] == "/drafts/{draft_id}"
+        assert "path" not in labels
         assert labels["status"] == 200
 
     @patch("app.metrics.record_metric")
-    def test_skips_static_requests(self, mock_record: MagicMock):
-        from app.main import app
-
+    def test_skips_unauthenticated_requests(self, mock_record: MagicMock):
+        app = _middleware_app(authenticated=False)
         client = TestClient(app, follow_redirects=False)
-        client.get("/static/css/tokens.css")
+        response = client.get("/drafts/abc-123")
+        assert response.status_code == 200
 
-        # No http_request_duration_ms should be recorded for static files
+        # A matched route but no auth in scope → no metric recorded.
         duration_calls = [
             c for c in mock_record.call_args_list if c[0][0] == "http_request_duration_ms"
         ]
-        static_calls = [
-            c
-            for c in duration_calls
-            if isinstance(c[0][2], dict) and c[0][2].get("path", "").startswith("/static/")
+        assert duration_calls == []
+
+    @patch("app.metrics.record_metric")
+    def test_skips_404_for_authenticated_user(self, mock_record: MagicMock):
+        app = _middleware_app(authenticated=True)
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/this/path/does/not/exist/" + "x" * 50)
+        assert response.status_code == 404
+
+        # An unrouted (attacker-chosen) path must never write a metric row even
+        # though the request is authenticated.
+        duration_calls = [
+            c for c in mock_record.call_args_list if c[0][0] == "http_request_duration_ms"
         ]
-        assert len(static_calls) == 0
+        assert duration_calls == []
+
+    @patch("app.metrics.record_metric")
+    def test_skips_static_requests(self, mock_record: MagicMock):
+        app = _middleware_app(authenticated=True)
+        client = TestClient(app, follow_redirects=False)
+        client.get("/static/x.css")
+
+        # No http_request_duration_ms should be recorded for static files.
+        duration_calls = [
+            c for c in mock_record.call_args_list if c[0][0] == "http_request_duration_ms"
+        ]
+        assert duration_calls == []
+
+    @patch("app.metrics.record_metric")
+    def test_real_app_skips_unauthenticated_ping(self, mock_record: MagicMock):
+        """Integration: /api/ping (unauthenticated, DB-free) is not recorded."""
+        from app.main import app
+
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/api/ping")
+        assert response.status_code == 200
+
+        duration_calls = [
+            c for c in mock_record.call_args_list if c[0][0] == "http_request_duration_ms"
+        ]
+        assert duration_calls == []
 
 
 class TestTrackDuration:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -53,6 +53,10 @@ def _authenticated_user() -> dict[str, Any]:
 
 
 class TestRecordMetric:
+    # Retention disabled in the INSERT-batching tests so the only commit is the
+    # batch commit (retention runs a *second* committed transaction otherwise —
+    # exercised separately in TestRetention).
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "0"})
     @patch("app.metrics._connect")
     def test_buffers_then_flushes(self, mock_connect: MagicMock):
         import app.metrics as m
@@ -106,6 +110,7 @@ class TestRecordMetric:
         # Flush should not raise even though the DB is down
         m._flush_buffer()
 
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "0"})
     @patch("app.metrics._connect")
     def test_bulk_flushes_multiple_rows(self, mock_connect: MagicMock):
         import app.metrics as m
@@ -126,7 +131,7 @@ class TestRecordMetric:
         assert rows[0][0] == "m1"
         assert rows[1][0] == "m2"
         assert rows[2][0] == "m3"
-        # Single commit for the whole batch
+        # Single commit for the whole batch (retention disabled here).
         mock_conn.commit.assert_called_once()
 
 
@@ -158,6 +163,8 @@ class TestRetention:
         assert "%s::interval" in sql
         assert "interval %s" not in sql
         assert params == ("7 days",)
+        # A successful prune engages the throttle (timestamp recorded).
+        assert m._last_retention_sweep is not None
 
     @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "0"})
     @patch("app.metrics._connect")
@@ -204,6 +211,166 @@ class TestRetention:
             c for c in mock_conn.execute.call_args_list if "DELETE FROM metrics" in c[0][0]
         ]
         assert delete_calls == []
+
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "7"})
+    @patch("app.metrics._connect")
+    def test_prune_failure_keeps_rows_and_allows_retry(self, mock_connect: MagicMock):
+        """A failed DELETE must not lose the flushed rows nor block the next sweep.
+
+        The metric rows are committed *before* the prune, so even though the
+        DELETE raises the INSERT survives; and the sweep claim is rolled back so
+        retention is still "due" on the next flush (no hour-long throttle on a
+        prune that never happened) — and the flush backoff is NOT engaged.
+        """
+        import app.metrics as m
+
+        m._last_retention_sweep = None
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        # The INSERT (executemany) succeeds; the retention DELETE raises.
+        def execute_side_effect(sql: str, *args: Any):
+            if "DELETE FROM metrics" in sql:
+                raise RuntimeError("prune boom")
+            return MagicMock()
+
+        mock_conn.execute.side_effect = execute_side_effect
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        m.record_metric("ret_metric", 1.0)
+        m._flush_buffer()
+
+        # Rows were flushed (executemany ran and the INSERT was committed).
+        mock_cursor.executemany.assert_called_once()
+        assert mock_conn.commit.call_count >= 1
+        # The DELETE was attempted exactly once and failed.
+        delete_calls = [
+            c for c in mock_conn.execute.call_args_list if "DELETE FROM metrics" in c[0][0]
+        ]
+        assert len(delete_calls) == 1
+        # Claim rolled back -> retention is still due on the next flush.
+        assert m._last_retention_sweep is None
+        # The aborted DELETE transaction was rolled back so the connection is
+        # left reusable (no InFailedSqlTransaction leaking to the with-exit).
+        mock_conn.rollback.assert_called_once()
+        # A prune failure must NOT trip the flush-failure backoff (the DB and
+        # the INSERT were fine), and must NOT re-buffer the flushed rows.
+        assert not m._flush_suppressed()
+        assert len(m._BUFFER) == 0
+
+    @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "7"})
+    @patch("app.metrics._connect")
+    def test_prune_abort_does_not_break_flush_with_realistic_conn(self, mock_connect: MagicMock):
+        """End-to-end: a DELETE that aborts the txn must not crash the flush.
+
+        Mimics psycopg: a failed statement poisons the transaction so any later
+        command (including the with-exit commit) raises until rollback. The
+        flush must roll back the prune and exit cleanly with rows committed.
+        """
+        import app.db as db
+        import app.metrics as m
+
+        m._last_retention_sweep = None
+
+        class _FakeConn:
+            def __init__(self) -> None:
+                self.aborted = False
+                self.committed_batches = 0
+                self._cursor = MagicMock()
+
+            def cursor(self) -> MagicMock:
+                return self._cursor
+
+            def execute(self, sql: str, *args: Any):
+                if "DELETE FROM metrics" in sql:
+                    self.aborted = True
+                    raise RuntimeError("prune boom")
+                return MagicMock()
+
+            def commit(self) -> None:
+                if self.aborted:
+                    raise RuntimeError("InFailedSqlTransaction")
+                self.committed_batches += 1
+
+            def rollback(self) -> None:
+                self.aborted = False
+
+            @property
+            def closed(self) -> bool:
+                return False
+
+        conn = _FakeConn()
+        # Wrap in the REAL _PooledConnection so the genuine __exit__ runs: it
+        # commits on clean exit, which would raise InFailedSqlTransaction if the
+        # aborted prune transaction had not been rolled back by _maybe_prune.
+        fake_pool = MagicMock(name="pool")
+        mock_connect.return_value = db._PooledConnection(fake_pool, conn)  # type: ignore[arg-type]
+
+        m.record_metric("ret_metric", 1.0)
+        m._flush_buffer()  # must not raise
+
+        # INSERT committed once + the with-exit commit (both succeeded because
+        # the aborted prune was rolled back); retention is still due; rows were
+        # not re-buffered; backoff not engaged; connection returned to the pool.
+        assert conn.committed_batches >= 1
+        assert conn.aborted is False
+        assert m._last_retention_sweep is None
+        assert len(m._BUFFER) == 0
+        assert not m._flush_suppressed()
+        fake_pool.putconn.assert_called_once_with(conn)
+
+    def test_concurrent_flush_attempts_issue_single_prune(self):
+        """Two flushes overlapping the prune window issue exactly one DELETE."""
+        import threading
+
+        import app.metrics as m
+
+        m._last_retention_sweep = None
+
+        delete_attempts: list[str] = []
+        # Gate so the second _maybe_prune runs while the first holds the claim.
+        first_in_delete = threading.Event()
+        release_first = threading.Event()
+
+        def fake_conn_factory(blocking: bool) -> MagicMock:
+            conn = MagicMock()
+
+            def execute(sql: str, *args: Any):
+                if "DELETE FROM metrics" in sql:
+                    delete_attempts.append(sql)
+                    if blocking:
+                        first_in_delete.set()
+                        release_first.wait(timeout=2)
+                return MagicMock()
+
+            conn.execute.side_effect = execute
+            return conn
+
+        with patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "7"}):
+            errors: list[BaseException] = []
+
+            def run(blocking: bool):
+                try:
+                    m._maybe_prune(fake_conn_factory(blocking))
+                except Exception as exc:  # pragma: no cover - defensive
+                    errors.append(exc)
+
+            t1 = threading.Thread(target=run, args=(True,))
+            t1.start()
+            assert first_in_delete.wait(timeout=2), "first prune never reached DELETE"
+
+            # Second flush runs while the first still holds the claim: it must
+            # observe the (just-claimed) sweep timestamp and skip the DELETE.
+            run(False)
+
+            release_first.set()
+            t1.join(timeout=2)
+
+        assert errors == []
+        assert len(delete_attempts) == 1
 
 
 class TestScheduleFlush:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -33,12 +33,12 @@ def _no_background_flush():
         # in-flight flag, or a retention sweep from one test can't affect another.
         m._flush_suppressed_until = 0.0
         m._flush_in_progress = False
-        m._last_retention_sweep = 0.0
+        m._last_retention_sweep = None
         yield
         m._BUFFER.clear()
         m._flush_suppressed_until = 0.0
         m._flush_in_progress = False
-        m._last_retention_sweep = 0.0
+        m._last_retention_sweep = None
 
 
 def _authenticated_user() -> dict[str, Any]:
@@ -137,7 +137,7 @@ class TestRetention:
         import app.metrics as m
 
         # Force the throttle to allow a sweep this flush.
-        m._last_retention_sweep = 0.0
+        m._last_retention_sweep = None
 
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
@@ -164,7 +164,7 @@ class TestRetention:
     def test_retention_disabled(self, mock_connect: MagicMock):
         import app.metrics as m
 
-        m._last_retention_sweep = 0.0
+        m._last_retention_sweep = None
 
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
@@ -183,21 +183,22 @@ class TestRetention:
     @patch.dict("os.environ", {"METRICS_RETENTION_DAYS": "7"})
     @patch("app.metrics._connect")
     def test_retention_throttled_to_one_sweep_per_interval(self, mock_connect: MagicMock):
-        import time
-
         import app.metrics as m
 
-        # Pretend a sweep just happened: the next flush must NOT prune.
-        m._last_retention_sweep = time.monotonic()
+        # Pin the clock so the test is fully deterministic (no wall-clock /
+        # boot-relative dependence): a sweep happened 1s ago, well inside the
+        # interval, so the next flush must NOT prune.
+        with patch.object(m.time, "monotonic", return_value=10_000.0):
+            m._last_retention_sweep = 9_999.0
 
-        mock_conn = MagicMock()
-        mock_cursor = MagicMock()
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
-        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+            mock_connect.return_value.__exit__ = MagicMock(return_value=False)
 
-        m.record_metric("ret_metric", 1.0)
-        m._flush_buffer()
+            m.record_metric("ret_metric", 1.0)
+            m._flush_buffer()
 
         delete_calls = [
             c for c in mock_conn.execute.call_args_list if "DELETE FROM metrics" in c[0][0]

--- a/uv.lock
+++ b/uv.lock
@@ -1404,6 +1404,9 @@ wheels = [
 binary = [
     { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
 ]
+pool = [
+    { name = "psycopg-pool" },
+]
 
 [[package]]
 name = "psycopg-binary"
@@ -1432,6 +1435,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
     { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
     { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -1789,7 +1804,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mistune" },
     { name = "postmarker" },
-    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pyjwt" },
     { name = "pyshacl" },
     { name = "python-docx" },
@@ -1818,7 +1833,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "mistune", specifier = ">=3.0" },
     { name = "postmarker", specifier = ">=1.0" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.0" },
     { name = "pyjwt" },
     { name = "pyshacl" },
     { name = "python-docx" },


### PR DESCRIPTION
Part of #861. Closes #877.

Addresses the three review findings for `app/db.py` + `app/metrics.py`. Verified each finding against review commit `3cc9ba0`; all three were still present (none already fixed).

## A — `psycopg_pool.ConnectionPool` behind `get_connection()`
`app/db.py` previously opened a **fresh `psycopg.connect` per call** — the dashboard's ~10 serial widget queries, a docs-detail render's 3 queries, every metric flush and job-poll each paid a full TCP+auth handshake.

**Fix:**
- `get_connection()` is now backed by a process-wide `ConnectionPool`, created **lazily behind a thread-safe double-checked lock** (the `ClaudeProvider`/`SparqlClient` singleton pattern) so importing `app.db` never opens a socket — stub-mode/unit-test callers stay decoupled.
- **Public contract preserved exactly.** A `_PooledConnection` wrapper makes the return value work BOTH as a context manager (`with get_connection() as conn:` → commit/rollback + return to pool on exit, mirroring `psycopg.Connection.__exit__`) AND as a bare handle (`conn = get_connection(); …; conn.close()` → `close()` returns it to the pool). The sync advisory-lock holder in `app/sync/orchestrator.py` (the only bare consumer, which explicitly `pg_advisory_unlock`s + commits before `close()`) is untouched.
- **Patch-path contract honoured.** Tests patch `get_connection` *where imported* (`app.rag.retriever.get_connection`, `app.docs.analyze_handler.get_connection`, `app.jobs.queue.get_connection`, …). Since the public `get_connection` name stays in `app.db` and callers `from app.db import get_connection`, every existing monkeypatch seam keeps working — verified by running the full set of `app.db`-consuming test files (387 passed).
- **Sizing & docs:** env-tunable `DB_POOL_MIN`/`DB_POOL_MAX` (default 1/10), plus `DB_POOL_TIMEOUT`, `DB_CONNECT_TIMEOUT`. Comment documents that the job worker holds a pooled connection only for one `FOR UPDATE SKIP LOCKED` claim and the WS watcher loops check out per-iteration (offloaded via `asyncio.to_thread`) — neither holds across iterations; only the bare sync-lock connection is long-lived and it's released the moment the sync ends.
- **Circuit breaker (important):** psycopg_pool's `getconn` *blocks* up to `DB_POOL_TIMEOUT` when Postgres is unreachable (it always routes through a background worker). The old bare `psycopg.connect` failed in ~1 ms — and the **CI `lint-and-test` job runs `pytest` with no Postgres service**, so several pre-existing tests with unmocked `get_connection` seams (e.g. `app.chat.ontology_version`, `app.notifications.notify`) relied on that instant failure. A short cooldown breaker (`DB_BREAKER_COOLDOWN`) trips on a checkout failure so subsequent calls fail fast instead of each waiting the timeout, restoring the fast-fail behaviour while pooling normally when the DB is up. `atexit` closes the pool on shutdown.
- `psycopg[pool]` added to `pyproject.toml` (extras `binary,pool`); `uv.lock` updated (psycopg-pool 3.3.1).

## B — metrics middleware + flush hygiene (`app/metrics.py`)
- **Route template, not raw path:** `MetricsMiddleware` now labels with the *matched route template* (`/drafts/{id}`) resolved from the Starlette scope, never `request.url.path` — an attacker hitting `/x/<random>` a million times can no longer explode label cardinality.
- **Skip 404 / unrouted / unauthenticated:** unmatched paths (no `endpoint` in scope) and requests without `scope["auth"]` are not recorded (routing + auth Beforeware run downstream of the middleware, so the scope is populated by the time `call_next` returns).
- **Label cap:** route labels are truncated to `_MAX_LABEL_LEN` (200).
- **Retention (self-contained):** `_maybe_prune` issues a throttled (≤1×/hour) `DELETE FROM metrics WHERE recorded_at < now() - %s::interval` piggybacked on the existing flush connection, env-tunable via `METRICS_RETENTION_DAYS` (0 disables). Uses the `%s::interval` cast — **not** the Postgres-rejected `interval %s`. **Migration `043_metrics_retention_index.sql`** adds `idx_metrics_recorded_at` so the name-agnostic sweep is an index scan (migration 011's index leads with `name`).
- **Flush-timer race:** `_schedule_flush()` now performs the `_flush_timer` check-and-set **entirely under `_lock`** (was a check outside the lock). Added a single-flight guard + failure backoff + bounded buffer + bounded shutdown flush so a down DB can't serialise repeated blocking flushes or wedge interpreter exit.

## C — flaky `test_bulk_flushes_multiple_rows` (#877)
Root cause: the test cleared and read the module-global `_BUFFER`, which the background flusher thread could partially consume between the test's `record_metric()` calls and its explicit `_flush_buffer()`.
**Fix:** an autouse fixture patches `_schedule_flush` to a no-op and resets module flush state for every test in the file, so the buffer is deterministic. **Verified by running the test 30× in a loop — 0 failures.** Also retargeted the middleware tests to the new authenticated-route-template / skip-404 / skip-unauthenticated behaviour (against a minimal app for determinism, no DB).

## Already-fixed items
None — all three findings were still present at the reviewed state.

## Deferred (out of scope)
- A handful of pre-existing tests call a real `get_connection()` through **unmocked seams in out-of-scope modules** (`tests/test_chat_orchestrator.py` doesn't mock `app.chat.ontology_version.get_connection`; `tests/test_docs_analyze_handler.py` doesn't mock the `app.notifications.notify` path). Before this PR they got a free pass from `psycopg.connect`'s instant failure. The circuit breaker keeps them green and fast, but the clean follow-up is to mock those seams in the respective test files (outside this PR's strict scope: `app/db.py`, `app/metrics.py`, `tests/test_metrics.py`, `tests/test_db_pool.py`, `pyproject.toml`, `uv.lock`).

## Test results
- `uv run ruff format --check <touched>` → clean; `uv run ruff check <touched>` → All checks passed!
- `uv run pyright` → **0 errors, 0 warnings, 0 informations**
- `uv run pytest tests/test_metrics.py tests/test_db_pool.py -q` → **26 passed**
- Flaky `#877` 30× loop → **0 failures / 30**
- All `app.db`-consumer test files (`test_jobs_queue`, `test_rag_*`, `test_docs_*`, `test_chat_*`, `test_auth*`, `test_audit`, `test_profile_routes`, `test_llm_cost_tracker`, `test_tenant_scoping_legacy_consumers`, `test_migrate`) → **387 passed, 1 skipped**
- Whole suite (CI-equivalent: no Postgres) → **4693 passed, 50 skipped** in ~43 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)