### PR TITLE
refactor(config): typed settings module — 49-var registry + migrate 28 modules off inline env reads (#897)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,145 +1,293 @@
+# Seadusloome environment template
+# =================================
+#
+# This file is the operator-facing companion to the typed settings
+# registry in app/config.py (ENV_REGISTRY, #897). Every variable the
+# application reads is declared there with its type, default, and a
+# one-line description; this template documents the same set grouped by
+# section, with the richer deployment guidance ops actually need.
+#
+# Conventions:
+#   - Active entries (NAME=value) carry a runnable local-dev default.
+#   - Commented entries (# NAME=default) are optional/advanced knobs you
+#     rarely need to set; uncomment to override. The shown value is the
+#     built-in default.
+#   - Secret-flagged vars ship with empty or REPLACE_WITH_... placeholders
+#     only — never a real-looking secret. Generate real values per the
+#     inline `Generate with:` hints.
+
+# =====================================================================
 # PostgreSQL
+# =====================================================================
+
+# POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB are consumed by the
+# docker-compose postgres container (NOT read by the app — the app uses
+# DATABASE_URL). Keep them in sync with the DATABASE_URL below.
 POSTGRES_USER=seadusloome
 POSTGRES_PASSWORD=localdev
 POSTGRES_DB=seadusloome
+
+# Postgres DSN. Unset: app.db falls back to the localhost dev DSN in
+# development and raises in any other environment.
 DATABASE_URL=postgresql://seadusloome:localdev@postgres:5432/seadusloome
 
+# Connection-pool sizing and timeouts (advanced — app.db clamps and
+# reads these once at import). Defaults are fine for the 5-50 concurrent
+# user target; tune only under measured pool pressure.
+# DB_POOL_MIN=1
+# DB_POOL_MAX=10
+# DB_POOL_TIMEOUT=2.0
+# DB_CONNECT_TIMEOUT=5
+# DB_BREAKER_COOLDOWN=2.0
+
+# =====================================================================
 # Jena Fuseki
+# =====================================================================
+
+# Base URL of the Apache Jena Fuseki triplestore.
 JENA_URL=http://jena:3030
+
+# Fuseki dataset name queried by the app and loaded by the sync.
 JENA_DATASET=ontology
+
+# Fuseki admin credential for sync graph management. Unset: dev-only
+# fallback inside app.sync (fails closed outside development).
 FUSEKI_ADMIN_PASSWORD=localdev
 
-# Ontology source repository (used by sync pipeline)
-# Override if using a fork or private mirror.
+# =====================================================================
+# Ontology sync
+# =====================================================================
+
+# Ontology source repository for the sync pipeline. NOTE: not read by
+# the app yet — the running sync uses a baked-in default; override here
+# only once the app starts honouring it. Useful as documentation for a
+# fork or private mirror.
 ONTOLOGY_REPO_URL=https://github.com/henrikaavik/estonian-legal-ontology.git
 
-# GitHub webhook secret for verifying push events from the ontology repo.
-# Set this to the same value configured in your GitHub webhook settings.
-# When empty, webhook signature verification is skipped (dev only).
+# HMAC secret for GitHub push-webhook signature verification. Set this
+# to the same value configured in your GitHub webhook settings. Empty:
+# signature verification is skipped (dev only).
 GITHUB_WEBHOOK_SECRET=
 
-# Sentry error tracking (optional — omit to disable)
-# Obtain a DSN from your Sentry project settings.
-SENTRY_DSN=
-# Set by CI/CD or Dockerfile ARG; falls back to `git rev-parse --short HEAD`.
-GIT_SHA=
+# Absolute minimum triple count for post-sync verification; negative
+# values clamp to 0, garbage falls back to the default (advanced).
+# SYNC_MIN_TRIPLES=1000000
 
-# App configuration
+# =====================================================================
+# App
+# =====================================================================
+
+# Deployment environment (development | test | ci | staging |
+# production). Read via config.get_app_env(); drives the fail-closed
+# stub gate config.is_stub_allowed(). Stubs are permitted only in
+# development/test/ci/staging — production (and any unrecognised value)
+# disables them and raises on missing credentials.
 APP_ENV=development
-# Generate with: openssl rand -hex 32
+
+# Public base URL of the deployment. Used for password-reset links
+# (defaults to http://localhost:8000 there) and the CSRF origin
+# allowlist (own-origin only when unset). Set in staging/production.
+# APP_BASE_URL=https://seadusloome.sixtyfour.ee
+
+# Background-job worker mode (inproc | standalone). Read via
+# config.get_worker_mode(); unknown values raise at startup. Default
+# inproc runs the worker as a daemon thread in the web container; see
+# docs/operations/worker-modes.md for standalone.
+# WORKER_MODE=inproc
+
+# TEST-ONLY: the literal "1" suppresses the lifespan background worker.
+# pytest sets it at import time; in Coolify this MUST NOT be set or
+# uploads stay status='uploaded' forever. Only "1" has any effect.
+# DISABLE_BACKGROUND_WORKER=
+
+# =====================================================================
+# Auth & cookies
+# =====================================================================
+
+# JWT signing secret (HS256, >= 32 UTF-8 bytes). Unset: dev fallback in
+# development, refused elsewhere. Whitespace is significant — never
+# normalized. Generate with: openssl rand -hex 32
 SECRET_KEY=REPLACE_WITH_RANDOM_64_CHAR_HEX
-# Set to 1 in production (cookies only sent over HTTPS)
-COOKIE_SECURE=0
 
-# HMAC key for signed expiring impact-report download URLs (issue #307).
-# Optional: when unset, falls back to SECRET_KEY so a single rotation
-# rotates both. Generate with: openssl rand -hex 32
-DOWNLOAD_TOKEN_SECRET=
+# Secure flag on auth cookies (cookies sent over HTTPS only). Defaults
+# to true when unset, which is what production wants — so leave it unset
+# (or "true") in staging/production. Only the literal "true"
+# (case-insensitive) enables it; numeric values do NOT work — setting it
+# to "1" silently DISABLES secure cookies. Set false ONLY for local HTTP
+# development, as below.
+COOKIE_SECURE=false
 
-# Phase 2: Document Upload + Impact Analysis
-# -------------------------------------------
+# Comma-separated proxy hosts trusted for X-Forwarded-* parsing. Empty:
+# built-in Traefik/Coolify defaults. Wildcards are refused
+# (app.auth.perimeter).
+# TRUSTED_PROXY_HOSTS=
 
-# Encryption key for draft file storage (AES-128-CBC via Fernet).
-# REQUIRED when APP_ENV=production. Without it, the storage module
-# falls back to an ephemeral key per container restart, which
-# SILENTLY DESTROYS all previously uploaded draft encryption keys.
-# Generate with:
-#   uv run python -c "from app.storage.encrypted import generate_encryption_key; print(generate_encryption_key())"
-STORAGE_ENCRYPTION_KEY=REPLACE_WITH_GENERATED_FERNET_KEY
+# HTTP Origin/Referer CSRF check. On unless set to one of
+# off/0/false/no/disabled (emergency escape hatch only).
+# CSRF_ORIGIN_CHECK=true
 
-# Absolute directory where encrypted draft files are written.
-# Must be a Coolify persistent volume in production.
-STORAGE_DIR=./storage/drafts
+# =====================================================================
+# Observability
+# =====================================================================
 
-# Absolute directory where generated .docx impact reports are written.
-# Must be a Coolify persistent volume in production.
-EXPORT_DIR=./storage/exports
+# Sentry project DSN. Unset/empty: Sentry stays disabled. Obtain from
+# your Sentry project settings.
+SENTRY_DSN=
 
-# Apache Tika REST endpoint for .docx/.pdf parsing.
+# Short commit hash for Sentry release tagging (set by CI/CD or
+# Dockerfile ARG); falls back to `git rev-parse --short HEAD`, then
+# 'unknown'.
+# GIT_SHA=
+
+# Sentry admin issue-panel access (read-only scope). All three are
+# needed for the in-app issue panel; leave unset to hide it.
+# SENTRY_API_TOKEN=
+# SENTRY_ORG_SLUG=
+# SENTRY_PROJECT_SLUG=
+
+# Days of app-metrics history to keep; 0 disables retention. Quirk
+# (#861): garbage values disable retention (0) rather than falling back
+# to the default.
+# METRICS_RETENTION_DAYS=30
+
+# =====================================================================
+# Documents & storage
+# =====================================================================
+
+# Apache Tika REST endpoint for .docx/.pdf parsing. Unset: stub mode in
+# dev environments, error in production.
 #
 # Deploy apache/tika (:3.3.0.0-full recommended) as a separate Coolify
 # application with network alias `seadusloome-tika` and set this to
 # http://seadusloome-tika:9998 in the Coolify env vars.
 #
 # In local docker-compose dev: the app service's environment: block
-# overrides this to http://tika:9998 (the compose service name), so
-# the value here doesn't matter for compose users.
+# overrides this to http://tika:9998 (the compose service name), so the
+# value here doesn't matter for compose users.
 #
-# In non-compose dev (direct `uv run python -m app.main`): leave
-# unset. TikaClient detects the missing URL and falls back to stub
-# mode, so the upload pipeline still works end-to-end without a
-# running Tika container.
+# In non-compose dev (direct `uv run python -m app.main`): leave unset.
+# TikaClient detects the missing URL and falls back to stub mode, so the
+# upload pipeline still works end-to-end without a running Tika container.
 TIKA_URL=
+
+# Tika request timeout in seconds.
 TIKA_TIMEOUT_SECONDS=60
 
-# Anthropic API key for Claude-powered entity extraction.
-# REQUIRED when APP_ENV=production AND real (non-stub) extraction is
-# expected. Without it, ClaudeProvider returns canned stub responses.
-ANTHROPIC_API_KEY=
+# Ceiling for extracted plaintext accepted from Tika (bytes); values
+# below 1 clamp to 1 (advanced).
+# TIKA_MAX_TEXT_BYTES=20971520
 
-# Model identifier used by ALL LLM-backed features: entity extraction,
-# impact analysis, advisory chat, AND the AI Law Drafter pipeline.
-# There is no separate DRAFTER_MODEL — the drafter calls get_default_provider()
-# which reads this same env var. Override here to switch all features at once.
-CLAUDE_MODEL=claude-sonnet-4-6
-
-# Maximum upload size in megabytes. Defaults to 50.
+# Maximum draft upload size in megabytes; values below 1 clamp to 1.
 MAX_UPLOAD_SIZE_MB=50
 
-# Phase 3A: AI Advisory Chat + AI Law Drafter
-# --------------------------------------------
+# Jaccard similarity threshold for the similar-drafts signal; valid
+# values are clamped to [0, 1] at the call site (advanced).
+# SEADUSLOOME_SIMILARITY_THRESHOLD=0.15
 
-# Maximum number of tokens the chat WebSocket handler will send to the LLM
-# per turn. Increase if long drafting sessions are truncated mid-clause.
-# Defaults to 4096 when unset.
-CHAT_MAX_TOKENS=4096
-
-# Phase 3C: RAG Pipeline + Rate Limiting
-# ----------------------------------------
-
-# Voyage AI API key for multilingual embeddings.
-# Required for RAG-grounded chat responses. Without it, the
-# embedding provider falls back to random stub vectors (dev only).
-VOYAGE_API_KEY=
-
-# Voyage AI model identifier. Default: voyage-multilingual-2
-# Only change if switching to a different Voyage model.
-VOYAGE_MODEL=voyage-multilingual-2
-
-# Voyage AI embedding dimensionality. Default: 1024
-# Must match the model's output dimensions and the pgvector index.
-VOYAGE_DIMENSIONS=1024
-
-# Per-user chat message rate limit (messages per hour). Default 100.
-CHAT_MAX_MESSAGES_PER_HOUR=100
-
-# Per-org monthly LLM cost budget in USD. Default 50.
-ORG_MAX_MONTHLY_COST_USD=50.0
-
-# HMAC secret for the reference-resolver miss-log identifier.
-# REQUIRED when APP_ENV=production — the resolver refuses to start
-# without it because the alternative is leaking pre-publication draft
-# reference text into plain logs. Outside production a dev-only
-# fallback sentinel is used so imports and tests work without setup.
-# See docs/2026-05-18-bugfix-plan.md Wave 2 Step 2 "Add diagnostic
-# logging" for the full rationale (HMAC vs plain SHA-256, rotation
-# cadence, downstream audit log shape).
-# Generate with: openssl rand -hex 32
+# HMAC key for reference-resolver miss-log identifiers. REQUIRED in
+# production — the resolver refuses to start without it because the
+# alternative is leaking pre-publication draft reference text into plain
+# logs. Dev sentinel otherwise. Generate with: openssl rand -hex 32
 RESOLVER_REF_HASH_SECRET=
 
-# Phase 4: TARA SSO (stub — requires Phase 5 implementation)
-# -----------------------------------------------------------
-# Set AUTH_PROVIDER=tara to switch from JWT to TARA SSO.
-# All four vars are required when AUTH_PROVIDER=tara.
+# HMAC key for signed expiring report-download URLs (issue #307).
+# Optional: when unset, falls back to SECRET_KEY so a single rotation
+# rotates both. Generate with: openssl rand -hex 32
+DOWNLOAD_TOKEN_SECRET=
+
+# Directory for generated .docx/.pdf exports. Unset: dev-friendly
+# ./storage/exports outside production. Must be a Coolify persistent
+# volume in production.
+EXPORT_DIR=./storage/exports
+
+# Fernet key(s) for encrypted draft storage, comma-separated for
+# MultiFernet rotation (first encrypts, all decrypt). REQUIRED in
+# production — without it the storage module falls back to an ephemeral
+# per-restart key, which SILENTLY DESTROYS previously uploaded draft
+# encryption keys. Generate with:
+#   uv run python -c "from app.storage.encrypted import generate_encryption_key; print(generate_encryption_key())"
+STORAGE_ENCRYPTION_KEY=REPLACE_WITH_GENERATED_FERNET_KEY
+
+# Directory for encrypted draft files. Unset: ./storage/drafts in dev,
+# /var/seadusloome/drafts in production. Must be a Coolify persistent
+# volume in production.
+STORAGE_DIR=./storage/drafts
+
+# =====================================================================
+# LLM & embeddings
+# =====================================================================
+
+# Anthropic API key for Claude. Unset: ClaudeProvider serves stub
+# responses in dev environments, raises in production.
+ANTHROPIC_API_KEY=
+
+# Model id used by ALL LLM-backed features (extraction, impact analysis,
+# advisory chat, AND the AI Law Drafter pipeline). There is no separate
+# DRAFTER_MODEL — override here to switch every feature at once. Default
+# lives in app.llm.claude.DEFAULT_MODEL.
+CLAUDE_MODEL=claude-sonnet-4-6
+
+# Voyage AI key for embeddings. Unset: deterministic stub vectors in dev
+# environments, raises in production.
+VOYAGE_API_KEY=
+
+# Voyage AI embedding model id. Default lives in
+# app.rag.embedding.DEFAULT_MODEL.
+VOYAGE_MODEL=voyage-multilingual-2
+
+# Embedding dimensionality; must match the model output and the pgvector
+# index.
+VOYAGE_DIMENSIONS=1024
+
+# =====================================================================
+# Chat & cost limits
+# =====================================================================
+
+# Per-user chat message rate limit (messages per hour).
+CHAT_MAX_MESSAGES_PER_HOUR=100
+
+# Per-organisation monthly LLM cost budget in USD.
+ORG_MAX_MONTHLY_COST_USD=50.0
+
+# Auto-generate conversation titles after the first exchange (advanced).
+# CHAT_AUTO_TITLE_ENABLED=true
+
+# Suggest follow-up questions after assistant replies (advanced).
+# CHAT_FOLLOW_UPS_ENABLED=true
+
+# =====================================================================
+# Background jobs
+# =====================================================================
+
+# Orphan-job recovery (reaper) timing. All advanced — non-positive or
+# garbage values fall back to the defaults (app.jobs.worker). The two
+# *_TIMEOUT_S vars default to DEFAULT_REAPER_CLAIMED_TIMEOUT_S /
+# DEFAULT_REAPER_RUNNING_TIMEOUT_S when unset.
+# JOB_REAPER_INTERVAL_S=60.0
+# JOB_REAPER_CLAIMED_TIMEOUT_S=
+# JOB_REAPER_RUNNING_TIMEOUT_S=
+
+# =====================================================================
+# Email
+# =====================================================================
+
+# Postmark server token. Unset: stub provider in dev environments,
+# raises in production.
+POSTMARK_API_TOKEN=
+
+# Sender address for outgoing mail. Default: "Seadusloome
+# <noreply@sixtyfour.ee>" (app.email.service).
+# EMAIL_FROM=Seadusloome <noreply@sixtyfour.ee>
+
+# =====================================================================
+# Auth provider — Phase 4 TARA SSO (stub — requires Phase 5)
+# =====================================================================
+#
+# NOT read by the app yet (app/auth/tara_provider.py is a documented
+# stub). Set AUTH_PROVIDER=tara to switch from JWT to TARA SSO once
+# implemented; all four TARA_* vars become required then.
 AUTH_PROVIDER=jwt
 TARA_CLIENT_ID=
 TARA_CLIENT_SECRET=
 TARA_REDIRECT_URI=https://seadusloome.sixtyfour.ee/auth/callback
 TARA_ISSUER_URL=https://tara.ria.ee
-
-# TEST-ONLY flag — NEVER set this in production.
-# pytest/conftest.py sets it to "1" at import time to suppress the
-# lifespan background worker during test runs. In Coolify this var
-# MUST NOT be set or uploads will silently stay in status='uploaded'
-# forever.
-# DISABLE_BACKGROUND_WORKER=

--- a/app/admin/cost_dashboard.py
+++ b/app/admin/cost_dashboard.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 import csv
 import io
 import logging
-import os
 from datetime import UTC, datetime
 
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
 from starlette.responses import Response
 
+from app import config
 from app.db import get_connection as _connect
 from app.ui.data.data_table import Column, DataTable
 from app.ui.layout import PageShell
@@ -159,7 +159,7 @@ def _get_cost_by_org(window: str = _DEFAULT_WINDOW, org_id: str | None = None) -
 
     When *org_id* is given the result is restricted to that single org.
     """
-    max_cost = float(os.environ.get("ORG_MAX_MONTHLY_COST_USD", "50.0"))
+    max_cost = config.env_float("ORG_MAX_MONTHLY_COST_USD")
     start = _window_start(window)
     params: list = [start]
     where_clause = ""

--- a/app/admin/rate_limits.py
+++ b/app/admin/rate_limits.py
@@ -6,6 +6,7 @@ import logging
 
 from fasthtml.common import *  # noqa: F403
 
+from app import config
 from app.admin._shared import _tooltip
 from app.db import get_connection as _connect
 from app.ui.data.data_table import Column, DataTable
@@ -18,10 +19,8 @@ logger = logging.getLogger(__name__)
 
 def _get_rate_limit_stats() -> dict:  # type: ignore[type-arg]
     """Return per-org cost vs budget and top-user message rates for the admin card."""
-    import os
-
-    max_cost = float(os.environ.get("ORG_MAX_MONTHLY_COST_USD", "50.0"))
-    max_msgs = int(os.environ.get("CHAT_MAX_MESSAGES_PER_HOUR", "100"))
+    max_cost = config.env_float("ORG_MAX_MONTHLY_COST_USD")
+    max_msgs = config.env_int("CHAT_MAX_MESSAGES_PER_HOUR")
 
     stats: dict = {  # type: ignore[type-arg]
         "max_monthly_cost_usd": max_cost,

--- a/app/admin/sentry_panel.py
+++ b/app/admin/sentry_panel.py
@@ -25,13 +25,13 @@ Design notes:
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 import httpx
 from fasthtml.common import *  # noqa: F403
 from starlette.requests import Request
 
+from app import config
 from app.admin._shared import _tooltip
 from app.ui.data.data_table import Column, DataTable
 from app.ui.layout import PageShell
@@ -53,9 +53,9 @@ def _sentry_env() -> tuple[str, str, str] | None:
     not-configured branch with ``monkeypatch.delenv`` and keeps the
     token-vs-slug distinction local to this module.
     """
-    token = os.environ.get("SENTRY_API_TOKEN")
-    org = os.environ.get("SENTRY_ORG_SLUG")
-    project = os.environ.get("SENTRY_PROJECT_SLUG")
+    token = config.env_str("SENTRY_API_TOKEN")
+    org = config.env_str("SENTRY_ORG_SLUG")
+    project = config.env_str("SENTRY_PROJECT_SLUG")
     if not (token and org and project):
         return None
     return token, org, project

--- a/app/auth/cookies.py
+++ b/app/auth/cookies.py
@@ -6,11 +6,11 @@ defaults to ``True`` (production) and can be overridden via the
 ``COOKIE_SECURE`` environment variable for local development.
 """
 
-import os
-
 from starlette.responses import Response
 
-COOKIE_SECURE = os.environ.get("COOKIE_SECURE", "true").lower() == "true"
+from app import config
+
+COOKIE_SECURE = config.env_bool("COOKIE_SECURE")
 
 
 def set_auth_cookie(response: Response, key: str, value: str, max_age: int) -> None:

--- a/app/auth/jwt_provider.py
+++ b/app/auth/jwt_provider.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -12,6 +11,7 @@ import bcrypt
 import jwt
 import psycopg
 
+from app import config
 from app.auth.provider import AuthProvider, UserDict
 from app.db import get_connection
 
@@ -36,7 +36,7 @@ def _load_secret_key() -> str:
     happens on a laptop or in Coolify, and dev already has the (long)
     :data:`_DEV_SECRET_KEY` fallback when the variable is simply unset.
     """
-    value = os.environ.get("SECRET_KEY")
+    value = config.env_str("SECRET_KEY")
     if value:
         if len(value.encode("utf-8")) < MIN_SECRET_KEY_BYTES:
             raise RuntimeError(
@@ -47,7 +47,7 @@ def _load_secret_key() -> str:
                 "it in the environment."
             )
         return value
-    if os.environ.get("APP_ENV", "development") == "development":
+    if config.get_app_env() == "development":
         return _DEV_SECRET_KEY
     raise RuntimeError("SECRET_KEY must be set in non-development environments")
 

--- a/app/auth/perimeter.py
+++ b/app/auth/perimeter.py
@@ -50,7 +50,6 @@ checks for emergencies (default: enforced).
 from __future__ import annotations
 
 import logging
-import os
 import re
 from typing import Any
 from urllib.parse import urlsplit
@@ -59,6 +58,7 @@ from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
+from app import config
 from app.auth.middleware import _TOKEN_BEARER_PATHS
 
 logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ def get_trusted_proxy_hosts() -> list[str]:
     the bad value visible. Globs are not supported by uvicorn anyway —
     any non-``*`` wildcard entry would silently never match.
     """
-    raw = os.environ.get("TRUSTED_PROXY_HOSTS", "").strip()
+    raw = config.env_str("TRUSTED_PROXY_HOSTS", "").strip()
     if not raw:
         return list(DEFAULT_TRUSTED_PROXY_HOSTS)
     hosts = [item.strip() for item in raw.split(",") if item.strip()]
@@ -186,8 +186,7 @@ def is_origin_check_enabled() -> bool:
     Read per-request so a container restart is not required to flip it
     in tests; the cost is one env lookup.
     """
-    raw = os.environ.get("CSRF_ORIGIN_CHECK", "").strip().lower()
-    return raw not in {"off", "0", "false", "no", "disabled"}
+    return config.env_bool("CSRF_ORIGIN_CHECK")
 
 
 def _origin_of_url(url: str) -> str | None:
@@ -231,7 +230,7 @@ def allowed_origins(scope: dict[str, Any]) -> set[str]:
     own = _request_own_origin(scope)
     if own:
         allowed.add(own)
-    base = os.environ.get("APP_BASE_URL", "").strip()
+    base = config.env_str("APP_BASE_URL", "").strip()
     if base:
         base_origin = _origin_of_url(base)
         if base_origin:

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import os
 
 from fasthtml.common import *
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
+from app import config
 from app.auth import throttle
 from app.auth.audit import log_action
 from app.auth.cookies import clear_auth_cookie, set_auth_cookie
@@ -289,7 +289,7 @@ def forgot_post(req: Request, email: str):
             user_id, full_name = row
             raw = issue_reset_token(user_id=user_id, created_by=None, conn=conn)
             conn.commit()
-            base = os.environ.get("APP_BASE_URL", "http://localhost:8000").rstrip("/")
+            base = config.env_str("APP_BASE_URL", "http://localhost:8000").rstrip("/")
             reset_url = f"{base}/auth/reset/{raw}"
             subject, html, text = password_reset(full_name=full_name, reset_url=reset_url)
             try:

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import secrets
 import threading
 import time
@@ -13,6 +12,7 @@ from fasthtml.common import to_xml
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
 
+from app import config
 from app.auth.audit import log_action
 from app.auth.organizations import list_orgs
 from app.auth.password import (
@@ -955,7 +955,7 @@ def _admin_reset_email(req: Request, user_id: str, *, base_path: str, active_nav
         raw = issue_reset_token(user_id=user_id, created_by=auth.get("id"), conn=conn)
         conn.commit()
 
-    base = os.environ.get("APP_BASE_URL", "http://localhost:8000").rstrip("/")
+    base = config.env_str("APP_BASE_URL", "http://localhost:8000").rstrip("/")
     reset_url = f"{base}/auth/reset/{raw}"
     subject, html, text = password_reset_admin(
         full_name=user["full_name"],

--- a/app/chat/orchestrator.py
+++ b/app/chat/orchestrator.py
@@ -47,7 +47,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -55,6 +54,7 @@ from contextlib import aclosing
 from dataclasses import dataclass, field
 from typing import Any
 
+from app import config
 from app.auth.policy import can_access_conversation
 from app.chat.models import (
     Conversation,
@@ -195,10 +195,7 @@ def _is_follow_ups_enabled() -> bool:
     unset. Any truthy value (``"1"``, ``"true"``, ``"yes"``, ``"on"``)
     enables the feature; anything else disables it.
     """
-    raw = os.environ.get("CHAT_FOLLOW_UPS_ENABLED")
-    if raw is None:
-        return True
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return config.env_bool("CHAT_FOLLOW_UPS_ENABLED")
 
 
 # ---------------------------------------------------------------------------

--- a/app/chat/rate_limiter.py
+++ b/app/chat/rate_limiter.py
@@ -24,12 +24,12 @@ frontend can display quota headroom and retry timers.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from app import config
 from app.db import get_connection
 
 if TYPE_CHECKING:
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 # Backward-compatible aliases for tests that import these names.
 # The actual check functions re-read from the environment each call so
 # that config changes take effect without a process restart.
-_MAX_MESSAGES_PER_HOUR = int(os.environ.get("CHAT_MAX_MESSAGES_PER_HOUR", "100"))
-_MAX_MONTHLY_COST_USD = float(os.environ.get("ORG_MAX_MONTHLY_COST_USD", "50.0"))
+_MAX_MESSAGES_PER_HOUR = config.env_int("CHAT_MAX_MESSAGES_PER_HOUR")
+_MAX_MONTHLY_COST_USD = config.env_float("ORG_MAX_MONTHLY_COST_USD")
 
 # Alert when cost usage crosses this fraction of the monthly cap.
 _COST_ALERT_FRACTION = 0.8
@@ -49,12 +49,12 @@ _COST_ALERT_FRACTION = 0.8
 
 def _get_max_messages_per_hour() -> int:
     """Read the rate limit from the environment on each call."""
-    return int(os.environ.get("CHAT_MAX_MESSAGES_PER_HOUR", "100"))
+    return config.env_int("CHAT_MAX_MESSAGES_PER_HOUR")
 
 
 def _get_max_monthly_cost_usd() -> float:
     """Read the cost cap from the environment on each call."""
-    return float(os.environ.get("ORG_MAX_MONTHLY_COST_USD", "50.0"))
+    return config.env_float("ORG_MAX_MONTHLY_COST_USD")
 
 
 class RateLimitExceededError(Exception):

--- a/app/config.py
+++ b/app/config.py
@@ -614,7 +614,7 @@ ENV_REGISTRY: tuple[EnvSetting, ...] = (
         "float",
         None,
         "Age after which a 'claimed' job is returned to the queue. "
-        "Default: app.jobs.worker.DEFAULT_REAPER_CLAIMED_TIMEOUT_S.",
+        "Default: DEFAULT_REAPER_CLAIMED_TIMEOUT_S (app/jobs/queue.py).",
         section="Background jobs",
         parse="site",
     ),
@@ -623,7 +623,7 @@ ENV_REGISTRY: tuple[EnvSetting, ...] = (
         "float",
         None,
         "Age after which a 'running' job is presumed orphaned and retried. "
-        "Default: app.jobs.worker.DEFAULT_REAPER_RUNNING_TIMEOUT_S.",
+        "Default: DEFAULT_REAPER_RUNNING_TIMEOUT_S (app/jobs/queue.py).",
         section="Background jobs",
         parse="site",
     ),
@@ -702,9 +702,13 @@ def env_str(name: str, default: str | None = None) -> str | None:
     Returns the value verbatim — no strip/normalization (secrets are key
     material). The *default* is supplied by the call site so string vars
     keep their historical per-site defaults exactly.
+
+    ``parse="site"`` entries of any kind are also readable here — that is
+    the documented escape hatch for module-local parsers (their kind/
+    default declarations stay purely descriptive).
     """
     setting = _setting(name)
-    if setting.kind != "str":
+    if setting.kind != "str" and setting.parse != "site":
         raise TypeError(f"{name} is declared kind={setting.kind!r}; use env_{setting.kind}()")
     return os.environ.get(name, default)
 

--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
+from typing import overload
 
 logger = logging.getLogger(__name__)
 
@@ -108,10 +110,7 @@ def is_chat_auto_title_enabled() -> bool:
     (``"1"``, ``"true"``, ``"yes"``, ``"on"``, case-insensitive)
     enables the feature. Defaults to True when unset.
     """
-    raw = os.environ.get("CHAT_AUTO_TITLE_ENABLED")
-    if raw is None:
-        return True
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
+    return env_bool("CHAT_AUTO_TITLE_ENABLED")
 
 
 # ---------------------------------------------------------------------------
@@ -153,3 +152,646 @@ def get_worker_mode() -> str:
             f"WORKER_MODE={raw!r} is invalid; expected one of {sorted(_VALID_WORKER_MODES)}"
         )
     return raw
+
+
+# ---------------------------------------------------------------------------
+# Typed settings registry (#897)
+# ---------------------------------------------------------------------------
+#
+# Every environment variable the application reads is declared here with its
+# type, documented default, and a one-line description. ``app/`` modules
+# outside this file MUST NOT read ``os.environ`` directly (pinned by
+# ``tests/test_settings_registry.py``); they call the typed getters instead:
+#
+#     from app import config
+#
+#     pool_max = config.env_int("DB_POOL_MAX")
+#     tika_url = config.env_str("TIKA_URL")
+#
+# Design rules:
+#
+# - **Call-time reads.** Getters read ``os.environ`` on every call (no
+#   import-time snapshot), so ``monkeypatch.setenv`` in tests and Coolify
+#   env edits behave exactly as before. Modules that intentionally read a
+#   value once at import time (``app.db`` pool sizing,
+#   ``app.auth.jwt_provider.SECRET_KEY``, ``app.sync.webhook.WEBHOOK_SECRET``)
+#   keep that timing — they just source the string from here.
+# - **No hidden normalization.** ``env_str`` returns the value exactly like
+#   ``os.environ.get`` — no ``strip()``/``lower()`` — because several values
+#   (SECRET_KEY, webhook and token secrets) are key material in which
+#   whitespace is significant. Call sites keep their own ``strip()`` /
+#   ``rstrip()`` behaviour.
+# - **Domain logic stays in the owning module.** Stub fallbacks,
+#   raise-in-production gates, fallback chains (DOWNLOAD_TOKEN_SECRET →
+#   SECRET_KEY), and bespoke clamps live next to the feature they protect;
+#   this module owns *declaration + typed parsing* only.
+# - ``parse="site"`` entries are declared for inventory/docs purposes but
+#   keep a module-local parser whose semantics are too quirky to generalize
+#   (e.g. ``METRICS_RETENTION_DAYS`` falls back to 0 — retention *disabled*
+#   — on garbage, not to its default). Those sites read the raw string via
+#   ``env_str`` and parse locally; ``env_int``/``env_float`` refuse such
+#   names so the quirk cannot be flattened by accident.
+
+
+@dataclass(frozen=True)
+class EnvSetting:
+    """Declaration of one environment variable consumed by the app.
+
+    ``default`` is the *documented* default. For ``int``/``float``/``bool``
+    entries it is also enforced by the typed getters; for ``str`` entries
+    the call site supplies it (several string vars carry different defaults
+    at different call sites — e.g. ``APP_BASE_URL``), and for
+    ``parse="site"`` entries the owning module applies it locally.
+    """
+
+    name: str
+    kind: str  # "str" | "int" | "float" | "bool"
+    default: str | int | float | bool | None
+    description: str
+    secret: bool = False
+    section: str = "App"
+    # int/float parsing: "strict" (ValueError propagates — config typos
+    # crash at first read, matching the historical int()/float() call
+    # sites), "lenient" (warn + default), or "site" (module-local parser).
+    parse: str = "strict"
+    # Lenient parses only: clamp floor applied to *valid* values.
+    minimum: int | float | None = None
+    # bool parsing: "truthy"       — {"1","true","yes","on"}, default when unset
+    #               "true-literal" — value.lower() == "true", default when unset
+    #               "one-literal"  — value == "1" exactly (unset → False)
+    #               "off-set"      — NOT in {"off","0","false","no","disabled"}
+    bool_style: str = "truthy"
+
+
+_MIB = 1024 * 1024
+
+ENV_REGISTRY: tuple[EnvSetting, ...] = (
+    # --- PostgreSQL --------------------------------------------------------
+    EnvSetting(
+        "DATABASE_URL",
+        "str",
+        None,
+        "Postgres DSN. Unset: app.db falls back to the localhost dev DSN in "
+        "development and raises in any other environment.",
+        secret=True,
+        section="PostgreSQL",
+    ),
+    EnvSetting(
+        "DB_POOL_MIN",
+        "int",
+        1,
+        "Connection-pool floor (app.db clamps to >= 0 at import).",
+        section="PostgreSQL",
+    ),
+    EnvSetting(
+        "DB_POOL_MAX",
+        "int",
+        10,
+        "Connection-pool ceiling (app.db clamps to >= 1 at import).",
+        section="PostgreSQL",
+    ),
+    EnvSetting(
+        "DB_POOL_TIMEOUT",
+        "float",
+        2.0,
+        "Seconds to wait for a free pooled connection before failing.",
+        section="PostgreSQL",
+    ),
+    EnvSetting(
+        "DB_CONNECT_TIMEOUT",
+        "int",
+        5,
+        "TCP connect timeout (seconds) for new Postgres connections.",
+        section="PostgreSQL",
+    ),
+    EnvSetting(
+        "DB_BREAKER_COOLDOWN",
+        "float",
+        2.0,
+        "Circuit-breaker cooldown (seconds) after pool exhaustion.",
+        section="PostgreSQL",
+    ),
+    # --- Jena Fuseki --------------------------------------------------------
+    EnvSetting(
+        "JENA_URL",
+        "str",
+        "http://localhost:3030",
+        "Base URL of the Apache Jena Fuseki triplestore.",
+        section="Jena Fuseki",
+    ),
+    EnvSetting(
+        "JENA_DATASET",
+        "str",
+        "ontology",
+        "Fuseki dataset name queried by the app and loaded by the sync.",
+        section="Jena Fuseki",
+    ),
+    EnvSetting(
+        "FUSEKI_ADMIN_PASSWORD",
+        "str",
+        None,
+        "Fuseki admin credential for sync graph management. Unset: dev-only "
+        "fallback inside app.sync (fails closed outside development).",
+        secret=True,
+        section="Jena Fuseki",
+    ),
+    # --- Ontology sync ------------------------------------------------------
+    EnvSetting(
+        "GITHUB_WEBHOOK_SECRET",
+        "str",
+        "",
+        "HMAC secret for GitHub push-webhook signature verification. "
+        "Empty: signature verification is skipped (dev only).",
+        secret=True,
+        section="Ontology sync",
+    ),
+    EnvSetting(
+        "SYNC_MIN_TRIPLES",
+        "int",
+        1_000_000,
+        "Absolute minimum triple count for post-sync verification; "
+        "negative values clamp to 0, garbage falls back to the default.",
+        section="Ontology sync",
+        parse="lenient",
+        minimum=0,
+    ),
+    # --- App ----------------------------------------------------------------
+    EnvSetting(
+        "APP_ENV",
+        "str",
+        "development",
+        "Deployment environment (development | test | ci | staging | "
+        "production). Read via config.get_app_env(); drives the fail-closed "
+        "stub gate config.is_stub_allowed().",
+        section="App",
+        parse="site",
+    ),
+    EnvSetting(
+        "WORKER_MODE",
+        "str",
+        "inproc",
+        "Background-job worker mode (inproc | standalone). Read via "
+        "config.get_worker_mode(); unknown values raise at startup.",
+        section="App",
+        parse="site",
+    ),
+    EnvSetting(
+        "DISABLE_BACKGROUND_WORKER",
+        "bool",
+        False,
+        'TEST-ONLY: literal "1" suppresses the lifespan background worker. '
+        "Never set in production or uploads stay status='uploaded' forever.",
+        section="App",
+        bool_style="one-literal",
+    ),
+    EnvSetting(
+        "APP_BASE_URL",
+        "str",
+        None,
+        "Public base URL of the deployment. Used for password-reset links "
+        "(default http://localhost:8000 there) and the CSRF origin "
+        "allowlist (no default there — own-origin only).",
+        section="App",
+    ),
+    # --- Auth & cookies -----------------------------------------------------
+    EnvSetting(
+        "SECRET_KEY",
+        "str",
+        None,
+        "JWT signing secret (HS256, >= 32 UTF-8 bytes). Unset: dev fallback "
+        "in development, refused elsewhere. Whitespace is significant — "
+        "never normalized.",
+        secret=True,
+        section="Auth & cookies",
+    ),
+    EnvSetting(
+        "COOKIE_SECURE",
+        "bool",
+        True,
+        'Secure flag on auth cookies. Only the literal "true" '
+        "(case-insensitive) enables it when set; defaults to true when "
+        "unset. NB: COOKIE_SECURE=1 disables it.",
+        section="Auth & cookies",
+        bool_style="true-literal",
+    ),
+    EnvSetting(
+        "TRUSTED_PROXY_HOSTS",
+        "str",
+        "",
+        "Comma-separated proxy hosts trusted for X-Forwarded-* parsing. "
+        "Empty: built-in Traefik/Coolify defaults. Wildcards are refused "
+        "(app.auth.perimeter).",
+        section="Auth & cookies",
+    ),
+    EnvSetting(
+        "CSRF_ORIGIN_CHECK",
+        "bool",
+        True,
+        "HTTP Origin/Referer CSRF check. On unless set to one of "
+        "off/0/false/no/disabled (emergency escape hatch only).",
+        section="Auth & cookies",
+        bool_style="off-set",
+    ),
+    # --- Observability ------------------------------------------------------
+    EnvSetting(
+        "SENTRY_DSN",
+        "str",
+        None,
+        "Sentry project DSN. Unset/empty: Sentry stays disabled.",
+        secret=True,
+        section="Observability",
+    ),
+    EnvSetting(
+        "GIT_SHA",
+        "str",
+        None,
+        "Short commit hash for Sentry release tagging (set by CI/CD); "
+        "falls back to `git rev-parse --short HEAD`, then 'unknown'.",
+        section="Observability",
+    ),
+    EnvSetting(
+        "SENTRY_API_TOKEN",
+        "str",
+        None,
+        "Sentry API token for the admin issue panel (read-only scope).",
+        secret=True,
+        section="Observability",
+    ),
+    EnvSetting(
+        "SENTRY_ORG_SLUG",
+        "str",
+        None,
+        "Sentry organisation slug for the admin issue panel.",
+        section="Observability",
+    ),
+    EnvSetting(
+        "SENTRY_PROJECT_SLUG",
+        "str",
+        None,
+        "Sentry project slug for the admin issue panel.",
+        section="Observability",
+    ),
+    EnvSetting(
+        "METRICS_RETENTION_DAYS",
+        "int",
+        30,
+        "Days of app-metrics history to keep; 0 disables retention. "
+        "Quirk preserved from #861: garbage values disable retention (0) "
+        "rather than falling back to the default.",
+        section="Observability",
+        parse="site",
+    ),
+    # --- Documents & storage ------------------------------------------------
+    EnvSetting(
+        "TIKA_URL",
+        "str",
+        None,
+        "Apache Tika REST endpoint for .docx/.pdf parsing. Unset: stub "
+        "mode in dev environments, error in production.",
+        section="Documents & storage",
+    ),
+    EnvSetting(
+        "TIKA_TIMEOUT_SECONDS",
+        "float",
+        60.0,
+        "Tika request timeout in seconds.",
+        section="Documents & storage",
+        parse="lenient",
+    ),
+    EnvSetting(
+        "TIKA_MAX_TEXT_BYTES",
+        "int",
+        20 * _MIB,
+        "Ceiling for extracted plaintext accepted from Tika (bytes); values below 1 clamp to 1.",
+        section="Documents & storage",
+        parse="lenient",
+        minimum=1,
+    ),
+    EnvSetting(
+        "MAX_UPLOAD_SIZE_MB",
+        "int",
+        50,
+        "Maximum draft upload size in megabytes; values below 1 clamp to 1.",
+        section="Documents & storage",
+        parse="lenient",
+        minimum=1,
+    ),
+    EnvSetting(
+        "SEADUSLOOME_SIMILARITY_THRESHOLD",
+        "float",
+        0.15,
+        "Jaccard similarity threshold for the similar-drafts signal; "
+        "valid values are clamped to [0, 1] at the call site.",
+        section="Documents & storage",
+        parse="lenient",
+    ),
+    EnvSetting(
+        "RESOLVER_REF_HASH_SECRET",
+        "str",
+        None,
+        "HMAC key for reference-resolver miss-log identifiers. Required in "
+        "production; dev sentinel otherwise (app.docs.reference_resolver).",
+        secret=True,
+        section="Documents & storage",
+    ),
+    EnvSetting(
+        "DOWNLOAD_TOKEN_SECRET",
+        "str",
+        None,
+        "HMAC key for signed expiring report-download URLs. Unset: falls "
+        "back to SECRET_KEY so one rotation rotates both.",
+        secret=True,
+        section="Documents & storage",
+    ),
+    EnvSetting(
+        "EXPORT_DIR",
+        "str",
+        None,
+        "Directory for generated .docx/.pdf exports. Unset: dev-friendly "
+        "./storage/exports outside production (app.docs.docx_export).",
+        section="Documents & storage",
+    ),
+    EnvSetting(
+        "STORAGE_ENCRYPTION_KEY",
+        "str",
+        None,
+        "Fernet key(s) for encrypted draft storage, comma-separated for "
+        "MultiFernet rotation (first encrypts, all decrypt). Required in "
+        "production.",
+        secret=True,
+        section="Documents & storage",
+    ),
+    EnvSetting(
+        "STORAGE_DIR",
+        "str",
+        None,
+        "Directory for encrypted draft files. Unset: ./storage/drafts in "
+        "dev environments, /var/seadusloome/drafts in production.",
+        section="Documents & storage",
+    ),
+    # --- LLM & embeddings ---------------------------------------------------
+    EnvSetting(
+        "ANTHROPIC_API_KEY",
+        "str",
+        None,
+        "Anthropic API key for Claude. Unset: ClaudeProvider serves stub "
+        "responses in dev environments, raises in production.",
+        secret=True,
+        section="LLM & embeddings",
+    ),
+    EnvSetting(
+        "CLAUDE_MODEL",
+        "str",
+        "claude-sonnet-4-6",
+        "Model id used by ALL LLM-backed features (extraction, impact, "
+        "chat, drafter). Default lives in app.llm.claude.DEFAULT_MODEL.",
+        section="LLM & embeddings",
+    ),
+    EnvSetting(
+        "VOYAGE_API_KEY",
+        "str",
+        None,
+        "Voyage AI key for embeddings. Unset: deterministic stub vectors "
+        "in dev environments, raises in production.",
+        secret=True,
+        section="LLM & embeddings",
+    ),
+    EnvSetting(
+        "VOYAGE_MODEL",
+        "str",
+        "voyage-multilingual-2",
+        "Voyage AI embedding model id. Default lives in app.rag.embedding.DEFAULT_MODEL.",
+        section="LLM & embeddings",
+    ),
+    EnvSetting(
+        "VOYAGE_DIMENSIONS",
+        "int",
+        1024,
+        "Embedding dimensionality; must match the model output and the pgvector index.",
+        section="LLM & embeddings",
+    ),
+    # --- Chat & cost limits -------------------------------------------------
+    EnvSetting(
+        "CHAT_MAX_MESSAGES_PER_HOUR",
+        "int",
+        100,
+        "Per-user chat message rate limit (messages per hour).",
+        section="Chat & cost limits",
+    ),
+    EnvSetting(
+        "ORG_MAX_MONTHLY_COST_USD",
+        "float",
+        50.0,
+        "Per-organisation monthly LLM cost budget in USD.",
+        section="Chat & cost limits",
+    ),
+    EnvSetting(
+        "CHAT_AUTO_TITLE_ENABLED",
+        "bool",
+        True,
+        "Auto-generate conversation titles after the first exchange.",
+        section="Chat & cost limits",
+    ),
+    EnvSetting(
+        "CHAT_FOLLOW_UPS_ENABLED",
+        "bool",
+        True,
+        "Suggest follow-up questions after assistant replies.",
+        section="Chat & cost limits",
+    ),
+    # --- Background jobs ----------------------------------------------------
+    EnvSetting(
+        "JOB_REAPER_INTERVAL_S",
+        "float",
+        60.0,
+        "Seconds between orphan-job recovery passes. Non-positive or "
+        "garbage values fall back to the default (app.jobs.worker).",
+        section="Background jobs",
+        parse="site",
+    ),
+    EnvSetting(
+        "JOB_REAPER_CLAIMED_TIMEOUT_S",
+        "float",
+        None,
+        "Age after which a 'claimed' job is returned to the queue. "
+        "Default: app.jobs.worker.DEFAULT_REAPER_CLAIMED_TIMEOUT_S.",
+        section="Background jobs",
+        parse="site",
+    ),
+    EnvSetting(
+        "JOB_REAPER_RUNNING_TIMEOUT_S",
+        "float",
+        None,
+        "Age after which a 'running' job is presumed orphaned and retried. "
+        "Default: app.jobs.worker.DEFAULT_REAPER_RUNNING_TIMEOUT_S.",
+        section="Background jobs",
+        parse="site",
+    ),
+    # --- Email --------------------------------------------------------------
+    EnvSetting(
+        "POSTMARK_API_TOKEN",
+        "str",
+        None,
+        "Postmark server token. Unset: stub provider in dev environments, raises in production.",
+        secret=True,
+        section="Email",
+    ),
+    EnvSetting(
+        "EMAIL_FROM",
+        "str",
+        None,
+        'Sender address for outgoing mail. Default: "Seadusloome '
+        '<noreply@sixtyfour.ee>" (app.email.service).',
+        section="Email",
+    ),
+)
+
+_SETTINGS_BY_NAME: dict[str, EnvSetting] = {s.name: s for s in ENV_REGISTRY}
+
+_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+_OFF_VALUES = frozenset({"off", "0", "false", "no", "disabled"})
+
+_VALID_KINDS = frozenset({"str", "int", "float", "bool"})
+_VALID_PARSES = frozenset({"strict", "lenient", "site"})
+_VALID_BOOL_STYLES = frozenset({"truthy", "true-literal", "one-literal", "off-set"})
+
+
+def _validate_registry() -> None:
+    """Fail fast at import on malformed registry entries (incl. dupes)."""
+    if len(_SETTINGS_BY_NAME) != len(ENV_REGISTRY):
+        raise RuntimeError("ENV_REGISTRY contains duplicate variable names")
+    for s in ENV_REGISTRY:
+        if s.kind not in _VALID_KINDS:
+            raise RuntimeError(f"{s.name}: unknown kind {s.kind!r}")
+        if s.parse not in _VALID_PARSES:
+            raise RuntimeError(f"{s.name}: unknown parse {s.parse!r}")
+        if s.bool_style not in _VALID_BOOL_STYLES:
+            raise RuntimeError(f"{s.name}: unknown bool_style {s.bool_style!r}")
+        if s.kind == "int" and s.parse != "site" and not isinstance(s.default, int):
+            raise RuntimeError(f"{s.name}: int entries need an int default")
+        if s.kind == "float" and s.parse != "site" and not isinstance(s.default, (int, float)):
+            raise RuntimeError(f"{s.name}: float entries need a numeric default")
+        if s.kind == "bool" and not isinstance(s.default, bool):
+            raise RuntimeError(f"{s.name}: bool entries need a bool default")
+        if s.minimum is not None and s.parse != "lenient":
+            raise RuntimeError(f"{s.name}: minimum is only valid with parse='lenient'")
+
+
+_validate_registry()
+
+
+def _setting(name: str) -> EnvSetting:
+    try:
+        return _SETTINGS_BY_NAME[name]
+    except KeyError:
+        raise KeyError(
+            f"{name!r} is not declared in app.config.ENV_REGISTRY; "
+            "declare it there before reading it."
+        ) from None
+
+
+@overload
+def env_str(name: str) -> str | None: ...
+@overload
+def env_str(name: str, default: str) -> str: ...
+
+
+def env_str(name: str, default: str | None = None) -> str | None:
+    """``os.environ.get(name, default)`` with registry validation.
+
+    Returns the value verbatim — no strip/normalization (secrets are key
+    material). The *default* is supplied by the call site so string vars
+    keep their historical per-site defaults exactly.
+    """
+    setting = _setting(name)
+    if setting.kind != "str":
+        raise TypeError(f"{name} is declared kind={setting.kind!r}; use env_{setting.kind}()")
+    return os.environ.get(name, default)
+
+
+def env_int(name: str) -> int:
+    """Registry-typed int read; default and parse mode come from the registry.
+
+    ``parse="strict"`` lets ValueError propagate (matching historical
+    ``int(os.environ.get(...))`` call sites); ``parse="lenient"`` warns and
+    returns the default, clamping valid values to ``minimum`` when declared.
+    """
+    setting = _setting(name)
+    if setting.kind != "int":
+        raise TypeError(f"{name} is declared kind={setting.kind!r}; use env_{setting.kind}()")
+    if setting.parse == "site":
+        raise TypeError(
+            f"{name} is parsed by its owning module (parse='site'); read the raw "
+            "string via env_str() there instead."
+        )
+    default = setting.default
+    assert isinstance(default, int)
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        if setting.parse == "lenient":
+            logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+            return default
+        raise
+    if setting.minimum is not None and value < setting.minimum:
+        return int(setting.minimum)
+    return value
+
+
+def env_float(name: str) -> float:
+    """Registry-typed float read; same strict/lenient contract as env_int."""
+    setting = _setting(name)
+    if setting.kind != "float":
+        raise TypeError(f"{name} is declared kind={setting.kind!r}; use env_{setting.kind}()")
+    if setting.parse == "site":
+        raise TypeError(
+            f"{name} is parsed by its owning module (parse='site'); read the raw "
+            "string via env_str() there instead."
+        )
+    default = setting.default
+    assert isinstance(default, (int, float))
+    raw = os.environ.get(name)
+    if raw is None:
+        return float(default)
+    try:
+        value = float(raw)
+    except ValueError:
+        if setting.parse == "lenient":
+            logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+            return float(default)
+        raise
+    if setting.minimum is not None and value < setting.minimum:
+        return float(setting.minimum)
+    return value
+
+
+def env_bool(name: str) -> bool:
+    """Registry-typed bool read; the parse style comes from the registry.
+
+    Styles (declared per-entry, preserving each site's historical
+    semantics): ``truthy`` — member of {1,true,yes,on} case-insensitively,
+    registry default when unset; ``true-literal`` — exactly "true"
+    case-insensitively (NB ``COOKIE_SECURE=1`` is *false*); ``one-literal``
+    — exactly "1" (unset → False); ``off-set`` — true unless a member of
+    {off,0,false,no,disabled}.
+    """
+    setting = _setting(name)
+    if setting.kind != "bool":
+        raise TypeError(f"{name} is declared kind={setting.kind!r}; use env_{setting.kind}()")
+    raw = os.environ.get(name)
+    style = setting.bool_style
+    if style == "truthy":
+        if raw is None:
+            return bool(setting.default)
+        return raw.strip().lower() in _TRUTHY_VALUES
+    if style == "true-literal":
+        if raw is None:
+            return bool(setting.default)
+        return raw.lower() == "true"
+    if style == "one-literal":
+        return raw == "1"
+    # "off-set" — validated at import, nothing else can reach here.
+    return (raw or "").strip().lower() not in _OFF_VALUES

--- a/app/db.py
+++ b/app/db.py
@@ -26,12 +26,13 @@ bare form.
 from __future__ import annotations
 
 import atexit
-import os
 import threading
 import time
 from typing import TYPE_CHECKING, Any
 
 import psycopg
+
+from app import config
 
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
@@ -43,10 +44,10 @@ _DEV_DATABASE_URL = "postgresql://seadusloome:localdev@localhost:5432/seadusloom
 
 def _load_database_url() -> str:
     """Return the DATABASE_URL, enforcing an explicit value off-dev."""
-    value = os.environ.get("DATABASE_URL")
+    value = config.env_str("DATABASE_URL")
     if value:
         return value
-    if os.environ.get("APP_ENV", "development") == "development":
+    if config.get_app_env() == "development":
         return _DEV_DATABASE_URL
     raise RuntimeError("DATABASE_URL must be set in non-development environments")
 
@@ -70,8 +71,8 @@ DATABASE_URL = _load_database_url()
 # under Postgres' default ``max_connections`` while collapsing the
 # connection-per-query storm that motivated this change. Override with
 # ``DB_POOL_MIN`` / ``DB_POOL_MAX`` per deployment.
-_POOL_MIN = max(0, int(os.environ.get("DB_POOL_MIN", "1")))
-_POOL_MAX = max(1, int(os.environ.get("DB_POOL_MAX", "10")))
+_POOL_MIN = max(0, config.env_int("DB_POOL_MIN"))
+_POOL_MAX = max(1, config.env_int("DB_POOL_MAX"))
 # Seconds getconn() blocks waiting for the pool to hand back a connection
 # before raising PoolTimeout. psycopg_pool always routes getconn through its
 # background maintenance worker, so this also bounds how long a *single* call
@@ -81,10 +82,10 @@ _POOL_MAX = max(1, int(os.environ.get("DB_POOL_MAX", "10")))
 # breaker below keeps a dead DB from making *every* subsequent call pay even
 # this wait. Raise ``DB_POOL_TIMEOUT`` in production if a connection-storm
 # warm-up is expected.
-_POOL_TIMEOUT = float(os.environ.get("DB_POOL_TIMEOUT", "2"))
+_POOL_TIMEOUT = config.env_float("DB_POOL_TIMEOUT")
 # Per-attempt TCP/auth connect timeout, applied via the libpq ``connect_timeout``
 # keyword so a dead host fails in seconds rather than the OS default (~75s).
-_CONNECT_TIMEOUT = int(os.environ.get("DB_CONNECT_TIMEOUT", "5"))
+_CONNECT_TIMEOUT = config.env_int("DB_CONNECT_TIMEOUT")
 # Circuit breaker: when a checkout fails (PoolTimeout / OperationalError) the
 # DB is treated as unavailable for this cooldown, during which get_connection()
 # fails *immediately* instead of making each caller wait DB_POOL_TIMEOUT again.
@@ -93,7 +94,7 @@ _CONNECT_TIMEOUT = int(os.environ.get("DB_CONNECT_TIMEOUT", "5"))
 # runs without a Postgres service — does not serialise into one timeout per
 # call) while still pooling normally when the DB is up. Kept short so a
 # transient blip self-heals within a couple of seconds of DB recovery.
-_BREAKER_COOLDOWN = float(os.environ.get("DB_BREAKER_COOLDOWN", "2"))
+_BREAKER_COOLDOWN = config.env_float("DB_BREAKER_COOLDOWN")
 
 _pool: ConnectionPool | None = None
 _pool_lock = threading.Lock()

--- a/app/docs/docx_export.py
+++ b/app/docs/docx_export.py
@@ -51,6 +51,7 @@ from docx import Document
 from docx.enum.section import WD_SECTION
 from docx.shared import Pt
 
+from app import config
 from app.docs.draft_model import Draft
 from app.docs.labels import TYPE_LABELS_ET as _TYPE_LABELS_ET
 from app.ontology.relations import legal_phrase
@@ -184,8 +185,8 @@ def _resolve_export_dir(raw: str | None, app_env: str | None) -> Path:
 def _load_export_dir() -> Path:
     """Return the root export directory with a dev-friendly default."""
     return _resolve_export_dir(
-        os.environ.get("EXPORT_DIR"),
-        os.environ.get("APP_ENV"),
+        config.env_str("EXPORT_DIR"),
+        config.get_app_env(),
     )
 
 

--- a/app/docs/reference_resolver.py
+++ b/app/docs/reference_resolver.py
@@ -51,7 +51,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
-import os
 import re
 import threading
 from collections import Counter, defaultdict
@@ -59,6 +58,7 @@ from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Any
 
+from app import config
 from app.config import is_stub_allowed
 from app.docs.entity_extractor import ExtractedRef
 from app.ontology.queries import ESTLEG_NS, PREFIXES
@@ -1033,7 +1033,7 @@ def _get_ref_hash_secret() -> bytes:
     Tests monkeypatch this helper directly to keep assertions on the
     hashed identifier stable.
     """
-    secret = os.environ.get(_REF_HASH_SECRET_ENV)
+    secret = config.env_str(_REF_HASH_SECRET_ENV)
     if secret:
         return secret.encode("utf-8")
     if not is_stub_allowed():  # production

--- a/app/docs/signed_urls.py
+++ b/app/docs/signed_urls.py
@@ -37,11 +37,11 @@ import hashlib
 import hmac
 import json
 import logging
-import os
 import secrets
 import time
 from typing import Any
 
+from app import config
 from app.config import is_stub_allowed
 
 logger = logging.getLogger(__name__)
@@ -75,10 +75,10 @@ def _load_signing_key() -> bytes:
        so a misconfigured deploy can't silently sign tokens with a
        well-known value.
     """
-    explicit = os.environ.get(_DOWNLOAD_TOKEN_SECRET_ENV)
+    explicit = config.env_str(_DOWNLOAD_TOKEN_SECRET_ENV)
     if explicit:
         return explicit.encode("utf-8")
-    jwt_secret = os.environ.get("SECRET_KEY")
+    jwt_secret = config.env_str("SECRET_KEY")
     if jwt_secret:
         return jwt_secret.encode("utf-8")
     if not is_stub_allowed():  # production

--- a/app/docs/similarity.py
+++ b/app/docs/similarity.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
+
+from app import config
 
 logger = logging.getLogger(__name__)
 
@@ -47,19 +48,7 @@ def get_similarity_threshold() -> float:
     Defaults to :data:`DEFAULT_SIMILARITY_THRESHOLD` (0.15) when the
     variable is absent or unparseable.
     """
-    raw = os.environ.get(
-        "SEADUSLOOME_SIMILARITY_THRESHOLD",
-        str(DEFAULT_SIMILARITY_THRESHOLD),
-    )
-    try:
-        v = float(raw)
-    except ValueError:
-        logger.warning(
-            "similarity: invalid SEADUSLOOME_SIMILARITY_THRESHOLD=%r, using default %.2f",
-            raw,
-            DEFAULT_SIMILARITY_THRESHOLD,
-        )
-        return DEFAULT_SIMILARITY_THRESHOLD
+    v = config.env_float("SEADUSLOOME_SIMILARITY_THRESHOLD")
     return max(0.0, min(1.0, v))
 
 

--- a/app/docs/tika_client.py
+++ b/app/docs/tika_client.py
@@ -58,12 +58,12 @@ Env vars
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from typing import Any
 
 import httpx
 
+from app import config
 from app.config import is_stub_allowed
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ def _load_url(explicit: str | None) -> str | None:
     """Return the effective Tika URL, or ``None`` to trigger stub/error mode."""
     if explicit:
         return explicit.rstrip("/")
-    raw = os.environ.get("TIKA_URL")
+    raw = config.env_str("TIKA_URL")
     if raw:
         return raw.rstrip("/")
     return None
@@ -112,36 +112,20 @@ def _load_timeout(explicit: float | None) -> float:
     """Return the effective request timeout in seconds."""
     if explicit is not None:
         return float(explicit)
-    raw = os.environ.get("TIKA_TIMEOUT_SECONDS", "60")
-    try:
-        return float(raw)
-    except ValueError:
-        logger.warning("Invalid TIKA_TIMEOUT_SECONDS=%r, falling back to 60", raw)
-        return 60.0
+    return config.env_float("TIKA_TIMEOUT_SECONDS")
 
 
-# Default ceiling for the extracted-text response (#858). 20 MiB of
-# plaintext is far beyond any real legislative draft (the biggest
-# corpus acts come in well under 5 MB of text) while still small enough
-# that one runaway extraction cannot OOM the worker or bloat the
-# encrypted ``parsed_text`` column.
-_DEFAULT_MAX_TEXT_BYTES = 20 * 1024 * 1024
-
-
+# The default ceiling for the extracted-text response (#858) lives in the
+# TIKA_MAX_TEXT_BYTES registry entry (app/config.py): 20 MiB of plaintext is
+# far beyond any real legislative draft (the biggest corpus acts come in
+# well under 5 MB of text) while still small enough that one runaway
+# extraction cannot OOM the worker or bloat the encrypted ``parsed_text``
+# column.
 def _load_max_text_bytes(explicit: int | None) -> int:
     """Return the effective ``PUT /tika`` response byte ceiling."""
     if explicit is not None:
         return max(1, int(explicit))
-    raw = os.environ.get("TIKA_MAX_TEXT_BYTES", str(_DEFAULT_MAX_TEXT_BYTES))
-    try:
-        return max(1, int(raw))
-    except ValueError:
-        logger.warning(
-            "Invalid TIKA_MAX_TEXT_BYTES=%r, falling back to %d",
-            raw,
-            _DEFAULT_MAX_TEXT_BYTES,
-        )
-        return _DEFAULT_MAX_TEXT_BYTES
+    return config.env_int("TIKA_MAX_TEXT_BYTES")
 
 
 def _error_body_snippet(response: httpx.Response, limit: int = 200) -> str:

--- a/app/docs/upload.py
+++ b/app/docs/upload.py
@@ -37,13 +37,13 @@ from __future__ import annotations
 
 import io
 import logging
-import os
 import uuid
 import zipfile
 from typing import Any, Protocol
 
 import psycopg
 
+from app import config
 from app.auth.audit import log_action
 from app.auth.provider import UserDict
 from app.db import get_connection as _connect
@@ -174,9 +174,6 @@ class _UploadLike(Protocol):
 # ---------------------------------------------------------------------------
 
 
-_DEFAULT_MAX_UPLOAD_MB = 50
-
-
 def _max_upload_mb() -> int:
     """Return the configured ``MAX_UPLOAD_SIZE_MB`` clamped to ``[1, ∞)``.
 
@@ -185,17 +182,7 @@ def _max_upload_mb() -> int:
     §3 calls for 25 MB but 50 MB leaves headroom for scanned PDFs and is
     still well below the encryption overhead budget.
     """
-    raw = os.environ.get("MAX_UPLOAD_SIZE_MB", str(_DEFAULT_MAX_UPLOAD_MB))
-    try:
-        mb = int(raw)
-    except ValueError:
-        logger.warning(
-            "Invalid MAX_UPLOAD_SIZE_MB=%r, falling back to %d",
-            raw,
-            _DEFAULT_MAX_UPLOAD_MB,
-        )
-        mb = _DEFAULT_MAX_UPLOAD_MB
-    return max(1, mb)
+    return config.env_int("MAX_UPLOAD_SIZE_MB")
 
 
 def max_upload_bytes() -> int:

--- a/app/email/service.py
+++ b/app/email/service.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import os
 import threading
 
-from app.config import is_stub_allowed
+from app import config
 from app.email.provider import EmailProvider
 from app.email.stub_provider import StubProvider
 
@@ -34,11 +33,11 @@ def get_email_provider() -> EmailProvider:
         if _provider is not None:
             return _provider
 
-        token = os.environ.get("POSTMARK_API_TOKEN", "").strip()
-        from_addr = os.environ.get("EMAIL_FROM", "").strip() or _DEFAULT_FROM
+        token = config.env_str("POSTMARK_API_TOKEN", "").strip()
+        from_addr = config.env_str("EMAIL_FROM", "").strip() or _DEFAULT_FROM
 
         if not token:
-            if is_stub_allowed():
+            if config.is_stub_allowed():
                 _provider = StubProvider()
                 return _provider
             raise RuntimeError(

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -40,7 +40,6 @@ There are no stubs left in this module.
 from __future__ import annotations
 
 import logging
-import os
 import socket
 import threading
 import time
@@ -49,6 +48,7 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
+from app import config
 from app.jobs.queue import (
     DEFAULT_REAPER_CLAIMED_TIMEOUT_S,
     DEFAULT_REAPER_RUNNING_TIMEOUT_S,
@@ -66,7 +66,7 @@ DEFAULT_REAP_INTERVAL_S = 60.0
 
 def _env_seconds(name: str, default: float) -> float:
     """Read a positive seconds value from the environment, else *default*."""
-    raw = os.environ.get(name, "").strip()
+    raw = (config.env_str(name) or "").strip()
     if not raw:
         return default
     try:

--- a/app/llm/claude.py
+++ b/app/llm/claude.py
@@ -20,13 +20,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import re
 import threading
 import time
 from collections.abc import AsyncIterator
 from typing import Any
 
+from app import config
 from app.config import STUB_ALLOWED_ENVS, get_app_env, is_stub_allowed
 from app.llm.provider import LLMProvider, StreamEvent
 from app.llm.retry import retry_async, retry_sync
@@ -55,7 +55,7 @@ class ClaudeProvider(LLMProvider):
     """
 
     def __init__(self) -> None:
-        api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+        api_key = config.env_str("ANTHROPIC_API_KEY", "").strip()
 
         if not api_key:
             if not is_stub_allowed():
@@ -78,7 +78,7 @@ class ClaudeProvider(LLMProvider):
             self._stubbed = False
             self._api_key = api_key
 
-        self._model = os.environ.get("CLAUDE_MODEL", DEFAULT_MODEL)
+        self._model = config.env_str("CLAUDE_MODEL", DEFAULT_MODEL)
         # Lazy-initialised SDK clients; only built on first real call so
         # stub users never need the ``anthropic`` package installed.
         self._client: Any = None

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import threading
 import time
 from pathlib import Path
@@ -12,6 +11,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
+from app import config
 from app.admin import register_admin_routes
 from app.analyysikeskus import register_analyysikeskus_routes
 from app.annotations.routes import register_annotation_routes
@@ -128,7 +128,7 @@ async def lifespan(_app):  # type: ignore[no-untyped-def]
             exc_info=True,
         )
 
-    if os.environ.get("DISABLE_BACKGROUND_WORKER") == "1":
+    if config.env_bool("DISABLE_BACKGROUND_WORKER"):
         logger.info("Background worker disabled via DISABLE_BACKGROUND_WORKER=1")
         yield
         return
@@ -407,7 +407,7 @@ app, rt = fast_app(
 # TrustedHostMiddleware is too strict for local dev (it rejects the
 # `testserver` host used by Starlette's TestClient and plain `localhost`),
 # so enable it only when we're running in a non-development environment.
-if os.environ.get("APP_ENV", "development") != "development":
+if config.get_app_env() != "development":
     app.add_middleware(
         TrustedHostMiddleware,
         allowed_hosts=[

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -20,13 +20,13 @@ from __future__ import annotations
 import atexit
 import json
 import logging
-import os
 import threading
 import time
 from collections import deque
 from contextlib import contextmanager
 from typing import Any
 
+from app import config
 from app.db import get_connection as _connect
 
 logger = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ _last_retention_sweep: float | None = None
 
 def _retention_days() -> int:
     """Days of metrics history to keep; 0 (or invalid) disables retention."""
-    raw = os.environ.get("METRICS_RETENTION_DAYS", "30")
+    raw = config.env_str("METRICS_RETENTION_DAYS", "30")
     try:
         return max(0, int(raw))
     except ValueError:

--- a/app/observability.py
+++ b/app/observability.py
@@ -11,10 +11,11 @@ app and capture unhandled exceptions automatically.
 from __future__ import annotations
 
 import logging
-import os
 import re
 import subprocess
 from typing import Any
+
+from app import config
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +310,7 @@ def _get_git_sha() -> str:
     Dockerfile ``ARG``).  Falls back to ``git rev-parse --short HEAD``
     for local development.  Returns ``"unknown"`` when neither works.
     """
-    sha = os.environ.get("GIT_SHA")
+    sha = config.env_str("GIT_SHA")
     if sha:
         return sha
     try:
@@ -367,7 +368,7 @@ def init_sentry() -> None:
     Safe to call unconditionally — when the DSN is empty or missing,
     the function returns immediately without importing ``sentry_sdk``.
     """
-    dsn = os.environ.get("SENTRY_DSN")
+    dsn = config.env_str("SENTRY_DSN")
     if not dsn:
         logger.debug("SENTRY_DSN not set — Sentry disabled")
         return
@@ -378,7 +379,7 @@ def init_sentry() -> None:
         dsn=dsn,
         traces_sample_rate=0.1,
         release=_get_git_sha(),
-        environment=os.environ.get("APP_ENV", "development"),
+        environment=config.get_app_env(),
         before_send=_scrub_pii,  # type: ignore[arg-type]  # Sentry stubs define Event as TypedDict
         # Transactions sample real request URLs (reset links, signed
         # download tokens) — scrub them with the same function (#846).

--- a/app/ontology/sparql_client.py
+++ b/app/ontology/sparql_client.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 import threading
 import time
 
 import httpx
 
+from app import config
 from app.metrics import record_metric
 
 logger = logging.getLogger(__name__)
@@ -144,8 +144,8 @@ class SparqlClient:
         dataset: str | None = None,
         timeout: float = 30.0,
     ) -> None:
-        self.jena_url = jena_url or os.environ.get("JENA_URL", _DEFAULT_JENA_URL)
-        self.dataset = dataset or os.environ.get("JENA_DATASET", _DEFAULT_JENA_DATASET)
+        self.jena_url = jena_url or config.env_str("JENA_URL", _DEFAULT_JENA_URL)
+        self.dataset = dataset or config.env_str("JENA_DATASET", _DEFAULT_JENA_DATASET)
         self.timeout = timeout
 
     @property

--- a/app/rag/embedding.py
+++ b/app/rag/embedding.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import contextvars
 import logging
-import os
 import random
 import threading
 from abc import ABC, abstractmethod
@@ -28,6 +27,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
+from app import config
 from app.config import STUB_ALLOWED_ENVS, get_app_env, is_stub_allowed
 
 logger = logging.getLogger(__name__)
@@ -140,7 +140,7 @@ class VoyageProvider(EmbeddingProvider):
     """
 
     def __init__(self) -> None:
-        api_key = os.environ.get("VOYAGE_API_KEY", "").strip()
+        api_key = config.env_str("VOYAGE_API_KEY", "").strip()
 
         if not api_key:
             if not is_stub_allowed():
@@ -164,8 +164,8 @@ class VoyageProvider(EmbeddingProvider):
             self._stubbed = False
             self._api_key = api_key
 
-        self._model = os.environ.get("VOYAGE_MODEL", DEFAULT_MODEL)
-        self._dimensions = int(os.environ.get("VOYAGE_DIMENSIONS", str(DEFAULT_DIMENSIONS)))
+        self._model = config.env_str("VOYAGE_MODEL", DEFAULT_MODEL)
+        self._dimensions = config.env_int("VOYAGE_DIMENSIONS")
         # Lazy-initialised SDK client; only built on first real call so
         # stub users never need the ``voyageai`` package installed.
         self._client: Any = None

--- a/app/storage/encrypted.py
+++ b/app/storage/encrypted.py
@@ -64,7 +64,6 @@ frictionless, with a loud warning so nobody accidentally ships it.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import uuid
 from dataclasses import dataclass
@@ -72,7 +71,7 @@ from pathlib import Path
 
 from cryptography.fernet import Fernet, InvalidToken, MultiFernet
 
-from app.config import is_stub_allowed
+from app import config
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +136,7 @@ def _load_fernets() -> list[Fernet]:
     (Tika, Claude, Fernet) follow the same APP_ENV rule (#449, #865).
     """
     global _warned_dev_ephemeral
-    value = os.environ.get("STORAGE_ENCRYPTION_KEY")
+    value = config.env_str("STORAGE_ENCRYPTION_KEY")
     if value:
         segments = [seg.strip() for seg in value.split(",")]
         keys = [seg for seg in segments if seg]
@@ -161,7 +160,7 @@ def _load_fernets() -> list[Fernet]:
                     'print(generate_encryption_key())"`.'
                 ) from exc
         return fernets
-    if is_stub_allowed():
+    if config.is_stub_allowed():
         if not _warned_dev_ephemeral:
             logger.warning(
                 "STORAGE_ENCRYPTION_KEY not set — using ephemeral key. "
@@ -205,10 +204,10 @@ def _load_storage_dir() -> Path:
     test/staging/dev all default to the local relative path; only
     APP_ENV=production falls back to the system-wide ``/var`` path.
     """
-    raw = os.environ.get("STORAGE_DIR")
+    raw = config.env_str("STORAGE_DIR")
     if raw:
         return Path(raw)
-    if is_stub_allowed():
+    if config.is_stub_allowed():
         return Path("./storage/drafts").resolve()
     return Path("/var/seadusloome/drafts")
 

--- a/app/sync/jena_loader.py
+++ b/app/sync/jena_loader.py
@@ -22,16 +22,17 @@ rejects if left raw in the query string.
 """
 
 import logging
-import os
 import re
 from urllib.parse import quote
 
 import httpx
 
+from app import config
+
 logger = logging.getLogger(__name__)
 
-JENA_URL = os.environ.get("JENA_URL", "http://localhost:3030")
-JENA_DATASET = os.environ.get("JENA_DATASET", "ontology")
+JENA_URL = config.env_str("JENA_URL", "http://localhost:3030")
+JENA_DATASET = config.env_str("JENA_DATASET", "ontology")
 JENA_ADMIN_USER = "admin"
 
 # #853 / comment item 1: the Fuseki write endpoints are now behind
@@ -42,11 +43,12 @@ JENA_ADMIN_USER = "admin"
 # that. We now resolve the password lazily at first write and FAIL
 # CLOSED outside local development when it is missing.
 #
-# We read ``APP_ENV`` directly here (NOT via app.config) on purpose:
-# app/config.py is owned by another change set, and the gate we want is
-# the same "dev-only fallback" rule app.db already applies to
+# The gate matches the same "dev-only fallback" rule app.db applies to
 # DATABASE_URL — a missing secret is a hard error everywhere except
-# ``APP_ENV=development`` (the default for a fresh clone / tests).
+# ``APP_ENV=development`` (the default for a fresh clone / tests). The
+# password and APP_ENV are both sourced via the typed settings registry
+# (config.env_str / config.get_app_env, #897); the fail-closed domain
+# logic stays here next to the feature it protects.
 _DEV_FALLBACK_ADMIN_PASSWORD = "localdev"
 
 
@@ -71,10 +73,10 @@ def _resolve_admin_password() -> str:
       guessable password to an auth-guarded write endpoint in
       staging/production.
     """
-    value = os.environ.get("FUSEKI_ADMIN_PASSWORD")
+    value = config.env_str("FUSEKI_ADMIN_PASSWORD")
     if value:
         return value
-    if os.environ.get("APP_ENV", "development") == "development":
+    if config.get_app_env() == "development":
         return _DEV_FALLBACK_ADMIN_PASSWORD
     raise FusekiAdminPasswordError(
         "FUSEKI_ADMIN_PASSWORD must be set outside local development — "

--- a/app/sync/orchestrator.py
+++ b/app/sync/orchestrator.py
@@ -1,7 +1,6 @@
 """Sync pipeline orchestrator: GitHub → RDF → validate → Jena Fuseki."""
 
 import logging
-import os
 import re
 import shutil
 import subprocess
@@ -10,6 +9,7 @@ import threading
 from datetime import UTC, datetime
 from pathlib import Path
 
+from app import config
 from app.db import get_connection
 from app.sync.converter import convert_ontology, serialize_to_turtle
 from app.sync.jena_loader import (
@@ -71,7 +71,7 @@ def _scrub_secrets(text: str) -> str:
     if not text:
         return ""
     scrubbed = _URL_CREDENTIALS_RE.sub(r"\g<scheme>***:***@", text)
-    secret = os.environ.get("FUSEKI_ADMIN_PASSWORD")
+    secret = config.env_str("FUSEKI_ADMIN_PASSWORD")
     if secret and secret in scrubbed:
         scrubbed = scrubbed.replace(secret, "***")
     return scrubbed
@@ -103,31 +103,23 @@ ONTOLOGY_REPO = "https://github.com/henrikaavik/estonian-legal-ontology.git"
 STAGING_GRAPH = "urn:estleg:staging"
 
 # Lower bound for "this sync looks plausible". Default: 1,000,000 triples
-# (the enacted-law ontology has ~1.3M today). Overridable per env for
-# non-prod fixtures and tests. The effective threshold is the max of
-# this value and 80% of the current live-graph count — see
-# :func:`_compute_verification_threshold`.
-_DEFAULT_MIN_TRIPLES = 1_000_000
+# (the enacted-law ontology has ~1.3M today). Overridable per env via
+# ``SYNC_MIN_TRIPLES`` for non-prod fixtures and tests. The effective
+# threshold is the max of this value and 80% of the current live-graph
+# count — see :func:`_compute_verification_threshold`. The default and
+# lenient parse now live in the typed settings registry (#897).
 
 
 def _sync_min_triples() -> int:
     """Return the configured absolute minimum triple count for verification.
 
     Exposed as a function so tests (and ops overriding ``SYNC_MIN_TRIPLES``
-    at runtime) don't need to patch a module-level constant.
+    at runtime) don't need to patch a module-level constant. The registry
+    (#897) supplies the default (1,000,000), warns and falls back on a
+    garbage value, and clamps valid values to a floor of 0 — semantics
+    identical to the parser this replaced.
     """
-    raw = os.environ.get("SYNC_MIN_TRIPLES")
-    if raw is None:
-        return _DEFAULT_MIN_TRIPLES
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        logger.warning(
-            "Invalid SYNC_MIN_TRIPLES=%r; falling back to default %d",
-            raw,
-            _DEFAULT_MIN_TRIPLES,
-        )
-        return _DEFAULT_MIN_TRIPLES
+    return config.env_int("SYNC_MIN_TRIPLES")
 
 
 def _compute_verification_threshold(live_count: int) -> int:

--- a/app/sync/webhook.py
+++ b/app/sync/webhook.py
@@ -3,12 +3,12 @@
 import hashlib
 import hmac
 import logging
-import os
 import threading
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from app import config
 from app.sync.orchestrator import has_recent_running_row, run_sync
 from app.sync.webhook_deliveries import (
     DeliveryRerunResult,
@@ -18,7 +18,7 @@ from app.sync.webhook_deliveries import (
 
 logger = logging.getLogger(__name__)
 
-WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
+WEBHOOK_SECRET = config.env_str("GITHUB_WEBHOOK_SECRET", "")
 ONTOLOGY_REPO_FULL_NAME = "henrikaavik/estonian-legal-ontology"
 
 # #853 / comment item 3: cap the request body we will read into memory

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -169,6 +169,21 @@ def test_env_int_refuses_site_parsed_vars() -> None:
         config.env_int("METRICS_RETENTION_DAYS")
 
 
+def test_env_str_allows_site_parsed_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """parse="site" vars are readable as raw strings whatever their kind.
+
+    This is the documented escape hatch for module-local parsers
+    (app/metrics.py retention quirk, app/jobs/worker.py positive-seconds
+    parse) — without it those sites would be forced back onto os.environ.
+    """
+    monkeypatch.setenv("METRICS_RETENTION_DAYS", "7")
+    assert config.env_str("METRICS_RETENTION_DAYS", "30") == "7"
+    monkeypatch.delenv("METRICS_RETENTION_DAYS", raising=False)
+    assert config.env_str("METRICS_RETENTION_DAYS", "30") == "30"
+    monkeypatch.delenv("JOB_REAPER_INTERVAL_S", raising=False)
+    assert config.env_str("JOB_REAPER_INTERVAL_S") is None
+
+
 def test_env_bool_truthy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CHAT_FOLLOW_UPS_ENABLED", raising=False)
     assert config.env_bool("CHAT_FOLLOW_UPS_ENABLED") is True

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -1,0 +1,209 @@
+"""Typed settings registry contract (#897).
+
+Three pins:
+
+1. ``app/`` modules outside ``app/config.py`` perform NO direct
+   environment reads — every variable goes through the typed getters
+   (``env_str`` / ``env_int`` / ``env_float`` / ``env_bool``) or the
+   semantic helpers (``get_app_env`` etc.) in :mod:`app.config`.
+2. ``.env.example`` and ``ENV_REGISTRY`` stay in sync, both directions
+   (modulo an explicit allowlist of compose-only / future vars).
+3. The typed getters honour each entry's declared parse semantics
+   (strict vs lenient ints, the four bool styles, raw str passthrough).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app import config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+APP_DIR = REPO_ROOT / "app"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+# ---------------------------------------------------------------------------
+# 1. No inline env reads outside app/config.py
+# ---------------------------------------------------------------------------
+
+# Direct environment *reads*. A bare ``**os.environ`` spread (subprocess
+# env passthrough in app/docs/docx_export.py) is deliberately NOT matched:
+# it forwards the environment wholesale rather than reading config from it.
+_ENV_READ = re.compile(
+    r"os\.environ\.get\s*\(|os\.environ\s*\[|os\.getenv\s*\(|"
+    r"from\s+os\s+import\s+[^\n]*\b(?:environ|getenv)\b"
+)
+
+
+def test_no_inline_env_reads_outside_config() -> None:
+    offenders: list[str] = []
+    for path in sorted(APP_DIR.rglob("*.py")):
+        if path == APP_DIR / "config.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if _ENV_READ.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {stripped}")
+    assert not offenders, (
+        "Direct os.environ reads are not allowed outside app/config.py (#897). "
+        "Declare the variable in config.ENV_REGISTRY and read it via "
+        "config.env_str/env_int/env_float/env_bool instead:\n  " + "\n  ".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. .env.example <-> registry sync
+# ---------------------------------------------------------------------------
+
+# Variables allowed in .env.example without a registry entry: consumed by
+# docker-compose / the postgres container, or documented Phase-5 stubs that
+# nothing reads yet (app/auth/tara_provider.py docstring).
+ALLOWED_EXTRA_IN_ENV_EXAMPLE = frozenset(
+    {
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+        "ONTOLOGY_REPO_URL",
+        "AUTH_PROVIDER",
+        "TARA_CLIENT_ID",
+        "TARA_CLIENT_SECRET",
+        "TARA_REDIRECT_URI",
+        "TARA_ISSUER_URL",
+    }
+)
+
+# Matches both active entries (``NAME=...``) and documented-but-commented
+# entries (``# NAME=``), e.g. DISABLE_BACKGROUND_WORKER.
+_ENV_EXAMPLE_VAR = re.compile(r"^#?\s*([A-Z][A-Z0-9_]*)=", re.MULTILINE)
+
+
+def _env_example_names() -> set[str]:
+    return set(_ENV_EXAMPLE_VAR.findall(ENV_EXAMPLE.read_text(encoding="utf-8")))
+
+
+def test_env_example_documents_every_registry_var() -> None:
+    documented = _env_example_names()
+    missing = sorted(s.name for s in config.ENV_REGISTRY if s.name not in documented)
+    assert not missing, (
+        ".env.example is missing registry-declared variables (#897); "
+        f"document them (commented-out is fine): {missing}"
+    )
+
+
+def test_env_example_has_no_undeclared_vars() -> None:
+    declared = {s.name for s in config.ENV_REGISTRY} | ALLOWED_EXTRA_IN_ENV_EXAMPLE
+    unknown = sorted(_env_example_names() - declared)
+    assert not unknown, (
+        ".env.example documents variables that neither ENV_REGISTRY nor the "
+        f"compose/future allowlist declares — stale docs or a missed entry: {unknown}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Getter semantics
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_valid_and_unique() -> None:
+    names = [s.name for s in config.ENV_REGISTRY]
+    assert len(names) == len(set(names))
+    # _validate_registry() ran at import; re-run for explicitness.
+    config._validate_registry()
+
+
+def test_env_str_mirrors_environ_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TIKA_URL", raising=False)
+    assert config.env_str("TIKA_URL") is None
+    assert config.env_str("TIKA_URL", "http://x:9998") == "http://x:9998"
+    monkeypatch.setenv("TIKA_URL", "")
+    assert config.env_str("TIKA_URL") == ""  # set-but-empty is NOT defaulted
+    monkeypatch.setenv("TIKA_URL", "  spaced  ")
+    assert config.env_str("TIKA_URL") == "  spaced  "  # never normalized
+
+
+def test_env_str_rejects_undeclared_and_wrong_kind() -> None:
+    with pytest.raises(KeyError, match="ENV_REGISTRY"):
+        config.env_str("NOT_A_DECLARED_VAR")
+    with pytest.raises(TypeError, match="kind='int'"):
+        config.env_str("DB_POOL_MIN")
+    with pytest.raises(TypeError, match="kind='str'"):
+        config.env_int("TIKA_URL")
+
+
+def test_env_int_strict_propagates_garbage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DB_POOL_MIN", raising=False)
+    assert config.env_int("DB_POOL_MIN") == 1
+    monkeypatch.setenv("DB_POOL_MIN", "7")
+    assert config.env_int("DB_POOL_MIN") == 7
+    monkeypatch.setenv("DB_POOL_MIN", "seven")
+    with pytest.raises(ValueError):
+        config.env_int("DB_POOL_MIN")
+
+
+def test_env_int_lenient_warns_and_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TIKA_MAX_TEXT_BYTES", "garbage")
+    assert config.env_int("TIKA_MAX_TEXT_BYTES") == 20 * 1024 * 1024
+    monkeypatch.setenv("TIKA_MAX_TEXT_BYTES", "0")
+    assert config.env_int("TIKA_MAX_TEXT_BYTES") == 1  # clamped to minimum
+    monkeypatch.setenv("TIKA_MAX_TEXT_BYTES", "1024")
+    assert config.env_int("TIKA_MAX_TEXT_BYTES") == 1024
+
+
+def test_env_float_lenient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TIKA_TIMEOUT_SECONDS", raising=False)
+    assert config.env_float("TIKA_TIMEOUT_SECONDS") == 60.0
+    monkeypatch.setenv("TIKA_TIMEOUT_SECONDS", "2.5")
+    assert config.env_float("TIKA_TIMEOUT_SECONDS") == 2.5
+    monkeypatch.setenv("TIKA_TIMEOUT_SECONDS", "soon")
+    assert config.env_float("TIKA_TIMEOUT_SECONDS") == 60.0
+
+
+def test_env_int_refuses_site_parsed_vars() -> None:
+    with pytest.raises(TypeError, match="site"):
+        config.env_int("METRICS_RETENTION_DAYS")
+
+
+def test_env_bool_truthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CHAT_FOLLOW_UPS_ENABLED", raising=False)
+    assert config.env_bool("CHAT_FOLLOW_UPS_ENABLED") is True
+    for value in ("1", "true", "YES", " on "):
+        monkeypatch.setenv("CHAT_FOLLOW_UPS_ENABLED", value)
+        assert config.env_bool("CHAT_FOLLOW_UPS_ENABLED") is True
+    monkeypatch.setenv("CHAT_FOLLOW_UPS_ENABLED", "0")
+    assert config.env_bool("CHAT_FOLLOW_UPS_ENABLED") is False
+
+
+def test_env_bool_true_literal_cookie_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COOKIE_SECURE", raising=False)
+    assert config.env_bool("COOKIE_SECURE") is True
+    monkeypatch.setenv("COOKIE_SECURE", "True")
+    assert config.env_bool("COOKIE_SECURE") is True
+    # Historical quirk, deliberately preserved: only the literal "true"
+    # counts — "1" disables the secure flag.
+    monkeypatch.setenv("COOKIE_SECURE", "1")
+    assert config.env_bool("COOKIE_SECURE") is False
+
+
+def test_env_bool_one_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DISABLE_BACKGROUND_WORKER", raising=False)
+    assert config.env_bool("DISABLE_BACKGROUND_WORKER") is False
+    monkeypatch.setenv("DISABLE_BACKGROUND_WORKER", "true")
+    assert config.env_bool("DISABLE_BACKGROUND_WORKER") is False
+    monkeypatch.setenv("DISABLE_BACKGROUND_WORKER", "1")
+    assert config.env_bool("DISABLE_BACKGROUND_WORKER") is True
+
+
+def test_env_bool_off_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CSRF_ORIGIN_CHECK", raising=False)
+    assert config.env_bool("CSRF_ORIGIN_CHECK") is True
+    for value in ("off", "0", "FALSE", "no", " disabled "):
+        monkeypatch.setenv("CSRF_ORIGIN_CHECK", value)
+        assert config.env_bool("CSRF_ORIGIN_CHECK") is False
+    monkeypatch.setenv("CSRF_ORIGIN_CHECK", "anything-else")
+    assert config.env_bool("CSRF_ORIGIN_CHECK") is True


### PR DESCRIPTION
Closes #897. The one undelivered DoD item from #860, spun off after #890–#894 + #896.

## What

**`app/config.py` is now the single import point for configuration.** A declarative `ENV_REGISTRY` declares all **49** environment variables the app reads (the issue estimated 34) — name, kind, documented default, one-line description, secret flag, section, and parse mode — and four registry-validated typed getters (`env_str` / `env_int` / `env_float` / `env_bool`) replace every inline `os.environ` read across 28 modules. Reading an undeclared variable raises `KeyError`; reading through the wrong-typed getter raises `TypeError`.

- **Call-time reads preserved** — getters hit `os.environ` on every call, so `monkeypatch.setenv` and Coolify env edits behave exactly as before. Import-time constants (`app.db` pool sizing, `jwt_provider.SECRET_KEY`, `webhook.WEBHOOK_SECRET`, `cookies.COOKIE_SECURE`) keep their import-time timing; only the string source changed.
- **No hidden normalization** — `env_str` is a verbatim `os.environ.get` (SECRET_KEY and the token/webhook secrets are key material where whitespace matters). Call sites keep their own `strip()`/`rstrip()`.
- **Domain logic stays put** — stub gates, raise-in-production checks, fallback chains (`DOWNLOAD_TOKEN_SECRET` → `SECRET_KEY`), and clamps remain in their owning modules. `is_stub_allowed()` is unchanged and remains the single stub-mode gate (CLAUDE.md contract).
- **`parse="site"` escape hatch** — quirky parsers (`METRICS_RETENTION_DAYS` falls back to 0/disabled on garbage; `JOB_REAPER_*` accept positive-only seconds) stay module-local and read the raw string via `env_str`; `env_int`/`env_float` refuse those names so the quirks can't be flattened by accident.

**Pin test** (`tests/test_settings_registry.py`): no direct env reads in `app/` outside `config.py` (the one `{**os.environ}` subprocess spread in `docx_export.py` is deliberately exempt — it forwards the environment, it doesn't read config); two-way `.env.example` ↔ registry sync; per-style getter semantics (15 tests).

**`.env.example` regenerated from the registry** — 22 previously-undocumented vars added (DB pool knobs, reaper knobs, Sentry panel trio, proxy/CSRF, retention, similarity threshold, …), grouped by registry section, secrets as placeholders.

## Intentional behavior deltas (all called out, all narrow)

1. **APP_ENV normalization unification** — raw `os.environ.get("APP_ENV", "development") == "development"` compares in `db.py`, `main.py`, `jwt_provider.py`, `jena_loader.py`, `observability.py`, `docx_export.py` now go through `config.get_app_env()` (lowercased/stripped, the #847 canonical form). A typo'd `APP_ENV=Development` now normalizes instead of being treated as non-dev. This is the same unification #449/#847 applied to the stub gate.
2. **`.env.example` COOKIE_SECURE guidance fixed** — the old comment said "Set to 1 in production", but the code only honours the literal `"true"`; `COOKIE_SECURE=1` silently *disables* secure cookies. Docs now say so. (Code semantics unchanged and pinned by a test; hardening the parse is a separate decision.)
3. **`CHAT_MAX_TOKENS` removed from `.env.example`** — nothing reads it anywhere; stale doc.
4. **Lenient-parse warnings now log from `app.config`** (uniform "Invalid NAME=…; using default …") instead of per-module text for TIKA_TIMEOUT_SECONDS / TIKA_MAX_TEXT_BYTES / MAX_UPLOAD_SIZE_MB / SEADUSLOOME_SIMILARITY_THRESHOLD / SYNC_MIN_TRIPLES. No test asserted the old texts; values/defaults/clamps are identical.
5. Dead constants removed once the registry took over their defaults: `_DEFAULT_MAX_TEXT_BYTES` (tika_client), `_DEFAULT_MAX_UPLOAD_MB` (upload), `_DEFAULT_MIN_TRIPLES` (sync orchestrator).

## DoD mapping

- [x] Typed settings module declaring every env var with type, default, description — `ENV_REGISTRY`, 49 entries
- [x] Inline reads migrated, grep-clean outside `app/config.py` / `tests/` / `scripts/` — enforced by the pin test
- [x] `is_stub_allowed()` stays the single stub gate, reads through the settings module
- [x] Test pinning no direct env reads in `app/` outside config
- [x] `.env.example` regenerated from the settings inventory

## Verification

- Whole-repo `ruff` clean, whole-repo `pyright` 0 errors
- Full suite green locally (including the new 15 registry tests); framework-free data-layer pins (`test_worker_standalone`, `test_import_safety`, `test_dashboard_import_direction`) all pass — `app.config` is stdlib-only, so the new imports add zero framework modules to the worker container
- Built by 7 parallel agents over disjoint file scopes (core-infra / auth / docs / llm+chat / sync+jena / admin+jobs+email+storage / env-example), integrated and re-verified as one tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
