### PR TITLE
fix(auth): parse COOKIE_SECURE as truthy — '1' must enable the Secure flag (#899)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,9 +111,8 @@ SECRET_KEY=REPLACE_WITH_RANDOM_64_CHAR_HEX
 
 # Secure flag on auth cookies (cookies sent over HTTPS only). Defaults
 # to true when unset, which is what production wants — so leave it unset
-# (or "true") in staging/production. Only the literal "true"
-# (case-insensitive) enables it; numeric values do NOT work — setting it
-# to "1" silently DISABLES secure cookies. Set false ONLY for local HTTP
+# (or "true") in staging/production. Any truthy value (1/true/yes/on,
+# case-insensitive) enables it (#899). Set false ONLY for local HTTP
 # development, as below.
 COOKIE_SECURE=false
 

--- a/app/config.py
+++ b/app/config.py
@@ -368,11 +368,13 @@ ENV_REGISTRY: tuple[EnvSetting, ...] = (
         "COOKIE_SECURE",
         "bool",
         True,
-        'Secure flag on auth cookies. Only the literal "true" '
-        "(case-insensitive) enables it when set; defaults to true when "
-        "unset. NB: COOKIE_SECURE=1 disables it.",
+        "Secure flag on auth cookies. Truthy values (1/true/yes/on, "
+        "case-insensitive) enable it; defaults to true when unset. Set "
+        "false only for local HTTP development. (#899: was literal-"
+        '"true"-only, which silently disabled the flag for the '
+        "COOKIE_SECURE=1 prod config.)",
         section="Auth & cookies",
-        bool_style="true-literal",
+        bool_style="truthy",
     ),
     EnvSetting(
         "TRUSTED_PROXY_HOSTS",
@@ -778,9 +780,9 @@ def env_bool(name: str) -> bool:
     Styles (declared per-entry, preserving each site's historical
     semantics): ``truthy`` — member of {1,true,yes,on} case-insensitively,
     registry default when unset; ``true-literal`` — exactly "true"
-    case-insensitively (NB ``COOKIE_SECURE=1`` is *false*); ``one-literal``
-    — exactly "1" (unset → False); ``off-set`` — true unless a member of
-    {off,0,false,no,disabled}.
+    case-insensitively (no current entry; COOKIE_SECURE moved to truthy in
+    #899); ``one-literal`` — exactly "1" (unset → False); ``off-set`` —
+    true unless a member of {off,0,false,no,disabled}.
     """
     setting = _setting(name)
     if setting.kind != "bool":

--- a/tests/test_settings_registry.py
+++ b/tests/test_settings_registry.py
@@ -194,15 +194,18 @@ def test_env_bool_truthy(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.env_bool("CHAT_FOLLOW_UPS_ENABLED") is False
 
 
-def test_env_bool_true_literal_cookie_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_env_bool_cookie_secure_truthy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("COOKIE_SECURE", raising=False)
     assert config.env_bool("COOKIE_SECURE") is True
     monkeypatch.setenv("COOKIE_SECURE", "True")
     assert config.env_bool("COOKIE_SECURE") is True
-    # Historical quirk, deliberately preserved: only the literal "true"
-    # counts — "1" disables the secure flag.
+    # #899: "1" must ENABLE the flag — prod sets COOKIE_SECURE=1, and the
+    # historical literal-"true"-only parse silently disabled Secure there.
     monkeypatch.setenv("COOKIE_SECURE", "1")
-    assert config.env_bool("COOKIE_SECURE") is False
+    assert config.env_bool("COOKIE_SECURE") is True
+    for value in ("0", "false", "no", "off", ""):
+        monkeypatch.setenv("COOKIE_SECURE", value)
+        assert config.env_bool("COOKIE_SECURE") is False
 
 
 def test_env_bool_one_literal(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #899. Follow-up to #898's verification, which found the Seadusloome prod web container running `COOKIE_SECURE=1` + `APP_ENV=production` — with the historical literal-`"true"`-only parse, **the Secure flag on auth cookies has been silently OFF in production**. The old `.env.example` ("Set to 1 in production") actively instructed operators to set that broken value.

## Change

- `COOKIE_SECURE` registry entry: `bool_style="true-literal"` → `"truthy"` — `{1,true,yes,on}` (case-insensitive) enable, `0/false/no/off`/empty disable, unset stays **true**. Strictly safer: no configuration becomes less secure, and the value prod actually has now means what the operator intended.
- Test pins the new semantics (incl. `"1"` → True with the #899 rationale).
- `.env.example` comment updated.

After merge + deploy, prod's existing `COOKIE_SECURE=1` takes effect as Secure-on with no Coolify change needed. DoD item to verify post-deploy: `Set-Cookie` on `/auth/login` carries `Secure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)