### PR TITLE
fix(infra): framework-free data layer at runtime — seal the three import leaks (#895)

### DIFF
--- a/app/analyysikeskus/eu_transposition.py
+++ b/app/analyysikeskus/eu_transposition.py
@@ -432,7 +432,7 @@ def list_overdue_or_upcoming_transpositions(
             result to the caller's org. Today every authenticated user
             sees the same nation-wide list. The parameter is on the
             signature now so the call sites in
-            :mod:`app.templates.dashboard` don't need to change when the
+            :mod:`app.dashboard.service` don't need to change when the
             scoping lands.
         sparql_client: Optional :class:`SparqlClient` override (tests
             inject one whose ``.query`` is mocked).

--- a/app/analyysikeskus/result_shell.py
+++ b/app/analyysikeskus/result_shell.py
@@ -55,7 +55,7 @@ _LAW_SCOPE_OPTIONS: list[tuple[str, str]] = [
 def _card(heading: str, content: Any) -> Any:
     """A compact section card — ``Card(CardHeader(H3(...)), CardBody(...))``.
 
-    Mirrors ``app/templates/dashboard.py::_section_card`` so the
+    Mirrors ``app/dashboard/pages.py::_section_card`` so the
     Analüüsikeskus pages share the dense-but-calm card rhythm with the
     rest of ``app/``.
     """

--- a/app/analyysikeskus/routes/_directory.py
+++ b/app/analyysikeskus/routes/_directory.py
@@ -45,7 +45,7 @@ def _get_recent_analyses(user_id: str | None, org_id: str | None) -> list[dict[s
     """Return recent analysis activity for the directory page, newest first.
 
     Two small org-scoped raw-SQL queries — mirroring the try/except → log
-    + return ``[]`` pattern from ``app/templates/dashboard.py``'s widget
+    + return ``[]`` pattern from ``app/dashboard/service.py``'s widget
     loaders — merged into one list capped at :data:`_MAX_RECENT_ANALYSES`:
 
     * **Impact reports** — the latest report per draft for the org (via a
@@ -188,7 +188,7 @@ def _recent_analyses_card(items: list[dict[str, Any]]) -> Any:
     """The "Hiljutised analüüsid" card — a DataTable of recent activity.
 
     Empty → a single muted "Veel pole analüüse." row (consistent with how
-    ``app/templates/dashboard.py`` renders its empty section bodies).
+    ``app/dashboard/pages.py`` renders its empty section bodies).
     """
     if not items:
         return Card(

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,7 +1,79 @@
-from app.auth.audit import log_action as log_action
-from app.auth.jwt_provider import JWTAuthProvider as JWTAuthProvider
-from app.auth.middleware import auth_before as auth_before
-from app.auth.provider import AuthProvider as AuthProvider
-from app.auth.provider import UserDict as UserDict
-from app.auth.roles import require_org_member as require_org_member
-from app.auth.roles import require_role as require_role
+"""Authentication & authorization package.
+
+This package mixes two kinds of module:
+
+    - Framework-coupled web-layer modules — :mod:`app.auth.middleware`,
+      :mod:`app.auth.roles`, :mod:`app.auth.jwt_provider` — which legitimately
+      import ``fasthtml`` / ``starlette``; they *are* the web layer.
+    - Neutral leaves — :mod:`app.auth.audit` (imports only
+      :func:`app.db.get_connection`) and :mod:`app.auth.provider` (ABC +
+      ``TypedDict`` only) — which import no web framework at all.
+
+The public re-exports are resolved *lazily* (PEP 562 module ``__getattr__``)
+rather than eagerly imported at package import time, mirroring
+:mod:`app.dashboard` and :mod:`app.analyysikeskus`. Eagerly re-exporting them
+meant that ``import app.auth.audit`` — the audit-logging path the standalone
+worker container reaches via the ``app.docs`` job handlers — ran this
+``__init__`` and pulled the fasthtml-coupled ``middleware`` / ``roles`` /
+``jwt_provider`` siblings into ``sys.modules``, dragging ~13 FastHTML modules
+into a worker that must stay framework-free (the promise in
+``app/docs/__init__``'s docstring). Lazy exports keep the neutral leaves
+(``audit``, ``provider``) importable framework-free, while
+``from app.auth import require_role`` / ``log_action`` / ``JWTAuthProvider``
+etc. keep working for the web layer and only load their framework-coupled
+home module when the name is actually requested (#895).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.auth.audit import log_action
+    from app.auth.jwt_provider import JWTAuthProvider
+    from app.auth.middleware import auth_before
+    from app.auth.provider import AuthProvider, UserDict
+    from app.auth.roles import require_org_member, require_role
+
+__all__ = [
+    "AuthProvider",
+    "JWTAuthProvider",
+    "UserDict",
+    "auth_before",
+    "log_action",
+    "require_org_member",
+    "require_role",
+]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve the public re-exports from their home modules (PEP 562)."""
+    if name == "log_action":
+        from app.auth.audit import log_action
+
+        return log_action
+    if name == "JWTAuthProvider":
+        from app.auth.jwt_provider import JWTAuthProvider
+
+        return JWTAuthProvider
+    if name == "auth_before":
+        from app.auth.middleware import auth_before
+
+        return auth_before
+    if name == "AuthProvider":
+        from app.auth.provider import AuthProvider
+
+        return AuthProvider
+    if name == "UserDict":
+        from app.auth.provider import UserDict
+
+        return UserDict
+    if name == "require_org_member":
+        from app.auth.roles import require_org_member
+
+        return require_org_member
+    if name == "require_role":
+        from app.auth.roles import require_role
+
+        return require_role
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/dashboard/__init__.py
+++ b/app/dashboard/__init__.py
@@ -22,9 +22,12 @@ registrar is actually requested.
 
 The lazy export is one half of the guarantee; the other lives in the service
 layer itself, which defers its sole ``app.analyysikeskus.eu_transposition``
-import to call time (importing that package runs its ``__init__`` → SPARQL
-client → ``app.metrics`` → starlette). Both are needed for a fresh
-``import app.dashboard.service`` to stay framework-free at runtime.
+import to call time — so a fresh ``import app.dashboard.service`` stays clear of
+the whole ``app.analyysikeskus`` import graph. (That deferral once also fenced
+off a transitive starlette floor reached through ``app.metrics``; #895 split the
+middleware out of ``app.metrics`` and sealed it, so the deferral now buys
+import-graph hygiene rather than framework isolation.) Both halves keep a fresh
+``import app.dashboard.service`` framework-free at runtime.
 """
 
 from __future__ import annotations

--- a/app/dashboard/service.py
+++ b/app/dashboard/service.py
@@ -517,13 +517,14 @@ def _get_eu_transposition_deadlines(
     ``ReadTimeout`` at the network layer, the worker exits cleanly, and
     there is no orphaned thread.
     """
-    # Deferred to call time, not module scope: importing any
-    # ``app.analyysikeskus`` submodule first executes that package's
-    # ``__init__`` and, via its SPARQL client → ``app.metrics``, pulls in the
-    # starlette stack. Keeping it here means ``import app.dashboard.service``
-    # stays framework-free at runtime (pinned by
-    # ``tests/test_dashboard_import_direction.py``; the remaining transitive
-    # framework floor reached on the *first call* is tracked in #895).
+    # Deferred to call time, not module scope: this keeps
+    # ``import app.dashboard.service`` independent of the whole
+    # ``app.analyysikeskus`` import graph and keeps the patch point at the
+    # dependency's canonical home. (It originally also guarded against a
+    # framework coupling — importing an ``app.analyysikeskus`` submodule ran
+    # that package's ``__init__`` → SPARQL client → ``app.metrics`` → starlette
+    # — but that was sealed in #895.) The runtime guarantee is pinned by
+    # ``tests/test_dashboard_import_direction.py`` either way.
     from app.analyysikeskus.eu_transposition import (
         DEFAULT_TRANSPOSITION_HORIZON_DAYS,
         list_overdue_or_upcoming_transpositions,

--- a/app/docs/status.py
+++ b/app/docs/status.py
@@ -53,9 +53,14 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from app.ui.primitives.badge import BadgeVariant
+if TYPE_CHECKING:
+    # Annotation-only. ``app.ui.primitives.badge`` is a fasthtml component
+    # module, and this status SSOT sits under the framework-free data layer
+    # (``draft_model`` → every docs job handler → the standalone worker), so a
+    # runtime import here would pull fasthtml into all of them (#895).
+    from app.ui.primitives.badge import BadgeVariant
 
 
 @dataclass(frozen=True)

--- a/app/explorer/start_panel.py
+++ b/app/explorer/start_panel.py
@@ -12,7 +12,7 @@ This module is the *data* layer: three pure, individually-testable functions —
 :func:`get_user_bookmarks`, :func:`get_high_risk_reports`,
 :func:`get_recent_drafts` — each with a clean signature that can later be wrapped
 as a REST endpoint or an MCP tool (see ``CLAUDE.md`` — "Internal service
-functions"). They mirror the helper pattern in ``app/templates/dashboard.py``
+functions"). They mirror the helper pattern in ``app/dashboard/service.py``
 (``_get_bookmarks`` / ``_get_high_risk_reports``) — every query is **org-scoped
 at the SQL layer** (bookmarks are scoped by ``user_id``), wrapped in
 ``try/except`` → log + return ``[]`` so a DB hiccup degrades the panel to "empty"

--- a/app/main.py
+++ b/app/main.py
@@ -448,7 +448,7 @@ app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=get_trusted_proxy_hosts
 # Record per-request latency into the metrics table for the admin
 # performance dashboard.  Added after ProxyHeadersMiddleware so that
 # the request path is already resolved when the middleware fires.
-from app.metrics import MetricsMiddleware  # noqa: E402
+from app.metrics_middleware import MetricsMiddleware  # noqa: E402
 
 app.add_middleware(MetricsMiddleware)
 

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,12 +1,16 @@
-"""Application-level performance metrics: recording, middleware, and helpers.
+"""Application-level performance metrics: recording and helpers.
+
+Deliberately framework-free: this module imports no starlette/fasthtml so the
+data layer (SPARQL client, LLM/RAG providers) and the standalone background
+worker can call ``record_metric`` without dragging in the web framework (#895).
+The starlette ASGI ``MetricsMiddleware`` that consumes ``record_metric`` lives
+in ``app.metrics_middleware``.
 
 Provides:
 - ``record_metric(name, value, labels)`` — buffer a metric for periodic
   bulk INSERT into the ``metrics`` Postgres table (created by migration 011).
   Never blocks the caller; flushes every ``_FLUSH_INTERVAL`` seconds or when
   the buffer reaches ``_FLUSH_SIZE`` entries.
-- ``MetricsMiddleware`` — Starlette ASGI middleware that records per-request
-  latency labelled with the *matched route template* and method.
 - ``track_duration(name, **labels)`` — context manager that measures a code
   block's wall-clock duration in milliseconds and records it.
 """
@@ -22,11 +26,6 @@ import time
 from collections import deque
 from contextlib import contextmanager
 from typing import Any
-
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
-from starlette.routing import Match
 
 from app.db import get_connection as _connect
 
@@ -260,80 +259,6 @@ def _flush_on_shutdown() -> None:
 
 # Flush remaining metrics on interpreter shutdown
 atexit.register(_flush_on_shutdown)
-
-
-# ---------------------------------------------------------------------------
-# Starlette middleware
-# ---------------------------------------------------------------------------
-
-
-def _matched_route_template(request: Request) -> str | None:
-    """Return the matched route's template (e.g. ``/drafts/{id}``), or None.
-
-    Records the *template* rather than ``request.url.path`` so an attacker
-    can't blow up label cardinality by hitting ``/x/<random>`` a million times:
-    every variable segment collapses to its placeholder. Returns ``None`` when
-    no route matched (a 404 / unrouted path) so those are never recorded.
-    """
-    scope = request.scope
-    # A matched route always populates ``endpoint`` in this Starlette version;
-    # its absence means the request 404'd before reaching any handler.
-    if scope.get("endpoint") is None:
-        return None
-
-    for route in request.app.routes:
-        try:
-            match, _ = route.matches(scope)
-        except Exception:
-            continue
-        if match is Match.FULL:
-            template = getattr(route, "path_format", None) or getattr(route, "path", None)
-            if isinstance(template, str) and template:
-                return template[:_MAX_LABEL_LEN]
-            return None
-    return None
-
-
-class MetricsMiddleware(BaseHTTPMiddleware):
-    """Record ``http_request_duration_ms`` for every authenticated request.
-
-    Labels include ``method``, ``route`` (the matched template, not the raw
-    path), and ``status``.  Requests are skipped to keep the table clean and
-    bounded:
-
-    * ``/static/...`` asset requests (high volume, no signal);
-    * unrouted paths / 404s (attacker-chosen paths carry no real route);
-    * unauthenticated requests (pre-auth probing shouldn't pollute metrics).
-    """
-
-    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[type-arg]
-        if request.url.path.startswith("/static/"):
-            return await call_next(request)
-
-        start = time.perf_counter()
-        response: Response = await call_next(request)
-        duration_ms = (time.perf_counter() - start) * 1000
-
-        # Routing + the auth Beforeware run downstream of this middleware, so
-        # ``endpoint`` and ``auth`` are populated by the time ``call_next``
-        # returns.
-        if not request.scope.get("auth"):
-            return response
-
-        route_template = _matched_route_template(request)
-        if route_template is None:
-            return response
-
-        record_metric(
-            "http_request_duration_ms",
-            round(duration_ms, 2),
-            {
-                "method": request.method,
-                "route": route_template,
-                "status": response.status_code,
-            },
-        )
-        return response
 
 
 # ---------------------------------------------------------------------------

--- a/app/metrics_middleware.py
+++ b/app/metrics_middleware.py
@@ -1,0 +1,99 @@
+"""Starlette ASGI middleware that records per-request latency.
+
+The middleware is the ONLY starlette-coupled part of the metrics subsystem.
+Keeping it out of ``app.metrics`` keeps ``record_metric`` (and the buffer +
+flush machinery) importable by the framework-free data layer — the SPARQL
+client, the LLM/RAG providers — and the standalone background worker without
+transitively loading starlette (#895).
+
+Dependency direction: middleware → metrics core (this module imports
+``record_metric`` from ``app.metrics``; ``app.metrics`` never imports back).
+
+Provides:
+- ``MetricsMiddleware`` — Starlette ASGI middleware that records per-request
+  latency labelled with the *matched route template* and method.
+"""
+
+from __future__ import annotations
+
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Match
+
+from app.metrics import _MAX_LABEL_LEN, record_metric
+
+# ---------------------------------------------------------------------------
+# Starlette middleware
+# ---------------------------------------------------------------------------
+
+
+def _matched_route_template(request: Request) -> str | None:
+    """Return the matched route's template (e.g. ``/drafts/{id}``), or None.
+
+    Records the *template* rather than ``request.url.path`` so an attacker
+    can't blow up label cardinality by hitting ``/x/<random>`` a million times:
+    every variable segment collapses to its placeholder. Returns ``None`` when
+    no route matched (a 404 / unrouted path) so those are never recorded.
+    """
+    scope = request.scope
+    # A matched route always populates ``endpoint`` in this Starlette version;
+    # its absence means the request 404'd before reaching any handler.
+    if scope.get("endpoint") is None:
+        return None
+
+    for route in request.app.routes:
+        try:
+            match, _ = route.matches(scope)
+        except Exception:
+            continue
+        if match is Match.FULL:
+            template = getattr(route, "path_format", None) or getattr(route, "path", None)
+            if isinstance(template, str) and template:
+                return template[:_MAX_LABEL_LEN]
+            return None
+    return None
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Record ``http_request_duration_ms`` for every authenticated request.
+
+    Labels include ``method``, ``route`` (the matched template, not the raw
+    path), and ``status``.  Requests are skipped to keep the table clean and
+    bounded:
+
+    * ``/static/...`` asset requests (high volume, no signal);
+    * unrouted paths / 404s (attacker-chosen paths carry no real route);
+    * unauthenticated requests (pre-auth probing shouldn't pollute metrics).
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[type-arg]
+        if request.url.path.startswith("/static/"):
+            return await call_next(request)
+
+        start = time.perf_counter()
+        response: Response = await call_next(request)
+        duration_ms = (time.perf_counter() - start) * 1000
+
+        # Routing + the auth Beforeware run downstream of this middleware, so
+        # ``endpoint`` and ``auth`` are populated by the time ``call_next``
+        # returns.
+        if not request.scope.get("auth"):
+            return response
+
+        route_template = _matched_route_template(request)
+        if route_template is None:
+            return response
+
+        record_metric(
+            "http_request_duration_ms",
+            round(duration_ms, 2),
+            {
+                "method": request.method,
+                "route": route_template,
+                "status": response.status_code,
+            },
+        )
+        return response

--- a/tests/test_analyysikeskus_services_no_framework.py
+++ b/tests/test_analyysikeskus_services_no_framework.py
@@ -13,9 +13,12 @@ HTTP response / FT node) for the unresolved branch, which needs no Jena.
 Fresh-subprocess runtime tests then pin what the AST scan cannot see: the
 package ``__init__`` resolves its UI exports lazily (PEP 562), so importing
 ``app.analyysikeskus`` — or only the ``services/`` subpackage — never loads
-the package's own ``routes`` / ``result_shell`` FastHTML layer. (The residual
-transitive framework floor under the services, via ``app.docs``'s eager init
-and ``app.metrics``'s starlette middleware imports, is tracked in #895.)
+the package's own ``routes`` / ``result_shell`` FastHTML layer **and** loads
+zero ``fasthtml`` / ``starlette`` modules at all. The residual transitive
+framework floor that once leaked under the services (via ``app.docs``'s eager
+``__init__`` → ``app.auth`` and ``app.metrics``'s starlette middleware imports)
+was removed in #895 — the runtime tests below now assert zero framework, not a
+floor.
 """
 
 from __future__ import annotations
@@ -145,14 +148,19 @@ def test_normi_unresolved_returns_typed_result_not_response() -> None:
 # ---------------------------------------------------------------------------
 # Runtime import-direction tests (subprocess) — the AST scan above only proves
 # the service *source files* carry no direct ``fasthtml`` / ``starlette``
-# import. These pin the *runtime* invariant #860/#894 actually owns: the
-# analyysikeskus package's ``__init__`` must resolve its public exports
-# lazily (PEP 562), so importing the package — or only the framework-free
-# ``services/`` subpackage — never drags the package's own FastHTML UI layer
-# (``routes`` / ``result_shell``) into ``sys.modules``. Run in fresh
-# subprocesses so the assertions see a pristine ``sys.modules`` (the parent
-# test process has long since imported fasthtml + the UI layer transitively,
-# which would mask any regression).
+# import. These pin the *runtime* invariant: importing the package — or only
+# the framework-free ``services/`` subpackage — loads zero ``fasthtml`` /
+# ``starlette`` modules. That rests on two fixes: #860/#894 made the package
+# ``__init__`` resolve its public exports lazily (PEP 562) so it never drags
+# its own FastHTML UI layer (``routes`` / ``result_shell``) into
+# ``sys.modules``, and #895 sealed the transitive leaks the services reached
+# through their neutral dependencies (metrics middleware split out of
+# ``app.metrics``; lazy ``app.auth`` init; ``BadgeVariant`` type-only in
+# ``app.docs.status``). The UI-layer named-module checks are kept alongside the
+# bare zero-framework count because they localize a regression faster. Run in
+# fresh subprocesses so the assertions see a pristine ``sys.modules`` (the
+# parent test process has long since imported fasthtml + the UI layer
+# transitively, which would mask any regression).
 # ---------------------------------------------------------------------------
 
 
@@ -208,27 +216,44 @@ def test_package_init_loads_no_framework() -> None:
     assert "OK" in result.stdout
 
 
-def test_importing_services_does_not_load_package_ui() -> None:
-    """``import app.analyysikeskus.services`` must not load the package's UI layer.
+def test_importing_services_loads_no_framework() -> None:
+    """``import app.analyysikeskus.services`` must load zero framework — full guarantee.
 
-    Scope note: importing the service subpackage today *still* pulls
-    ``fasthtml`` / ``starlette`` into ``sys.modules`` through pre-existing
-    leaks that live **outside** this package and are out of scope for
-    #860/#894 — the service modules import ``app.docs.reference_resolver``
-    (whose ``app.docs`` package ``__init__`` eagerly imports handlers →
-    ``app.auth`` → ``fasthtml``) and ``app.ontology.sparql_client`` (→
-    ``app.metrics``, which imports Starlette middleware at module scope).
-    Those are tracked in issue #895. This test therefore does **not** assert
-    "zero framework modules" — it would fail today; it pins exactly the
-    invariant this package owns: importing only the framework-free service
-    layer never loads ``app.analyysikeskus``'s *own* FastHTML UI siblings
-    (``routes`` / ``result_shell``), which only the lazy package ``__init__``
-    makes possible. When #895 lands and the upstream leaks are sealed, this
-    can be tightened to assert no ``fasthtml`` / ``starlette`` at all.
+    The full framework-free guarantee now holds for the service subpackage: a
+    fresh ``import app.analyysikeskus.services`` pulls **no** ``fasthtml`` /
+    ``starlette`` module into ``sys.modules``. Two independent fixes make this
+    true:
+
+    * #894 — the package ``__init__`` exports its UI siblings (``routes`` /
+      ``result_shell``) lazily (PEP 562 ``__getattr__``), so importing the
+      service layer never drags in ``app.analyysikeskus``'s *own* FastHTML UI.
+    * #895 — the transitive leaks the services reached through their neutral
+      dependencies were sealed: the ``MetricsMiddleware`` was split out of
+      ``app.metrics`` (no more starlette floor under ``app.ontology.sparql_client``);
+      ``app.auth.__init__`` went lazy (PEP 562); and ``BadgeVariant`` is now a
+      ``TYPE_CHECKING``-only import in ``app.docs.status`` — so the service
+      modules' ``app.docs.reference_resolver`` import no longer loads
+      ``fasthtml``.
+
+    The zero-framework assertion is the real contract; the UI-layer assertions
+    (``routes`` / ``result_shell`` absent) are kept alongside it because they
+    localize a regression faster — if a future change reintroduces an eager UI
+    export in the package ``__init__``, the named-module check points straight
+    at it, whereas the bare framework count only says "something leaked".
+
+    Run in a fresh subprocess so the assertions see a pristine ``sys.modules``
+    — the parent test process has long since imported fasthtml + the UI layer
+    transitively, which would mask any regression.
     """
     code = (
         "import sys\n"
         "import app.analyysikeskus.services  # noqa: F401\n"
+        "framework = sorted(m for m in sys.modules "
+        "if m.startswith(('fasthtml', 'starlette')))\n"
+        "assert not framework, "
+        "'import app.analyysikeskus.services pulled in a web framework: ' + repr(framework) + "
+        "' -- the service layer must stay framework-free (PEP 562 lazy UI exports "
+        "in the package __init__, plus the upstream leaks sealed in #895)'\n"
         "ui = [m for m in ('app.analyysikeskus.routes', "
         "'app.analyysikeskus.result_shell') if m in sys.modules]\n"
         "assert not ui, "
@@ -245,8 +270,8 @@ def test_importing_services_does_not_load_package_ui() -> None:
         text=True,
     )
     assert result.returncode == 0, (
-        "fresh-subprocess import of app.analyysikeskus.services loaded the "
-        "package's own FastHTML UI layer (routes / result_shell).\n"
+        "fresh-subprocess import of app.analyysikeskus.services loaded a web "
+        "framework or the package's own FastHTML UI layer (routes / result_shell).\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert "OK" in result.stdout

--- a/tests/test_dashboard_import_direction.py
+++ b/tests/test_dashboard_import_direction.py
@@ -23,17 +23,20 @@ The contract is pinned **both ways**. The AST scan above guards the source
 import surface; a runtime ``sys.modules`` check (like
 ``tests/test_impact_import_direction``'s) then proves the guarantee actually
 holds at import time. ``service.py``'s one ``app.analyysikeskus`` dependency —
-the neutral ``eu_transposition`` data helper — is deferred to *call time*
-rather than imported at module scope, because importing any
-``app.analyysikeskus`` submodule executes that package's ``__init__`` and,
-through its SPARQL client → ``app.metrics``, pulls in the starlette stack. With
+the neutral ``eu_transposition`` data helper — is still deferred to *call time*
+rather than imported at module scope, so a fresh ``import app.dashboard.service``
+touches no ``app.analyysikeskus`` module at all (this keeps the patch point at
+the dependency's canonical home and keeps the import graphs independent). With
 that import deferred, a fresh ``import app.dashboard.service`` loads neither
 ``fasthtml`` nor ``starlette`` nor any ``app.analyysikeskus`` module — which is
 exactly what ``test_importing_service_loads_no_framework_at_runtime`` asserts in
-a pristine subprocess. (The package-init coupling and the residual
-``app.metrics`` starlette floor reached on the *first call* are tracked in issue
-#895; they are out of scope for this layer because nothing in ``service.py``
-itself reaches them until invoked.)
+a pristine subprocess. Historically the deferral also guarded against a
+transitive starlette floor (importing an ``app.analyysikeskus`` submodule ran
+that package's ``__init__`` → SPARQL client → ``app.metrics``, which imported
+Starlette middleware at module scope); that floor was sealed in #895 (the
+``MetricsMiddleware`` was split out of ``app.metrics``), so the deferral now
+buys import-graph hygiene rather than framework isolation — but the runtime
+assertion holds regardless.
 """
 
 from __future__ import annotations
@@ -191,12 +194,16 @@ def test_importing_service_loads_no_framework_at_runtime() -> None:
 
     The AST scan above guards the *source* import surface; this guards the
     *runtime* one. ``service.py`` defers its single ``app.analyysikeskus``
-    data-helper import (``eu_transposition``) to call time, because importing
-    any ``app.analyysikeskus`` submodule runs that package's ``__init__`` and,
-    via its SPARQL client → ``app.metrics``, drags in the starlette stack. With
-    that import deferred, a fresh ``import app.dashboard.service`` must load
-    neither ``fasthtml`` nor ``starlette`` — and, to pin the deferral itself, no
-    ``app.analyysikeskus`` module either.
+    data-helper import (``eu_transposition``) to call time, which keeps a fresh
+    ``import app.dashboard.service`` clear of the entire ``app.analyysikeskus``
+    import graph. (That deferral once also fenced off a transitive starlette
+    floor — an ``app.analyysikeskus`` submodule ran the package ``__init__`` →
+    SPARQL client → ``app.metrics``, which imported Starlette middleware at
+    module scope — but #895 split the middleware out of ``app.metrics`` and
+    sealed that floor.) With the import deferred, a fresh
+    ``import app.dashboard.service`` must load neither ``fasthtml`` nor
+    ``starlette`` — and, to pin the deferral itself, no ``app.analyysikeskus``
+    module either.
 
     Run in a subprocess so the assertion sees a pristine ``sys.modules`` — the
     parent test process has almost certainly already imported ``fasthtml`` and

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,4 +1,5 @@
-"""Tests for app.metrics — record_metric, MetricsMiddleware, track_duration (#545)."""
+"""Tests for app.metrics (record_metric, track_duration) and
+app.metrics_middleware (MetricsMiddleware) (#545, #895)."""
 
 from __future__ import annotations
 
@@ -420,7 +421,7 @@ def _middleware_app(*, authenticated: bool):
     from starlette.responses import PlainTextResponse
     from starlette.routing import Route
 
-    from app.metrics import MetricsMiddleware
+    from app.metrics_middleware import MetricsMiddleware
 
     async def item(request: Any) -> PlainTextResponse:
         return PlainTextResponse("ok")
@@ -449,7 +450,7 @@ def _middleware_app(*, authenticated: bool):
 
 
 class TestMetricsMiddleware:
-    @patch("app.metrics.record_metric")
+    @patch("app.metrics_middleware.record_metric")
     def test_records_route_template_for_authenticated_request(self, mock_record: MagicMock):
         app = _middleware_app(authenticated=True)
         client = TestClient(app, follow_redirects=False)
@@ -467,7 +468,7 @@ class TestMetricsMiddleware:
         assert "path" not in labels
         assert labels["status"] == 200
 
-    @patch("app.metrics.record_metric")
+    @patch("app.metrics_middleware.record_metric")
     def test_skips_unauthenticated_requests(self, mock_record: MagicMock):
         app = _middleware_app(authenticated=False)
         client = TestClient(app, follow_redirects=False)
@@ -480,7 +481,7 @@ class TestMetricsMiddleware:
         ]
         assert duration_calls == []
 
-    @patch("app.metrics.record_metric")
+    @patch("app.metrics_middleware.record_metric")
     def test_skips_404_for_authenticated_user(self, mock_record: MagicMock):
         app = _middleware_app(authenticated=True)
         client = TestClient(app, follow_redirects=False)
@@ -494,7 +495,7 @@ class TestMetricsMiddleware:
         ]
         assert duration_calls == []
 
-    @patch("app.metrics.record_metric")
+    @patch("app.metrics_middleware.record_metric")
     def test_skips_static_requests(self, mock_record: MagicMock):
         app = _middleware_app(authenticated=True)
         client = TestClient(app, follow_redirects=False)
@@ -506,7 +507,7 @@ class TestMetricsMiddleware:
         ]
         assert duration_calls == []
 
-    @patch("app.metrics.record_metric")
+    @patch("app.metrics_middleware.record_metric")
     def test_real_app_skips_unauthenticated_ping(self, mock_record: MagicMock):
         """Integration: /api/ping (unauthenticated, DB-free) is not recorded."""
         from app.main import app

--- a/tests/test_worker_standalone.py
+++ b/tests/test_worker_standalone.py
@@ -18,10 +18,15 @@ from __future__ import annotations
 
 import importlib
 import os
+import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# tests/ -> repo root (anchors the fresh-subprocess imports below).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # ---------------------------------------------------------------------------
 # register_all_handlers
@@ -166,6 +171,53 @@ class TestStandaloneImportIsolation:
             f"{leaked_route_modules}. The standalone worker container "
             "should stay framework-free at startup."
         )
+
+
+def test_worker_import_surface_loads_no_framework() -> None:
+    """The standalone worker's import surface must load zero ``fasthtml`` / ``starlette``.
+
+    This is the #895 contract for the worker container. ``app/docs/__init__.py``
+    promises the worker process — which only ever imports ``app.jobs.registry``
+    (and, transitively, ``app.docs`` so the ``@register_handler`` decorators
+    fire) — never loads the web framework. Before #895 that promise was broken:
+    importing ``app.docs`` eagerly pulled in roughly a dozen fasthtml modules
+    via ``app.auth``'s eager ``__init__`` and via ``app.docs.status`` →
+    ``app.ui.primitives.badge``. #895 sealed both leaks (lazy ``app.auth``
+    init; ``BadgeVariant`` is now a ``TYPE_CHECKING``-only import in
+    ``app.docs.status``), so a fresh import of either entry point now loads
+    no framework at all.
+
+    The sibling in-process check
+    (:meth:`TestStandaloneImportIsolation.test_register_all_handlers_does_not_load_route_modules`)
+    can only prove the *route* modules stay out, because the parent test process
+    has already imported fasthtml transitively. This runs in a fresh subprocess
+    so it sees a pristine ``sys.modules`` and can assert *zero* framework — the
+    stronger guarantee the worker container actually needs.
+    """
+    code = (
+        "import sys\n"
+        "import app.jobs.registry  # noqa: F401  -- the standalone worker's entry import\n"
+        "import app.docs  # noqa: F401  -- pulled in so @register_handler side effects fire\n"
+        "framework = sorted(m for m in sys.modules "
+        "if m.startswith(('fasthtml', 'starlette')))\n"
+        "assert not framework, "
+        "'the standalone worker import surface pulled in a web framework: ' + repr(framework) + "
+        "' -- app.docs / app.jobs.registry must stay framework-free so the worker "
+        "container never loads FastHTML/Starlette (the #895 contract)'\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "fresh-subprocess import of the standalone worker surface "
+        "(app.jobs.registry + app.docs) loaded a web framework.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #895. Follow-through on the combined-merge review of #893/#894: the reviewer's P2 ("`import app.analyysikeskus.services` still loads 42 FastHTML/Starlette modules — mergeable only if the reduced contract is intentional") is resolved the strong way — the contract is now **zero framework modules at runtime**, enforced by tests.

## The three leaks (bisected per-module in fresh subprocesses)

| Leak | Mechanism | Fix |
|---|---|---|
| 16 starlette modules under the whole data layer | `app/metrics.py` hosted `MetricsMiddleware` next to `record_metric`, so `sparql_client`/`jobs.worker`/`app.llm`/`rag.retriever` all pulled starlette | Middleware + `_matched_route_template` moved to new `app/metrics_middleware.py` (no re-export shim, per #891 precedent); `app/main.py` + `tests/test_metrics.py` import/patch sites updated |
| 13 fasthtml modules via `app.auth` | Eager `app/auth/__init__.py` re-exports pulled `jwt_provider`/`middleware`/`roles` whenever the docs handlers imported the neutral `audit` leaf | Lazy PEP 562 `__getattr__` (mirrors `app/dashboard`, `app/analyysikeskus`); consumer audit found no eager-attribute reliance |
| 13 fasthtml modules via `app.docs.status` | `from app.ui.primitives.badge import BadgeVariant` — but `BadgeVariant` is a `Literal` alias used **only in annotations**, and `status` sits under `draft_model` → every docs handler → the worker | `TYPE_CHECKING`-only import |

## Guards tightened (now that the full guarantee holds)

- `test_importing_services_loads_no_framework` (renamed): fresh `import app.analyysikeskus.services` asserts **zero** fasthtml/starlette (was: only "doesn't load the package's own UI layer").
- `test_worker_standalone.py` gains a fresh-subprocess guard: `import app.jobs.registry` + `import app.docs` load zero framework — pins `app/docs/__init__.py`'s worker-container promise, which had been silently violated.
- Stale "tracked in #895" floor prose updated in the dashboard service/init and both import-direction test docstrings.

## Also: review P3 sweep

Post-#893 stale `app/templates/dashboard.py` references in `result_shell.py`, `eu_transposition.py`, `routes/_directory.py`, `start_panel.py` repointed to the real new homes (`app/dashboard/service.py` vs `pages.py`, per what each comment describes; every referenced symbol verified to exist). Dated `docs/*.md` review records deliberately untouched.

## Verification

- Fresh-subprocess bisect: `app.analyysikeskus.services`, `app.docs`, `app.docs.reference_resolver`, `app.dashboard.service`, `app.impact`, `app.jobs.registry`, `app.llm`, `app.metrics` → **0 framework modules each**.
- Full suite: **5037 passed, 50 skipped** (exit 0). Full-repo pyright: **0 errors**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
