### PR TITLE
refactor(ui): own target_dom_id in app/ui, pin ui-layer import direction (#860)

### DIFF
--- a/app/annotations/row_keys.py
+++ b/app/annotations/row_keys.py
@@ -35,6 +35,13 @@ lookups. Three helpers mediate the boundary:
 The original URI stays the round-trip identity; only the URL path
 segment and the DOM id use the encoded / hashed form.
 
+``target_dom_id`` is a UI-layer concern and now lives in
+:mod:`app.ui.dom_ids` so that the :mod:`app.ui` annotation primitives can
+import it without reaching into this feature package (the disallowed
+ui→feature direction, #860). It is re-exported here for the feature's own
+internal callers — the round-trip identity story above still reads as a
+single contract.
+
 Why base64url instead of percent-encoding (#781 follow-up):
 
 Percent-encoding only round-trips if the raw value contains no
@@ -55,6 +62,24 @@ import base64
 import hashlib
 import json
 from typing import Any
+
+# #860: ``target_dom_id`` is a UI-layer helper (app.ui.dom_ids). Re-exported
+# here for annotations-internal callers so the feature→ui import direction is
+# the only edge — the app.ui annotation primitives import it from app.ui.dom_ids
+# directly rather than reaching back into this feature module.
+from app.ui.dom_ids import target_dom_id
+
+__all__ = [
+    "collect_row_specs",
+    "decode_row_key",
+    "row_key_for_conflict",
+    "row_key_for_entity",
+    "row_key_for_eu",
+    "row_key_for_gap",
+    "safe_row_key",
+    "stable_hash",
+    "target_dom_id",
+]
 
 
 def stable_hash(parts: list[str]) -> str:
@@ -179,24 +204,3 @@ def decode_row_key(encoded: str) -> str:
         return ""
     padded = encoded + "=" * (-len(encoded) % 4)
     return base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
-
-
-def target_dom_id(target_kind: str, target_id: str) -> str:
-    """Return a CSS-safe DOM id for an annotation container.
-
-    The id must be selectable via ``getElementById`` AND via CSS
-    selectors / HTMX ``hx-target="#..."`` queries.  Raw ontology URIs
-    contain ``/``, ``:``, ``#``, and ``%`` (after percent-encoding) —
-    all of which are CSS structural characters that need backslash
-    escapes inside a selector.  Hashing the raw ``target_id`` into a
-    sha256-truncated hex digest sidesteps the problem entirely: the
-    result is ``[0-9a-f]+`` and therefore always a valid CSS identifier.
-
-    The 16-char digest gives ~64 bits of collision resistance which is
-    plenty for one report page worth of rows.  Data attributes still
-    carry the original URI for round-trip identification — only the
-    DOM id is the hashed form.
-    """
-    raw = f"{target_kind}:{target_id or ''}"
-    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-    return f"annotation-popover-{target_kind}-{digest}"

--- a/app/ui/dom_ids.py
+++ b/app/ui/dom_ids.py
@@ -1,0 +1,47 @@
+"""CSS-safe DOM id derivation for UI surfaces.
+
+This is a *UI-layer* concern: turning an arbitrary application identifier
+(typically a raw ontology URI containing ``/``, ``:``, ``#``, and ``%``)
+into a string that is simultaneously a valid ``getElementById`` id, a valid
+CSS selector, and a valid HTMX ``hx-target="#..."`` query.
+
+It lives in :mod:`app.ui` (alongside :mod:`app.ui.safe_url`) rather than in
+a feature module so that the :mod:`app.ui` primitives that need it —
+``AnnotationButton`` (``app.ui.primitives.annotation_button``) and
+``AnnotationPopover`` (``app.ui.surfaces.annotation_popover``) — can import
+it without reaching back into a feature package (the disallowed ui→feature
+direction, #860). The annotations feature re-exports it from
+:mod:`app.annotations.row_keys` for its own internal callers (the allowed
+feature→ui direction).
+
+The output shape is a locked-in contract: live DOM ids and the
+``hx-target`` selectors that pair the button + popover surfaces depend on
+it, and its format is pinned by tests. Do not change the hashing length or
+the ``annotation-popover-{kind}-{digest}`` template without coordinating a
+DOM migration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def target_dom_id(target_kind: str, target_id: str) -> str:
+    """Return a CSS-safe DOM id for an annotation container.
+
+    The id must be selectable via ``getElementById`` AND via CSS
+    selectors / HTMX ``hx-target="#..."`` queries.  Raw ontology URIs
+    contain ``/``, ``:``, ``#``, and ``%`` (after percent-encoding) —
+    all of which are CSS structural characters that need backslash
+    escapes inside a selector.  Hashing the raw ``target_id`` into a
+    sha256-truncated hex digest sidesteps the problem entirely: the
+    result is ``[0-9a-f]+`` and therefore always a valid CSS identifier.
+
+    The 16-char digest gives ~64 bits of collision resistance which is
+    plenty for one report page worth of rows.  Data attributes still
+    carry the original URI for round-trip identification — only the
+    DOM id is the hashed form.
+    """
+    raw = f"{target_kind}:{target_id or ''}"
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return f"annotation-popover-{target_kind}-{digest}"

--- a/app/ui/primitives/annotation_button.py
+++ b/app/ui/primitives/annotation_button.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 
 from fasthtml.common import *  # noqa: F403
 
-from app.annotations.row_keys import target_dom_id
+from app.ui.dom_ids import target_dom_id
 from app.ui.primitives.badge import Badge
 
 

--- a/app/ui/surfaces/annotation_popover.py
+++ b/app/ui/surfaces/annotation_popover.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from fasthtml.common import *  # noqa: F403
 
-from app.annotations.row_keys import target_dom_id
+from app.ui.dom_ids import target_dom_id
 from app.ui.primitives.badge import Badge
 
 

--- a/tests/test_ui_import_direction.py
+++ b/tests/test_ui_import_direction.py
@@ -1,0 +1,163 @@
+"""Architectural guard: the ``app.ui`` layer must not import feature modules.
+
+``app.ui`` is the shared design-system / presentation layer. Features
+(``app.docs``, ``app.chat``, ``app.drafter``, …) compose ``app.ui``
+primitives — the dependency arrow points feature→ui. The reverse edge
+(ui→feature) couples the design system to one feature's domain logic and
+creates import cycles the moment a feature imports a ui primitive that
+imports back into that feature.
+
+#860 removed the concrete ``app.ui.primitives.annotation_button`` /
+``app.ui.surfaces.annotation_popover`` → ``app.annotations.row_keys`` edge
+by relocating ``target_dom_id`` into ``app.ui.dom_ids``. This test pins the
+*whole* ui layer so the edge cannot reappear (here or anywhere else under
+``app/ui``).
+
+The scan is AST-based and walks *every* import node — including imports
+nested inside functions (the lazy-import idiom used in
+``app.ui.components.search_routes``) — so a deferred import cannot dodge the
+guard.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Feature packages the ui layer must never depend on. Deliberately excludes
+# genuinely-shared lower layers (``app.ontology``, ``app.auth``, ``app.db``,
+# ``app.config``, ``app.storage``, ``app.llm`` …): those sit *below* ui in the
+# dependency stack and are fair game.
+FORBIDDEN_ROOTS: frozenset[str] = frozenset(
+    {
+        "app.annotations",
+        "app.docs",
+        "app.chat",
+        "app.drafter",
+        "app.analyysikeskus",
+        "app.admin",
+        "app.explorer",
+        "app.impact",
+    }
+)
+
+# Pre-existing ui→feature edges that #860 is NOT in scope to remove. Each is a
+# ``(module_dotted_path, forbidden_root)`` pair. Documented here with a TODO so
+# the guard stays green while making the remaining debt explicit and grep-able.
+#
+# TODO(#860): app.ui.components.search_routes lazily imports app.explorer.routes
+# (``_get_client`` / ``_sanitize_regex``) and app.ontology.queries to back the
+# global-search dropdown. ``app.ontology`` is a shared lower layer (not in
+# FORBIDDEN_ROOTS), but the explorer.routes dependency is a real ui→feature edge
+# that needs its own extraction (move the shared SPARQL client/sanitiser helpers
+# out of app.explorer.routes into a neutral module). Out of scope for #860's
+# target_dom_id move; allowlisted until then.
+ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("app.ui.components.search_routes", "app.explorer"),
+    }
+)
+
+_UI_ROOT = Path(__file__).resolve().parent.parent / "app" / "ui"
+
+
+def _module_dotted_path(py_file: Path) -> str:
+    """``…/app/ui/primitives/badge.py`` -> ``app.ui.primitives.badge``."""
+    repo_root = _UI_ROOT.parent.parent
+    rel = py_file.relative_to(repo_root).with_suffix("")
+    parts = list(rel.parts)
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _forbidden_root_for(name: str | None) -> str | None:
+    """Return the forbidden root *name* falls under, else ``None``.
+
+    ``name`` is a dotted import target (``app.explorer.routes`` or, for a
+    bare ``import app.explorer``, ``app.explorer``). A target matches a root
+    if it equals the root or is a submodule of it (prefix + ``.``), so
+    ``app.adminpanel`` does NOT match ``app.admin``.
+    """
+    if not name:
+        return None
+    for root in FORBIDDEN_ROOTS:
+        if name == root or name.startswith(root + "."):
+            return root
+    return None
+
+
+def _iter_imported_names(tree: ast.Module) -> list[str]:
+    """Every dotted module name imported anywhere in *tree* (nested included)."""
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            # Skip relative imports (level > 0): they resolve within app.ui by
+            # construction and cannot point at a sibling feature package.
+            if node.level == 0 and node.module:
+                names.append(node.module)
+    return names
+
+
+_UI_PY_FILES = sorted(_UI_ROOT.rglob("*.py"))
+
+
+def test_ui_root_has_python_files() -> None:
+    """Sanity: the glob actually found ui modules (guards a silent no-op)."""
+    assert _UI_PY_FILES, f"no .py files discovered under {_UI_ROOT}"
+
+
+@pytest.mark.parametrize("py_file", _UI_PY_FILES, ids=lambda p: p.name)
+def test_ui_module_does_not_import_feature_package(py_file: Path) -> None:
+    """No module under ``app/ui`` may import a feature package (#860).
+
+    Allowlisted, documented pre-existing edges are tolerated; every new edge
+    fails the build.
+    """
+    module = _module_dotted_path(py_file)
+    tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+
+    violations: list[str] = []
+    for imported in _iter_imported_names(tree):
+        root = _forbidden_root_for(imported)
+        if root is None:
+            continue
+        if (module, root) in ALLOWLIST:
+            continue
+        violations.append(f"{module} imports {imported} (forbidden root {root})")
+
+    assert not violations, (
+        "app.ui must not import feature modules (ui->feature is the disallowed "
+        "direction; see #860):\n  " + "\n  ".join(violations)
+    )
+
+
+def test_allowlist_entries_are_still_real() -> None:
+    """An allowlisted edge that no longer exists is stale debt — flag it.
+
+    Keeps ALLOWLIST honest: once the underlying import is removed (e.g. the
+    explorer.routes extraction lands), this test fails and forces the entry
+    out, so the allowlist never silently hides a now-clean module.
+    """
+    repo_root = _UI_ROOT.parent.parent
+    stale: list[tuple[str, str]] = []
+    for module, root in ALLOWLIST:
+        py_file = repo_root / Path(*module.split(".")).with_suffix(".py")
+        init_file = repo_root / Path(*module.split(".")) / "__init__.py"
+        source_path = py_file if py_file.exists() else init_file
+        if not source_path.exists():
+            stale.append((module, root))
+            continue
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+        if not any(_forbidden_root_for(name) == root for name in _iter_imported_names(tree)):
+            stale.append((module, root))
+
+    assert not stale, (
+        "ALLOWLIST contains entries whose ui->feature import no longer exists "
+        "— remove them (the underlying edge is gone):\n  "
+        + "\n  ".join(f"{m} -> {r}" for m, r in stale)
+    )

--- a/tests/test_ui_import_direction.py
+++ b/tests/test_ui_import_direction.py
@@ -17,11 +17,23 @@ The scan is AST-based and walks *every* import node — including imports
 nested inside functions (the lazy-import idiom used in
 ``app.ui.components.search_routes``) — so a deferred import cannot dodge the
 guard.
+
+Relative imports are resolved to their absolute dotted path *before* the
+forbidden-roots check, using the importing module's own package as the
+anchor (the same algorithm CPython's importmachinery uses). This matters:
+a relative import can escape ``app.ui`` entirely — e.g.
+``from ...explorer.routes import x`` written inside
+``app.ui.components.search_routes`` resolves to ``app.explorer.routes`` —
+so skipping ``level > 0`` nodes (the original bug, #890 review) would let a
+forbidden edge slip through disguised as a "local" import. Every import,
+absolute or relative, is normalised to an absolute path and checked the
+same way, and the allowlist is keyed on that resolved path.
 """
 
 from __future__ import annotations
 
 import ast
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -63,14 +75,26 @@ ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
 _UI_ROOT = Path(__file__).resolve().parent.parent / "app" / "ui"
 
 
-def _module_dotted_path(py_file: Path) -> str:
-    """``…/app/ui/primitives/badge.py`` -> ``app.ui.primitives.badge``."""
+def _module_and_package(py_file: Path) -> tuple[str, str]:
+    """Map a file to its ``(module, package)`` dotted paths.
+
+    * ``…/app/ui/primitives/badge.py`` ->
+      (``app.ui.primitives.badge``, ``app.ui.primitives``) — a regular module
+      anchors relative imports against its parent package.
+    * ``…/app/ui/components/__init__.py`` ->
+      (``app.ui.components``, ``app.ui.components``) — an ``__init__`` *is* its
+      package, so relative imports anchor against itself, not its parent
+      (matching CPython).
+    """
     repo_root = _UI_ROOT.parent.parent
     rel = py_file.relative_to(repo_root).with_suffix("")
     parts = list(rel.parts)
     if parts[-1] == "__init__":
-        parts = parts[:-1]
-    return ".".join(parts)
+        package_parts = parts[:-1]
+        module = ".".join(package_parts)
+        return module, module
+    module = ".".join(parts)
+    return module, _package_of(module)
 
 
 def _forbidden_root_for(name: str | None) -> str | None:
@@ -89,17 +113,82 @@ def _forbidden_root_for(name: str | None) -> str | None:
     return None
 
 
-def _iter_imported_names(tree: ast.Module) -> list[str]:
-    """Every dotted module name imported anywhere in *tree* (nested included)."""
+def _package_of(module: str) -> str:
+    """Return the package a *module* lives in.
+
+    A module's "package" is its parent dotted path:
+    ``app.ui.components.search_routes`` -> ``app.ui.components``. For a
+    package's own ``__init__`` (which we represent by the package's dotted
+    path, e.g. ``app.ui.components``) the package *is* itself — Python
+    anchors relative imports in an ``__init__`` against the package it
+    defines, not its parent. We can't distinguish the two from the dotted
+    name alone, so the caller passes the package directly when scanning an
+    ``__init__`` (see ``_module_and_package`` / ``_iter_resolved_imports``).
+    """
+    return module.rpartition(".")[0]
+
+
+def _resolve_relative_import(
+    package: str,
+    level: int,
+    module: str | None,
+) -> str | None:
+    """Resolve a relative ``ImportFrom`` to its absolute dotted path.
+
+    Mirrors CPython's ``importlib._bootstrap._resolve_name``: starting from
+    the importing module's *package*, ``level`` dots walk up one package per
+    dot beyond the first (``level=1`` = current package, ``level=2`` = parent,
+    …), then ``module`` (the text after the dots, if any) is appended.
+
+    Args:
+        package: The package the importing module lives in
+            (``app.ui.components`` for ``app.ui.components.search_routes``;
+            for an ``__init__`` the package it defines).
+        level: ``ast.ImportFrom.level`` — the number of leading dots.
+        module: ``ast.ImportFrom.module`` — the dotted text after the dots,
+            or ``None`` for ``from . import x`` / ``from .. import x``.
+
+    Returns:
+        The absolute dotted path the import targets, or ``None`` if the
+        relative import walks above the top-level package (malformed — Python
+        would raise ``ImportError`` at import time, and it cannot name a
+        feature package anyway).
+    """
+    if level <= 0:
+        # Absolute import: ``module`` is already the absolute path.
+        return module
+    # ``level`` dots strip ``level - 1`` trailing components off the package.
+    bits = package.split(".") if package else []
+    if level - 1 > len(bits):
+        # Escapes above the project root — not resolvable / not a feature.
+        return None
+    base = bits[: len(bits) - (level - 1)]
+    if module:
+        base = base + module.split(".")
+    return ".".join(base) if base else None
+
+
+def _iter_resolved_imports(tree: ast.Module, module: str, package: str) -> list[str]:
+    """Every imported module name in *tree*, resolved to an absolute path.
+
+    Walks *every* import node (nested/lazy included). ``ast.Import`` targets
+    are always absolute. ``ast.ImportFrom`` targets are resolved against
+    *package* via :func:`_resolve_relative_import` so a relative import that
+    escapes ``app.ui`` is checked exactly like the equivalent absolute import.
+
+    Args:
+        tree: The parsed module AST.
+        module: The importing module's own dotted path (for diagnostics).
+        package: The package to anchor relative imports against.
+    """
     names: list[str] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             names.extend(alias.name for alias in node.names)
         elif isinstance(node, ast.ImportFrom):
-            # Skip relative imports (level > 0): they resolve within app.ui by
-            # construction and cannot point at a sibling feature package.
-            if node.level == 0 and node.module:
-                names.append(node.module)
+            resolved = _resolve_relative_import(package, node.level, node.module)
+            if resolved:
+                names.append(resolved)
     return names
 
 
@@ -118,11 +207,11 @@ def test_ui_module_does_not_import_feature_package(py_file: Path) -> None:
     Allowlisted, documented pre-existing edges are tolerated; every new edge
     fails the build.
     """
-    module = _module_dotted_path(py_file)
+    module, package = _module_and_package(py_file)
     tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
 
     violations: list[str] = []
-    for imported in _iter_imported_names(tree):
+    for imported in _iter_resolved_imports(tree, module, package):
         root = _forbidden_root_for(imported)
         if root is None:
             continue
@@ -152,8 +241,10 @@ def test_allowlist_entries_are_still_real() -> None:
         if not source_path.exists():
             stale.append((module, root))
             continue
+        _module, package = _module_and_package(source_path)
         tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-        if not any(_forbidden_root_for(name) == root for name in _iter_imported_names(tree)):
+        resolved = _iter_resolved_imports(tree, _module, package)
+        if not any(_forbidden_root_for(name) == root for name in resolved):
             stale.append((module, root))
 
     assert not stale, (
@@ -161,3 +252,134 @@ def test_allowlist_entries_are_still_real() -> None:
         "— remove them (the underlying edge is gone):\n  "
         + "\n  ".join(f"{m} -> {r}" for m, r in stale)
     )
+
+
+# ---------------------------------------------------------------------------
+# Resolver unit tests (#890 review): a relative import that escapes app.ui
+# must be resolved to its absolute path and caught like any absolute import.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRelativeImport:
+    """``_resolve_relative_import`` mirrors CPython's relative-name resolution."""
+
+    def test_absolute_import_passes_through(self) -> None:
+        # level=0 -> the module text is already absolute.
+        assert (
+            _resolve_relative_import("app.ui.components", 0, "app.explorer.routes")
+            == "app.explorer.routes"
+        )
+
+    def test_single_dot_with_module_is_current_package(self) -> None:
+        # ``from .sibling import x`` in app.ui.surfaces.* -> app.ui.surfaces.sibling
+        assert (
+            _resolve_relative_import("app.ui.surfaces", 1, "annotation_popover")
+            == "app.ui.surfaces.annotation_popover"
+        )
+
+    def test_single_dot_no_module_is_the_package_itself(self) -> None:
+        # ``from . import dom_ids`` -> the package; the imported *name* (dom_ids)
+        # is a member, not part of the module path AST gives us.
+        assert _resolve_relative_import("app.ui.surfaces", 1, None) == "app.ui.surfaces"
+
+    def test_two_dots_no_module_is_parent_package(self) -> None:
+        # ``from .. import primitives`` in app.ui.surfaces.* -> app.ui
+        assert _resolve_relative_import("app.ui.surfaces", 2, None) == "app.ui"
+
+    def test_two_dots_with_module_is_sibling_subpackage(self) -> None:
+        # ``from ..primitives import badge`` in app.ui.surfaces.* -> app.ui.primitives
+        assert _resolve_relative_import("app.ui.surfaces", 2, "primitives") == "app.ui.primitives"
+
+    def test_three_dots_escapes_app_ui_into_feature_package(self) -> None:
+        # THE BUG (#890 review): ``from ...explorer.routes import x`` written in
+        # app.ui.components.search_routes resolves OUT of app.ui to a feature.
+        # package = app.ui.components, level=3 strips 2 trailing parts -> app,
+        # then append explorer.routes -> app.explorer.routes.
+        assert (
+            _resolve_relative_import("app.ui.components", 3, "explorer.routes")
+            == "app.explorer.routes"
+        )
+
+    def test_over_deep_relative_import_returns_none(self) -> None:
+        # More dots than the package is deep -> walks above the project root.
+        # Python would raise ImportError; we treat it as unresolvable (and it
+        # cannot name a feature package anyway).
+        assert _resolve_relative_import("app.ui", 5, "x") is None
+
+
+class TestRelativeImportGuard:
+    """End-to-end: the AST scan + forbidden-root check on synthetic modules.
+
+    These prove the *whole* pipeline (parse -> resolve -> classify) catches a
+    relative escape and stays clean for genuinely-internal relative imports —
+    independent of whatever the real files under app/ui happen to contain.
+    """
+
+    def _resolved(self, source: str, module: str, package: str) -> list[str]:
+        tree = ast.parse(source)
+        return _iter_resolved_imports(tree, module, package)
+
+    def _forbidden_hits(self, source: str, module: str, package: str) -> list[str]:
+        return [
+            name
+            for name in self._resolved(source, module, package)
+            if _forbidden_root_for(name) is not None
+        ]
+
+    def test_relative_escape_into_feature_is_caught(self) -> None:
+        # A nested (function-level) relative import that escapes into a feature.
+        source = textwrap.dedent(
+            """
+            def _lazy():
+                from ...explorer.routes import _get_client  # escapes app.ui
+                return _get_client
+            """
+        )
+        hits = self._forbidden_hits(source, "app.ui.components.search_routes", "app.ui.components")
+        assert hits == ["app.explorer.routes"], hits
+        assert _forbidden_root_for(hits[0]) == "app.explorer"
+
+    def test_relative_escape_into_annotations_is_caught(self) -> None:
+        # The exact edge #860 removed, re-introduced via a relative spelling.
+        source = "from ...annotations.row_keys import target_dom_id\n"
+        hits = self._forbidden_hits(
+            source, "app.ui.primitives.annotation_button", "app.ui.primitives"
+        )
+        assert hits == ["app.annotations.row_keys"], hits
+
+    def test_internal_single_dot_import_is_clean(self) -> None:
+        # ``from . import dom_ids`` stays inside app.ui -> no forbidden hit.
+        source = "from . import dom_ids\n"
+        assert (
+            self._forbidden_hits(source, "app.ui.surfaces.annotation_popover", "app.ui.surfaces")
+            == []
+        )
+
+    def test_internal_two_dot_import_is_clean(self) -> None:
+        # ``from .. import primitives`` -> app.ui.primitives -> not forbidden.
+        source = "from .. import primitives\n"
+        assert (
+            self._forbidden_hits(source, "app.ui.surfaces.annotation_popover", "app.ui.surfaces")
+            == []
+        )
+
+    def test_internal_two_dot_sibling_subpackage_is_clean(self) -> None:
+        # ``from ..primitives.badge import Badge`` -> app.ui.primitives.badge.
+        source = "from ..primitives.badge import Badge\n"
+        assert (
+            self._forbidden_hits(source, "app.ui.surfaces.annotation_popover", "app.ui.surfaces")
+            == []
+        )
+
+    def test_init_anchors_relative_import_against_itself(self) -> None:
+        # In app/ui/components/__init__.py the package IS app.ui.components, so
+        # ``from .search_routes import x`` stays internal (anchors on itself,
+        # not the parent) — and a 2-dot escape lands one level shallower than
+        # the same spelling in a non-__init__ sibling module.
+        internal = "from .search_routes import global_search_routes\n"
+        assert self._forbidden_hits(internal, "app.ui.components", "app.ui.components") == []
+        # ``from ...explorer import routes`` in the __init__ (package
+        # app.ui.components): strip 2 -> app, append explorer -> app.explorer.
+        escape = "from ...explorer import routes\n"
+        hits = self._forbidden_hits(escape, "app.ui.components", "app.ui.components")
+        assert hits == ["app.explorer"], hits


### PR DESCRIPTION
Part of #860.

## The move

`target_dom_id` lived in `app/annotations/row_keys.py` and was imported by two `app/ui` primitives — `ui/primitives/annotation_button.py` and `ui/surfaces/annotation_popover.py` — i.e. the **disallowed ui→feature** import edge.

It is now a UI-layer concern in a new module **`app/ui/dom_ids.py`** (sibling to the existing `app/ui/safe_url.py`, which is the precedent for a standalone URL/CSS-safety helper living directly under `app/ui`). The two consumers now import from `app.ui.dom_ids`.

Only `target_dom_id` and its single transitive dep (`hashlib`) moved. The annotation-specific row-key helpers (`safe_row_key` / `decode_row_key` base64url, `stable_hash`, the `row_key_for_*` formulas, `collect_row_specs`) stay in `app.annotations.row_keys` — they ARE the annotation contract.

**Behaviour is byte-for-byte identical.** The output shape `annotation-popover-{kind}-{16-hex-digest}` is pinned by the existing #773 tests and live DOM ids / paired `hx-target` selectors depend on it; the hashing length and template are unchanged.

## The re-export decision

`app/annotations/row_keys.py` now does `from app.ui.dom_ids import target_dom_id` and re-exports it (added to `__all__`). This keeps the **feature→ui** direction (the allowed one) as the only new edge, and lets the annotation-internal callers keep working unchanged:

- The `app.ui` primitives import from **`app.ui.dom_ids`** (clean direction).
- The annotation route tests (`tests/test_annotations_routes.py`, `tests/test_annotations_version_routes.py`) and any annotations-internal caller keep importing from **`app.annotations.row_keys`** via the re-export.

Verified `app.ui.dom_ids.target_dom_id is app.annotations.row_keys.target_dom_id` (same object). No import cycle: `app.ui.dom_ids` imports only `hashlib`, and `app.annotations.__init__` does not import `app.ui`.

## New guard test

`tests/test_ui_import_direction.py` AST-scans **every** module under `app/ui/` (walking nested/lazy imports too, so a deferred `import` can't dodge it) and asserts none imports `app.annotations`, `app.docs`, `app.chat`, `app.drafter`, `app.analyysikeskus`, `app.admin`, `app.explorer`, or `app.impact`. This pins the whole ui layer, not just this one symbol. A companion test fails if an allowlisted edge ever disappears, so the allowlist can't go stale.

## Pre-existing ui→feature violation found (allowlisted, NOT fixed here)

The scan surfaced **one** other existing violation, left untouched per scope and allowlisted with a `TODO(#860)`:

- **`app/ui/components/search_routes.py`** lazily imports `from app.explorer.routes import _get_client, _sanitize_regex` (function-level, inside `try/except`) to back the global-search dropdown. Fixing it needs the shared SPARQL client/sanitiser helpers extracted out of `app.explorer.routes` into a neutral module — out of scope for this `target_dom_id` move. (Its sibling import `app.ontology.queries` is **not** flagged: `app.ontology` is a shared lower layer, not a feature.)

## Test results

- `ruff check app tests` — clean.
- `pyright` (repo-wide) — 0 errors, 0 warnings.
- `pytest -q tests/test_annotations_routes.py tests/test_annotations_version_routes.py tests/test_ui_import_direction.py tests/test_ui_surfaces.py` — **149 passed**.
- All DB-independent ui + import-safety suites — **280 passed**.
- `pytest --collect-only` — **5007 tests collected, no import/collection errors** (collection imports the entire app + test tree, confirming the module move breaks nothing at import time).
- Full DB-backed suite (`pytest -q`, baseline ~4724) could not run in this environment (no Docker daemon / Postgres available); the change is import-graph-only with zero DB interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)